### PR TITLE
Fix #25080: Missing water edges in certain land slope configurations

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -43,6 +43,7 @@
 - Fix: [#25062] Certain peep actions cannot be triggered if they are under or inside a track piece due to faulty verification of them being on a level crossing.
 - Fix: [#25067] Progress bars can flicker when downloading maps in multiplayer mode.
 - Fix: [#25075] The Hybrid Coaster quarter loops draw over land edges and walls directly next to them.
+- Fix: [#25080] Water has missing land edges when opposite corners of the tile and adjacent tile are the same height and the others are lower.
 
 0.4.25 (2025-08-03)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -568,8 +568,9 @@ static void ViewportSurfaceDrawTileSideBottom(
             return;
         }
 
-        neighbourCornerHeight1 = std::max(cornerHeight1, neighbourCornerHeight1);
-        neighbourCornerHeight2 = std::max(cornerHeight2, neighbourCornerHeight2);
+        const int16_t minimumNeighbourCornerHeight = std::min(neighbourCornerHeight1, neighbourCornerHeight2);
+        neighbourCornerHeight1 = std::max(cornerHeight1, minimumNeighbourCornerHeight);
+        neighbourCornerHeight2 = std::max(cornerHeight2, minimumNeighbourCornerHeight);
 
         cornerHeight1 = height;
         cornerHeight2 = height;


### PR DESCRIPTION
This fixes water having missing land edges when opposite corners of the tile and adjacent tile are the same height and the others are lower.

Fixes #25080.

This is a regression from #23947. I've made sure not to reintroduce that bug when fixing this one. This starts the water edges at the max of the lowest neighbouring corner height and the corner height.

<img width="760" height="525" alt="wateredgebug" src="https://github.com/user-attachments/assets/6edd2d24-d598-4b5f-a751-1a35a7f9fb2f" />
Fix:
<img width="760" height="525" alt="wateredgefix" src="https://github.com/user-attachments/assets/d9619aa5-46bd-4db0-9a2f-e21fb4e4a846" />
<img width="760" height="525" alt="wateredgefixunderground" src="https://github.com/user-attachments/assets/d5543c52-1427-4113-a3a4-601e98cdf876" />

Save:
[waterbug2.zip](https://github.com/user-attachments/files/22066087/waterbug2.zip)
