### PR TITLE
Fix check in Peep::IsOnLevelCrossing()

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -39,6 +39,7 @@
 - Fix: [#25005] The Corkscrew Roller Coaster inline twist inverted supports draw below the track.
 - Fix: [#25006] The Twister Roller Coaster inline twists do not draw in tunnels at some angles.
 - Fix: [#25046] Zooming with the zoom buttons on the extra viewport is not focused on the centre of the viewport.
+- Fix: [#25062] Certain peep actions cannot be triggered if they are under or inside a track piece due to faulty verification of them being on a level crossing.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -322,8 +322,13 @@ bool Peep::ShouldWaitForLevelCrossing() const
 
 bool Peep::IsOnLevelCrossing() const
 {
-    auto trackElement = MapGetTrackElementAt(GetLocation());
-    return trackElement != nullptr;
+    auto loc = GetLocation();
+    auto pathElement = MapGetFootpathElement(loc);
+    if (pathElement != nullptr)
+    {
+        return pathElement->AsPath()->IsLevelCrossing(loc);
+    }
+    return false;
 }
 
 bool Peep::IsOnPathBlockedByVehicle() const

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 4;
+constexpr uint8_t kNetworkStreamVersion = 5;
 
 const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
 


### PR DESCRIPTION
Previously it would return true if the guest was in a restroom or in a first-aid station, now it will only return true if the peep really is on a level crossing.