### PR TITLE
Change land tool to account for sloped track and paths

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,6 @@
 0.4.27 (in development)
 ------------------------------------------------------------------------
-- Improved: [#25032] The land tool now takes sloped track and paths into account when modifying land.
+- Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 
 0.4.26 (2025-09-06)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.27 (in development)
 ------------------------------------------------------------------------
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
+- Improved: [#25032] The land tool now takes sloped track and paths into account when modifying land.
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.4.27 (in development)
 ------------------------------------------------------------------------
-- Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 - Improved: [#25032] The land tool now takes sloped track and paths into account when modifying land.
+- Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
@@ -154,7 +154,7 @@ namespace OpenRCT2::GameActions
         auto crossingMode = isQueue || (_slope != kTileSlopeFlat) ? CreateCrossingMode::none
                                                                   : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), crossingMode);
+            { _loc, zLow, zHigh }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat, crossingMode);
         if (!entrancePath && canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -224,7 +224,7 @@ namespace OpenRCT2::GameActions
                                                                   : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
             { _loc, zLow, zHigh }, &MapPlaceNonSceneryClearFunc, quarterTile, GAME_COMMAND_FLAG_APPLY | GetFlags(),
-            crossingMode);
+            kTileSlopeFlat, crossingMode);
         if (!entrancePath && canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -318,7 +318,7 @@ namespace OpenRCT2::GameActions
         auto crossingMode = isQueue || (_slope != kTileSlopeFlat) ? CreateCrossingMode::none
                                                                   : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), crossingMode);
+            { _loc, zLow, zHigh }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat, crossingMode);
         if (!entrancePath && canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_CANT_BUILD_FOOTPATH_HERE;
@@ -387,7 +387,7 @@ namespace OpenRCT2::GameActions
                                                                   : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
             { _loc, zLow, zHigh }, &MapPlaceNonSceneryClearFunc, quarterTile, GAME_COMMAND_FLAG_APPLY | GetFlags(),
-            crossingMode);
+            kTileSlopeFlat, crossingMode);
         if (!entrancePath && canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_CANT_BUILD_FOOTPATH_HERE;

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -141,7 +141,7 @@ namespace OpenRCT2::GameActions
 
             auto clearResult = MapCanConstructWithClearAt(
                 { _coords, _height * kCoordsZStep, zCorner * kCoordsZStep }, &MapSetLandHeightClearFunc, { 0b1111, 0 }, 0,
-                CreateCrossingMode::none);
+                _style, CreateCrossingMode::none);
             if (clearResult.Error != Status::Ok)
             {
                 clearResult.Error = Status::Disallowed;

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -138,7 +138,8 @@ namespace OpenRCT2::GameActions
             QuarterTile quarterTile = QuarterTile{ tile.corners, 0 }.Rotate(_loc.direction);
             const auto isTree = (sceneryEntry->flags & LARGE_SCENERY_FLAG_IS_TREE) != 0;
             auto canBuild = MapCanConstructWithClearAt(
-                { curTile, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags(), CreateCrossingMode::none, isTree);
+                { curTile, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
+                CreateCrossingMode::none, isTree);
             if (canBuild.Error != Status::Ok)
             {
                 canBuild.ErrorTitle = STR_CANT_POSITION_THIS_HERE;
@@ -269,7 +270,8 @@ namespace OpenRCT2::GameActions
             QuarterTile quarterTile = QuarterTile{ tile.corners, 0 }.Rotate(_loc.direction);
             const auto isTree = (sceneryEntry->flags & LARGE_SCENERY_FLAG_IS_TREE) != 0;
             auto canBuild = MapCanConstructWithClearAt(
-                { curTile, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags(), CreateCrossingMode::none, isTree);
+                { curTile, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
+                CreateCrossingMode::none, isTree);
             if (canBuild.Error != Status::Ok)
             {
                 if (banner != nullptr)

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -18,6 +18,7 @@
 #include "../world/Footpath.h"
 #include "../world/Map.h"
 #include "../world/Wall.h"
+#include "../world/tile_element/Slope.h"
 #include "../world/tile_element/SurfaceElement.h"
 #include "../world/tile_element/TrackElement.h"
 
@@ -106,7 +107,8 @@ namespace OpenRCT2::GameActions
         }
 
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc.ToTileStart(), baseHeight, clearanceHeight }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags());
+            { _loc.ToTileStart(), baseHeight, clearanceHeight }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags(),
+            kTileSlopeFlat);
         if (canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -171,7 +173,7 @@ namespace OpenRCT2::GameActions
 
         auto canBuild = MapCanConstructWithClearAt(
             { _loc.ToTileStart(), baseHeight, clearanceHeight }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 },
-            GetFlags() | GAME_COMMAND_FLAG_APPLY);
+            GetFlags() | GAME_COMMAND_FLAG_APPLY, kTileSlopeFlat);
         if (canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -20,6 +20,7 @@
 #include "../world/MapAnimation.h"
 #include "../world/Wall.h"
 #include "../world/tile_element/EntranceElement.h"
+#include "../world/tile_element/Slope.h"
 
 namespace OpenRCT2::GameActions
 {
@@ -115,7 +116,7 @@ namespace OpenRCT2::GameActions
         }
         auto clear_z = z + (_isExit ? RideExitHeight : RideEntranceHeight);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, z, clear_z }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags());
