### PR TITLE
Fix Hybrid Coaster large banked sloped turn to orth support rotation

### DIFF
--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -14453,7 +14453,7 @@ namespace OpenRCT2::HybridRC
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(
-                    session, supportType.wooden, WoodenSupportSubType::nwSe, DirectionNext(direction), height,
+                    session, supportType.wooden, WoodenSupportSubType::neSw, DirectionNext(direction), height,
                     session.SupportColours, WoodenSupportTransitionType::up25Deg);
                 if (direction == 0 || direction == 1)
                 {


### PR DESCRIPTION
I missed this one in #25001, the change log entry from that probably covers this, or I could add another if you prefer.

<img width="671" height="418" alt="hybridsupportrotationbug" src="https://github.com/user-attachments/assets/7c732c31-d897-4262-97df-4212b61e0aec" />
<img width="671" height="418" alt="hybridsupportrotationfix" src="https://github.com/user-attachments/assets/77aa1d8e-8ce6-446f-b54c-a99788e97734" />

Save:
[hybrid support rotation.zip](https://github.com/user-attachments/files/22042073/hybrid.support.rotation.zip)
