### PR TITLE
Fix extra viewport zoom buttons not centred on middle of viewport

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -34,6 +34,7 @@
 - Fix: [#25002] The large right turn to diagonal on the Miniature Railway draws incorrectly at certain angles.
 - Fix: [#25005] The Corkscrew Roller Coaster inline twist inverted supports draw below the track.
 - Fix: [#25006] The Twister Roller Coaster inline twists do not draw in tunnels at some angles.
+- Fix: [#25046] Zooming with the zoom buttons on the extra viewport is not focused on the centre of the viewport.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -121,20 +121,12 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WIDX_ZOOM_IN:
                 {
-                    if (viewport != nullptr && viewport->zoom > ZoomLevel::min())
-                    {
-                        viewport->zoom--;
-                        Invalidate();
-                    }
+                    WindowZoomIn(*this, false);
                     break;
                 }
                 case WIDX_ZOOM_OUT:
                 {
-                    if (viewport != nullptr && viewport->zoom < ZoomLevel::max())
-                    {
-                        viewport->zoom++;
-                        Invalidate();
-                    }
+                    WindowZoomOut(*this, false);
                     break;
                 }
                 case WIDX_LOCATE:


### PR DESCRIPTION
This fixes the extra viewport zoom buttons not centering the zoom on the middle of the viewport.
Just setting the zoom level is not enough, this replaces that with the proper functions that handle everything.

https://github.com/user-attachments/assets/79e68f37-598a-4bfe-aea9-a6c2cb2dd3ee

https://github.com/user-attachments/assets/ed258040-7fed-4da9-94e7-1e1440ac0938