+            { _loc, z, clear_z }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags(), kTileSlopeFlat);
         if (canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = errorTitle;
@@ -185,7 +186,8 @@ namespace OpenRCT2::GameActions
 
         auto clear_z = z + (_isExit ? RideExitHeight : RideEntranceHeight);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, z, clear_z }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags() | GAME_COMMAND_FLAG_APPLY);
+            { _loc, z, clear_z }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags() | GAME_COMMAND_FLAG_APPLY,
+            kTileSlopeFlat);
         if (canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = errorTitle;
@@ -251,7 +253,8 @@ namespace OpenRCT2::GameActions
         }
         int16_t baseZ = loc.z;
         int16_t clearZ = baseZ + (isExit ? RideExitHeight : RideEntranceHeight);
-        auto canBuild = MapCanConstructWithClearAt({ loc, baseZ, clearZ }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, 0);
+        auto canBuild = MapCanConstructWithClearAt(
+            { loc, baseZ, clearZ }, &MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, 0, kTileSlopeFlat);
         if (canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = errorTitle;

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -267,7 +267,8 @@ namespace OpenRCT2::GameActions
         QuarterTile quarterTile = QuarterTile{ collisionQuadrants, supports }.Rotate(quadRotation);
         const auto isTree = sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_IS_TREE);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags(), CreateCrossingMode::none, isTree);
+            { _loc, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat, CreateCrossingMode::none,
+            isTree);
         if (canBuild.Error != Status::Ok)
         {
             canBuild.ErrorTitle = STR_CANT_POSITION_THIS_HERE;
@@ -405,7 +406,7 @@ namespace OpenRCT2::GameActions
         QuarterTile quarterTile = QuarterTile{ collisionQuadrants, supports }.Rotate(quadRotation);
         const auto isTree = sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_IS_TREE);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags() | GAME_COMMAND_FLAG_APPLY,
