### PR TITLE
Fix #12831: Zooming to cursor on land edges sometimes moves the camera incorrectly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Change: [#23351] Diagonal sloped Go-Kart track can no longer be built without cheats if the karts do not have sprites for them.
 - Change: [#24606] Increase Misc Entity limit from 1600 to 3200.
 - Change: [#24974] Raise the Go-Karts maximum support height to allow 2 large sloped turns to be built on flat ground.
+- Fix: [#12831] Zooming to cursor on land edges sometimes causes the camera to move to the wrong position.
 - Fix: [#16988] AppImage version does not show changelog.
 - Fix: [#18048] Play music from all ride's stations.
 - Fix: [#19137] Non-inverted left corkscrew supports are incorrect at one angle (original bug).

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -411,38 +411,6 @@ static constexpr float kWindowScrollLocations[][2] = {
         }
     }
 
-    void WindowViewportGetMapCoordsByCursor(
-        const WindowBase& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y)
-    {
-        // Get mouse position to offset against.
-        auto mouseCoords = ContextGetCursorPositionScaled();
-
-        // Compute map coordinate by mouse position.
-        auto viewportPos = w.viewport->ScreenToViewportCoord(mouseCoords);
-        auto coordsXYZ = ViewportAdjustForMapHeight(viewportPos, w.viewport->rotation);
-        auto mapCoords = ViewportPosToMapPos(viewportPos, coordsXYZ.z, w.viewport->rotation);
-        *map_x = mapCoords.x;
-        *map_y = mapCoords.y;
-
-        // Get viewport coordinates centring around the tile.
-        int32_t z = TileElementHeight(mapCoords);
-
-        auto centreLoc = centre_2d_coordinates({ mapCoords.x, mapCoords.y, z }, w.viewport);
-        if (!centreLoc)
-        {
-            LOG_ERROR("Invalid location.");
-            return;
-        }
-
-        // Rebase mouse position onto centre of window, and compensate for zoom level.
-        int32_t rebased_x = w.viewport->zoom.ApplyTo(w.width / 2 - mouseCoords.x);
-        int32_t rebased_y = w.viewport->zoom.ApplyTo(w.height / 2 - mouseCoords.y);
-
-        // Compute cursor offset relative to tile.
-        *offset_x = w.viewport->zoom.ApplyTo(w.savedViewPos.x - (centreLoc->x + rebased_x));
-        *offset_y = w.viewport->zoom.ApplyTo(w.savedViewPos.y - (centreLoc->y + rebased_y));
-    }
-
     void WindowViewportCentreTileAroundCursor(WindowBase& w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y)
     {
         // Get viewport coordinates centring around the tile.

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -469,6 +469,9 @@ static constexpr float kWindowScrollLocations[][2] = {
             }
         }
 
+        v->viewPos.x = w.savedViewPos.x;
+        v->viewPos.y = w.savedViewPos.y;
+
         // HACK: Prevents the redraw from failing when there is
         // a window on top of the viewport.
         auto* windowMgr = Ui::GetWindowManager();

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -411,30 +411,6 @@ static constexpr float kWindowScrollLocations[][2] = {
         }
     }
 
-    void WindowViewportCentreTileAroundCursor(WindowBase& w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y)
-    {
-        // Get viewport coordinates centring around the tile.
-        int32_t z = TileElementHeight({ map_x, map_y });
-        auto centreLoc = centre_2d_coordinates({ map_x, map_y, z }, w.viewport);
-
-        if (!centreLoc.has_value())
-        {
-            LOG_ERROR("Invalid location.");
-            return;
-        }
-
-        // Get mouse position to offset against.
-        auto mouseCoords = ContextGetCursorPositionScaled();
-
-        // Rebase mouse position onto centre of window, and compensate for zoom level.
-        int32_t rebased_x = w.viewport->zoom.ApplyTo((w.width >> 1) - mouseCoords.x);
-        int32_t rebased_y = w.viewport->zoom.ApplyTo((w.height >> 1) - mouseCoords.y);
-
-        // Apply offset to the viewport.
-        w.savedViewPos = { centreLoc->x + rebased_x + w.viewport->zoom.ApplyInversedTo(offset_x),
-                           centreLoc->y + rebased_y + w.viewport->zoom.ApplyInversedTo(offset_y) };
-    }
-
     /**
      * For all windows with viewports, ensure they do not have a zoom level less than the minimum.
      */

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -306,8 +306,6 @@ namespace OpenRCT2
     WindowBase* WindowGetMain();
 
     void WindowScrollToLocation(WindowBase& w, const CoordsXYZ& coords);
-    void WindowViewportGetMapCoordsByCursor(
-        const WindowBase& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y);
     void WindowViewportCentreTileAroundCursor(WindowBase& w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y);
     void WindowCheckAllValidZoom();
     void WindowZoomSet(WindowBase& w, ZoomLevel zoomLevel, bool atCursor);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -306,7 +306,6 @@ namespace OpenRCT2
     WindowBase* WindowGetMain();
 
     void WindowScrollToLocation(WindowBase& w, const CoordsXYZ& coords);
-    void WindowViewportCentreTileAroundCursor(WindowBase& w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y);
     void WindowCheckAllValidZoom();
     void WindowZoomSet(WindowBase& w, ZoomLevel zoomLevel, bool atCursor);
 


### PR DESCRIPTION
This fixes #12831: Zooming to cursor on land edges sometimes moves the camera incorrectly.

It calculates the offset of the camera much simpler without checking anything that is being pointed to. This also removes the now unused subfunctions because there's probably not another reason to use them.

As far as I can tell, this is still the expected behaviour, it keeps the same point under the cursor when you zoom. I don't think there is an edge case or something that checking the land tile was covering.

Also tested this with the extra viewport and it works fine.


https://github.com/user-attachments/assets/4dbc7193-0b68-4c33-9cad-5e4b0bde70c8


https://github.com/user-attachments/assets/2192ecad-2e39-4b11-b4b6-a280d4d10600

