### PR TITLE
Fix Hybrid Coaster quarter loops drawing over land edges and walls

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -42,6 +42,7 @@
 - Fix: [#25054] Panning a viewport in a window that is partially outside the game’s window can draw incorrectly or crash in software rendering.
 - Fix: [#25062] Certain peep actions cannot be triggered if they are under or inside a track piece due to faulty verification of them being on a level crossing.
 - Fix: [#25067] Progress bars can flicker when downloading maps in multiplayer mode.
+- Fix: [#25075] The Hybrid Coaster quarter loops draw over land edges and walls directly next to them.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -11001,7 +11001,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 31 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 1),
-                            { 0, 0, height }, { { 0, 32, height + 8 }, { 32, 1, 48 } });
+                            { 0, 0, height }, { { 0, 28, height + 8 }, { 32, 1, 48 } });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -11009,7 +11009,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 26, 4, height + 8 }, { 2, 20, 31 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 7),
-                            { 0, 0, height }, { { 0, 32, height + 8 }, { 32, 1, 48 } });
+                            { 0, 0, height }, { { 0, 28, height + 8 }, { 32, 1, 48 } });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -11017,7 +11017,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 26, 4, height + 8 }, { 2, 20, 31 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 13),
-                            { 0, 0, height }, { { 0, 32, height + 8 }, { 32, 1, 48 } });
+                            { 0, 0, height }, { { 0, 28, height + 8 }, { 32, 1, 48 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -11025,7 +11025,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 4, 6, height + 8 }, { 2, 20, 31 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 19),
-                            { 0, 0, height }, { { 0, 32, height + 8 }, { 32, 1, 48 } });
+                            { 0, 0, height }, { { 0, 28, height + 8 }, { 32, 1, 48 } });
                         break;
                 }
                 PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
@@ -11037,10 +11037,10 @@ namespace OpenRCT2::HybridRC
                     case 0:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 2),
-                            { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                            { 0, 0, height }, { { -2, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 3),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 64 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 55 } });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -11048,7 +11048,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 9),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 64 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 55 } });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -11056,15 +11056,15 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 15),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 64 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 55 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 20),
-                            { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
+                            { 0, 0, height }, { { -2, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 21),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 64 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 55 } });
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(
@@ -11081,7 +11081,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 5),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 32 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 32 } });
                         break;
                     case 1:
                         PaintAddImageAsParentRotated(
@@ -11089,7 +11089,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 11),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 32 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 32 } });
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
@@ -11097,7 +11097,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 17),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 32 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 32 } });
                         break;
                     case 3:
                         PaintAddImageAsParentRotated(
@@ -11105,7 +11105,7 @@ namespace OpenRCT2::HybridRC
                             { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                         PaintAddImageAsParentRotated(
                             session, direction, GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_QUARTER_LOOP + 23),
-                            { 0, 0, height }, { { 0, 32, height }, { 32, 1, 32 } });
+                            { 0, 0, height }, { { 0, 28, height }, { 32, 1, 32 } });
                         break;
                 }
                 WoodenASupportsPaintSetupRotated(


### PR DESCRIPTION
Fixes the Hybrid Coaster quarter loops drawing over land edges and walls.
These bounding boxes were on the next tile (offset 32), this brings them back in, same as it's usually done elsewhere. Slightly adjusts 2 others (within track bounds) to avoid train glitching.

<img width="176" height="332" alt="hybridquarterloopbug1" src="https://github.com/user-attachments/assets/fc724205-a3dc-4ca2-af06-cefb93b19e13" /><img width="176" height="332" alt="hybridquarterloopfix1" src="https://github.com/user-attachments/assets/75beeb8c-7930-4acc-bc76-9d4a29848194" />
<img width="178" height="320" alt="hybridquarterloopbug2" src="https://github.com/user-attachments/assets/54388118-c186-45ce-8f2e-03f05c8cfdbf" /><img width="178" height="320" alt="hybridquarterloopfix2" src="https://github.com/user-attachments/assets/9f7f7a45-0d97-46ff-ba43-cee48f8ee398" />

Save:
[hybrid quarter loop.zip](https://github.com/user-attachments/files/22061168/hybrid.quarter.loop.zip)