+            { _loc, zLow, zHigh }, &MapPlaceSceneryClearFunc, quarterTile, GetFlags() | GAME_COMMAND_FLAG_APPLY, kTileSlopeFlat,
             CreateCrossingMode::none, isTree);
         if (canBuild.Error != Status::Ok)
         {

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -263,7 +263,8 @@ namespace OpenRCT2::GameActions
                 ? CreateCrossingMode::trackOverPath
                 : CreateCrossingMode::none;
             auto canBuild = MapCanConstructWithClearAt(
-                { mapLoc, baseZ, clearanceZ }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), crossingMode);
+                { mapLoc, baseZ, clearanceZ }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
+                crossingMode);
             if (canBuild.Error != Status::Ok)
             {
                 canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -468,7 +469,7 @@ namespace OpenRCT2::GameActions
                 : CreateCrossingMode::none;
             auto canBuild = MapCanConstructWithClearAt(
                 mapLocWithClearance, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags() | GAME_COMMAND_FLAG_APPLY,
-                crossingMode);
+                kTileSlopeFlat, crossingMode);
             if (canBuild.Error != Status::Ok)
             {
                 canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -1166,6 +1166,7 @@
     <ClCompile Include="world\tile_element\EntranceElement.cpp" />
     <ClCompile Include="world\tile_element\LargeSceneryElement.cpp" />
     <ClCompile Include="world\tile_element\PathElement.cpp" />
+    <ClCompile Include="world\tile_element\Slope.cpp" />
     <ClCompile Include="world\tile_element\SmallSceneryElement.cpp" />
     <ClCompile Include="world\tile_element\SurfaceElement.cpp" />
     <ClCompile Include="world\tile_element\TileElement.cpp" />

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 1;
+constexpr uint8_t kStreamVersion = 2;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -78,61 +78,7 @@ static constexpr CoordsXY viewport_surface_paint_data[][4] = {
     },
 };
 
-enum
-{
-    CORNER_TOP,
-    CORNER_RIGHT,
-    CORNER_BOTTOM,
-    CORNER_LEFT
-};
-
-struct CornerHeight
-{
-    uint8_t top;
-    uint8_t right;
-    uint8_t bottom;
-    uint8_t left;
-};
-
 // clang-format off
-/**
-*  rct2: 0x0097B4A4 (R), 0x0097B4C4 (T), 0x0097B4E4 (L), 0x0097B504 (B)
-*/
-static constexpr CornerHeight corner_heights[] = {
-    // T  R  B  L
-    { 0, 0, 0, 0 },
-    { 0, 0, 1, 0 },
-    { 0, 0, 0, 1 },
-    { 0, 0, 1, 1 },
-    { 1, 0, 0, 0 },
-    { 1, 0, 1, 0 },
-    { 1, 0, 0, 1 },
-    { 1, 0, 1, 1 },
-    { 0, 1, 0, 0 },
-    { 0, 1, 1, 0 },
-    { 0, 1, 0, 1 },
-    { 0, 1, 1, 1 },
-    { 1, 1, 0, 0 },
-    { 1, 1, 1, 0 },
-    { 1, 1, 0, 1 },
-    { 1, 1, 1, 1 },
-    { 0, 0, 0, 0 },
-    { 0, 0, 1, 0 },
-    { 0, 0, 0, 1 },
-    { 0, 0, 1, 1 },
-    { 1, 0, 0, 0 },
-    { 1, 0, 1, 0 },
-    { 1, 0, 0, 1 },
-    { 1, 0, 1, 2 },
-    { 0, 1, 0, 0 },
-    { 0, 1, 1, 0 },
-    { 0, 1, 0, 1 },
-    { 0, 1, 2, 1 },
-    { 1, 1, 0, 0 },
-    { 1, 2, 1, 0 },
-    { 2, 1, 0, 1 },
-    { 1, 1, 1, 1 },
-};
 
 // bottom left tint
 static constexpr uint8_t Byte97B524[] = {
@@ -214,7 +160,7 @@ struct TileDescriptor
     const TileElement* tile_element;
     const TerrainSurfaceObject* surfaceObject;
     uint8_t slope;
-    CornerHeight corner_heights;
+    SlopeRelativeCornerHeights corner_heights;
 };
 
 struct TileSurfaceBoundaryData
@@ -997,7 +943,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
     const uint8_t rotation = session.CurrentRotation;
     const uint8_t surfaceShape = ViewportSurfacePaintSetupGetRelativeSlope(tileElement, rotation);
     const CoordsXY& base = session.SpritePosition;
-    const CornerHeight& cornerHeights = corner_heights[surfaceShape];
+    const auto cornerHeights = GetSlopeRelativeCornerHeights(surfaceShape);
     const TileElement* elementPtr = &reinterpret_cast<const TileElement&>(tileElement);
 
     const auto* surfaceObject = tileElement.GetSurfaceObject();
