### PR TITLE
Add foundations for multiple parks

### DIFF
--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -270,8 +270,11 @@ static void ShortcutShowFinancialInformation()
         return;
 
     if (!(isInTrackDesignerOrManager()))
-        if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+    {
+        const auto& gameState = getGameState();
+        if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             ContextOpenWindow(WindowClass::finances);
+    }
 }
 
 static void ShortcutShowResearchInformation()

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -318,12 +318,12 @@ namespace OpenRCT2::Ui::FileBrowser
                     case (LoadSaveType::scenario):
                     {
                         SetAndSaveConfigPath(Config::Get().general.lastSaveScenarioDirectory, pathBuffer);
-                        int32_t parkFlagsBackup = gameState.park.flags;
-                        gameState.park.flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+                        int32_t parkFlagsBackup = getPlayerPark(gameState).flags;
+                        getPlayerPark(gameState).flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
                         gameState.editorStep = EditorStep::Invalid;
                         gameState.scenarioFileName = std::string(String::toStringView(pathBuffer, std::size(pathBuffer)));
                         int32_t success = ScenarioSave(gameState, pathBuffer, Config::Get().general.savePluginData ? 3 : 2);
-                        gameState.park.flags = parkFlagsBackup;
+                        getPlayerPark(gameState).flags = parkFlagsBackup;
 
                         if (success)
                         {
@@ -407,12 +407,12 @@ namespace OpenRCT2::Ui::FileBrowser
                     case LoadSaveType::scenario:
                     {
                         SetAndSaveConfigPath(Config::Get().general.lastSaveScenarioDirectory, pathBuffer);
-                        int32_t parkFlagsBackup = gameState.park.flags;
-                        gameState.park.flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
+                        int32_t parkFlagsBackup = getPlayerPark(gameState).flags;
+                        getPlayerPark(gameState).flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
                         gameState.editorStep = EditorStep::Invalid;
                         gameState.scenarioFileName = std::string(String::toStringView(pathBuffer, std::size(pathBuffer)));
                         int32_t success = ScenarioSave(gameState, pathBuffer, Config::Get().general.savePluginData ? 3 : 2);
-                        gameState.park.flags = parkFlagsBackup;
+                        getPlayerPark(gameState).flags = parkFlagsBackup;
 
                         if (success)
                         {
@@ -527,7 +527,8 @@ namespace OpenRCT2::Ui::FileBrowser
             }
             else
             {
-                auto buffer = getGameState().park.name;
+                const auto& gameState = getGameState();
+                auto buffer = getPlayerPark(gameState).name;
                 if (buffer.empty())
                 {
                     buffer = LanguageGetString(STR_UNNAMED_PARK);

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -148,8 +148,10 @@ namespace OpenRCT2::Ui
                 break;
             case ViewportInteractionItem::parkEntrance:
             {
-                auto& gameState = getGameState();
-                auto parkName = gameState.park.name.c_str();
+                // TODO: get park id from element
+                const auto& gameState = getGameState();
+                auto& park = getPlayerPark(gameState);
+                auto parkName = park.name.c_str();
 
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_STRING);

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -530,7 +530,7 @@ static StringId window_cheats_page_titles[] = {
                         setWidgetDisabled(WIDX_NO_MONEY, true);
                     }
 
-                    auto moneyDisabled = (gameState.park.flags & PARK_FLAGS_NO_MONEY) != 0;
+                    auto moneyDisabled = (getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY) != 0;
                     setCheckboxValue(WIDX_NO_MONEY, moneyDisabled);
                     setWidgetDisabled(WIDX_ADD_SET_MONEY_GROUP, moneyDisabled);
                     setWidgetDisabled(WIDX_MONEY_SPINNER, moneyDisabled);
@@ -551,7 +551,7 @@ static StringId window_cheats_page_titles[] = {
                 }
                 case WINDOW_CHEATS_PAGE_PARK:
                     widgets[WIDX_OPEN_CLOSE_PARK].text = STR_CHEAT_OPEN_PARK;
-                    if (gameState.park.flags & PARK_FLAGS_PARK_OPEN)
+                    if (getPlayerPark(gameState).flags & PARK_FLAGS_PARK_OPEN)
                         widgets[WIDX_OPEN_CLOSE_PARK].text = STR_CHEAT_CLOSE_PARK;
 
                     setCheckboxValue(WIDX_FORCE_PARK_RATING, Park::GetForcedRating() >= 0);
@@ -941,10 +941,12 @@ static StringId window_cheats_page_titles[] = {
 
         void onMouseUpMoney(WidgetIndex widgetIndex)
         {
+            const auto& gameState = getGameState();
+
             switch (widgetIndex)
             {
                 case WIDX_NO_MONEY:
-                    CheatsSet(CheatType::noMoney, getGameState().park.flags & PARK_FLAGS_NO_MONEY ? 0 : 1);
+                    CheatsSet(CheatType::noMoney, getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY ? 0 : 1);
                     break;
                 case WIDX_MONEY_SPINNER:
                     MoneyToString(_moneySpinnerValue, _moneySpinnerText, kMoneyStringMaxlength, false);

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -189,8 +189,9 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw cost amount
+            const auto& gameState = getGameState();
             if (_clearSceneryCost != kMoney64Undefined && _clearSceneryCost != 0
-                && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+                && !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_clearSceneryCost);

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -82,8 +82,9 @@ namespace OpenRCT2::Ui::Windows
             auto currentRide = GetRide(rideId);
             if (currentRide != nullptr)
             {
-                auto stringId = (getGameState().park.flags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID
-                                                                                  : STR_DEMOLISH_RIDE_ID_MONEY;
+                const auto& gameState = getGameState();
+                const auto& park = getPlayerPark(gameState);
+                auto stringId = (park.flags & PARK_FLAGS_NO_MONEY) ? STR_DEMOLISH_RIDE_ID : STR_DEMOLISH_RIDE_ID_MONEY;
                 auto ft = Formatter();
                 currentRide->formatNameTo(ft);
                 ft.Add<money64>(_demolishRideCost);

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -86,7 +86,7 @@ namespace OpenRCT2::Ui::Windows
         {
             auto& gameState = getGameState();
             return gameState.entities.GetNumFreeEntities() != kMaxEntities
-                || gameState.park.flags & PARK_FLAGS_SPRITES_INITIALISED;
+                || getUpdatingPark(gameState).flags & PARK_FLAGS_SPRITES_INITIALISED;
         }
 
         void onPrepareDraw() override

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -737,7 +737,7 @@ namespace OpenRCT2::Ui::Windows
         void ShowObjectiveDropdown()
         {
             const auto& gameState = getGameState();
-            const auto& park = gameState.park;
+            const auto& park = getPlayerPark(gameState);
             const auto& scenarioOptions = gameState.scenarioOptions;
 
             auto objectiveType = EnumValue(scenarioOptions.objective.Type);
@@ -749,7 +749,7 @@ namespace OpenRCT2::Ui::Windows
                 if (obj == Scenario::ObjectiveType::none || obj == Scenario::ObjectiveType::buildTheBest)
                     continue;
 
-                const bool objectiveAllowedByMoneyUsage = !(gameState.park.flags & PARK_FLAGS_NO_MONEY)
+                const bool objectiveAllowedByMoneyUsage = !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
                     || !Scenario::ObjectiveNeedsMoney(obj);
 
                 // This objective can only work if the player can ask money for rides.
@@ -971,9 +971,10 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_HARD_PARK_RATING:
                 {
                     auto& gameState = getGameState();
+                    const auto& park = getPlayerPark(gameState);
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::ParkRatingHigherDifficultyLevel,
-                        gameState.park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
+                        park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -1039,12 +1040,12 @@ namespace OpenRCT2::Ui::Windows
             invalidateWidget(WIDX_TAB_1);
 
             auto& gameState = getGameState();
-            auto& park = gameState.park;
+            auto& park = getPlayerPark(gameState);
 
             auto objectiveType = gameState.scenarioOptions.objective.Type;
 
             // Check if objective is allowed by money and pay-per-ride settings.
-            const bool objectiveAllowedByMoneyUsage = !(park.flags & PARK_FLAGS_NO_MONEY)
+            const bool objectiveAllowedByMoneyUsage = !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
                 || !ObjectiveNeedsMoney(objectiveType);
 
             // This objective can only work if the player can ask money for rides.
@@ -1141,7 +1142,7 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
 
-            setWidgetPressed(WIDX_HARD_PARK_RATING, gameState.park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
+            setWidgetPressed(WIDX_HARD_PARK_RATING, getPlayerPark(gameState).flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
         }
 
         /**
@@ -1228,7 +1229,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_PARK_NAME:
                 {
                     WindowTextInputRawOpen(
-                        this, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, gameState.park.name.c_str(),
+                        this, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, getPlayerPark(gameState).name.c_str(),
                         kParkNameMaxLength);
                     break;
                 }
@@ -1291,7 +1292,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t widthToSet = widgets[WIDX_PARK_NAME].left - 16;
 
             {
-                auto parkName = gameState.park.name.c_str();
+                auto parkName = getPlayerPark(gameState).name.c_str();
 
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_STRING);
@@ -1353,7 +1354,7 @@ namespace OpenRCT2::Ui::Windows
 
                     if (scenarioOptions.name.empty())
                     {
-                        scenarioOptions.name = gameState.park.name;
+                        scenarioOptions.name = getPlayerPark(gameState).name;
                     }
                     break;
                 }
@@ -1386,11 +1387,15 @@ namespace OpenRCT2::Ui::Windows
         void FinancialMouseUp(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
+
+            // TODO: use window-specific park
+            const auto& park = getPlayerPark(gameState);
+
             switch (widgetIndex)
             {
                 case WIDX_NO_MONEY:
                 {
-                    auto newMoneySetting = (gameState.park.flags & PARK_FLAGS_NO_MONEY) ? 0 : 1;
+                    auto newMoneySetting = (park.flags & PARK_FLAGS_NO_MONEY) ? 0 : 1;
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::NoMoney, newMoneySetting);
                     GameActions::Execute(&scenarioSetSetting, gameState);
@@ -1401,7 +1406,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::ForbidMarketingCampaigns,
-                        gameState.park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
+                        park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -1409,8 +1414,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_RCT1_INTEREST:
                 {
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                        GameActions::ScenarioSetSetting::UseRCT1Interest,
-                        gameState.park.flags & PARK_FLAGS_RCT1_INTEREST ? 0 : 1);
+                        GameActions::ScenarioSetSetting::UseRCT1Interest, park.flags & PARK_FLAGS_RCT1_INTEREST ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -1426,6 +1430,10 @@ namespace OpenRCT2::Ui::Windows
         void FinancialMouseDown(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
+
+            // TODO: use window-specific park
+            const auto& park = getPlayerPark(gameState);
+
             switch (widgetIndex)
             {
                 case WIDX_INITIAL_CASH_INCREASE:
@@ -1455,10 +1463,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_INITIAL_LOAN_INCREASE:
-                    if (gameState.park.bankLoan < 5000000.00_GBP)
+                    if (getPlayerPark(gameState).bankLoan < 5000000.00_GBP)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::InitialLoan, gameState.park.bankLoan + 1000.00_GBP);
+                            GameActions::ScenarioSetSetting::InitialLoan, park.bankLoan + 1000.00_GBP);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1468,10 +1476,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_INITIAL_LOAN_DECREASE:
-                    if (gameState.park.bankLoan > 0.00_GBP)
+                    if (getPlayerPark(gameState).bankLoan > 0.00_GBP)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::InitialLoan, gameState.park.bankLoan - 1000.00_GBP);
+                            GameActions::ScenarioSetSetting::InitialLoan, park.bankLoan - 1000.00_GBP);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1481,10 +1489,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_MAXIMUM_LOAN_INCREASE:
-                    if (gameState.park.maxBankLoan < 5000000.00_GBP)
+                    if (getPlayerPark(gameState).maxBankLoan < 5000000.00_GBP)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::MaximumLoanSize, gameState.park.maxBankLoan + 1000.00_GBP);
+                            GameActions::ScenarioSetSetting::MaximumLoanSize, park.maxBankLoan + 1000.00_GBP);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1494,10 +1502,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_MAXIMUM_LOAN_DECREASE:
-                    if (gameState.park.maxBankLoan > 0.00_GBP)
+                    if (getPlayerPark(gameState).maxBankLoan > 0.00_GBP)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::MaximumLoanSize, gameState.park.maxBankLoan - 1000.00_GBP);
+                            GameActions::ScenarioSetSetting::MaximumLoanSize, park.maxBankLoan - 1000.00_GBP);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1507,10 +1515,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_INTEREST_RATE_INCREASE:
-                    if (gameState.park.bankLoanInterestRate < kMaxBankLoanInterestRate)
+                    if (getPlayerPark(gameState).bankLoanInterestRate < kMaxBankLoanInterestRate)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::AnnualInterestRate, gameState.park.bankLoanInterestRate + 1);
+                            GameActions::ScenarioSetSetting::AnnualInterestRate, park.bankLoanInterestRate + 1);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1520,9 +1528,9 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_INTEREST_RATE_DECREASE:
-                    if (gameState.park.bankLoanInterestRate > 0)
+                    if (getPlayerPark(gameState).bankLoanInterestRate > 0)
                     {
-                        auto interest = std::min<uint8_t>(kMaxBankLoanInterestRate, gameState.park.bankLoanInterestRate - 1);
+                        auto interest = std::min<uint8_t>(kMaxBankLoanInterestRate, park.bankLoanInterestRate - 1);
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                             GameActions::ScenarioSetSetting::AnnualInterestRate, interest);
                         GameActions::Execute(&scenarioSetSetting, gameState);
@@ -1534,10 +1542,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_ENTRY_PRICE_INCREASE:
-                    if (gameState.park.entranceFee < kMaxEntranceFee)
+                    if (getPlayerPark(gameState).entranceFee < kMaxEntranceFee)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::ParkChargeEntryFee, gameState.park.entranceFee + 1.00_GBP);
+                            GameActions::ScenarioSetSetting::ParkChargeEntryFee, park.entranceFee + 1.00_GBP);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1547,10 +1555,10 @@ namespace OpenRCT2::Ui::Windows
                     invalidate();
                     break;
                 case WIDX_ENTRY_PRICE_DECREASE:
-                    if (gameState.park.entranceFee > 0.00_GBP)
+                    if (getPlayerPark(gameState).entranceFee > 0.00_GBP)
                     {
                         auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
-                            GameActions::ScenarioSetSetting::ParkChargeEntryFee, gameState.park.entranceFee - 1.00_GBP);
+                            GameActions::ScenarioSetSetting::ParkChargeEntryFee, park.entranceFee - 1.00_GBP);
                         GameActions::Execute(&scenarioSetSetting, gameState);
                     }
                     else
@@ -1571,9 +1579,9 @@ namespace OpenRCT2::Ui::Windows
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() - 2,
                         colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 4);
 
-                    if (gameState.park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+                    if (park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                         gDropdown.items[2].setChecked(true);
-                    else if (gameState.park.flags & PARK_FLAGS_PARK_FREE_ENTRY)
+                    else if (park.flags & PARK_FLAGS_PARK_FREE_ENTRY)
                         gDropdown.items[0].setChecked(true);
                     else
                         gDropdown.items[1].setChecked(true);
@@ -1620,8 +1628,9 @@ namespace OpenRCT2::Ui::Windows
         {
             SetPressedTab();
 
-            auto& gameState = getGameState();
-            auto& park = gameState.park;
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
 
             bool noMoney = park.flags & PARK_FLAGS_NO_MONEY;
             setWidgetPressed(WIDX_NO_MONEY, noMoney);
@@ -1700,7 +1709,6 @@ namespace OpenRCT2::Ui::Windows
             WindowDrawWidgets(*this, rt);
             DrawTabImages(rt);
 
-            const auto& gameState = getGameState();
             const auto wColour2 = colours[1];
 
             const auto& initialCashWidget = widgets[WIDX_INITIAL_CASH];
@@ -1713,12 +1721,16 @@ namespace OpenRCT2::Ui::Windows
                 drawText(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
 
+            // TODO: for specific parks?
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             const auto& initialLoanWidget = widgets[WIDX_INITIAL_LOAN];
             if (initialLoanWidget.type != WidgetType::empty)
             {
                 screenCoords = windowPos + ScreenCoordsXY{ initialLoanWidget.left + 1, initialLoanWidget.top + 1 };
                 auto ft = Formatter();
-                ft.Add<money64>(gameState.park.bankLoan);
+                ft.Add<money64>(park.bankLoan);
                 auto colour = !isWidgetDisabled(WIDX_INITIAL_LOAN) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
                 drawText(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
@@ -1728,7 +1740,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 screenCoords = windowPos + ScreenCoordsXY{ maximumLoanWidget.left + 1, maximumLoanWidget.top + 1 };
                 auto ft = Formatter();
-                ft.Add<money64>(getGameState().park.maxBankLoan);
+                ft.Add<money64>(park.maxBankLoan);
                 auto colour = !isWidgetDisabled(WIDX_MAXIMUM_LOAN) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
                 drawText(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
@@ -1739,8 +1751,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords = windowPos + ScreenCoordsXY{ interestRateWidget.left + 1, interestRateWidget.top + 1 };
 
                 auto ft = Formatter();
-                ft.Add<int16_t>(
-                    std::clamp<int16_t>(static_cast<int16_t>(gameState.park.bankLoanInterestRate), INT16_MIN, INT16_MAX));
+                ft.Add<int16_t>(std::clamp<int16_t>(static_cast<int16_t>(park.bankLoanInterestRate), INT16_MIN, INT16_MAX));
                 auto colour = !isWidgetDisabled(WIDX_INTEREST_RATE) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
                 drawText(rt, screenCoords, STR_PERCENT_FORMAT_LABEL, ft, colour);
             }
@@ -1753,9 +1764,9 @@ namespace OpenRCT2::Ui::Windows
 
                 auto ft = Formatter();
                 // Pay for park and/or rides value
-                if (gameState.park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
+                if (park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                     ft.Add<StringId>(STR_PAID_ENTRY_PAID_RIDES);
-                else if (gameState.park.flags & PARK_FLAGS_PARK_FREE_ENTRY)
+                else if (park.flags & PARK_FLAGS_PARK_FREE_ENTRY)
                     ft.Add<StringId>(STR_FREE_PARK_ENTER);
                 else
                     ft.Add<StringId>(STR_PAY_PARK_ENTER);
@@ -1771,7 +1782,7 @@ namespace OpenRCT2::Ui::Windows
                 // Entry price value
                 screenCoords = windowPos + ScreenCoordsXY{ entryPriceWidget.left + 1, entryPriceWidget.top + 1 };
                 auto ft = Formatter();
-                ft.Add<money64>(gameState.park.entranceFee);
+                ft.Add<money64>(park.entranceFee);
                 auto colour = !isWidgetDisabled(WIDX_INITIAL_CASH) ? wColour2 : wColour2.withFlag(ColourFlag::inset, true);
                 drawText(rt, screenCoords, STR_CURRENCY_FORMAT_LABEL, ft, colour);
             }
@@ -1790,6 +1801,7 @@ namespace OpenRCT2::Ui::Windows
         {
             auto& gameState = getGameState();
             auto& scenarioOptions = gameState.scenarioOptions;
+            auto& park = getPlayerPark(gameState);
 
             switch (widgetIndex)
             {
@@ -1911,8 +1923,8 @@ namespace OpenRCT2::Ui::Windows
                         { windowPos.x + dropdownWidget.left, windowPos.y + dropdownWidget.top }, dropdownWidget.height() - 2,
                         colours[1], 0, Dropdown::Flag::StayOpen, 4, dropdownWidget.width() - 4);
 
-                    const auto preferLess = gameState.park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
-                    const auto preferMore = gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                    const auto preferLess = park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                    const auto preferMore = park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
 
                     auto prefItem = 1;
                     if (preferLess && preferMore)
@@ -1929,7 +1941,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::GuestGenerationHigherDifficultyLevel,
-                        gameState.park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
+                        park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -1966,8 +1978,11 @@ namespace OpenRCT2::Ui::Windows
         {
             SetPressedTab();
 
-            auto& gameState = getGameState();
-            bool noMoney = gameState.park.flags & PARK_FLAGS_NO_MONEY;
+            // TODO: use specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
+            bool noMoney = park.flags & PARK_FLAGS_NO_MONEY;
 
             setWidgetDisabled(WIDX_CASH_PER_GUEST_LABEL, noMoney);
             setWidgetDisabled(WIDX_CASH_PER_GUEST, noMoney);
@@ -1976,7 +1991,7 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
 
-            setWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
+            setWidgetPressed(WIDX_HARD_GUEST_GENERATION, park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
         }
 
         void GuestsDraw(RenderTarget& rt)
@@ -2028,8 +2043,8 @@ namespace OpenRCT2::Ui::Windows
                 const auto& guestsIntensity = widgets[WIDX_GUESTS_INTENSITY_PREFERENCE];
                 screenCoords = windowPos + ScreenCoordsXY{ guestsIntensity.left + 1, guestsIntensity.top + 1 };
 
-                const auto preferLess = gameState.park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
-                const auto preferMore = gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                const auto preferLess = getPlayerPark(gameState).flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                const auto preferMore = getPlayerPark(gameState).flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
 
                 StringId prefString = STR_GUESTS_PREFER_INTENSITY_BALANCED;
                 if (preferLess && preferMore)
@@ -2052,13 +2067,17 @@ namespace OpenRCT2::Ui::Windows
         void LandMouseUp(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
+
+            // TODO: select specific park
+            const auto& park = getPlayerPark(gameState);
+
             switch (widgetIndex)
             {
                 case WIDX_FORBID_TREE_REMOVAL:
                 {
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::ForbidTreeRemoval,
-                        gameState.park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
+                        park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -2067,7 +2086,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::ForbidLandscapeChanges,
-                        gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
+                        park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -2076,7 +2095,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto scenarioSetSetting = GameActions::ScenarioSetSettingAction(
                         GameActions::ScenarioSetSetting::ForbidHighConstruction,
-                        gameState.park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
+                        park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION ? 0 : 1);
                     GameActions::Execute(&scenarioSetSetting, gameState);
                     invalidate();
                     break;
@@ -2163,8 +2182,11 @@ namespace OpenRCT2::Ui::Windows
         {
             SetPressedTab();
 
-            auto& gameState = getGameState();
-            bool noMoney = gameState.park.flags & PARK_FLAGS_NO_MONEY;
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
+            bool noMoney = park.flags & PARK_FLAGS_NO_MONEY;
 
             setWidgetDisabled(WIDX_LAND_COST_LABEL, noMoney);
             setWidgetDisabled(WIDX_LAND_COST, noMoney);
@@ -2175,9 +2197,9 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST_INCREASE, noMoney);
             setWidgetDisabled(WIDX_CONSTRUCTION_RIGHTS_COST_DECREASE, noMoney);
 
-            setWidgetPressed(WIDX_FORBID_TREE_REMOVAL, gameState.park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL);
-            setWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
-            setWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
+            setWidgetPressed(WIDX_FORBID_TREE_REMOVAL, park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL);
+            setWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
+            setWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
         }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -234,7 +234,9 @@ namespace OpenRCT2::Ui::Windows
 
         void SetDisabledTabs()
         {
-            disabledWidgets = (getGameState().park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+            disabledWidgets = (park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
         }
 
     public:
@@ -318,6 +320,9 @@ namespace OpenRCT2::Ui::Windows
                 setWidgetPressed(WIDX_TAB_1 + i, false);
             setWidgetPressed(WIDX_TAB_1 + page, true);
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             Widget* graphPageWidget;
             bool centredGraph;
             switch (page)
@@ -334,17 +339,17 @@ namespace OpenRCT2::Ui::Windows
                 case WINDOW_FINANCES_PAGE_VALUE_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = false;
-                    _graphProps.series = getGameState().park.valueHistory;
+                    _graphProps.series = park.valueHistory;
                     break;
                 case WINDOW_FINANCES_PAGE_PROFIT_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = true;
-                    _graphProps.series = getGameState().park.weeklyProfitHistory;
+                    _graphProps.series = park.weeklyProfitHistory;
                     break;
                 case WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = true;
-                    _graphProps.series = getGameState().park.cashHistory;
+                    _graphProps.series = park.cashHistory;
                     break;
                 default:
                     return;
@@ -357,6 +362,10 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
             DrawTabImages(rt);
 
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             switch (page)
             {
                 case WINDOW_FINANCES_PAGE_SUMMARY:
@@ -364,22 +373,20 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH:
                 {
-                    auto& gameState = getGameState();
-                    const auto cashLessLoan = gameState.park.cash - gameState.park.bankLoan;
+                    const auto cashLessLoan = park.cash - park.bankLoan;
                     const auto fmt = cashLessLoan >= 0 ? STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_POSITIVE
                                                        : STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_NEGATIVE;
                     onDrawGraph(rt, cashLessLoan, fmt);
                     break;
                 }
                 case WINDOW_FINANCES_PAGE_VALUE_GRAPH:
-                    onDrawGraph(rt, getGameState().park.value, STR_FINANCES_PARK_VALUE);
+                    onDrawGraph(rt, park.value, STR_FINANCES_PARK_VALUE);
                     break;
                 case WINDOW_FINANCES_PAGE_PROFIT_GRAPH:
                 {
-                    auto& gameState = getGameState();
-                    const auto fmt = gameState.park.currentProfit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE
-                                                                       : STR_FINANCES_WEEKLY_PROFIT_LOSS;
-                    onDrawGraph(rt, gameState.park.currentProfit, fmt);
+                    const auto fmt = park.currentProfit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE
+                                                             : STR_FINANCES_WEEKLY_PROFIT_LOSS;
+                    onDrawGraph(rt, park.currentProfit, fmt);
                     break;
                 }
                 case WINDOW_FINANCES_PAGE_MARKETING:
@@ -425,7 +432,10 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += kTableCellHeight;
             }
 
-            auto& gameState = getGameState();
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Expenditure / Income values for each month
             auto currentMonthYear = GetDate().GetMonthsElapsed();
             for (int32_t i = SummaryMaxAvailableMonth(); i >= 0; i--)
@@ -448,7 +458,7 @@ namespace OpenRCT2::Ui::Windows
                 money64 profit = 0;
                 for (int32_t j = 0; j < static_cast<int32_t>(ExpenditureType::count); j++)
                 {
-                    auto expenditure = gameState.park.expenditureTable[i][j];
+                    auto expenditure = park.expenditureTable[i][j];
                     if (expenditure != 0)
                     {
                         profit += expenditure;
@@ -544,16 +554,20 @@ namespace OpenRCT2::Ui::Windows
         void onMouseDownSummary(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
+
+            // TODO: use window-specific park
+            const auto& park = getPlayerPark(gameState);
+
             switch (widgetIndex)
             {
                 case WIDX_LOAN_INCREASE:
                 {
                     // If loan can be increased, do so.
                     // If not, action shows error message.
-                    auto newLoan = gameState.park.bankLoan + 1000.00_GBP;
-                    if (gameState.park.bankLoan < gameState.park.maxBankLoan)
+                    auto newLoan = park.bankLoan + 1000.00_GBP;
+                    if (park.bankLoan < park.maxBankLoan)
                     {
-                        newLoan = std::min(gameState.park.maxBankLoan, newLoan);
+                        newLoan = std::min(park.maxBankLoan, newLoan);
                     }
                     auto gameAction = GameActions::ParkSetLoanAction(newLoan);
                     GameActions::Execute(&gameAction, gameState);
@@ -564,10 +578,10 @@ namespace OpenRCT2::Ui::Windows
                     // If loan is positive, decrease it.
                     // If loan is negative, action shows error message.
                     // If loan is exactly 0, prevent error message.
-                    if (gameState.park.bankLoan != 0)
+                    if (park.bankLoan != 0)
                     {
-                        auto newLoan = gameState.park.bankLoan - 1000.00_GBP;
-                        if (gameState.park.bankLoan > 0)
+                        auto newLoan = park.bankLoan - 1000.00_GBP;
+                        if (park.bankLoan > 0)
                         {
                             newLoan = std::max(0.00_GBP, newLoan);
                         }
@@ -581,7 +595,10 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDrawSummary()
         {
-            _loanSpinnerText = FormatStringID(STR_CURRENCY_FORMAT, getGameState().park.bankLoan);
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
+            _loanSpinnerText = FormatStringID(STR_CURRENCY_FORMAT, park.bankLoan);
             widgets[WIDX_LOAN].setString(_loanSpinnerText.c_str());
 
             // Keep up with new months being added in the first two years.
@@ -593,7 +610,9 @@ namespace OpenRCT2::Ui::Windows
         {
             auto titleBarBottom = widgets[WIDX_TITLE].bottom;
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, titleBarBottom + 37 };
+
             auto& gameState = getGameState();
+            auto& park = getPlayerPark(gameState);
 
             // Expenditure / Income heading
             drawText(
@@ -624,17 +643,17 @@ namespace OpenRCT2::Ui::Windows
 
             // Loan and interest rate
             drawText(rt, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_LOAN);
-            if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
+            if (!(park.flags & PARK_FLAGS_RCT1_INTEREST))
             {
                 auto ft = Formatter();
-                ft.Add<uint16_t>(gameState.park.bankLoanInterestRate);
+                ft.Add<uint16_t>(getPlayerPark(gameState).bankLoanInterestRate);
                 drawText(rt, windowPos + ScreenCoordsXY{ 167, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, ft);
             }
 
             // Current cash
             auto ft = Formatter();
-            ft.Add<money64>(gameState.park.cash);
-            StringId stringId = gameState.park.cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
+            ft.Add<money64>(park.cash);
+            StringId stringId = getPlayerPark(gameState).cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
             drawText(rt, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 280 }, stringId, ft);
 
             // Objective related financial information
@@ -651,10 +670,10 @@ namespace OpenRCT2::Ui::Windows
             {
                 // Park value and company value
                 ft = Formatter();
-                ft.Add<money64>(gameState.park.value);
+                ft.Add<money64>(getPlayerPark(gameState).value);
                 drawText(rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 265 }, STR_PARK_VALUE_LABEL, ft);
                 ft = Formatter();
-                ft.Add<money64>(gameState.park.companyValue);
+                ft.Add<money64>(getPlayerPark(gameState).companyValue);
                 drawText(rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 280 }, STR_COMPANY_VALUE_LABEL, ft);
             }
         }
@@ -678,8 +697,11 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDrawMarketing()
         {
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Count number of active campaigns
-            int32_t numActiveCampaigns = static_cast<int32_t>(getGameState().park.marketingCampaigns.size());
+            int32_t numActiveCampaigns = static_cast<int32_t>(park.marketingCampaigns.size());
             int32_t y = widgets[WIDX_TAB_1].top + std::max(1, numActiveCampaigns) * kListRowHeight + 75;
 
             // Update group box positions
@@ -741,7 +763,10 @@ namespace OpenRCT2::Ui::Windows
                         break;
                     default:
                     {
-                        auto parkName = getGameState().park.name.c_str();
+                        const auto& gameState = getGameState();
+                        const auto& park = getPlayerPark(gameState);
+
+                        auto parkName = park.name.c_str();
                         ft.Add<StringId>(STR_STRING);
                         ft.Add<const char*>(parkName);
                     }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -615,7 +615,8 @@ namespace OpenRCT2::Ui::Windows
                 + ScreenCoordsXY{ widgets[WIDX_CONSTRUCT].midX(), widgets[WIDX_CONSTRUCT].bottom - 12 };
             if (_windowFootpathCost != kMoney64Undefined)
             {
-                if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+                const auto& gameState = getGameState();
+                if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
                 {
                     auto ft = Formatter();
                     ft.Add<money64>(_windowFootpathCost);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -106,19 +106,20 @@ namespace OpenRCT2::Ui::Windows
             // Figure out how much line height we have to work with.
             uint32_t line_height = FontGetLineHeight(FontStyle::medium);
 
-            auto& gameState = getGameState();
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
 
             // Draw money
-            if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+            if (!(park.flags & PARK_FLAGS_NO_MONEY))
             {
                 const auto& widget = widgets[WIDX_MONEY];
                 auto screenCoords = ScreenCoordsXY{ windowPos.x + widget.midX(),
                                                     windowPos.y + widget.midY() - (line_height == 10 ? 5 : 6) };
 
                 auto colour = GetHoverWidgetColour(WIDX_MONEY);
-                StringId stringId = gameState.park.cash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
+                StringId stringId = park.cash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
                 auto ft = Formatter();
-                ft.Add<money64>(gameState.park.cash);
+                ft.Add<money64>(park.cash);
                 drawText(rt, screenCoords, stringId, ft, { colour, TextAlignment::centre });
             }
 
@@ -139,12 +140,11 @@ namespace OpenRCT2::Ui::Windows
                 const auto& widget = widgets[WIDX_GUESTS];
                 auto screenCoords = ScreenCoordsXY{ windowPos.x + widget.midX(), windowPos.y + widget.midY() - 6 };
 
-                StringId stringId = gameState.park.numGuestsInPark == 1
-                    ? _guestCountFormatsSingular[gameState.park.guestChangeModifier]
-                    : _guestCountFormats[gameState.park.guestChangeModifier];
+                StringId stringId = park.numGuestsInPark == 1 ? _guestCountFormatsSingular[park.guestChangeModifier]
+                                                              : _guestCountFormats[park.guestChangeModifier];
                 auto colour = GetHoverWidgetColour(WIDX_GUESTS);
                 auto ft = Formatter();
-                ft.Add<uint32_t>(gameState.park.numGuestsInPark);
+                ft.Add<uint32_t>(park.numGuestsInPark);
                 drawText(rt, screenCoords, stringId, ft, { colour, TextAlignment::centre });
             }
 
@@ -153,8 +153,7 @@ namespace OpenRCT2::Ui::Windows
                 const auto& widget = widgets[WIDX_PARK_RATING];
                 auto screenCoords = windowPos + ScreenCoordsXY{ widget.left + 11, widget.midY() - 5 };
 
-                DrawParkRating(
-                    rt, colours[3].colour, false, screenCoords, std::max(10, ((gameState.park.rating / 4) * 263) / 256));
+                DrawParkRating(rt, colours[3].colour, false, screenCoords, std::max(10, ((park.rating / 4) * 263) / 256));
             }
         }
 
@@ -441,11 +440,14 @@ namespace OpenRCT2::Ui::Windows
         {
             News::Item* newsItem;
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             switch (widgetIndex)
             {
                 case WIDX_LEFT_OUTSET:
                 case WIDX_MONEY:
-                    if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+                    if (!(park.flags & PARK_FLAGS_NO_MONEY))
                         ContextOpenWindow(WindowClass::finances);
                     break;
                 case WIDX_GUESTS:
@@ -495,16 +497,17 @@ namespace OpenRCT2::Ui::Windows
         StringWithArgs onTooltip(WidgetIndex widgetIndex, StringId fallback) override
         {
             const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
             auto ft = Formatter();
 
             switch (widgetIndex)
             {
                 case WIDX_MONEY:
-                    ft.Add<money64>(gameState.park.currentProfit);
-                    ft.Add<money64>(gameState.park.value);
+                    ft.Add<money64>(park.currentProfit);
+                    ft.Add<money64>(park.value);
                     break;
                 case WIDX_PARK_RATING:
-                    ft.Add<int16_t>(gameState.park.rating);
+                    ft.Add<int16_t>(park.rating);
                     break;
             }
             return { fallback, ft };
@@ -527,7 +530,8 @@ namespace OpenRCT2::Ui::Windows
                 + 1;
 
             // Reposition left widgets in accordance with line height... depending on whether there is money in play.
-            if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+            const auto& gameState = getGameState();
+            if (getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
             {
                 widgets[WIDX_MONEY].type = WidgetType::empty;
                 widgets[WIDX_GUESTS].top = 1;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -499,7 +499,9 @@ namespace OpenRCT2::Ui::Windows
                 if (!widgetIsDisabled(*this, WIDX_PICKUP))
                     invalidate();
             }
-            if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+
+            const auto& gameState = getGameState();
+            if (getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
             {
                 newDisabledWidgets |= (1uLL << WIDX_TAB_4); // Disable finance tab if no money
             }
@@ -1642,7 +1644,8 @@ namespace OpenRCT2::Ui::Windows
 
         std::pair<ImageId, Formatter> InventoryFormatItem(Guest& guest, ShopItem item) const
         {
-            auto parkName = getGameState().park.name.c_str();
+            const auto& gameState = getGameState();
+            auto parkName = getPlayerPark(gameState).name.c_str();
 
             // Default item image
             auto& itemDesc = GetShopItemDescriptor(item);

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -947,8 +947,9 @@ namespace OpenRCT2::Ui::Windows
 
         static GuestItem::CompareFunc GetGuestCompareFunc()
         {
-            return getGameState().park.flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES ? CompareGuestItem<true>
-                                                                                : CompareGuestItem<false>;
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+            return park.flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES ? CompareGuestItem<true> : CompareGuestItem<false>;
         }
     };
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -290,7 +290,8 @@ namespace OpenRCT2::Ui::Windows
 
             screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->bottom + 5 };
 
-            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 // Draw raise cost amount
                 if (_landToolRaiseCost != kMoney64Undefined && _landToolRaiseCost != 0)

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -409,8 +409,9 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw cost amount
+            const auto& gameState = getGameState();
             if (_landRightsCost != kMoney64Undefined && _landRightsCost != 0
-                && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+                && !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_landRightsCost);

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -867,7 +867,9 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP].type = WidgetType::groupbox;
                 widgets[WIDX_LAST_DEVELOPMENT_GROUP].type = WidgetType::groupbox;
                 widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WidgetType::flatBtn;
-                if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+
+                const auto& gameState = getGameState();
+                if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
                     widgets[WIDX_RESEARCH_FUNDING_BUTTON].type = WidgetType::flatBtn;
 
                 newMinSize = { 300, kWindowHeightResearch };
@@ -989,7 +991,8 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Price
-            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 // Get price of ride
                 auto startPieceId = GetRideTypeDescriptor(item.Type).StartTrackPiece;

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -400,19 +400,26 @@ namespace OpenRCT2::Ui::Windows
     private:
         void SetDisabledTabs()
         {
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Disable price tab if money is disabled
-            disabledWidgets = (getGameState().park.flags & PARK_FLAGS_NO_MONEY) ? (1uLL << WIDX_TAB_4) : 0;
+            disabledWidgets = (park.flags & PARK_FLAGS_NO_MONEY) ? (1uLL << WIDX_TAB_4) : 0;
         }
 
         void PrepareWindowTitleText()
         {
-            widgets[WIDX_TITLE].setString(getGameState().park.name.c_str());
+            const auto& gameState = getGameState();
+            auto parkName = getPlayerPark(gameState).name.c_str();
+            widgets[WIDX_TITLE].setString(parkName);
         }
 
 #pragma region Entrance page
         void onMouseUpEntrance(WidgetIndex widgetIndex)
         {
-            auto& park = getGameState().park;
+            // TODO: use window-specific park
+            auto& gameState = getGameState();
+            auto& park = getPlayerPark(gameState);
             switch (widgetIndex)
             {
                 case WIDX_BUY_LAND_RIGHTS:
@@ -453,7 +460,9 @@ namespace OpenRCT2::Ui::Windows
                 WindowDropdownShowText(
                     { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(), colours[1], 0, 2);
 
-                if (Park::IsOpen(getGameState().park))
+                // TODO: use window-specific park
+                const auto& gameState = getGameState();
+                if (Park::IsOpen(getPlayerPark(gameState)))
                 {
                     gDropdown.defaultIndex = 0;
                     gDropdown.items[1].setChecked(true);
@@ -468,7 +477,8 @@ namespace OpenRCT2::Ui::Windows
 
         void onDropdownEntrance(WidgetIndex widgetIndex, int32_t dropdownIndex)
         {
-            auto& park = getGameState().park;
+            auto& gameState = getGameState();
+            auto& park = getPlayerPark(gameState);
             if (widgetIndex == WIDX_OPEN_OR_CLOSE)
             {
                 if (dropdownIndex == -1)
@@ -502,14 +512,18 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDrawEntrance()
         {
-            const auto& gameState = getGameState();
             initScrollWidgets();
 
             SetPressedTab();
 
-            widgets[WIDX_TITLE].setString(gameState.park.name.c_str());
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
+            // TODO: use window-specific park
+            widgets[WIDX_TITLE].setString(park.name.c_str());
+            const bool parkIsOpen = Park::IsOpen(park);
+
             // Set open / close park button state
-            const bool parkIsOpen = Park::IsOpen(gameState.park);
             widgets[WIDX_OPEN_OR_CLOSE].image = ImageId(parkIsOpen ? SPR_OPEN : SPR_CLOSED);
             const auto closeLightImage = SPR_G2_RCT1_CLOSE_BUTTON_0 + !parkIsOpen * 2
                 + widgetIsPressed(*this, WIDX_CLOSE_LIGHT);
@@ -523,8 +537,8 @@ namespace OpenRCT2::Ui::Windows
             else
                 disabledWidgets &= ~((1uLL << WIDX_OPEN_OR_CLOSE) | (1uLL << WIDX_CLOSE_LIGHT) | (1uLL << WIDX_OPEN_LIGHT));
 
-            // only allow purchase of land when there is money
-            if (gameState.park.flags & PARK_FLAGS_NO_MONEY)
+            // Only allow purchase of land when there is money
+            if (getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
                 widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::empty;
             else
                 widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::flatBtn;
@@ -594,8 +608,10 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw park closed / open label
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
             auto ft = Formatter();
-            ft.Add<StringId>(Park::IsOpen(getGameState().park) ? STR_PARK_OPEN : STR_PARK_CLOSED);
+            ft.Add<StringId>(Park::IsOpen(getPlayerPark(gameState)) ? STR_PARK_OPEN : STR_PARK_CLOSED);
 
             auto* labelWidget = &widgets[WIDX_STATUS];
             drawTextEllipsised(
@@ -608,12 +624,14 @@ namespace OpenRCT2::Ui::Windows
             if (page != WINDOW_PARK_PAGE_ENTRANCE)
                 return;
 
+            // TODO: use window-specific park
             const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
 
             std::optional<Focus> newFocus = std::nullopt;
-            if (!gameState.park.entrances.empty())
+            if (!getPlayerPark(gameState).entrances.empty())
             {
-                const auto& entrance = gameState.park.entrances[0];
+                const auto& entrance = park.entrances[0];
                 newFocus = Focus(CoordsXYZ{ entrance.x + 16, entrance.y + 16, entrance.z + 32 });
             }
 
@@ -678,9 +696,12 @@ namespace OpenRCT2::Ui::Windows
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             _ratingProps.min = 0;
             _ratingProps.max = 1000;
-            _ratingProps.series = getGameState().park.ratingHistory;
+            _ratingProps.series = park.ratingHistory;
             const Widget* background = &widgets[WIDX_PAGE_BACKGROUND];
             _ratingGraphBounds = { windowPos + ScreenCoordsXY{ background->left + 4, background->top + 15 },
                                    windowPos + ScreenCoordsXY{ background->right - 4, background->bottom - 4 } };
@@ -702,9 +723,12 @@ namespace OpenRCT2::Ui::Windows
 
             Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Current value
             Formatter ft;
-            ft.Add<uint16_t>(getGameState().park.rating);
+            ft.Add<uint16_t>(park.rating);
             drawText(rt, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_PARK_RATING_LABEL, ft);
 
             // Graph border
@@ -748,8 +772,11 @@ namespace OpenRCT2::Ui::Windows
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
 
+            // TODO: use window-specific park
             const auto& gameState = getGameState();
-            _guestProps.series = gameState.park.guestsInParkHistory;
+            const auto& park = getPlayerPark(gameState);
+
+            _guestProps.series = park.guestsInParkHistory;
             const Widget* background = &widgets[WIDX_PAGE_BACKGROUND];
             _guestGraphBounds = { windowPos + ScreenCoordsXY{ background->left + 4, background->top + 15 },
                                   windowPos + ScreenCoordsXY{ background->right - 4, background->bottom - 4 } };
@@ -757,9 +784,9 @@ namespace OpenRCT2::Ui::Windows
             // Calculate Y axis max and min
             _guestProps.min = 0;
             _guestProps.max = 5000;
-            for (size_t i = 0; i < std::size(gameState.park.guestsInParkHistory); i++)
+            for (size_t i = 0; i < std::size(getPlayerPark(gameState).guestsInParkHistory); i++)
             {
-                auto value = gameState.park.guestsInParkHistory[i];
+                auto value = getPlayerPark(gameState).guestsInParkHistory[i];
                 if (value == kGuestsInParkHistoryUndefined)
                     continue;
                 while (value > _guestProps.max)
@@ -783,9 +810,12 @@ namespace OpenRCT2::Ui::Windows
 
             Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Current value
             Formatter ft;
-            ft.Add<uint32_t>(getGameState().park.numGuestsInPark);
+            ft.Add<uint32_t>(park.numGuestsInPark);
             drawText(rt, windowPos + ScreenCoordsXY{ widget->left + 3, widget->top + 2 }, STR_GUESTS_IN_PARK_LABEL, ft);
 
             // Graph border
@@ -813,20 +843,22 @@ namespace OpenRCT2::Ui::Windows
         void onMouseDownPrice(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
-            auto& park = gameState.park;
+
+            // TODO: use window-specific park
+            const auto& park = getPlayerPark(gameState);
 
             switch (widgetIndex)
             {
                 case WIDX_INCREASE_PRICE:
                 {
-                    const auto newFee = std::min(kMaxEntranceFee, gameState.park.entranceFee + 1.00_GBP);
+                    const auto newFee = std::min(kMaxEntranceFee, park.entranceFee + 1.00_GBP);
                     auto gameAction = GameActions::ParkSetEntranceFeeAction(newFee);
                     GameActions::Execute(&gameAction, gameState);
                     break;
                 }
                 case WIDX_DECREASE_PRICE:
                 {
-                    const auto newFee = std::max(0.00_GBP, gameState.park.entranceFee - 1.00_GBP);
+                    const auto newFee = std::max(0.00_GBP, park.entranceFee - 1.00_GBP);
                     auto gameAction = GameActions::ParkSetEntranceFeeAction(newFee);
                     GameActions::Execute(&gameAction, gameState);
                     break;
@@ -856,7 +888,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PRICE_LABEL].tooltip = kStringIdNone;
             widgets[WIDX_PRICE].tooltip = kStringIdNone;
 
-            auto& park = getGameState().park;
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
 
             if (!Park::EntranceFeeUnlocked(park))
             {
@@ -886,13 +920,14 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
             DrawTabImages(rt);
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 30 };
             auto ft = Formatter();
-            ft.Add<money64>(getGameState().park.totalIncomeFromAdmissions);
+            ft.Add<money64>(park.totalIncomeFromAdmissions);
             drawText(rt, screenCoords, STR_INCOME_FROM_ADMISSIONS, ft);
-
-            auto& park = getGameState().park;
 
             money64 parkEntranceFee = Park::GetEntranceFee(park);
             ft = Formatter();
@@ -951,9 +986,12 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-            auto& gameState = getGameState();
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Draw park size
-            auto parkSize = gameState.park.size * 10;
+            auto parkSize = park.size * 10;
             auto stringIndex = STR_PARK_SIZE_METRIC_LABEL;
             if (Config::Get().general.measurementFormat == MeasurementFormat::Imperial)
             {
@@ -985,12 +1023,12 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw number of guests in park
             ft = Formatter();
-            ft.Add<uint32_t>(gameState.park.numGuestsInPark);
+            ft.Add<uint32_t>(park.numGuestsInPark);
             drawText(rt, screenCoords, STR_GUESTS_IN_PARK_LABEL, ft);
             screenCoords.y += kListRowHeight;
 
             ft = Formatter();
-            ft.Add<uint32_t>(gameState.park.totalAdmissions);
+            ft.Add<uint32_t>(park.totalAdmissions);
             drawText(rt, screenCoords, STR_TOTAL_ADMISSIONS, ft);
         }
 #pragma endregion
@@ -1056,8 +1094,11 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
             PrepareWindowTitleText();
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Show name input button on scenario completion.
-            if (getGameState().park.flags & PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT)
+            if (park.flags & PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT)
             {
                 widgets[WIDX_ENTER_NAME].type = WidgetType::button;
                 widgets[WIDX_ENTER_NAME].top = height - 19;
@@ -1143,7 +1184,9 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-            auto& currentAwards = getGameState().park.currentAwards;
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+            const auto& currentAwards = park.currentAwards;
 
             for (const auto& award : currentAwards)
             {

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -81,8 +81,10 @@ namespace OpenRCT2::Ui::Windows
             auto currentRide = GetRide(rideId);
             if (currentRide != nullptr)
             {
-                auto stringId = (getGameState().park.flags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY
-                                                                                  : STR_REFURBISH_RIDE_ID_MONEY;
+                const auto& gameState = getGameState();
+                const auto& park = getPlayerPark(gameState);
+                auto stringId = (park.flags & PARK_FLAGS_NO_MONEY) ? STR_REFURBISH_RIDE_ID_NO_MONEY
+                                                                   : STR_REFURBISH_RIDE_ID_MONEY;
                 auto ft = Formatter();
                 currentRide->formatNameTo(ft);
                 ft.Add<money64>(_demolishRideCost / 2);

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -534,7 +534,8 @@ namespace OpenRCT2::Ui::Windows
         const auto& gameState = getGameState();
         auto widgetOffset = GetWidgetIndexOffset(baseWidgetIndex, WIDX_RESEARCH_FUNDING);
 
-        if ((gameState.park.flags & PARK_FLAGS_NO_MONEY) || gameState.researchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
+        if ((getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
+            || gameState.researchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
         {
             w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].type = WidgetType::empty;
             w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].type = WidgetType::empty;
@@ -579,7 +580,7 @@ namespace OpenRCT2::Ui::Windows
     void WindowResearchFundingDraw(WindowBase* w, Drawing::RenderTarget& rt)
     {
         const auto& gameState = getGameState();
-        if (gameState.park.flags & PARK_FLAGS_NO_MONEY)
+        if (getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY)
             return;
 
         int32_t currentResearchLevel = gameState.researchFundingLevel;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1424,8 +1424,9 @@ namespace OpenRCT2::Ui::Windows
                 disabledTabs |= (1uLL << WIDX_TAB_6); // 0x200
             }
 
+            const auto& gameState = getGameState();
             if (rtd.specialType == RtdSpecialType::cashMachine || rtd.specialType == RtdSpecialType::firstAid
-                || (getGameState().park.flags & PARK_FLAGS_NO_MONEY) != 0)
+                || (getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY) != 0)
                 disabledTabs |= (1uLL << WIDX_TAB_9); // 0x1000
 
             if (gLegacyScene == LegacyScene::trackDesigner)
@@ -4116,10 +4117,13 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
             drawTabImages(rt);
 
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
+
             // Locate mechanic button image
             Widget* widget = &widgets[WIDX_LOCATE_MECHANIC];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
-            auto image = ImageId(SPR_MECHANIC, Drawing::Colour::black, getGameState().park.staffMechanicColour);
+            auto image = ImageId(SPR_MECHANIC, Drawing::Colour::black, park.staffMechanicColour);
             GfxDrawSprite(rt, image, screenCoords);
 
             // Inspection label
@@ -6440,7 +6444,8 @@ namespace OpenRCT2::Ui::Windows
         static void UpdateSamePriceThroughoutFlags(ShopItem shop_item)
         {
             const auto& gameState = getGameState();
-            const auto existingFlags = gameState.park.samePriceThroughoutPark;
+            const auto& park = getPlayerPark(gameState);
+            const auto existingFlags = park.samePriceThroughoutPark;
 
             auto newFlags = existingFlags;
             if (GetShopItemDescriptor(shop_item).IsPhoto())
@@ -6574,7 +6579,8 @@ namespace OpenRCT2::Ui::Windows
             auto rideEntry = ride->getRideEntry();
             const auto& rtd = ride->getRideTypeDescriptor();
 
-            auto& park = getGameState().park;
+            auto& gameState = getGameState();
+            auto& park = getPlayerPark(gameState);
 
             return Park::RidePricesUnlocked(park) || rtd.specialType == RtdSpecialType::toilet
                 || (rideEntry != nullptr && rideEntry->shop_item[0] != ShopItem::none);
@@ -6737,7 +6743,8 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PRIMARY_PRICE_LABEL].tooltip = kStringIdNone;
             widgets[WIDX_PRIMARY_PRICE].tooltip = kStringIdNone;
 
-            auto& park = getGameState().park;
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
 
             // If ride prices are locked, do not allow setting the price, unless we're dealing with a shop or toilet.
             const auto& rtd = ride->getRideTypeDescriptor();

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1724,8 +1724,9 @@ namespace OpenRCT2::Ui::Windows
             if (_rideConstructionState != RideConstructionState::Place)
                 drawText(rt, screenCoords, STR_BUILD_THIS, { TextAlignment::centre });
 
+            const auto& gameState = getGameState();
             screenCoords.y += 11;
-            if (_currentTrackPrice != kMoney64Undefined && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            if (_currentTrackPrice != kMoney64Undefined && !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_currentTrackPrice);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -326,7 +326,8 @@ namespace OpenRCT2::Ui::Windows
                 int32_t numItems = 0;
                 for (int32_t type = INFORMATION_TYPE_STATUS; type <= lastType; type++)
                 {
-                    if ((getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+                    const auto& gameState = getGameState();
+                    if ((getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
                     {
                         if (ride_info_type_money_mapping[type])
                         {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -904,7 +904,8 @@ namespace OpenRCT2::Ui::Windows
             }
 
             auto [name, price] = GetNameAndPrice(selectedSceneryEntry);
-            if (price != kMoney64Undefined && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (price != kMoney64Undefined && !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(price);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -938,7 +938,8 @@ namespace OpenRCT2::Ui::Windows
 
             auto screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_RESIZE].left + 4, widgets[WIDX_RESIZE].top + 4 };
 
-            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -281,7 +281,8 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
             DrawTabImages(rt);
 
-            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(GetStaffWage(GetSelectedStaffType()));
@@ -599,10 +600,13 @@ namespace OpenRCT2::Ui::Windows
 
         void DrawTabImages(RenderTarget& rt) const
         {
+            // TODO: use window-specific park
             const auto& gameState = getGameState();
-            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_HANDYMEN, AnimationPeepType::handyman, gameState.park.staffHandymanColour);
-            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_MECHANICS, AnimationPeepType::mechanic, gameState.park.staffMechanicColour);
-            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_SECURITY, AnimationPeepType::security, gameState.park.staffSecurityColour);
+            const auto& park = getPlayerPark(gameState);
+
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_HANDYMEN, AnimationPeepType::handyman, park.staffHandymanColour);
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_MECHANICS, AnimationPeepType::mechanic, park.staffMechanicColour);
+            DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_SECURITY, AnimationPeepType::security, park.staffSecurityColour);
             DrawTabImage(rt, WINDOW_STAFF_LIST_TAB_ENTERTAINERS, AnimationPeepType::entertainer);
         }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1148,7 +1148,8 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_PAUSE].type = WidgetType::empty;
             }
 
-            if ((getGameState().park.flags & PARK_FLAGS_NO_MONEY) || !Config::Get().interface.toolbarShowFinances)
+            const auto& gameState = getGameState();
+            if ((getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY) || !Config::Get().interface.toolbarShowFinances)
                 widgets[WIDX_FINANCES].type = WidgetType::empty;
         }
 
@@ -1376,21 +1377,21 @@ namespace OpenRCT2::Ui::Windows
 
         void onDraw(Drawing::RenderTarget& rt) override
         {
-            const auto& gameState = getGameState();
-            int32_t imgId;
-
             WindowDrawWidgets(*this, rt);
+
+            // TODO: use window-specific park
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
 
             ScreenCoordsXY screenPos{};
             // Draw staff button image (setting masks to the staff colours)
             if (widgets[WIDX_STAFF].type != WidgetType::empty)
             {
                 screenPos = { windowPos.x + widgets[WIDX_STAFF].left, windowPos.y + widgets[WIDX_STAFF].top };
-                imgId = SPR_TOOLBAR_STAFF;
+                int32_t imgId = SPR_TOOLBAR_STAFF;
                 if (widgetIsPressed(*this, WIDX_STAFF))
                     imgId++;
-                GfxDrawSprite(
-                    rt, ImageId(imgId, gameState.park.staffHandymanColour, gameState.park.staffMechanicColour), screenPos);
+                GfxDrawSprite(rt, ImageId(imgId, park.staffHandymanColour, park.staffMechanicColour), screenPos);
             }
 
             // Draw fast forward button
@@ -1483,7 +1484,7 @@ namespace OpenRCT2::Ui::Windows
                     screenPos.y++;
 
                 // Draw (de)sync icon.
-                imgId = (Network::IsDesynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
+                int32_t imgId = (Network::IsDesynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
                 GfxDrawSprite(rt, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
 
                 // Draw number of players.

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -385,7 +385,8 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Price
-            if (_placementCost != kMoney64Undefined && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (_placementCost != kMoney64Undefined && !(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 auto ft = Formatter();
                 ft.Add<money64>(_placementCost);

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -148,7 +148,9 @@ namespace OpenRCT2::Ui::Windows
             // Locate mechanic button image
             const auto& widget = widgets[WIDX_HIDE_STAFF];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.top };
-            auto image = ImageId(SPR_MECHANIC, Drawing::Colour::black, getGameState().park.staffMechanicColour);
+
+            const auto& gameState = getGameState();
+            auto image = ImageId(SPR_MECHANIC, Drawing::Colour::black, getPlayerPark(gameState).staffMechanicColour);
             GfxDrawSprite(rt, image, screenCoords);
         }
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -165,7 +165,8 @@ namespace OpenRCT2::Ui::Windows
                 drawText(rt, screenCoords - ScreenCoordsXY{ 0, 2 }, STR_LAND_TOOL_SIZE_VALUE, ft, { TextAlignment::centre });
             }
 
-            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            const auto& gameState = getGameState();
+            if (!(getPlayerPark(gameState).flags & PARK_FLAGS_NO_MONEY))
             {
                 // Draw raise cost amount
                 screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x, widgets[WIDX_PREVIEW].bottom + windowPos.y + 5 };

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -116,7 +116,7 @@ namespace OpenRCT2::Editor
         gameStateInitAll(gameState, kDefaultMapSize);
         gLegacyScene = LegacyScene::scenarioEditor;
         gameState.editorStep = EditorStep::ObjectSelection;
-        gameState.park.flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+        getUpdatingPark(gameState).flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         gameState.scenarioOptions.category = Scenario::Category::other;
         ObjectListLoad();
         ContextResetSubsystems();
@@ -309,9 +309,9 @@ namespace OpenRCT2::Editor
         UpdateConsolidatedPatrolAreas();
 
         auto& gameState = getGameState();
-        auto& park = gameState.park;
         auto& scenarioOptions = gameState.scenarioOptions;
 
+        auto& park = getUpdatingPark(gameState);
         park.numGuestsInPark = 0;
         park.numGuestsHeadingForPark = 0;
         park.numGuestsInParkLastWeek = 0;
@@ -501,19 +501,19 @@ namespace OpenRCT2::Editor
     ResultWithMessage CheckPark()
     {
         auto& gameState = getGameState();
-        auto& park = gameState.park;
+        auto& park = getUpdatingPark(gameState);
         int32_t parkSize = Park::UpdateSize(park);
         if (parkSize == 0)
         {
             return { false, STR_PARK_MUST_OWN_SOME_LAND };
         }
 
-        if (gameState.park.entrances.empty())
+        if (park.entrances.empty())
         {
             return { false, STR_NO_PARK_ENTRANCES };
         }
 
-        for (const auto& parkEntrance : gameState.park.entrances)
+        for (const auto& parkEntrance : park.entrances)
         {
             int32_t direction = DirectionReverse(parkEntrance.direction);
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -202,7 +202,8 @@ static void FixGuestsHeadingToParkCount()
         }
     }
 
-    auto& park = getGameState().park;
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
     if (park.numGuestsHeadingForPark != guestsHeadingToPark)
     {
         LOG_VERBOSE(
@@ -225,7 +226,8 @@ static void FixGuestCount()
         }
     }
 
-    auto& park = getGameState().park;
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
     if (park.numGuestsInPark != guestCount)
     {
         LOG_VERBOSE("Corrected bad amount of guests in park: %u -> %u", park.numGuestsInPark, guestCount);

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -40,6 +40,9 @@ namespace OpenRCT2
 {
     static auto _gameState = std::make_unique<GameState_t>();
 
+    static ParkId _playerParkId{};
+    static ParkId _updatingParkId{};
+
     GameState_t& getGameState()
     {
         return *_gameState;
@@ -368,5 +371,37 @@ namespace OpenRCT2
 #endif
 
         gInUpdateCode = false;
+    }
+
+    Park::ParkData& getPlayerPark()
+    {
+        return _gameState.parks[EnumValue(_playerParkId)];
+    }
+
+    ParkId getPlayerParkId()
+    {
+        return _playerParkId;
+    }
+
+    void setPlayerParkId(ParkId newParkId)
+    {
+        assert(EnumValue(newParkId) < _gameState.parks.size());
+        _playerParkId = newParkId;
+    }
+
+    Park::ParkData& getUpdatingPark()
+    {
+        return _gameState.parks[EnumValue(_updatingParkId)];
+    }
+
+    ParkId getUpdatingParkId()
+    {
+        return _updatingParkId;
+    }
+
+    void setUpdatingParkId(ParkId newParkId)
+    {
+        assert(EnumValue(newParkId) < _gameState.parks.size());
+        _updatingParkId = newParkId;
     }
 } // namespace OpenRCT2

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -40,9 +40,6 @@ namespace OpenRCT2
 {
     static auto _gameState = std::make_unique<GameState_t>();
 
-    static ParkId _playerParkId{};
-    static ParkId _updatingParkId{};
-
     GameState_t& getGameState()
     {
         return *_gameState;
@@ -64,7 +61,12 @@ namespace OpenRCT2
         gameState.currentTicks = 0;
 
         MapInit(mapSize);
-        Park::Initialise(gameState.park, gameState);
+
+        gameState.parks.clear();
+        Park::ParkData park{};
+        gameState.parks.push_back(park);
+        Park::Initialise(park, gameState);
+
         FinanceInit();
         BannerInit(gameState);
         RideInitAll();
@@ -327,8 +329,8 @@ namespace OpenRCT2
 
         if (!isInEditorMode())
         {
-            auto& park = gameState.park;
-            Park::Update(park, gameState);
+            for (auto& park : gameState.parks)
+                Park::Update(park, gameState);
         }
 
         ResearchUpdate();
@@ -373,35 +375,45 @@ namespace OpenRCT2
         gInUpdateCode = false;
     }
 
-    Park::ParkData& getPlayerPark()
+    const Park::ParkData& getPlayerPark(const GameState_t& gameState)
     {
-        return _gameState.parks[EnumValue(_playerParkId)];
+        return gameState.parks[gameState.playerParkId.ToUnderlying()];
     }
 
-    ParkId getPlayerParkId()
+    Park::ParkData& getPlayerPark(GameState_t& gameState)
     {
-        return _playerParkId;
+        return gameState.parks[gameState.playerParkId.ToUnderlying()];
     }
 
-    void setPlayerParkId(ParkId newParkId)
+    ParkId getPlayerParkId(const GameState_t& gameState)
     {
-        assert(EnumValue(newParkId) < _gameState.parks.size());
-        _playerParkId = newParkId;
+        return gameState.playerParkId;
     }
 
-    Park::ParkData& getUpdatingPark()
+    void setPlayerParkId(GameState_t& gameState, ParkId newParkId)
     {
-        return _gameState.parks[EnumValue(_updatingParkId)];
+        assert(newParkId.ToUnderlying() < gameState.parks.size());
+        gameState.playerParkId = newParkId;
     }
 
-    ParkId getUpdatingParkId()
+    const Park::ParkData& getUpdatingPark(const GameState_t& gameState)
     {
-        return _updatingParkId;
+        return gameState.parks[gameState.updatingParkId.ToUnderlying()];
     }
 
-    void setUpdatingParkId(ParkId newParkId)
+    Park::ParkData& getUpdatingPark(GameState_t& gameState)
     {
-        assert(EnumValue(newParkId) < _gameState.parks.size());
-        _updatingParkId = newParkId;
+        return gameState.parks[gameState.updatingParkId.ToUnderlying()];
+    }
+
+    ParkId getUpdatingParkId(const GameState_t& gameState)
+    {
+        return gameState.updatingParkId;
+    }
+
+    void setUpdatingParkId(GameState_t& gameState, ParkId newParkId)
+    {
+        assert(newParkId.ToUnderlying() < gameState.parks.size());
+        gameState.updatingParkId = newParkId;
     }
 } // namespace OpenRCT2

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -38,7 +38,10 @@ namespace OpenRCT2
 
     struct GameState_t
     {
-        Park::ParkData park{};
+        std::vector<Park::ParkData> parks{};
+        ParkId playerParkId{};
+        ParkId updatingParkId{};
+
         Scenario::Options scenarioOptions;
         std::string pluginStorage;
         uint32_t currentTicks{};
@@ -109,10 +112,13 @@ namespace OpenRCT2
     void gameStateTick();
     void gameStateUpdateLogic();
 
-    Park::ParkData& getPlayerPark();
-    ParkId getPlayerParkId();
-    void setPlayerParkId(ParkId newParkId);
-    Park::ParkData& getUpdatingPark();
-    ParkId getUpdatingParkId();
-    void setUpdatingParkId(ParkId newParkId);
+    const Park::ParkData& getPlayerPark(const GameState_t& gameState);
+    Park::ParkData& getPlayerPark(GameState_t& gameState);
+    ParkId getPlayerParkId(const GameState_t& gameState);
+    void setPlayerParkId(GameState_t& gameState, ParkId newParkId);
+
+    const Park::ParkData& getUpdatingPark(const GameState_t& gameState);
+    Park::ParkData& getUpdatingPark(GameState_t& gameState);
+    ParkId getUpdatingParkId(const GameState_t& gameState);
+    void setUpdatingParkId(GameState_t& gameState, ParkId newParkId);
 } // namespace OpenRCT2

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -12,6 +12,7 @@
 #include "Cheats.h"
 #include "Date.h"
 #include "Editor.h"
+#include "Identifiers.h"
 #include "Limits.h"
 #include "core/Random.hpp"
 #include "entity/EntityRegistry.h"
@@ -108,4 +109,10 @@ namespace OpenRCT2
     void gameStateTick();
     void gameStateUpdateLogic();
 
+    Park::ParkData& getPlayerPark();
+    ParkId getPlayerParkId();
+    void setPlayerParkId(ParkId newParkId);
+    Park::ParkData& getUpdatingPark();
+    ParkId getUpdatingParkId();
+    void setUpdatingParkId(ParkId newParkId);
 } // namespace OpenRCT2

--- a/src/openrct2/Identifiers.h
+++ b/src/openrct2/Identifiers.h
@@ -14,6 +14,7 @@
 #include <limits>
 
 using BannerIndex = TIdentifier<uint16_t, std::numeric_limits<uint16_t>::max(), struct BannerIndexTag>;
+using ParkId = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkIdTag>;
 using ParkEntranceIndex = TIdentifier<uint8_t, std::numeric_limits<uint8_t>::max(), struct ParkEntranceIndexTag>;
 using RideId = TIdentifier<uint16_t, std::numeric_limits<uint16_t>::max(), struct RideIdTag>;
 using EntityId = TIdentifier<uint16_t, std::numeric_limits<uint16_t>::max(), struct EntityIdTag>;

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -662,7 +662,8 @@ namespace OpenRCT2
 
         bool SerialiseParkParameters(DataSerialiser& serialiser)
         {
-            auto& park = getGameState().park;
+            auto& gameState = getGameState();
+            auto& park = getUpdatingPark(gameState);
 
             serialiser << park.guestGenerationProbability;
             serialiser << park.suggestedGuestMaximum;

--- a/src/openrct2/actions/GameActionRunner.cpp
+++ b/src/openrct2/actions/GameActionRunner.cpp
@@ -187,7 +187,7 @@ namespace OpenRCT2::GameActions
         }
 
         // TODO: pass different park based on player
-        auto& park = gameState.park;
+        auto& park = gameState.parks[0];
 
         auto result = action->Query(gameState, park);
         if (result.error == Status::ok)
@@ -340,7 +340,7 @@ namespace OpenRCT2::GameActions
             }
 
             // TODO: pass different park based on player
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
 
             // Execute the action, changing the game state
             result = action->Execute(gameState, park);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2363,9 +2363,7 @@ namespace OpenRCT2
     void Guest::SpendMoney(money64& peep_expend_type, money64 amount, ExpenditureType expenditure)
     {
         // TODO: get park based on guest
-        auto& gameState = getGameState();
-        auto& park = getUpdatingPark(gameState);
-        assert(!(park.flags & PARK_FLAGS_NO_MONEY));
+        assert(!(getUpdatingPark(getGameState()).flags & PARK_FLAGS_NO_MONEY));
 
         CashInPocket = std::max(0.00_GBP, CashInPocket - amount);
         CashSpent = AddClamp(CashSpent, amount);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2061,7 +2061,7 @@ namespace OpenRCT2
                     return false;
                 }
 
-                // TOOD: get park based on guest
+                // TODO: get park based on guest
                 auto& gameState = getGameState();
                 auto& park = getUpdatingPark(gameState);
 
@@ -2362,7 +2362,10 @@ namespace OpenRCT2
      */
     void Guest::SpendMoney(money64& peep_expend_type, money64 amount, ExpenditureType expenditure)
     {
-        assert(!(getGameState().park.flags & PARK_FLAGS_NO_MONEY));
+        // TODO: get park based on guest
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+        assert(!(park.flags & PARK_FLAGS_NO_MONEY));
 
         CashInPocket = std::max(0.00_GBP, CashInPocket - amount);
         CashSpent = AddClamp(CashSpent, amount);
@@ -2680,7 +2683,7 @@ namespace OpenRCT2
             && guest.VoucherRideId == guest.CurrentRide)
             return true;
 
-        // TOOD: get park based on guest
+        // TODO: get park based on guest
         auto& gameState = getGameState();
         auto& park = getUpdatingPark(gameState);
 
@@ -2778,7 +2781,7 @@ namespace OpenRCT2
     /* rct2: 0x00695555 */
     static int16_t GuestCalculateRideValueSatisfaction(Guest& guest, const Ride& ride)
     {
-        // TOOD: get park based on guest
+        // TODO: get park based on guest
         auto& gameState = getGameState();
         auto& park = getUpdatingPark(gameState);
 
@@ -2956,7 +2959,7 @@ namespace OpenRCT2
 
     static bool GuestShouldPreferredIntensityIncrease(Guest& guest)
     {
-        // TOOD: get park based on guest
+        // TODO: get park based on guest
         auto& gameState = getGameState();
         auto& park = getUpdatingPark(gameState);
 
@@ -3125,7 +3128,7 @@ namespace OpenRCT2
      */
     static void GuestDecideWhetherToLeavePark(Guest& guest)
     {
-        // TOOD: get park based on guest
+        // TODO: get park based on guest
         auto& gameState = getGameState();
         auto& park = getUpdatingPark(gameState);
 
@@ -7272,7 +7275,7 @@ namespace OpenRCT2
      */
     Guest* Guest::Generate(const CoordsXYZ& coords)
     {
-        // TOOD: pass park by ref
+        // TODO: pass park by ref
         auto& gameState = getGameState();
         auto& park = getUpdatingPark(gameState);
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1110,8 +1110,11 @@ namespace OpenRCT2
                         possible_thoughts[num_thoughts++] = PeepThoughtType::Toilet;
                     }
 
-                    if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY) && CashInPocket <= 9.00_GBP && Happiness >= 105
-                        && Energy >= 70)
+                    // TODO: get park based on peep
+                    auto& gameState = getGameState();
+                    auto& park = gameState.parks[0];
+
+                    if (!(park.flags & PARK_FLAGS_NO_MONEY) && CashInPocket <= 9.00_GBP && Happiness >= 105 && Energy >= 70)
                     {
                         /* The energy check was originally a second check on happiness.
                          * This was superfluous so should probably check something else.
@@ -1565,7 +1568,10 @@ namespace OpenRCT2
             return false;
         }
 
+        // TODO: get park based on guest
         auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
         if ((shopItem == ShopItem::sunglasses || shopItem == ShopItem::iceCream) && gameState.weatherCurrent.temperature < 12)
         {
             return false;
@@ -1591,7 +1597,7 @@ namespace OpenRCT2
 
         if (!hasVoucher)
         {
-            if (price != 0 && !(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+            if (price != 0 && !(park.flags & PARK_FLAGS_NO_MONEY))
             {
                 if (guest.CashInPocket == 0)
                 {
@@ -1632,7 +1638,7 @@ namespace OpenRCT2
                 itemValue -= price;
                 itemValue = std::max(0.80_GBP, itemValue);
 
-                if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+                if (!(park.flags & PARK_FLAGS_NO_MONEY))
                 {
                     if (itemValue >= static_cast<money64>(ScenarioRand() & 0x07))
                     {
@@ -1741,7 +1747,7 @@ namespace OpenRCT2
             guest.AmountOfSouvenirs++;
         }
 
-        if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+        if (!(park.flags & PARK_FLAGS_NO_MONEY))
             FinancePayment(shopItemDescriptor.Cost, expenditure);
 
         // Sets the expenditure type to *_FOODDRINK_SALES or *_SHOP_SALES appropriately.
@@ -1751,7 +1757,7 @@ namespace OpenRCT2
             guest.RemoveItem(ShopItem::voucher);
             guest.WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_INVENTORY;
         }
-        else if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+        else if (!(park.flags & PARK_FLAGS_NO_MONEY))
         {
             guest.SpendMoney(*expend_type, price, expenditure);
         }
@@ -2055,9 +2061,12 @@ namespace OpenRCT2
                     return false;
                 }
 
+                // TOOD: get park based on guest
                 auto& gameState = getGameState();
+                auto& park = getUpdatingPark(gameState);
+
                 // Basic price checks
-                if (ridePrice != 0 && !GuestHasVoucherForFreeRide(*this, ride) && !(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+                if (ridePrice != 0 && !GuestHasVoucherForFreeRide(*this, ride) && !(park.flags & PARK_FLAGS_NO_MONEY))
                 {
                     if (ridePrice > CashInPocket)
                     {
@@ -2207,7 +2216,7 @@ namespace OpenRCT2
 
                 // If the value of the ride hasn't yet been calculated, peeps will be willing to pay any amount for the ride.
                 if (value != kRideValueUndefined && !GuestHasVoucherForFreeRide(*this, ride)
-                    && !(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+                    && !(park.flags & PARK_FLAGS_NO_MONEY))
                 {
                     // The amount peeps are willing to pay is decreased by 75% if they had to pay to enter the park.
                     if (PeepFlags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY)
@@ -2234,7 +2243,7 @@ namespace OpenRCT2
                     // park.
                     if (ridePrice <= (value / 2) && peepAtRide)
                     {
-                        if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+                        if (!(park.flags & PARK_FLAGS_NO_MONEY))
                         {
                             if (!(PeepFlags & PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY))
                             {
@@ -2671,7 +2680,11 @@ namespace OpenRCT2
             && guest.VoucherRideId == guest.CurrentRide)
             return true;
 
-        if (guest.CashInPocket <= 0 && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+        // TOOD: get park based on guest
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
+        if (guest.CashInPocket <= 0 && !(park.flags & PARK_FLAGS_NO_MONEY))
         {
             guest.InsertNewThought(PeepThoughtType::SpentMoney);
             PeepUpdateRideAtEntranceTryLeave(guest);
@@ -2694,7 +2707,7 @@ namespace OpenRCT2
         auto value = ride.value;
         if (value != kRideValueUndefined)
         {
-            if (((value * 2) < ridePrice) && !(getGameState().cheats.ignorePrice))
+            if (((value * 2) < ridePrice) && !(gameState.cheats.ignorePrice))
             {
                 guest.InsertNewThought(PeepThoughtType::BadValue, guest.CurrentRide);
                 PeepUpdateRideAtEntranceTryLeave(guest);
@@ -2765,7 +2778,11 @@ namespace OpenRCT2
     /* rct2: 0x00695555 */
     static int16_t GuestCalculateRideValueSatisfaction(Guest& guest, const Ride& ride)
     {
-        if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+        // TOOD: get park based on guest
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
+        if (park.flags & PARK_FLAGS_NO_MONEY)
         {
             return -30;
         }
@@ -2939,7 +2956,11 @@ namespace OpenRCT2
 
     static bool GuestShouldPreferredIntensityIncrease(Guest& guest)
     {
-        if (getGameState().park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
+        // TOOD: get park based on guest
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
+        if (park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
             return false;
         if (guest.Happiness < 200)
             return false;
@@ -3104,12 +3125,16 @@ namespace OpenRCT2
      */
     static void GuestDecideWhetherToLeavePark(Guest& guest)
     {
+        // TOOD: get park based on guest
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
         if (guest.EnergyTarget >= 33)
         {
             guest.EnergyTarget -= 2;
         }
 
-        if (getGameState().weatherCurrent.temperature >= 21 && guest.Thirst >= 5)
+        if (gameState.weatherCurrent.temperature >= 21 && guest.Thirst >= 5)
         {
             guest.Thirst--;
         }
@@ -3124,7 +3149,7 @@ namespace OpenRCT2
          * in the park. */
         if (!(guest.PeepFlags & PEEP_FLAGS_LEAVING_PARK))
         {
-            if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+            if (park.flags & PARK_FLAGS_NO_MONEY)
             {
                 if (guest.Energy >= 70 && guest.Happiness >= 60)
                 {
@@ -3366,7 +3391,11 @@ namespace OpenRCT2
      */
     static bool PeepShouldUseCashMachine(Guest& guest, RideId rideIndex)
     {
-        if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+        // TODO: get park by peep
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
+        if (park.flags & PARK_FLAGS_NO_MONEY)
             return false;
         if (guest.PeepFlags & PEEP_FLAGS_LEAVING_PARK)
             return false;
@@ -7243,7 +7272,10 @@ namespace OpenRCT2
      */
     Guest* Guest::Generate(const CoordsXYZ& coords)
     {
+        // TOOD: pass park by ref
         auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+
         if (gameState.entities.GetNumFreeEntities() < 400)
             return nullptr;
 
@@ -7287,9 +7319,9 @@ namespace OpenRCT2
 
         /* Check which intensity boxes are enabled
          * and apply the appropriate intensity settings. */
-        if (gameState.park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
+        if (park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
         {
-            if (gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
+            if (park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
             {
                 intensityLowest = 0;
                 intensityHighest = 15;
@@ -7300,7 +7332,7 @@ namespace OpenRCT2
                 intensityHighest = 4;
             }
         }
-        else if (gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
+        else if (park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
         {
             intensityLowest = 9;
             intensityHighest = 15;
@@ -7309,7 +7341,7 @@ namespace OpenRCT2
         peep->Intensity = IntensityRange(intensityLowest, intensityHighest);
 
         uint8_t nauseaTolerance = ScenarioRand() & 0x7;
-        if (gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
+        if (park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES)
         {
             nauseaTolerance += 4;
         }
@@ -7366,7 +7398,7 @@ namespace OpenRCT2
             cash = 500;
         }
 
-        if (gameState.park.flags & PARK_FLAGS_NO_MONEY)
+        if (park.flags & PARK_FLAGS_NO_MONEY)
         {
             cash = 0;
         }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -795,8 +795,10 @@ namespace OpenRCT2
                 News::AddItemToQueue(News::ItemType::blank, STR_NEWS_ITEM_GUEST_DROWNED, x | (y << 16), ft);
             }
 
+            // TODO: get park based on peep
             auto& gameState = getGameState();
-            gameState.park.ratingCasualtyPenalty = std::min(gameState.park.ratingCasualtyPenalty + 25, 1000);
+            auto& park = gameState.parks[0];
+            park.ratingCasualtyPenalty = std::min(park.ratingCasualtyPenalty + 25, 1000);
             Remove();
             return;
         }
@@ -962,12 +964,14 @@ namespace OpenRCT2
      */
     void PeepProblemWarningsUpdate()
     {
+        // TODO: get park based on peep
         auto& gameState = getGameState();
+        auto& park = gameState.parks[0];
 
         Ride* ride;
         uint32_t hungerCounter = 0, lostCounter = 0, noexitCounter = 0, thirstCounter = 0, litterCounter = 0,
                  disgustCounter = 0, toiletCounter = 0, vandalismCounter = 0;
-        uint8_t* warningThrottle = gameState.park.peepWarningThrottle;
+        uint8_t* warningThrottle = park.peepWarningThrottle;
 
         int32_t inQueueCounter = 0;
         int32_t tooLongQueueCounter = 0;
@@ -1047,7 +1051,7 @@ namespace OpenRCT2
         // could maybe be packed into a loop, would lose a lot of clarity though
         if (warningThrottle[0])
             --warningThrottle[0];
-        else if (hungerCounter >= kPeepHungerWarningThreshold && hungerCounter >= gameState.park.numGuestsInPark / 16)
+        else if (hungerCounter >= kPeepHungerWarningThreshold && hungerCounter >= park.numGuestsInPark / 16)
         {
             warningThrottle[0] = 4;
             if (Config::Get().notifications.guestWarnings)
@@ -1059,7 +1063,7 @@ namespace OpenRCT2
 
         if (warningThrottle[1])
             --warningThrottle[1];
-        else if (thirstCounter >= kPeepThirstWarningThreshold && thirstCounter >= gameState.park.numGuestsInPark / 16)
+        else if (thirstCounter >= kPeepThirstWarningThreshold && thirstCounter >= park.numGuestsInPark / 16)
         {
             warningThrottle[1] = 4;
             if (Config::Get().notifications.guestWarnings)
@@ -1071,7 +1075,7 @@ namespace OpenRCT2
 
         if (warningThrottle[2])
             --warningThrottle[2];
-        else if (toiletCounter >= kPeepToiletWarningThreshold && toiletCounter >= gameState.park.numGuestsInPark / 16)
+        else if (toiletCounter >= kPeepToiletWarningThreshold && toiletCounter >= park.numGuestsInPark / 16)
         {
             warningThrottle[2] = 4;
             if (Config::Get().notifications.guestWarnings)
@@ -1083,7 +1087,7 @@ namespace OpenRCT2
 
         if (warningThrottle[3])
             --warningThrottle[3];
-        else if (litterCounter >= kPeepLitterWarningThreshold && litterCounter >= gameState.park.numGuestsInPark / 32)
+        else if (litterCounter >= kPeepLitterWarningThreshold && litterCounter >= park.numGuestsInPark / 32)
         {
             warningThrottle[3] = 4;
             if (Config::Get().notifications.guestWarnings)
@@ -1095,7 +1099,7 @@ namespace OpenRCT2
 
         if (warningThrottle[4])
             --warningThrottle[4];
-        else if (disgustCounter >= kPeepDisgustWarningThreshold && disgustCounter >= gameState.park.numGuestsInPark / 32)
+        else if (disgustCounter >= kPeepDisgustWarningThreshold && disgustCounter >= park.numGuestsInPark / 32)
         {
             warningThrottle[4] = 4;
             if (Config::Get().notifications.guestWarnings)
@@ -1107,7 +1111,7 @@ namespace OpenRCT2
 
         if (warningThrottle[5])
             --warningThrottle[5];
-        else if (vandalismCounter >= kPeepVandalismWarningThreshold && vandalismCounter >= gameState.park.numGuestsInPark / 32)
+        else if (vandalismCounter >= kPeepVandalismWarningThreshold && vandalismCounter >= park.numGuestsInPark / 32)
         {
             warningThrottle[5] = 4;
             if (Config::Get().notifications.guestWarnings)
@@ -1476,9 +1480,12 @@ namespace OpenRCT2
     {
         if (Name == nullptr)
         {
+            // TODO: get park based on peep
             auto& gameState = getGameState();
-            const bool showGuestNames = gameState.park.flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
-            const bool showStaffNames = gameState.park.flags & PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
+            auto& park = gameState.parks[0];
+
+            const bool showGuestNames = park.flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            const bool showStaffNames = park.flags & PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
 
             auto* staff = As<Staff>();
             const bool isStaff = staff != nullptr;
@@ -1760,7 +1767,10 @@ namespace OpenRCT2
                 return true;
             }
 
+            // TODO: get park by peep
             auto& gameState = getGameState();
+            auto& park = getUpdatingPark(gameState);
+
             uint8_t entranceDirection = tile_element->GetDirection();
             if (entranceDirection != guest->PeepDirection)
             {
@@ -1780,7 +1790,7 @@ namespace OpenRCT2
                 if (!(guest->PeepFlags & PEEP_FLAGS_LEAVING_PARK))
                 {
                     // If the park is open and leaving flag isn't set return to centre
-                    if (gameState.park.flags & PARK_FLAGS_PARK_OPEN)
+                    if (park.flags & PARK_FLAGS_PARK_OPEN)
                     {
                         PeepReturnToCentreOfTile(guest);
                         return true;
@@ -1813,7 +1823,7 @@ namespace OpenRCT2
                 return true;
             }
 
-            if (!(gameState.park.flags & PARK_FLAGS_PARK_OPEN))
+            if (!(park.flags & PARK_FLAGS_PARK_OPEN))
             {
                 guest->State = PeepState::leavingPark;
                 guest->Var37 = 1;
@@ -1825,9 +1835,8 @@ namespace OpenRCT2
 
             bool found = false;
             auto entrance = std::find_if(
-                gameState.park.entrances.begin(), gameState.park.entrances.end(),
-                [coords](const auto& e) { return coords.ToTileStart() == e; });
-            if (entrance != gameState.park.entrances.end())
+                park.entrances.begin(), park.entrances.end(), [coords](const auto& e) { return coords.ToTileStart() == e; });
+            if (entrance != park.entrances.end())
             {
                 int16_t z = entrance->z / 8;
                 entranceDirection = entrance->direction;
@@ -1886,7 +1895,7 @@ namespace OpenRCT2
                 return true;
             }
 
-            auto entranceFee = Park::GetEntranceFee(gameState.park);
+            auto entranceFee = Park::GetEntranceFee(park);
             if (entranceFee != 0)
             {
                 if (guest->HasItem(ShopItem::voucher))
@@ -1914,12 +1923,11 @@ namespace OpenRCT2
                     return true;
                 }
 
-                gameState.park.totalIncomeFromAdmissions = AddClamp(gameState.park.totalIncomeFromAdmissions, entranceFee);
+                park.totalIncomeFromAdmissions = AddClamp(park.totalIncomeFromAdmissions, entranceFee);
                 guest->SpendMoney(guest->PaidToEnter, entranceFee, ExpenditureType::parkEntranceTickets);
                 guest->PeepFlags |= PEEP_FLAGS_HAS_PAID_FOR_PARK_ENTRY;
             }
 
-            auto& park = getGameState().park;
             park.totalAdmissions = AddClamp<uint64_t>(park.totalAdmissions, 1);
 
             auto* windowMgr = Ui::GetWindowManager();
@@ -2284,8 +2292,11 @@ namespace OpenRCT2
                 return true;
             }
 
+            auto& gameState = getGameState();
+            auto& park = getUpdatingPark(gameState);
+
             auto cost = ride->price[0];
-            if (cost != 0 && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+            if (cost != 0 && !(park.flags & PARK_FLAGS_NO_MONEY))
             {
                 ride->totalProfit = AddClamp(ride->totalProfit, cost);
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::income);
@@ -2552,7 +2563,9 @@ namespace OpenRCT2
 
         if (peep_a->Name == nullptr && peep_b->Name == nullptr)
         {
-            if (getGameState().park.flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
+            // TODO: get park by peep
+            auto& gameState = getGameState();
+            if (getUpdatingPark(gameState).flags & PARK_FLAGS_SHOW_REAL_GUEST_NAMES)
             {
                 // Potentially could find a more optional way of sorting dynamic real names
             }
@@ -2582,18 +2595,20 @@ namespace OpenRCT2
      */
     void PeepUpdateNames()
     {
+        // TODO: pass park by ref
         auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
         auto& config = Config::Get().general;
 
         if (config.showRealNamesOfGuests)
-            gameState.park.flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            park.flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         else
-            gameState.park.flags &= ~PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            park.flags &= ~PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
 
         if (config.showRealNamesOfStaff)
-            gameState.park.flags |= PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
+            park.flags |= PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
         else
-            gameState.park.flags &= ~PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
+            park.flags &= ~PARK_FLAGS_SHOW_REAL_STAFF_NAMES;
 
         auto intent = Intent(INTENT_ACTION_REFRESH_GUEST_LIST);
         ContextBroadcastIntent(&intent);
@@ -2603,9 +2618,11 @@ namespace OpenRCT2
     void IncrementGuestsInPark()
     {
         auto& gameState = getGameState();
-        if (gameState.park.numGuestsInPark < UINT32_MAX)
+        auto& park = getUpdatingPark(gameState);
+
+        if (park.numGuestsInPark < UINT32_MAX)
         {
-            gameState.park.numGuestsInPark++;
+            park.numGuestsInPark++;
         }
         else
         {
@@ -2616,9 +2633,11 @@ namespace OpenRCT2
     void IncrementGuestsHeadingForPark()
     {
         auto& gameState = getGameState();
-        if (gameState.park.numGuestsHeadingForPark < UINT32_MAX)
+        auto& park = getUpdatingPark(gameState);
+
+        if (park.numGuestsHeadingForPark < UINT32_MAX)
         {
-            gameState.park.numGuestsHeadingForPark++;
+            park.numGuestsHeadingForPark++;
         }
         else
         {
@@ -2629,9 +2648,11 @@ namespace OpenRCT2
     void DecrementGuestsInPark()
     {
         auto& gameState = getGameState();
-        if (gameState.park.numGuestsInPark > 0)
+        auto& park = getUpdatingPark(gameState);
+
+        if (park.numGuestsInPark > 0)
         {
-            gameState.park.numGuestsInPark--;
+            park.numGuestsInPark--;
         }
         else
         {
@@ -2642,10 +2663,11 @@ namespace OpenRCT2
     void DecrementGuestsHeadingForPark()
     {
         auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
 
-        if (gameState.park.numGuestsHeadingForPark > 0)
+        if (park.numGuestsHeadingForPark > 0)
         {
-            gameState.park.numGuestsHeadingForPark--;
+            park.numGuestsHeadingForPark--;
         }
         else
         {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -961,7 +961,9 @@ namespace OpenRCT2
 
     Drawing::Colour StaffGetColour(StaffType staffType)
     {
-        const auto& park = getGameState().park;
+        // TODO: pass park by ref
+        const auto& gameState = getGameState();
+        const auto& park = getUpdatingPark(gameState);
         switch (staffType)
         {
             case StaffType::handyman:
@@ -980,7 +982,9 @@ namespace OpenRCT2
 
     GameActions::Result StaffSetColour(StaffType staffType, OpenRCT2::Drawing::Colour value)
     {
-        auto& park = getGameState().park;
+        // TODO: pass park by ref
+        auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
         switch (staffType)
         {
             case StaffType::handyman:

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -554,19 +554,19 @@ static void ConsoleCommandGet(InteractiveConsole& console, const arguments_t& ar
     {
         if (argv[0] == "park_rating")
         {
-            console.WriteFormatLine("park_rating %d", gameState.park.rating);
+            console.WriteFormatLine("park_rating %d", getUpdatingPark(gameState).rating);
         }
         else if (argv[0] == "park_value")
         {
-            console.WriteLine(FormatString("park_value {CURRENCY2DP}", gameState.park.value));
+            console.WriteLine(FormatString("park_value {CURRENCY2DP}", getUpdatingPark(gameState).value));
         }
         else if (argv[0] == "company_value")
         {
-            console.WriteLine(FormatString("company_value {CURRENCY2DP}", gameState.park.companyValue));
+            console.WriteLine(FormatString("company_value {CURRENCY2DP}", getUpdatingPark(gameState).companyValue));
         }
         else if (argv[0] == "money")
         {
-            console.WriteLine(FormatString("money {CURRENCY2DP}", gameState.park.cash));
+            console.WriteLine(FormatString("money {CURRENCY2DP}", getUpdatingPark(gameState).cash));
         }
         else if (argv[0] == "scenario_initial_cash")
         {
@@ -574,11 +574,11 @@ static void ConsoleCommandGet(InteractiveConsole& console, const arguments_t& ar
         }
         else if (argv[0] == "current_loan")
         {
-            console.WriteLine(FormatString("current_loan {CURRENCY2DP}", gameState.park.bankLoan));
+            console.WriteLine(FormatString("current_loan {CURRENCY2DP}", getUpdatingPark(gameState).bankLoan));
         }
         else if (argv[0] == "max_loan")
         {
-            console.WriteLine(FormatString("max_loan {CURRENCY2DP}", gameState.park.maxBankLoan));
+            console.WriteLine(FormatString("max_loan {CURRENCY2DP}", getUpdatingPark(gameState).maxBankLoan));
         }
         else if (argv[0] == "guest_initial_cash")
         {
@@ -626,52 +626,58 @@ static void ConsoleCommandGet(InteractiveConsole& console, const arguments_t& ar
         else if (argv[0] == "guest_prefer_less_intense_rides")
         {
             console.WriteFormatLine(
-                "guest_prefer_less_intense_rides %d", (gameState.park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES) != 0);
+                "guest_prefer_less_intense_rides %d",
+                (getUpdatingPark(gameState).flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES) != 0);
         }
         else if (argv[0] == "guest_prefer_more_intense_rides")
         {
             console.WriteFormatLine(
-                "guest_prefer_more_intense_rides %d", (gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES) != 0);
+                "guest_prefer_more_intense_rides %d",
+                (getUpdatingPark(gameState).flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES) != 0);
         }
         else if (argv[0] == "forbid_marketing_campaigns")
         {
             console.WriteFormatLine(
-                "forbid_marketing_campaigns %d", (gameState.park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
+                "forbid_marketing_campaigns %d",
+                (getUpdatingPark(gameState).flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
         }
         else if (argv[0] == "forbid_landscape_changes")
         {
             console.WriteFormatLine(
-                "forbid_landscape_changes %d", (gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES) != 0);
+                "forbid_landscape_changes %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES) != 0);
         }
         else if (argv[0] == "forbid_tree_removal")
         {
-            console.WriteFormatLine("forbid_tree_removal %d", (gameState.park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL) != 0);
+            console.WriteFormatLine(
+                "forbid_tree_removal %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_FORBID_TREE_REMOVAL) != 0);
         }
         else if (argv[0] == "forbid_high_construction")
         {
             console.WriteFormatLine(
-                "forbid_high_construction %d", (gameState.park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION) != 0);
+                "forbid_high_construction %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION) != 0);
         }
         else if (argv[0] == "pay_for_rides")
         {
-            console.WriteFormatLine("pay_for_rides %d", (gameState.park.flags & PARK_FLAGS_PARK_FREE_ENTRY) != 0);
+            console.WriteFormatLine("pay_for_rides %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_PARK_FREE_ENTRY) != 0);
         }
         else if (argv[0] == "no_money")
         {
-            console.WriteFormatLine("no_money %d", (gameState.park.flags & PARK_FLAGS_NO_MONEY) != 0);
+            console.WriteFormatLine("no_money %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_NO_MONEY) != 0);
         }
         else if (argv[0] == "difficult_park_rating")
         {
-            console.WriteFormatLine("difficult_park_rating %d", (gameState.park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING) != 0);
+            console.WriteFormatLine(
+                "difficult_park_rating %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_DIFFICULT_PARK_RATING) != 0);
         }
         else if (argv[0] == "difficult_guest_generation")
         {
             console.WriteFormatLine(
-                "difficult_guest_generation %d", (gameState.park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
+                "difficult_guest_generation %d",
+                (getUpdatingPark(gameState).flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION) != 0);
         }
         else if (argv[0] == "park_open")
         {
-            console.WriteFormatLine("park_open %d", (gameState.park.flags & PARK_FLAGS_PARK_OPEN) != 0);
+            console.WriteFormatLine("park_open %d", (getUpdatingPark(gameState).flags & PARK_FLAGS_PARK_OPEN) != 0);
         }
         else if (argv[0] == "game_speed")
         {
@@ -795,7 +801,7 @@ static void ConsoleCommandSet(InteractiveConsole& console, const arguments_t& ar
         if (varName == "money" && InvalidArguments(&invalidArgs, double_valid[0]))
         {
             money64 money = ToMoney64FromGBP(double_val[0]);
-            if (gameState.park.cash != money)
+            if (getUpdatingPark(gameState).cash != money)
             {
                 ConsoleSetVariableAction<GameActions::CheatSetAction>(console, varName, CheatType::setMoney, money);
             }
@@ -813,7 +819,8 @@ static void ConsoleCommandSet(InteractiveConsole& console, const arguments_t& ar
         else if (varName == "current_loan" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
             auto amount = std::clamp(
-                ToMoney64FromGBP(int_val[0]) - ToMoney64FromGBP(int_val[0] % 1000), 0.00_GBP, gameState.park.maxBankLoan);
+                ToMoney64FromGBP(int_val[0]) - ToMoney64FromGBP(int_val[0] % 1000), 0.00_GBP,
+                getUpdatingPark(gameState).maxBankLoan);
             ConsoleSetVariableAction<GameActions::ScenarioSetSettingAction>(
                 console, varName, GameActions::ScenarioSetSetting::InitialLoan, amount);
         }
@@ -880,7 +887,7 @@ static void ConsoleCommandSet(InteractiveConsole& console, const arguments_t& ar
         }
         else if (varName == "pay_for_rides" && InvalidArguments(&invalidArgs, int_valid[0]))
         {
-            SET_FLAG(gameState.park.flags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
+            SET_FLAG(getUpdatingPark(gameState).flags, PARK_FLAGS_PARK_FREE_ENTRY, int_val[0]);
             console.Execute("get pay_for_rides");
         }
         else if (varName == "no_money" && InvalidArguments(&invalidArgs, int_valid[0]))

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -113,7 +113,8 @@ void ScreenshotCheck()
 
 static std::string ScreenshotGetParkName()
 {
-    return getGameState().park.name;
+    const auto& gameState = getGameState();
+    return getUpdatingPark(gameState).name;
 }
 
 static std::string ScreenshotGetDirectory()

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -224,7 +224,7 @@ static bool AwardIsDeservedMostBeautiful(GameState_t& gameState, Park::ParkData&
         }
     }
 
-    return (negativeCount <= 15 && positiveCount > getGameState().park.numGuestsInPark / 128);
+    return (negativeCount <= 15 && positiveCount > getUpdatingPark(gameState).numGuestsInPark / 128);
 }
 
 /** Entrance fee is more than total ride value. */
@@ -312,7 +312,7 @@ static bool AwardIsDeservedBestFood(GameState_t& gameState, Park::ParkData& park
         }
     }
 
-    if (shops < 7 || uniqueShops < 4 || shops < getGameState().park.numGuestsInPark / 128)
+    if (shops < 7 || uniqueShops < 4 || shops < getUpdatingPark(gameState).numGuestsInPark / 128)
         return false;
 
     // Count hungry peeps
@@ -357,7 +357,7 @@ static bool AwardIsDeservedWorstFood(GameState_t& gameState, Park::ParkData& par
         }
     }
 
-    if (uniqueShops > 2 || shops > getGameState().park.numGuestsInPark / 256)
+    if (uniqueShops > 2 || shops > getUpdatingPark(gameState).numGuestsInPark / 256)
         return false;
 
     // Count hungry peeps
@@ -389,7 +389,7 @@ static bool AwardIsDeservedBestToilets(GameState_t& gameState, Park::ParkData& p
         return false;
 
     // At least one open toilet for every 128 guests
-    if (numToilets < getGameState().park.numGuestsInPark / 128u)
+    if (numToilets < getUpdatingPark(gameState).numGuestsInPark / 128u)
         return false;
 
     // Count number of guests who are thinking they need the toilet
@@ -411,6 +411,7 @@ static bool AwardIsDeservedMostDisappointing(GameState_t& gameState, Park::ParkD
 {
     if (activeAwardTypes & EnumToFlag(AwardType::bestValue))
         return false;
+
     if (park.rating > 650)
         return false;
 
@@ -602,12 +603,17 @@ static bool AwardIsDeserved(GameState_t& gameState, Park::ParkData& park, AwardT
 
 void AwardReset()
 {
-    getGameState().park.currentAwards.clear();
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
+    park.currentAwards.clear();
 }
 
 static void AwardAdd(AwardType type)
 {
-    getGameState().park.currentAwards.push_back(Award{ 5u, type });
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
+
+    park.currentAwards.push_back(Award{ 5u, type });
     if (Config::Get().notifications.parkAward)
     {
         News::AddItemToQueue(News::ItemType::award, AwardGetNews(type), 0, {});
@@ -623,8 +629,9 @@ void AwardUpdateAll()
 {
     PROFILED_FUNCTION();
 
-    auto& currentAwards = getGameState().park.currentAwards;
-    auto* windowMgr = Ui::GetWindowManager();
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
+    auto& currentAwards = park.currentAwards;
 
     // Decrease award times
     for (auto& award : currentAwards)
@@ -638,13 +645,12 @@ void AwardUpdateAll()
     if (res != std::end(currentAwards))
     {
         currentAwards.erase(res, std::end(currentAwards));
+
+        auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByClass(WindowClass::parkInformation);
     }
 
     // Only add new awards if park is open
-    auto& gameState = getGameState();
-    auto& park = gameState.park;
-
     if (park.flags & PARK_FLAGS_PARK_OPEN)
     {
         // Set active award types as flags
@@ -675,7 +681,9 @@ void AwardUpdateAll()
 
 void AwardGrant(AwardType type)
 {
-    auto& currentAwards = getGameState().park.currentAwards;
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
+    auto& currentAwards = park.currentAwards;
 
     // Remove award type if already granted
     std::erase_if(currentAwards, [type](const Award& award) { return award.Type == type; });

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -189,7 +189,7 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaignType)
 
 bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 {
-    // TOOD: pass park by ref
+    // TODO: pass park by ref
     auto& gameState = getGameState();
     auto& park = gameState.parks[0];
 

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -57,7 +57,8 @@ uint16_t MarketingGetCampaignGuestGenerationProbability(int32_t campaignType)
     if (campaign == nullptr)
         return 0;
 
-    auto& park = getGameState().park;
+    // TODO: pass park by ref
+    auto& park = getGameState().parks[0];
 
     // Lower probability of guest generation if price was already low
     auto probability = AdvertisingCampaignGuestGenerationProbabilities[campaign->Type];
@@ -119,7 +120,8 @@ void MarketingUpdate()
     if (gameState.cheats.neverendingMarketing)
         return;
 
-    for (auto it = gameState.park.marketingCampaigns.begin(); it != gameState.park.marketingCampaigns.end();)
+    for (auto it = getUpdatingPark(gameState).marketingCampaigns.begin();
+         it != getUpdatingPark(gameState).marketingCampaigns.end();)
     {
         auto& campaign = *it;
         if (campaign.flags.has(MarketingCampaignFlag::firstWeek))
@@ -136,7 +138,7 @@ void MarketingUpdate()
         if (campaign.WeeksLeft == 0)
         {
             MarketingRaiseFinishedNotification(campaign);
-            it = gameState.park.marketingCampaigns.erase(it);
+            it = getUpdatingPark(gameState).marketingCampaigns.erase(it);
         }
         else
         {
@@ -187,8 +189,9 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaignType)
 
 bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 {
+    // TOOD: pass park by ref
     auto& gameState = getGameState();
-    auto& park = gameState.park;
+    auto& park = gameState.parks[0];
 
     switch (campaignType)
     {
@@ -239,7 +242,8 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 
 MarketingCampaign* MarketingGetCampaign(int32_t campaignType)
 {
-    for (auto& campaign : getGameState().park.marketingCampaigns)
+    auto& gameState = getGameState();
+    for (auto& campaign : getUpdatingPark(gameState).marketingCampaigns)
     {
         if (campaign.Type == campaignType)
         {
@@ -259,7 +263,8 @@ void MarketingNewCampaign(const MarketingCampaign& campaign)
     }
     else
     {
-        getGameState().park.marketingCampaigns.push_back(campaign);
+        auto& gameState = getGameState();
+        getUpdatingPark(gameState).marketingCampaigns.push_back(campaign);
     }
 }
 
@@ -273,7 +278,8 @@ void MarketingCancelCampaignsForRide(const RideId rideId)
         return false;
     };
 
-    auto& v = getGameState().park.marketingCampaigns;
+    auto& gameState = getGameState();
+    auto& v = getUpdatingPark(gameState).marketingCampaigns;
     auto removedIt = std::remove_if(v.begin(), v.end(), isCampaignForRideFn);
     v.erase(removedIt, v.end());
 }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -111,7 +111,7 @@ void News::InitQueue(GameState_t& gameState)
     assert(gameState.newsItems.IsEmpty());
 
     // Throttles for warning types (PEEP_*_WARNING)
-    for (auto& warningThrottle : gameState.park.peepWarningThrottle)
+    for (auto& warningThrottle : getUpdatingPark(gameState).peepWarningThrottle)
     {
         warningThrottle = 0;
     }

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -330,7 +330,7 @@ void ResearchUpdate()
         return;
     }
 
-    if ((gameState.park.flags & PARK_FLAGS_NO_MONEY) && gameState.researchFundingLevel == RESEARCH_FUNDING_NONE)
+    if ((getUpdatingPark(gameState).flags & PARK_FLAGS_NO_MONEY) && gameState.researchFundingLevel == RESEARCH_FUNDING_NONE)
     {
         researchLevel = RESEARCH_FUNDING_NORMAL;
     }

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -64,7 +64,7 @@ namespace OpenRCT2::Network
     static std::string GetParkName()
     {
         auto& gameState = getGameState();
-        return gameState.park.name;
+        return getPlayerPark(gameState).name;
     }
 
     void DiscordService::Tick()

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2831,7 +2831,8 @@ namespace OpenRCT2::Network
                 GameActions::LoadOrQuitModes::OpenSavePrompt, PromptMode::saveBeforeQuit);
 
             auto& gameState = getGameState();
-            loadOrQuitAction.Execute(gameState, gameState.park);
+            auto& park = getPlayerPark(gameState);
+            loadOrQuitAction.Execute(gameState, park);
         }
     }
 

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -327,19 +327,21 @@ namespace OpenRCT2::Network
             };
 
             const auto& gameState = getGameState();
+            const auto& park = getUpdatingPark(gameState);
             const auto& date = GetDate();
+
             json_t mapSize = { { "x", gameState.mapSize.x - 2 }, { "y", gameState.mapSize.y - 2 } };
             json_t gameInfo = {
                 { "mapSize", mapSize },
                 { "day", date.GetMonthTicks() },
                 { "month", date.GetMonthsElapsed() },
-                { "guests", gameState.park.numGuestsInPark },
-                { "parkValue", gameState.park.value },
+                { "guests", park.numGuestsInPark },
+                { "parkValue", park.value },
             };
 
-            if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+            if (!(park.flags & PARK_FLAGS_NO_MONEY))
             {
-                gameInfo["cash"] = gameState.park.cash;
+                gameInfo["cash"] = park.cash;
             }
 
             root["gameInfo"] = gameInfo;

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -225,10 +225,12 @@ static void PaintParkEntranceScrollingText(
         return;
 
     auto& gameState = getGameState();
+    // TODO: use parkId (owner) from entrance element
+    const auto& park = getUpdatingPark(gameState);
+
     u8string bannerText;
-    if (gameState.park.flags & PARK_FLAGS_PARK_OPEN)
+    if (park.flags & PARK_FLAGS_PARK_OPEN)
     {
-        const auto& park = gameState.park;
         bannerText = ScrollingText::kParkBannerColourPrefix + park.name;
     }
     else

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -178,7 +178,7 @@ namespace OpenRCT2
             }
 
             // Initial cash will eventually be removed
-            gameState.scenarioOptions.initialCash = gameState.park.cash;
+            gameState.scenarioOptions.initialCash = gameState.parks[0].cash;
         }
 
         void Save(GameState_t& gameState, IStream& stream, int16_t compressionLevel)
@@ -489,7 +489,7 @@ namespace OpenRCT2
             os.readWriteChunk(ParkFileChunkType::SCENARIO, [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.scenarioOptions.category);
                 ReadWriteStringTable(cs, gameState.scenarioOptions.name, "en-GB");
-                ReadWriteStringTable(cs, gameState.park.name, "en-GB");
+                ReadWriteStringTable(cs, gameState.parks[0].name, "en-GB");
                 ReadWriteStringTable(cs, gameState.scenarioOptions.details, "en-GB");
 
                 cs.readWrite(gameState.scenarioOptions.objective.Type);
@@ -894,7 +894,7 @@ namespace OpenRCT2
         void ReadWriteParkChunk(GameState_t& gameState, OrcaStream& os)
         {
             // TODO: load/save all parks
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
 
             os.readWriteChunk(
                 ParkFileChunkType::PARK, [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -34,16 +34,17 @@ namespace OpenRCT2
 
     ParkPreview generatePreviewFromGameState(const GameState_t& gameState)
     {
+        const auto& park = getUpdatingPark(gameState);
         ParkPreview preview{
-            .parkName = gameState.park.name,
-            .parkRating = gameState.park.rating,
+            .parkName = park.name,
+            .parkRating = park.rating,
             .year = gameState.date.GetYear(),
             .month = gameState.date.GetMonth(),
             .day = gameState.date.GetDay(),
-            .parkUsesMoney = !(gameState.park.flags & PARK_FLAGS_NO_MONEY),
-            .cash = gameState.park.cash,
+            .parkUsesMoney = !(park.flags & PARK_FLAGS_NO_MONEY),
+            .cash = park.cash,
             .numRides = static_cast<uint16_t>(RideManager(gameState).size()),
-            .numGuests = static_cast<uint16_t>(gameState.park.numGuestsInPark),
+            .numGuests = static_cast<uint16_t>(park.numGuestsInPark),
         };
 
         if (auto image = generatePreviewMap(); image != std::nullopt)
@@ -182,9 +183,10 @@ namespace OpenRCT2
         if (gOpenRCT2NoGraphics)
             return std::nullopt;
 
-        const auto& gameState = getGameState();
         const auto mainWindow = WindowGetMain();
         const auto mainViewport = WindowGetViewport(mainWindow);
+
+        const auto& gameState = getGameState();
 
         CoordsXYZD mapPosXYZD{};
         if (mainViewport != nullptr)
@@ -194,9 +196,9 @@ namespace OpenRCT2
             const auto mapPos = ViewportPosToMapPos(centre, 24, mainViewport->rotation);
             mapPosXYZD = CoordsXYZD(mapPos.x, mapPos.y, int32_t{ TileElementHeight(mapPos) }, mainViewport->rotation);
         }
-        else if (!gameState.park.entrances.empty())
+        else if (!getUpdatingPark(gameState).entrances.empty())
         {
-            const auto& entrance = gameState.park.entrances[0];
+            const auto& entrance = getPlayerPark(gameState).entrances[0];
             mapPosXYZD = CoordsXYZD(entrance.x + 16, entrance.y + 16, entrance.z + 32, DirectionReverse(entrance.direction));
         }
         else

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -1573,7 +1573,9 @@ namespace OpenRCT2::PathFinding
     {
         std::optional<CoordsXYZ> chosenEntrance = std::nullopt;
         uint16_t nearestDist = 0xFFFF;
-        for (const auto& parkEntrance : getGameState().park.entrances)
+        auto& gameState = getGameState();
+        auto& park = getUpdatingPark(gameState);
+        for (const auto& parkEntrance : park.entrances)
         {
             auto dist = abs(parkEntrance.x - loc.x) + abs(parkEntrance.y - loc.y);
             if (dist < nearestDist)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -347,7 +347,7 @@ namespace OpenRCT2::RCT1
             // Do map initialisation, same kind of stuff done when loading scenario editor
             gameStateInitAll(gameState, { mapSize, mapSize });
             gameState.editorStep = EditorStep::ObjectSelection;
-            gameState.park.flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
+            gameState.parks[0].flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
             gameState.scenarioOptions.category = Scenario::Category::other;
         }
 
@@ -1474,7 +1474,7 @@ namespace OpenRCT2::RCT1
 
         void ImportFinance(GameState_t& gameState)
         {
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
 
             park.entranceFee = _s4.ParkEntranceFee;
             gameState.scenarioOptions.landPrice = ToMoney64(_s4.LandPrice);
@@ -2194,7 +2194,7 @@ namespace OpenRCT2::RCT1
                 }
             }
 
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
             park.name = std::move(parkName);
         }
 
@@ -2243,7 +2243,7 @@ namespace OpenRCT2::RCT1
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
             gameState.date = Date{ _s4.Month, _s4.Day };
 
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
 
             // Park rating
             park.rating = _s4.ParkRating;
@@ -2433,7 +2433,7 @@ namespace OpenRCT2::RCT1
             gameState.scenarioOptions.details = std::move(details);
             if (_isScenario && !parkName.empty())
             {
-                auto& park = gameState.park;
+                auto& park = gameState.parks[0];
                 park.name = std::move(parkName);
             }
         }
@@ -2527,7 +2527,7 @@ namespace OpenRCT2::RCT1
 
         void FixEntrancePositions(GameState_t& gameState)
         {
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
             park.entrances.clear();
 
             TileElementIterator it;

--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -660,8 +660,10 @@ static void ApplyPathFixes(const json_t& scenarioPatch)
                 slope = { FootpathSlopeType::sloped, direction };
             auto footpathPlaceAction = GameActions::FootpathPlaceAction(
                 coordinate.ToCoordsXYZ(), slope, surfaceObjIndex, railingsObjIndex, direction, constructionFlags);
+
             auto& gameState = getGameState();
-            auto result = footpathPlaceAction.Execute(gameState, gameState.park);
+            auto& park = getUpdatingPark(gameState);
+            auto result = footpathPlaceAction.Execute(gameState, park);
             if (result.error != GameActions::Status::ok)
             {
                 Guard::Assert(false, "Could not patch path");

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -368,7 +368,7 @@ namespace OpenRCT2::RCT2
             ImportEntities(gameState);
             ConvertPeepAnimationTypeToObjects(gameState);
 
-            auto& park = gameState.park;
+            auto& park = gameState.parks[0];
 
             gameState.scenarioOptions.initialCash = ToMoney64(_s6.InitialCash);
             park.bankLoan = ToMoney64(_s6.CurrentLoan);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5074,9 +5074,12 @@ bool Ride::isRide() const
 
 money64 RideGetPrice(const Ride& ride)
 {
-    auto& park = getGameState().park;
+    // TODO: get park by ride
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
     if (park.flags & PARK_FLAGS_NO_MONEY)
         return 0;
+
     if (ride.isRide())
     {
         if (!Park::RidePricesUnlocked(park))

--- a/src/openrct2/ride/ShopItem.cpp
+++ b/src/openrct2/ride/ShopItem.cpp
@@ -148,7 +148,8 @@ money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem)
 
 bool ShopItemHasCommonPrice(const ShopItem shopItem)
 {
-    return (getGameState().park.samePriceThroughoutPark & EnumToFlag(shopItem)) != 0;
+    const auto& gameState = getGameState();
+    return (getUpdatingPark(gameState).samePriceThroughoutPark & EnumToFlag(shopItem)) != 0;
 }
 
 bool ShopItemDescriptor::IsFood() const

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1935,8 +1935,8 @@ static bool TrackDesignPlacePreview(
 
     _trackDesignDrawingPreview = true;
     uint8_t backup_rotation = _currentTrackPieceDirection;
-    uint32_t backup_park_flags = gameState.park.flags;
-    gameState.park.flags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+    uint32_t backup_park_flags = getUpdatingPark(gameState).flags;
+    getUpdatingPark(gameState).flags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
     auto mapSize = TileCoordsXY{ gameState.mapSize.x * 16, gameState.mapSize.y * 16 };
 
     _currentTrackPieceDirection = 0;
@@ -1957,7 +1957,7 @@ static bool TrackDesignPlacePreview(
     auto res = TrackDesignPlaceVirtual(
         tds, td, TrackPlaceOperation::placeTrackPreview, placeScenery, *ride,
         { mapSize.x, mapSize.y, z, _currentTrackPieceDirection });
-    gameState.park.flags = backup_park_flags;
+    getUpdatingPark(gameState).flags = backup_park_flags;
 
     if (res.error == GameActions::Status::ok)
     {

--- a/src/openrct2/ride/Vehicle.Crash.cpp
+++ b/src/openrct2/ride/Vehicle.Crash.cpp
@@ -302,7 +302,7 @@ static void ride_train_crash(Ride& ride, uint16_t numFatalities)
         }
 
         // TODO: get park id from ride/vehicle
-        auto& park = getGameState().park;
+        auto& park = getUpdatingPark(getGameState());
         if (park.ratingCasualtyPenalty < 500)
         {
             park.ratingCasualtyPenalty += 200;

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -101,7 +101,7 @@ void ScenarioReset(GameState_t& gameState)
 
     News::InitQueue(gameState);
 
-    auto& park = gameState.park;
+    auto& park = getUpdatingPark(gameState);
     park.rating = Park::CalculateParkRating(park, gameState);
     park.value = Park::CalculateParkValue(park, gameState);
     park.companyValue = Park::CalculateCompanyValue(park);
@@ -190,7 +190,7 @@ void ScenarioFailure(GameState_t& gameState)
  */
 void ScenarioSuccess(GameState_t& gameState)
 {
-    auto companyValue = gameState.park.companyValue;
+    auto companyValue = getUpdatingPark(gameState).companyValue;
 
     gameState.scenarioCompletedCompanyValue = companyValue;
     PeepApplause();
@@ -198,7 +198,7 @@ void ScenarioSuccess(GameState_t& gameState)
     if (ScenarioRepositoryTryRecordHighscore(gameState.scenarioFileName.c_str(), companyValue, nullptr))
     {
         // Allow name entry
-        gameState.park.flags |= PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+        getUpdatingPark(gameState).flags |= PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
         gameState.scenarioCompanyValueRecord = companyValue;
     }
     ScenarioEnd();
@@ -214,7 +214,7 @@ void ScenarioSuccessSubmitName(GameState_t& gameState, const char* name)
     {
         gameState.scenarioCompletedBy = name;
     }
-    gameState.park.flags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
+    getUpdatingPark(gameState).flags &= ~PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT;
 }
 
 /**
@@ -223,7 +223,8 @@ void ScenarioSuccessSubmitName(GameState_t& gameState, const char* name)
  */
 static void ScenarioCheckEntranceFeeTooHigh()
 {
-    const auto& park = getGameState().park;
+    const auto& gameState = getGameState();
+    const auto& park = getUpdatingPark(gameState);
     const auto max_fee = AddClamp(park.totalRideValueForMoney, park.totalRideValueForMoney / 2);
 
     if ((park.flags & PARK_FLAGS_PARK_OPEN) && Park::GetEntranceFee(park) > max_fee)
@@ -299,7 +300,7 @@ static void ScenarioDayUpdate(GameState_t& gameState)
             break;
     }
 
-    auto& park = gameState.park;
+    auto& park = getUpdatingPark(gameState);
 
     // Lower the casualty penalty
     uint16_t casualtyPenaltyModifier = (park.flags & PARK_FLAGS_NO_MONEY) ? 40 : 7;
@@ -594,7 +595,7 @@ ResultWithMessage ScenarioPrepareForSave(GameState_t& gameState)
     }
 
     if (gameState.scenarioOptions.objective.Type == ObjectiveType::guestsAndRating)
-        gameState.park.flags |= PARK_FLAGS_PARK_OPEN;
+        getUpdatingPark(gameState).flags |= PARK_FLAGS_PARK_OPEN;
 
     ScenarioReset(gameState);
 
@@ -620,7 +621,7 @@ bool AllowEarlyCompletion()
 
 static void ScenarioCheckObjective(GameState_t& gameState)
 {
-    auto& park = gameState.park;
+    auto& park = getUpdatingPark(gameState);
     auto status = gameState.scenarioOptions.objective.Check(park, gameState);
     if (status == ObjectiveStatus::Success)
     {

--- a/src/openrct2/scripting/bindings/game/ScCheats.hpp
+++ b/src/openrct2/scripting/bindings/game/ScCheats.hpp
@@ -406,7 +406,7 @@ namespace OpenRCT2::Scripting
             int32_t adjusted = std::max(-1, std::min(valueInt, 999));
 
             auto& gameState = getGameState();
-            auto& park = gameState.park;
+            auto& park = getPlayerPark(gameState);
 
             gameState.cheats.forcedParkRating = adjusted;
 

--- a/src/openrct2/scripting/bindings/world/ScAward.cpp
+++ b/src/openrct2/scripting/bindings/world/ScAward.cpp
@@ -52,7 +52,10 @@ namespace OpenRCT2::Scripting
     Award* ScAward::GetAward(JSValue thisVal)
     {
         OpaqueAwardData* data = gScAward.GetOpaque<OpaqueAwardData*>(thisVal);
-        return &getGameState().park.currentAwards[data->index];
+
+        auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
+        return &park.currentAwards[data->index];
     }
 
     JSValue ScAward::type_get(JSContext* ctx, JSValue thisVal)

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -47,7 +47,9 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::cash_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.cash);
+        auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
+        return JS_NewInt64(ctx, park.cash);
     }
     JSValue ScPark::cash_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -55,9 +57,10 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
-        if (gameState.park.cash != valueInt)
+        auto& park = getPlayerPark(gameState);
+        if (park.cash != valueInt)
         {
-            gameState.park.cash = valueInt;
+            park.cash = valueInt;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }
@@ -66,7 +69,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::rating_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt32(ctx, getGameState().park.rating);
+        const auto& gameState = getGameState();
+        return JS_NewInt32(ctx, getPlayerPark(gameState).rating);
     }
     JSValue ScPark::rating_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -74,10 +78,12 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto valueClamped = std::min(std::max(0, valueInt), 999);
+
         auto& gameState = getGameState();
-        if (gameState.park.rating != valueClamped)
+        auto& park = getPlayerPark(gameState);
+        if (park.rating != valueClamped)
         {
-            gameState.park.rating = std::min(std::max(0, valueInt), 999);
+            park.rating = std::min(std::max(0, valueInt), 999);
             auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
             ContextBroadcastIntent(&intent);
         }
@@ -86,7 +92,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::bankLoan_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.bankLoan);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).bankLoan);
     }
     JSValue ScPark::bankLoan_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -94,10 +101,11 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
 
-        if (gameState.park.bankLoan != valueInt)
+        if (park.bankLoan != valueInt)
         {
-            gameState.park.bankLoan = valueInt;
+            park.bankLoan = valueInt;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }
@@ -106,7 +114,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::maxBankLoan_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.maxBankLoan);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).maxBankLoan);
     }
     JSValue ScPark::maxBankLoan_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -114,9 +123,11 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE()
 
         auto& gameState = getGameState();
-        if (gameState.park.maxBankLoan != valueInt)
+        auto& park = getPlayerPark(gameState);
+
+        if (park.maxBankLoan != valueInt)
         {
-            gameState.park.maxBankLoan = valueInt;
+            park.maxBankLoan = valueInt;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }
@@ -125,7 +136,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::entranceFee_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.entranceFee);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).entranceFee);
     }
     JSValue ScPark::entranceFee_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -133,9 +145,11 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
-        if (gameState.park.entranceFee != valueInt)
+        auto& park = getPlayerPark(gameState);
+
+        if (park.entranceFee != valueInt)
         {
-            gameState.park.entranceFee = valueInt;
+            park.entranceFee = valueInt;
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::parkInformation);
         }
@@ -144,17 +158,20 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::guests_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.numGuestsInPark);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).numGuestsInPark);
     }
 
     JSValue ScPark::suggestedGuestMaximum_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.suggestedGuestMaximum);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).suggestedGuestMaximum);
     }
 
     JSValue ScPark::guestGenerationProbability_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt32(ctx, getGameState().park.guestGenerationProbability);
+        const auto& gameState = getGameState();
+        return JS_NewInt32(ctx, getPlayerPark(gameState).guestGenerationProbability);
     }
 
     JSValue ScPark::generateGuest(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
@@ -186,7 +203,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::value_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.value);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).value);
     }
     JSValue ScPark::value_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -194,9 +212,10 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
-        if (gameState.park.value != valueInt)
+        auto& park = getPlayerPark(gameState);
+        if (park.value != valueInt)
         {
-            gameState.park.value = valueInt;
+            park.value = valueInt;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }
@@ -205,7 +224,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::companyValue_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.companyValue);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).companyValue);
     }
     JSValue ScPark::companyValue_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -213,10 +233,11 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
 
-        if (gameState.park.companyValue != valueInt)
+        if (park.companyValue != valueInt)
         {
-            gameState.park.companyValue = valueInt;
+            park.companyValue = valueInt;
             auto intent = Intent(INTENT_ACTION_UPDATE_CASH);
             ContextBroadcastIntent(&intent);
         }
@@ -225,12 +246,14 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::totalRideValueForMoney_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.totalRideValueForMoney);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).totalRideValueForMoney);
     }
 
     JSValue ScPark::totalAdmissions_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.totalAdmissions);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).totalAdmissions);
     }
     JSValue ScPark::totalAdmissions_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -238,10 +261,11 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
 
-        if (gameState.park.totalAdmissions != static_cast<uint64_t>(valueInt))
+        if (park.totalAdmissions != static_cast<uint64_t>(valueInt))
         {
-            gameState.park.totalAdmissions = static_cast<uint64_t>(valueInt);
+            park.totalAdmissions = static_cast<uint64_t>(valueInt);
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::parkInformation);
         }
@@ -250,7 +274,8 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::totalIncomeFromAdmissions_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.totalIncomeFromAdmissions);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).totalIncomeFromAdmissions);
     }
     JSValue ScPark::totalIncomeFromAdmissions_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
@@ -258,10 +283,11 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
 
-        if (gameState.park.totalIncomeFromAdmissions != valueInt)
+        if (park.totalIncomeFromAdmissions != valueInt)
         {
-            gameState.park.totalIncomeFromAdmissions = valueInt;
+            park.totalIncomeFromAdmissions = valueInt;
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::parkInformation);
         }
@@ -294,31 +320,37 @@ namespace OpenRCT2::Scripting
 
     JSValue ScPark::casualtyPenalty_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt32(ctx, getGameState().park.ratingCasualtyPenalty);
+        const auto& gameState = getGameState();
+        return JS_NewInt32(ctx, getPlayerPark(gameState).ratingCasualtyPenalty);
     }
     JSValue ScPark::casualtyPenalty_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
         JS_UNPACK_INT32(valueInt, ctx, value);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
-        getGameState().park.ratingCasualtyPenalty = valueInt;
+
+        auto& gameState = getGameState();
+        getPlayerPark(gameState).ratingCasualtyPenalty = valueInt;
         return JS_UNDEFINED;
     }
 
     JSValue ScPark::parkSize_get(JSContext* ctx, JSValue thisVal)
     {
-        return JS_NewInt64(ctx, getGameState().park.size);
+        const auto& gameState = getGameState();
+        return JS_NewInt64(ctx, getPlayerPark(gameState).size);
     }
 
     JSValue ScPark::name_get(JSContext* ctx, JSValue thisVal)
     {
-        return JSFromStdString(ctx, getGameState().park.name);
+        const auto& gameState = getGameState();
+        return JSFromStdString(ctx, getPlayerPark(gameState).name);
     }
     JSValue ScPark::name_set(JSContext* ctx, JSValue thisVal, JSValue value)
     {
         JS_UNPACK_STR(valueStr, ctx, value);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
-        auto& park = getGameState().park;
+        auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
         if (park.name != valueStr)
         {
             park.name = std::move(valueStr);
@@ -331,7 +363,9 @@ namespace OpenRCT2::Scripting
     {
         JS_UNPACK_STR(key, ctx, argv[0])
         auto mask = ParkFlagMap[key];
-        return JS_NewBool(ctx, (getGameState().park.flags & mask) != 0);
+
+        const auto& gameState = getGameState();
+        return JS_NewBool(ctx, (getPlayerPark(gameState).flags & mask) != 0);
     }
 
     JSValue ScPark::setFlag(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
@@ -341,11 +375,14 @@ namespace OpenRCT2::Scripting
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
 
         auto mask = ParkFlagMap[key];
+
         auto& gameState = getGameState();
+        auto& park = getPlayerPark(gameState);
         if (value)
-            gameState.park.flags |= mask;
+            park.flags |= mask;
         else
-            gameState.park.flags &= ~mask;
+            park.flags &= ~mask;
+
         GfxInvalidateScreen();
         return JS_UNDEFINED;
     }
@@ -457,10 +494,11 @@ namespace OpenRCT2::Scripting
         auto type = ScriptEngine::StringToExpenditureType(expenditureType);
         if (type != ExpenditureType::count)
         {
-            auto& gameState = getGameState();
+            const auto& gameState = getGameState();
+            const auto& park = getPlayerPark(gameState);
             for (size_t i = 0; i < recordedMonths; ++i)
             {
-                JS_SetPropertyInt64(ctx, result, i, JS_NewInt64(ctx, gameState.park.expenditureTable[i][EnumValue(type)]));
+                JS_SetPropertyInt64(ctx, result, i, JS_NewInt64(ctx, park.expenditureTable[i][EnumValue(type)]));
             }
         }
         return result;
@@ -470,8 +508,8 @@ namespace OpenRCT2::Scripting
     {
         JSValue result = JS_NewArray(ctx);
 
-        auto& gameState = getGameState();
-        for (size_t i = 0; i < gameState.park.currentAwards.size(); i++)
+        const auto& gameState = getGameState();
+        for (size_t i = 0; i < getPlayerPark(gameState).currentAwards.size(); i++)
         {
             JS_SetPropertyInt64(ctx, result, i, gScAward.New(ctx, i));
         }

--- a/src/openrct2/scripting/bindings/world/ScScenario.hpp
+++ b/src/openrct2/scripting/bindings/world/ScScenario.hpp
@@ -323,13 +323,15 @@ namespace OpenRCT2::Scripting
         {
             JS_UNPACK_STR(value, ctx, jsValue);
             JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+
             auto& gameState = getGameState();
             if (value == "inProgress")
                 gameState.scenarioCompletedCompanyValue = kMoney64Undefined;
             else if (value == "failed")
                 gameState.scenarioCompletedCompanyValue = kCompanyValueOnFailedObjective;
             else if (value == "completed")
-                gameState.scenarioCompletedCompanyValue = gameState.park.companyValue;
+                gameState.scenarioCompletedCompanyValue = getUpdatingPark(gameState).companyValue;
+
             return JS_UNDEFINED;
         }
 

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -49,7 +49,8 @@ static bool MapPlaceClearFunc(
 
     auto* scenery = (*tile_element)->AsSmallScenery()->GetEntry();
 
-    auto& park = getGameState().park;
+    const auto& gameState = getGameState();
+    const auto& park = getUpdatingPark(gameState);
     if (park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
     {
         if (scenery != nullptr && scenery->flags.has(SmallSceneryFlag::isTree))
@@ -257,7 +258,8 @@ GameActions::Result MapCanConstructWithClearAt(
             }
         }
 
-        if (getGameState().park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION && !isTree)
+        auto& gameState = getGameState();
+        if (getUpdatingPark(gameState).flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION && !isTree)
         {
             const auto heightFromGround = pos.clearanceZ - tileElement->GetBaseZ();
 

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -70,8 +70,11 @@ void ParkEntranceRemoveGhost()
 
 int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos)
 {
+    const auto& gameState = getGameState();
+    const auto& park = getUpdatingPark(gameState);
+
     int32_t i = 0;
-    for (const auto& entrance : getGameState().park.entrances)
+    for (const auto& entrance : park.entrances)
     {
         if (entrancePos == entrance)
         {
@@ -84,7 +87,8 @@ int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos)
 
 void ParkEntranceReset()
 {
-    getGameState().park.entrances.clear();
+    auto& gameState = getGameState();
+    getUpdatingPark(gameState).entrances.clear();
 }
 
 void RideEntranceExitPlaceProvisionalGhost()
@@ -213,7 +217,8 @@ void MazeEntranceHedgeRemoval(const CoordsXYE& entrance)
 
 void ParkEntranceFixLocations()
 {
-    auto& park = getGameState().park;
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
     // Fix ParkEntrance locations for which the tile_element no longer exists
     park.entrances.erase(
         std::remove_if(
@@ -224,7 +229,8 @@ void ParkEntranceFixLocations()
 
 void ParkEntranceUpdateLocations()
 {
-    auto& park = getGameState().park;
+    auto& gameState = getGameState();
+    auto& park = getUpdatingPark(gameState);
     park.entrances.clear();
     TileElementIterator it;
     TileElementIteratorBegin(&it);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2258,7 +2258,7 @@ namespace OpenRCT2
         for (auto& spawn : gameState.peepSpawns)
             shiftIfNotNull(spawn, amountToMove);
 
-        for (auto& entrance : gameState.park.entrances)
+        for (auto& entrance : getUpdatingPark(gameState).entrances)
             shiftIfNotNull(entrance, amountToMove);
 
         // Entities

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::Park
     static money64 calculateTotalRideValueForMoney(const ParkData& park, const GameState_t& gameState)
     {
         money64 totalRideValue = 0;
-        bool ridePricesUnlocked = RidePricesUnlocked(park) && !(gameState.park.flags & PARK_FLAGS_NO_MONEY);
+        bool ridePricesUnlocked = RidePricesUnlocked(park) && !(park.flags & PARK_FLAGS_NO_MONEY);
         for (auto& ride : RideManager(gameState))
         {
             if (ride.status != RideStatus::open)

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -104,7 +104,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     // Open park for free but charging for rides
     execute<GameActions::ParkSetParameterAction>(GameActions::ParkParameter::Open);
     execute<GameActions::ParkSetEntranceFeeAction>(0);
-    gameState.park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    getPlayerPark(gameState).flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find ferris wheel
     auto rideManager = RideManager(gameState);
@@ -164,7 +164,7 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
     // Open park for free but charging for rides
     execute<GameActions::ParkSetParameterAction>(GameActions::ParkParameter::Open);
     execute<GameActions::ParkSetEntranceFeeAction>(0);
-    gameState.park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+    getPlayerPark(gameState).flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find car ride
     auto rideManager = RideManager(gameState);


### PR DESCRIPTION
This extends the game state struct to support multiple parks. (Casual readers, please don't get your hopes up; this is very early days!)

At the moment, the game still only really supports one park, still. My goal with this PR is to get the fundamentals in place without any breaking changes. It is likely that some `getUpdatingPark` calls will need to be changed to `getPlayerPark`, or indeed a more-specific `getParkById`. However, fortunately, we don't yet need to concern ourselves too much with this in this PR.

What follows is a brief summary of changes.

First, `gameState.park` (#24965) has been encapsulated into a vector, `gameState.parks`. Any places that accessed it now use one of two accessors.

For most purposes, `getUpdatingPark()` is used. This refers the park currently being updated, e.g., by any of the game actions. The game action runner will ultimately be responsible for updating the underlying variable, `_currentUpdatingParkId`. Note that action themselves (i.e. players) will not be responsible for this, as we can't trust clients to be honest about what players they represent (i.e., prevent cheating).

For UI purposes, `getPlayerPark()` is used. While players can see more than one park, they will typically control only one of them. This then simplifies the window logic. As with the updating park, an underlying variable `_currentPlayerParkId` keeps track of what park is currently being controlled.

To emphasise, as said earlier, it is likely that some `getUpdatingPark` calls will need to be changed to `getPlayerPark`, or indeed a more-specific `getParkById`. Down the line, many functions that currently use these accessor functions should instead be passed a `ParkData` ref.

For now, we just need to ensure the game works as expected, without crashing.