### PR TITLE
Add reference to plug-ins to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ See [PRIVACY.md](PRIVACY.md) for more information.
 - [RCT subreddit](https://www.reddit.com/r/rct/)
 - [OpenRCT2 subreddit](https://www.reddit.com/r/openrct2/)
 - OpenRCT2 plug-ins
-    - [Plug-in directory](https://openrct2plugins.org)
+    - [Plug-in directory (unofficial)](https://openrct2plugins.org)
     - [Plug-in development documentation](https://github.com/OpenRCT2/OpenRCT2/blob/develop/distribution/scripting.md)
 
 ## Similar Projects


### PR DESCRIPTION
Currently neither the official website nor the README mentions this game has a plug-in system. This PR partially addresses this by adding a link to https://openrct2plugins.org and the plug-in development resource.

This should improve discoverability of the plug-in system a bit.