@@ -1039,7 +985,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
 
         const uint32_t surfaceSlope = ViewportSurfacePaintSetupGetRelativeSlope(*surfaceElement, rotation);
         const uint8_t baseHeight = surfaceElement->GetBaseZ() / 16;
-        const CornerHeight& ch = corner_heights[surfaceSlope];
+        const auto ch = GetSlopeRelativeCornerHeights(surfaceSlope);
 
         descriptor.tile_coords = TileCoordsXY{ position };
         descriptor.tile_element = reinterpret_cast<TileElement*>(surfaceElement);

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -122,6 +122,20 @@ static bool MapLoc68BABCShouldContinue(
         }
     }
 
+    if (slope != kTileSlopeFlat && tileElement->GetType() == TileElementType::Path && tileElement->AsPath()->IsSloped())
+    {
+        const auto slopeCornerHeights = GetSlopeCornerHeights(pos.baseZ, slope);
+
+        const PathElement& pathElement = *tileElement->AsPath();
+        const uint8_t pathSlope = Numerics::rol4(kTileSlopeSWSideUp, pathElement.GetSlopeDirection());
+        const auto pathCornerHeights = GetSlopeCornerHeights(pathElement.GetBaseZ(), pathSlope);
+
+        if (slopeCornerHeights <= pathCornerHeights)
+        {
+            return true;
+        }
+    }
+
     if (crossingMode == CreateCrossingMode::trackOverPath && canBuildCrossing && tileElement->GetType() == TileElementType::Path
         && tileElement->GetBaseZ() == pos.baseZ && !tileElement->AsPath()->IsQueue() && !tileElement->AsPath()->IsSloped())
     {

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -228,35 +228,8 @@ GameActions::Result MapCanConstructWithClearAt(
             }
             else
             {
-                auto northZ = tileElement->GetBaseZ();
-                auto eastZ = northZ;
-                auto southZ = northZ;
-                auto westZ = northZ;
-                const auto slope = tileElement->AsSurface()->GetSlope();
-                if (slope & kTileSlopeNCornerUp)
-                {
-                    northZ += kLandHeightStep;
-                    if (slope == (kTileSlopeSCornerDown | kTileSlopeDiagonalFlag))
-                        northZ += kLandHeightStep;
-                }
-                if (slope & kTileSlopeECornerUp)
-                {
-                    eastZ += kLandHeightStep;
-                    if (slope == (kTileSlopeWCornerDown | kTileSlopeDiagonalFlag))
-                        eastZ += kLandHeightStep;
-                }
-                if (slope & kTileSlopeSCornerUp)
-                {
-                    southZ += kLandHeightStep;
-                    if (slope == (kTileSlopeNCornerDown | kTileSlopeDiagonalFlag))
-                        southZ += kLandHeightStep;
-                }
-                if (slope & kTileSlopeWCornerUp)
-                {
-                    westZ += kLandHeightStep;
-                    if (slope == (kTileSlopeECornerDown | kTileSlopeDiagonalFlag))
-                        westZ += kLandHeightStep;
-                }
+                const auto [northZ, eastZ, southZ, westZ] = GetSlopeCornerHeights(
+                    tileElement->GetBaseZ(), tileElement->AsSurface()->GetSlope());
                 const auto baseHeight = pos.baseZ + (4 * kCoordsZStep);
                 const auto baseQuarter = quarterTile.GetBaseQuarterOccupied();
                 const auto zQuarter = quarterTile.GetZQuarterOccupied();

--- a/src/openrct2/world/ConstructionClearance.h
+++ b/src/openrct2/world/ConstructionClearance.h
@@ -52,7 +52,7 @@ struct ConstructClearResult
 };
 
 [[nodiscard]] OpenRCT2::GameActions::Result MapCanConstructWithClearAt(
-    const CoordsXYRangedZ& pos, CLEAR_FUNC clearFunc, QuarterTile quarterTile, uint8_t flags,
+    const CoordsXYRangedZ& pos, CLEAR_FUNC clearFunc, QuarterTile quarterTile, uint8_t flags, uint8_t slope,
     CreateCrossingMode crossingMode = CreateCrossingMode::none, bool isTree = false);
 
 [[nodiscard]] OpenRCT2::GameActions::Result MapCanConstructAt(const CoordsXYRangedZ& pos, QuarterTile bl);

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -899,3 +899,12 @@ struct ScreenRect : public RectRange<ScreenCoordsXY>
         return coords.x >= GetLeft() && coords.x <= GetRight() && coords.y >= GetTop() && coords.y <= GetBottom();
     }
 };
