### PR TITLE
Prevent progress bar from flickering during map download

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#25005] The Corkscrew Roller Coaster inline twist inverted supports draw below the track.
 - Fix: [#25006] The Twister Roller Coaster inline twists do not draw in tunnels at some angles.
 - Fix: [#25046] Zooming with the zoom buttons on the extra viewport is not focused on the centre of the viewport.
+- Fix: [#25067] Progress bars can flicker when downloading maps in multiplayer mode.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2776,6 +2776,8 @@ void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connecti
 
         _serverTickData.clear();
         _clientMapLoaded = false;
+
+        OpenNetworkProgress(STR_MULTIPLAYER_DOWNLOADING_MAP);
     }
     if (size > chunk_buffer.size())
     {
@@ -2785,7 +2787,6 @@ void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connecti
     const auto currentProgressKiB = (offset + chunksize) / 1024;
     const auto totalSizeKiB = size / 1024;
 
-    OpenNetworkProgress(STR_MULTIPLAYER_DOWNLOADING_MAP);
     GetContext().SetProgress(currentProgressKiB, totalSizeKiB, STR_STRING_M_OF_N_KIB);
 
     std::memcpy(&chunk_buffer[offset], const_cast<void*>(static_cast<const void*>(packet.Read(chunksize))), chunksize);


### PR DESCRIPTION
The progress bar for downloading a network map was being reset every time a packet was being handled, causing the progress bar to flicker between 0 and the actual progress.

Handling object list retrieval and successive object downloads could also do with a similar improvement, but requires additional refactors.