+
+// This uses the convention from the kTileSlope constants that north is at the bottom of the tile at rotation 0
+struct TileCornersZ
+{
+    int32_t north;
+    int32_t east;
+    int32_t south;
+    int32_t west;
+};

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -907,4 +907,9 @@ struct TileCornersZ
     int32_t east;
     int32_t south;
     int32_t west;
+
+    constexpr bool operator<=(const TileCornersZ& other) const
+    {
+        return north <= other.north && east <= other.east && south <= other.south && west <= other.west;
+    }
 };

--- a/src/openrct2/world/QuarterTile.cpp
+++ b/src/openrct2/world/QuarterTile.cpp
@@ -10,6 +10,7 @@
 #include "QuarterTile.h"
 
 #include "../Diagnostic.h"
+#include "../world/Map.h"
 
 // Rotate both of the values amount
 const QuarterTile QuarterTile::Rotate(uint8_t amount) const
@@ -62,4 +63,14 @@ uint8_t QuarterTile::GetBaseQuarterOccupied() const
 uint8_t QuarterTile::GetZQuarterOccupied() const
 {
     return (_val >> 4) & 0xF;
+}
+
+TileCornersZ QuarterTile::GetQuarterHeights(const int32_t height) const
+{
+    const uint8_t raisedQuarters = GetZQuarterOccupied();
+    const int32_t northZ = height + (raisedQuarters & 0b0001 ? kLandHeightStep : 0);
+    const int32_t eastZ = height + (raisedQuarters & 0b0010 ? kLandHeightStep : 0);
+    const int32_t southZ = height + (raisedQuarters & 0b0100 ? kLandHeightStep : 0);
+    const int32_t westZ = height + (raisedQuarters & 0b1000 ? kLandHeightStep : 0);
+    return { northZ, eastZ, southZ, westZ };
 }

--- a/src/openrct2/world/QuarterTile.h
+++ b/src/openrct2/world/QuarterTile.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "../world/Location.hpp"
+
 #include <cstdint>
 
 class QuarterTile
@@ -31,6 +33,7 @@ public:
     const QuarterTile Rotate(uint8_t amount) const;
     uint8_t GetBaseQuarterOccupied() const;
     uint8_t GetZQuarterOccupied() const;
+    TileCornersZ GetQuarterHeights(const int32_t height) const;
 };
 
 enum

--- a/src/openrct2/world/tile_element/Slope.cpp
+++ b/src/openrct2/world/tile_element/Slope.cpp
@@ -9,6 +9,8 @@
 
 #include "Slope.h"
 
+#include "../../world/MapLimits.h"
+
 #include <array>
 
 namespace OpenRCT2
@@ -53,5 +55,15 @@ namespace OpenRCT2
     SlopeRelativeCornerHeights GetSlopeRelativeCornerHeights(const uint8_t slope)
     {
         return kSlopeRelativeCornerHeights[slope & kTileSlopeMask];
+    }
+
+    TileCornersZ GetSlopeCornerHeights(const int32_t height, const uint8_t slope)
+    {
+        const auto cornerHeights = GetSlopeRelativeCornerHeights(slope);
+        const int32_t northZ = height + (cornerHeights.bottom * kLandHeightStep);
+        const int32_t eastZ = height + (cornerHeights.left * kLandHeightStep);
+        const int32_t southZ = height + (cornerHeights.top * kLandHeightStep);
+        const int32_t westZ = height + (cornerHeights.right * kLandHeightStep);
+        return { northZ, eastZ, southZ, westZ };
     }
 } // namespace OpenRCT2

--- a/src/openrct2/world/tile_element/Slope.cpp
+++ b/src/openrct2/world/tile_element/Slope.cpp
@@ -1,0 +1,57 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "Slope.h"
+
+#include <array>
+
+namespace OpenRCT2
+{
+    // clang-format off
+    static constexpr std::array<SlopeRelativeCornerHeights, kTileSlopeMask + 1> kSlopeRelativeCornerHeights = {{
+        { 0, 0, 0, 0 },
+        { 0, 0, 1, 0 },
+        { 0, 0, 0, 1 },
+        { 0, 0, 1, 1 },
+        { 1, 0, 0, 0 },
+        { 1, 0, 1, 0 },
+        { 1, 0, 0, 1 },
+        { 1, 0, 1, 1 },
+        { 0, 1, 0, 0 },
+        { 0, 1, 1, 0 },
+        { 0, 1, 0, 1 },
+        { 0, 1, 1, 1 },
+        { 1, 1, 0, 0 },
+        { 1, 1, 1, 0 },
+        { 1, 1, 0, 1 },
+        { 1, 1, 1, 1 },
+        { 0, 0, 0, 0 },
+        { 0, 0, 1, 0 },
+        { 0, 0, 0, 1 },
+        { 0, 0, 1, 1 },
+        { 1, 0, 0, 0 },
+        { 1, 0, 1, 0 },
+        { 1, 0, 0, 1 },
+        { 1, 0, 1, 2 },
+        { 0, 1, 0, 0 },
+        { 0, 1, 1, 0 },
+        { 0, 1, 0, 1 },
+        { 0, 1, 2, 1 },
+        { 1, 1, 0, 0 },
+        { 1, 2, 1, 0 },
+        { 2, 1, 0, 1 },
+        { 1, 1, 1, 1 },
+    }};
+    // clang-format on
+
+    SlopeRelativeCornerHeights GetSlopeRelativeCornerHeights(const uint8_t slope)
+    {
+        return kSlopeRelativeCornerHeights[slope & kTileSlopeMask];
+    }
+} // namespace OpenRCT2

--- a/src/openrct2/world/tile_element/Slope.h
+++ b/src/openrct2/world/tile_element/Slope.h
@@ -39,4 +39,14 @@ namespace OpenRCT2
     constexpr uint8_t kTileSlopeAboveTrackOrScenery = 0b00100000;
     // Special value, used when raising/lowering land corners/tiles
     constexpr uint8_t kTileSlopeRaiseOrLowerBaseHeight = 0b00100000;
+
+    struct SlopeRelativeCornerHeights
+    {
+        uint8_t top;
+        uint8_t right;
+        uint8_t bottom;
+        uint8_t left;
+    };
+
+    SlopeRelativeCornerHeights GetSlopeRelativeCornerHeights(const uint8_t slope);
 } // namespace OpenRCT2

--- a/src/openrct2/world/tile_element/Slope.h
+++ b/src/openrct2/world/tile_element/Slope.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "../../world/Location.hpp"
+
 #include <cstdint>
 
 namespace OpenRCT2
@@ -49,4 +51,5 @@ namespace OpenRCT2
     };
 
     SlopeRelativeCornerHeights GetSlopeRelativeCornerHeights(const uint8_t slope);
+    TileCornersZ GetSlopeCornerHeights(const int32_t height, const uint8_t slope);
 } // namespace OpenRCT2


### PR DESCRIPTION
This allows you to modify the land underneath sloped track and paths without the zero clearances cheat.

Closes #2296
Closes #2307

https://github.com/user-attachments/assets/8cb51199-a5b4-48e4-9cc3-34fd6ce7410e

It passes the slope in to the function that checks for construction clearances, and calculates whether it fits under the track or path.

In some very rare cases it is possible to build some track pieces in an arguably invalid way over 2 height sloped land, this does not let you raise the land in to that invalid position after the track piece has been built.