### PR TITLE
Move network classes and functions into Network namespace

### DIFF
--- a/src/openrct2-ui/ProvisionalElements.cpp
+++ b/src/openrct2-ui/ProvisionalElements.cpp
@@ -37,7 +37,7 @@ namespace OpenRCT2::Ui
         }
         // This is in non performant so only make network games suffer for it
         // non networked games do not need this as its to prevent desyncs.
-        if ((NetworkGetMode() != NETWORK_MODE_NONE) && windowMgr->FindByClass(WindowClass::TrackDesignPlace) != nullptr)
+        if ((Network::GetMode() != Network::Mode::none) && windowMgr->FindByClass(WindowClass::TrackDesignPlace) != nullptr)
         {
             TrackPlaceClearProvisionalTemporarily();
         }
@@ -57,7 +57,7 @@ namespace OpenRCT2::Ui
         }
         // This is in non performant so only make network games suffer for it
         // non networked games do not need this as its to prevent desyncs.
-        if ((NetworkGetMode() != NETWORK_MODE_NONE) && windowMgr->FindByClass(WindowClass::TrackDesignPlace) != nullptr)
+        if ((Network::GetMode() != Network::Mode::none) && windowMgr->FindByClass(WindowClass::TrackDesignPlace) != nullptr)
         {
             TrackPlaceRestoreProvisional();
         }

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -351,7 +351,7 @@ static void ShortcutReduceGameSpeed()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (NetworkGetMode() == NETWORK_MODE_NONE)
+    if (Network::GetMode() == Network::Mode::none)
         GameReduceGameSpeed();
 }
 
@@ -360,7 +360,7 @@ static void ShortcutIncreaseGameSpeed()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (NetworkGetMode() == NETWORK_MODE_NONE)
+    if (Network::GetMode() == Network::Mode::none)
         GameIncreaseGameSpeed();
 }
 
@@ -832,7 +832,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
         }
     });
     RegisterShortcut(ShortcutId::kInterfaceMultiplayerShow, STR_SHORTCUT_SHOW_MULTIPLAYER, []() {
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             OpenWindow(WindowClass::Multiplayer);
         }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -654,7 +654,7 @@ namespace OpenRCT2::Ui::Windows
                     nullLoc.SetNull();
                     GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Pickup,
                                                                 EntityId::FromUnderlying(number), nullLoc,
-                                                                NetworkGetCurrentPlayerId() };
+                                                                Network::GetCurrentPlayerId() };
                     pickupAction.SetCallback(
                         [peepnum = number](const GameActions::GameAction* ga, const GameActions::Result* result) {
                             if (result->Error != GameActions::Status::Ok)
@@ -923,7 +923,7 @@ namespace OpenRCT2::Ui::Windows
             _beingWatchedTimer++;
 
             // Disable peep watching thought for multiplayer as it's client specific
-            if (NetworkGetMode() == NETWORK_MODE_NONE)
+            if (Network::GetMode() == Network::Mode::none)
             {
                 // Create the "I have the strangest feeling I am being watched thought"
                 if (_beingWatchedTimer >= 3840)
@@ -1024,7 +1024,7 @@ namespace OpenRCT2::Ui::Windows
             GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Place,
                                                         EntityId::FromUnderlying(number),
                                                         { destCoords, tileElement->GetBaseZ() },
-                                                        NetworkGetCurrentPlayerId() };
+                                                        Network::GetCurrentPlayerId() };
             pickupAction.SetCallback([](const GameActions::GameAction* ga, const GameActions::Result* result) {
                 if (result->Error != GameActions::Status::Ok)
                     return;
@@ -1042,7 +1042,7 @@ namespace OpenRCT2::Ui::Windows
             GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Cancel,
                                                         EntityId::FromUnderlying(number),
                                                         { _pickedPeepX, 0, 0 },
-                                                        NetworkGetCurrentPlayerId() };
+                                                        Network::GetCurrentPlayerId() };
             GameActions::Execute(&pickupAction);
         }
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -546,7 +546,7 @@ namespace OpenRCT2::Ui::Windows
             const bool isSave = action == LoadSaveAction::save;
 
             // Pause the game if not on title scene, nor in network play.
-            if (gLegacyScene != LegacyScene::titleSequence && NetworkGetMode() == NETWORK_MODE_NONE)
+            if (gLegacyScene != LegacyScene::titleSequence && Network::GetMode() == Network::Mode::none)
             {
                 gGamePaused |= GAME_PAUSED_MODAL;
                 Audio::StopAll();
@@ -594,7 +594,7 @@ namespace OpenRCT2::Ui::Windows
             Config::Save();
 
             // Unpause the game if not on title scene, nor in network play.
-            if (gLegacyScene != LegacyScene::titleSequence && NetworkGetMode() == NETWORK_MODE_NONE)
+            if (gLegacyScene != LegacyScene::titleSequence && Network::GetMode() == Network::Mode::none)
             {
                 gGamePaused &= ~GAME_PAUSED_MODAL;
                 Audio::Resume();

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -136,7 +136,7 @@ namespace OpenRCT2::Ui::Windows
 
     static bool IsServerPlayerInvisible()
     {
-        return NetworkIsServerPlayerInvisible() && !Config::Get().general.DebuggingTools;
+        return Network::IsServerPlayerInvisible() && !Config::Get().general.DebuggingTools;
     }
 
     class MultiplayerWindow final : public Window
@@ -263,8 +263,8 @@ namespace OpenRCT2::Ui::Windows
                     }
                     case WIDX_RENAME_GROUP:
                     {
-                        int32_t groupIndex = NetworkGetGroupIndex(_selectedGroup);
-                        const utf8* groupName = NetworkGetGroupName(groupIndex);
+                        int32_t groupIndex = Network::GetGroupIndex(_selectedGroup);
+                        const utf8* groupName = Network::GetGroupName(groupIndex);
                         WindowTextInputRawOpen(
                             this, widgetIndex, STR_GROUP_NAME, STR_ENTER_NEW_NAME_FOR_THIS_GROUP, {}, groupName, 32);
                         break;
@@ -307,12 +307,12 @@ namespace OpenRCT2::Ui::Windows
         // Server name is displayed word-wrapped, so figure out how high it will be.
         {
             int32_t numLines;
-            GfxWrapString(NetworkGetServerName(), baseWidth, FontStyle::Medium, nullptr, &numLines);
+            GfxWrapString(Network::GetServerName(), baseWidth, FontStyle::Medium, nullptr, &numLines);
             baseHeight += (numLines + 1) * lineHeight + (kListRowHeight / 2);
         }
 
         // Likewise, for the optional server description -- which can be a little longer.
-        const auto& descString = NetworkGetServerDescription();
+        const auto& descString = Network::GetServerDescription();
         if (!descString.empty())
         {
             int32_t numLines;
@@ -322,15 +322,15 @@ namespace OpenRCT2::Ui::Windows
 
         // Finally, account for provider info, if present.
         {
-            const auto& providerName = NetworkGetServerProviderName();
+            const auto& providerName = Network::GetServerProviderName();
             if (!providerName.empty())
                 baseHeight += kListRowHeight;
 
-            const auto& providerEmail = NetworkGetServerProviderEmail();
+            const auto& providerEmail = Network::GetServerProviderEmail();
             if (!providerEmail.empty())
                 baseHeight += kListRowHeight;
 
-            const auto& providerWebsite = NetworkGetServerProviderWebsite();
+            const auto& providerWebsite = Network::GetServerProviderWebsite();
             if (!providerWebsite.empty())
                 baseHeight += kListRowHeight;
         }
@@ -354,7 +354,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 WindowSetResize(*this, { 420, 124 }, { 500, 450 });
 
-                no_list_items = (IsServerPlayerInvisible() ? NetworkGetNumVisiblePlayers() : NetworkGetNumPlayers());
+                no_list_items = (IsServerPlayerInvisible() ? Network::GetNumVisiblePlayers() : Network::GetNumPlayers());
 
                 widgets[WIDX_HEADER_PING].right = width - 5;
 
@@ -366,7 +366,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 WindowSetResize(*this, { 320, 200 }, { 320, 500 });
 
-                no_list_items = NetworkGetNumActions();
+                no_list_items = Network::GetNumActions();
 
                 selected_list_item = -1;
                 Invalidate();
@@ -419,7 +419,7 @@ namespace OpenRCT2::Ui::Windows
                 WindowAlignTabs(this, WIDX_TAB1, WIDX_TAB4);
 
                 // select other group if one is removed
-                while (NetworkGetGroupIndex(_selectedGroup) == -1 && _selectedGroup > 0)
+                while (Network::GetGroupIndex(_selectedGroup) == -1 && _selectedGroup > 0)
                 {
                     _selectedGroup--;
                 }
@@ -429,7 +429,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 WindowAlignTabs(this, WIDX_TAB1, WIDX_TAB4);
 
-                if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+                if (Network::GetMode() == Network::Mode::client)
                 {
                     widgets[WIDX_KNOWN_KEYS_ONLY_CHECKBOX].type = WidgetType::empty;
                 }
@@ -482,13 +482,13 @@ namespace OpenRCT2::Ui::Windows
                     case WIDX_DEFAULT_GROUP_DROPDOWN:
                     {
                         auto networkModifyGroup = GameActions::NetworkModifyGroupAction(
-                            GameActions::ModifyGroupType::SetDefault, NetworkGetGroupID(selectedIndex));
+                            GameActions::ModifyGroupType::SetDefault, Network::GetGroupID(selectedIndex));
                         GameActions::Execute(&networkModifyGroup);
                         break;
                     }
                     case WIDX_SELECTED_GROUP_DROPDOWN:
                     {
-                        _selectedGroup = NetworkGetGroupID(selectedIndex);
+                        _selectedGroup = Network::GetGroupID(selectedIndex);
                         break;
                     }
                 }
@@ -522,23 +522,23 @@ namespace OpenRCT2::Ui::Windows
     {
         auto widget = &widgets[widgetIndex];
         Widget* dropdownWidget = widget - 1;
-        auto numItems = NetworkGetNumGroups();
+        auto numItems = Network::GetNumGroups();
 
         WindowDropdownShowTextCustomWidth(
             windowPos + ScreenCoordsXY{ dropdownWidget->left, dropdownWidget->top }, dropdownWidget->height() + 1, colours[1],
             0, 0, numItems, widget->right - dropdownWidget->left);
 
-        for (auto i = 0; i < NetworkGetNumGroups(); i++)
+        for (auto i = 0; i < Network::GetNumGroups(); i++)
         {
-            gDropdown.items[i] = Dropdown::MenuLabel(NetworkGetGroupName(i));
+            gDropdown.items[i] = Dropdown::MenuLabel(Network::GetGroupName(i));
         }
         if (widget == &widgets[WIDX_DEFAULT_GROUP_DROPDOWN])
         {
-            gDropdown.items[NetworkGetGroupIndex(NetworkGetDefaultGroup())].setChecked(true);
+            gDropdown.items[Network::GetGroupIndex(Network::GetDefaultGroup())].setChecked(true);
         }
         else if (widget == &widgets[WIDX_SELECTED_GROUP_DROPDOWN])
         {
-            gDropdown.items[NetworkGetGroupIndex(_selectedGroup)].setChecked(true);
+            gDropdown.items[Network::GetGroupIndex(_selectedGroup)].setChecked(true);
         }
     }
 
@@ -573,7 +573,7 @@ namespace OpenRCT2::Ui::Windows
                     Invalidate();
                 }
 
-                screenSize = { 0, NetworkGetNumPlayers() * kScrollableRowHeight };
+                screenSize = { 0, Network::GetNumPlayers() * kScrollableRowHeight };
                 int32_t i = screenSize.height - widgets[WIDX_LIST].bottom + widgets[WIDX_LIST].top + 21;
                 if (i < 0)
                     i = 0;
@@ -593,7 +593,7 @@ namespace OpenRCT2::Ui::Windows
                     Invalidate();
                 }
 
-                screenSize = { 0, NetworkGetNumActions() * kScrollableRowHeight };
+                screenSize = { 0, Network::GetNumActions() * kScrollableRowHeight };
                 int32_t i = screenSize.height - widgets[WIDX_LIST].bottom + widgets[WIDX_LIST].top + 21;
                 if (i < 0)
                     i = 0;
@@ -622,7 +622,7 @@ namespace OpenRCT2::Ui::Windows
                 Invalidate();
 
                 int32_t player = (IsServerPlayerInvisible() ? index + 1 : index);
-                PlayerOpen(NetworkGetPlayerID(player));
+                PlayerOpen(Network::GetPlayerID(player));
                 break;
             }
 
@@ -684,7 +684,7 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = ScreenCoordsXY{ 3, widgets[WIDX_CONTENT_PANEL].top + 7 };
             int32_t newWidth = width - 6;
 
-            const auto& name = NetworkGetServerName();
+            const auto& name = Network::GetServerName();
             {
                 auto ft = Formatter();
                 ft.Add<const char*>(name.c_str());
@@ -692,7 +692,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += kListRowHeight / 2;
             }
 
-            const auto& description = NetworkGetServerDescription();
+            const auto& description = Network::GetServerDescription();
             if (!description.empty())
             {
                 auto ft = Formatter();
@@ -701,7 +701,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += kListRowHeight / 2;
             }
 
-            const auto& providerName = NetworkGetServerProviderName();
+            const auto& providerName = Network::GetServerProviderName();
             if (!providerName.empty())
             {
                 auto ft = Formatter();
@@ -710,7 +710,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += kListRowHeight;
             }
 
-            const auto& providerEmail = NetworkGetServerProviderEmail();
+            const auto& providerEmail = Network::GetServerProviderEmail();
             if (!providerEmail.empty())
             {
                 auto ft = Formatter();
@@ -719,7 +719,7 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += kListRowHeight;
             }
 
-            const auto& providerWebsite = NetworkGetServerProviderWebsite();
+            const auto& providerWebsite = Network::GetServerProviderWebsite();
             if (!providerWebsite.empty())
             {
                 auto ft = Formatter();
@@ -747,7 +747,7 @@ namespace OpenRCT2::Ui::Windows
         const int32_t firstPlayerInList = (IsServerPlayerInvisible() ? 1 : 0);
         int32_t listPosition = 0;
 
-        for (int32_t player = firstPlayerInList; player < NetworkGetNumPlayers(); player++)
+        for (int32_t player = firstPlayerInList; player < Network::GetNumPlayers(); player++)
         {
             if (screenCoords.y > rt.y + rt.height)
             {
@@ -767,12 +767,12 @@ namespace OpenRCT2::Ui::Windows
                     GfxFilterRect(
                         rt, { 0, screenCoords.y, 800, screenCoords.y + kScrollableRowHeight - 1 },
                         FilterPaletteID::PaletteDarken1);
-                    _buffer += NetworkGetPlayerName(player);
+                    _buffer += Network::GetPlayerName(player);
                     colour = colours[2];
                 }
                 else
                 {
-                    if (NetworkGetPlayerFlags(player) & NETWORK_PLAYER_FLAG_ISSERVER)
+                    if (Network::GetPlayerFlags(player) & Network::NETWORK_PLAYER_FLAG_ISSERVER)
                     {
                         _buffer += "{BABYBLUE}";
                     }
@@ -780,7 +780,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         _buffer += "{BLACK}";
                     }
-                    _buffer += NetworkGetPlayerName(player);
+                    _buffer += Network::GetPlayerName(player);
                 }
                 screenCoords.x = 0;
                 GfxClipString(_buffer.data(), 230, FontStyle::Medium);
@@ -788,22 +788,22 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw group name
                 _buffer.resize(0);
-                int32_t group = NetworkGetGroupIndex(NetworkGetPlayerGroup(player));
+                int32_t group = Network::GetGroupIndex(Network::GetPlayerGroup(player));
                 if (group != -1)
                 {
                     _buffer += "{BLACK}";
                     screenCoords.x = 173;
-                    _buffer += NetworkGetGroupName(group);
+                    _buffer += Network::GetGroupName(group);
                     GfxClipString(_buffer.data(), 80, FontStyle::Medium);
                     DrawText(rt, screenCoords, { colour }, _buffer.c_str());
                 }
 
                 // Draw last action
-                int32_t action = NetworkGetPlayerLastAction(player, 2000);
+                int32_t action = Network::GetPlayerLastAction(player, 2000);
                 auto ft = Formatter();
                 if (action != -999)
                 {
-                    ft.Add<StringId>(NetworkGetActionNameStringID(action));
+                    ft.Add<StringId>(Network::GetActionNameStringID(action));
                 }
                 else
                 {
@@ -813,7 +813,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw ping
                 _buffer.resize(0);
-                int32_t ping = NetworkGetPlayerPing(player);
+                int32_t ping = Network::GetPlayerPing(player);
                 if (ping <= 100)
                 {
                     _buffer += "{GREEN}";
@@ -844,11 +844,11 @@ namespace OpenRCT2::Ui::Windows
         thread_local std::string _buffer;
 
         Widget* widget = &widgets[WIDX_DEFAULT_GROUP];
-        int32_t group = NetworkGetGroupIndex(NetworkGetDefaultGroup());
+        int32_t group = Network::GetGroupIndex(Network::GetDefaultGroup());
         if (group != -1)
         {
             _buffer.assign("{WINDOW_COLOUR_2}");
-            _buffer += NetworkGetGroupName(group);
+            _buffer += Network::GetGroupName(group);
 
             auto ft = Formatter();
             ft.Add<const char*>(_buffer.c_str());
@@ -869,11 +869,11 @@ namespace OpenRCT2::Ui::Windows
             INSET_RECT_FLAG_BORDER_INSET);
 
         widget = &widgets[WIDX_SELECTED_GROUP];
-        group = NetworkGetGroupIndex(_selectedGroup);
+        group = Network::GetGroupIndex(_selectedGroup);
         if (group != -1)
         {
             _buffer.assign("{WINDOW_COLOUR_2}");
-            _buffer += NetworkGetGroupName(group);
+            _buffer += Network::GetGroupName(group);
             auto ft = Formatter();
             ft.Add<const char*>(_buffer.c_str());
             DrawTextEllipsised(
@@ -891,7 +891,7 @@ namespace OpenRCT2::Ui::Windows
             rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
             ColourMapA[colours[1].colour].mid_light);
 
-        for (int32_t i = 0; i < NetworkGetNumActions(); i++)
+        for (int32_t i = 0; i < Network::GetNumActions(); i++)
         {
             if (i == selected_list_item)
             {
@@ -905,10 +905,10 @@ namespace OpenRCT2::Ui::Windows
 
             if (screenCoords.y + kScrollableRowHeight + 1 >= rt.y)
             {
-                int32_t groupindex = NetworkGetGroupIndex(_selectedGroup);
+                int32_t groupindex = Network::GetGroupIndex(_selectedGroup);
                 if (groupindex != -1)
                 {
-                    if (NetworkCanPerformAction(groupindex, static_cast<NetworkPermission>(i)))
+                    if (Network::CanPerformAction(groupindex, static_cast<Network::Permission>(i)))
                     {
                         screenCoords.x = 0;
                         DrawText(rt, screenCoords, {}, u8"{WINDOW_COLOUR_2}✓");
@@ -917,7 +917,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw action name
                 auto ft = Formatter();
-                ft.Add<uint16_t>(NetworkGetActionNameStringID(i));
+                ft.Add<uint16_t>(Network::GetActionNameStringID(i));
                 DrawTextBasic(rt, { 10, screenCoords.y }, STR_WINDOW_COLOUR_2_STRINGID, ft);
             }
             screenCoords.y += kScrollableRowHeight;

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -772,7 +772,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    if (Network::GetPlayerFlags(player) & Network::NETWORK_PLAYER_FLAG_ISSERVER)
+                    if (Network::GetPlayerFlags(player) & Network::PlayerFlags::kIsServer)
                     {
                         _buffer += "{BABYBLUE}";
                     }

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -78,11 +78,11 @@ namespace OpenRCT2::Ui::Windows
             }
             if (text.empty())
             {
-                NetworkShutdownClient();
+                Network::ShutdownClient();
             }
             else
             {
-                NetworkSendPassword(_password);
+                Network::SendPassword(_password);
             }
         }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1885,7 +1885,7 @@ namespace OpenRCT2::Ui::Windows
                     Config::Get().general.AllowEarlyCompletion ^= 1;
                     // Only the server can control this setting and needs to send the
                     // current value of allow_early_completion to all clients
-                    if (NetworkGetMode() == NETWORK_MODE_SERVER)
+                    if (Network::GetMode() == Network::Mode::server)
                     {
                         auto setAllowEarlyCompletionAction = GameActions::ScenarioSetSettingAction(
                             GameActions::ScenarioSetSetting::AllowEarlyCompletion, Config::Get().general.AllowEarlyCompletion);
@@ -2011,7 +2011,7 @@ namespace OpenRCT2::Ui::Windows
 
             // The real name setting of clients is fixed to that of the server
             // and the server cannot change the setting during gameplay to prevent desyncs
-            if (NetworkGetMode() != NETWORK_MODE_NONE)
+            if (Network::GetMode() != Network::Mode::none)
             {
                 disabled_widgets |= (1uLL << WIDX_REAL_NAMES_GUESTS_CHECKBOX) | (1uLL << WIDX_REAL_NAMES_STAFF_CHECKBOX);
                 widgets[WIDX_REAL_NAMES_GUESTS_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
@@ -2020,7 +2020,7 @@ namespace OpenRCT2::Ui::Windows
                 // Disable the use of the allow_early_completion option during network play on clients.
                 // This is to prevent confusion on clients because changing this setting during network play wouldn't change
                 // the way scenarios are completed during this network-session
-                if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+                if (Network::GetMode() == Network::Mode::client)
                 {
                     disabled_widgets |= (1uLL << WIDX_ALLOW_EARLY_COMPLETION);
                     widgets[WIDX_ALLOW_EARLY_COMPLETION].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -409,7 +409,7 @@ namespace OpenRCT2::Ui::Windows
             // Only enable kick button for other players
             const bool canKick = Network::CanPerformAction(
                 Network::GetCurrentPlayerGroupIndex(), Network::Permission::KickPlayer);
-            const bool isServer = Network::GetPlayerFlags(playerIndex) & Network::NETWORK_PLAYER_FLAG_ISSERVER;
+            const bool isServer = Network::GetPlayerFlags(playerIndex) & Network::PlayerFlags::kIsServer;
             const bool isOwnWindow = (Network::GetCurrentPlayerId() == number);
             widgetSetEnabled(*this, WIDX_KICK, canKick && !isOwnWindow && !isServer);
         }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -280,7 +280,7 @@ namespace OpenRCT2::Ui::Windows
 
         void UpdateViewport(bool scroll)
         {
-            int32_t playerIndex = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+            int32_t playerIndex = Network::GetPlayerIndex(static_cast<uint8_t>(number));
             if (playerIndex == -1)
             {
                 return;
@@ -288,7 +288,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (viewport != nullptr)
             {
-                auto coord = NetworkGetPlayerLastActionCoord(playerIndex);
+                auto coord = Network::GetPlayerLastActionCoord(playerIndex);
                 if (coord.x != 0 || coord.y != 0 || coord.z != 0)
                 {
                     auto centreLoc = centre_2d_coordinates(coord, viewport);
@@ -327,10 +327,10 @@ namespace OpenRCT2::Ui::Windows
         void UpdateTitle()
         {
             auto ft = Formatter::Common();
-            int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+            int32_t player = Network::GetPlayerIndex(static_cast<uint8_t>(number));
             if (player != -1)
             {
-                ft.Add<const char*>(NetworkGetPlayerName(player)); // set title caption to player name
+                ft.Add<const char*>(Network::GetPlayerName(player)); // set title caption to player name
             }
             else
             {
@@ -350,7 +350,7 @@ namespace OpenRCT2::Ui::Windows
             frame_no++;
             InvalidateWidget(WIDX_TAB_1 + page);
 
-            if (NetworkGetPlayerIndex(static_cast<uint8_t>(number)) == -1)
+            if (Network::GetPlayerIndex(static_cast<uint8_t>(number)) == -1)
             {
                 Close();
                 return;
@@ -370,7 +370,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnPrepareDrawOverview()
         {
-            int32_t playerIndex = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+            int32_t playerIndex = Network::GetPlayerIndex(static_cast<uint8_t>(number));
             if (playerIndex == -1)
             {
                 return;
@@ -407,9 +407,10 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Only enable kick button for other players
-            const bool canKick = NetworkCanPerformAction(NetworkGetCurrentPlayerGroupIndex(), NetworkPermission::KickPlayer);
-            const bool isServer = NetworkGetPlayerFlags(playerIndex) & NETWORK_PLAYER_FLAG_ISSERVER;
-            const bool isOwnWindow = (NetworkGetCurrentPlayerId() == number);
+            const bool canKick = Network::CanPerformAction(
+                Network::GetCurrentPlayerGroupIndex(), Network::Permission::KickPlayer);
+            const bool isServer = Network::GetPlayerFlags(playerIndex) & Network::NETWORK_PLAYER_FLAG_ISSERVER;
+            const bool isOwnWindow = (Network::GetCurrentPlayerId() == number);
             widgetSetEnabled(*this, WIDX_KICK, canKick && !isOwnWindow && !isServer);
         }
 
@@ -418,21 +419,21 @@ namespace OpenRCT2::Ui::Windows
             DrawWidgets(rt);
             DrawTabImages(rt);
 
-            int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+            int32_t player = Network::GetPlayerIndex(static_cast<uint8_t>(number));
             if (player == -1)
             {
                 return;
             }
 
             // Draw current group
-            int32_t groupindex = NetworkGetGroupIndex(NetworkGetPlayerGroup(player));
+            int32_t groupindex = Network::GetGroupIndex(Network::GetPlayerGroup(player));
             if (groupindex != -1)
             {
                 Widget* widget = &widgets[WIDX_GROUP];
 
                 thread_local std::string _buffer;
                 _buffer.assign("{WINDOW_COLOUR_2}");
-                _buffer += NetworkGetGroupName(groupindex);
+                _buffer += Network::GetGroupName(groupindex);
                 auto ft = Formatter();
                 ft.Add<const char*>(_buffer.c_str());
 
@@ -448,17 +449,17 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<StringId>(STR_PING);
             DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
             char ping[64];
-            snprintf(ping, 64, "%d ms", NetworkGetPlayerPing(player));
+            snprintf(ping, 64, "%d ms", Network::GetPlayerPing(player));
             DrawText(rt, screenCoords + ScreenCoordsXY(30, 0), { colours[2] }, ping);
 
             // Draw last action
             screenCoords = windowPos + ScreenCoordsXY{ width / 2, height - 13 };
             int32_t updatedWidth = this->width - 8;
-            int32_t lastaction = NetworkGetPlayerLastAction(player, 0);
+            int32_t lastaction = Network::GetPlayerLastAction(player, 0);
             ft = Formatter();
             if (lastaction != -999)
             {
-                ft.Add<StringId>(NetworkGetActionNameStringID(lastaction));
+                ft.Add<StringId>(Network::GetActionNameStringID(lastaction));
             }
             else
             {
@@ -492,12 +493,12 @@ namespace OpenRCT2::Ui::Windows
                     WindowBase* mainWindow = WindowGetMain();
                     if (mainWindow != nullptr)
                     {
-                        int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+                        int32_t player = Network::GetPlayerIndex(static_cast<uint8_t>(number));
                         if (player == -1)
                         {
                             return;
                         }
-                        auto coord = NetworkGetPlayerLastActionCoord(player);
+                        auto coord = Network::GetPlayerLastActionCoord(player);
                         if (coord.x || coord.y || coord.z)
                         {
                             WindowScrollToLocation(*mainWindow, coord);
@@ -517,7 +518,7 @@ namespace OpenRCT2::Ui::Windows
         void OnDropdownOverview(WidgetIndex widgetIndex, int32_t dropdownIndex)
         {
             const auto playerId = static_cast<uint8_t>(number);
-            const auto playerIdx = NetworkGetPlayerIndex(playerId);
+            const auto playerIdx = Network::GetPlayerIndex(playerId);
             if (playerIdx == -1)
             {
                 return;
@@ -526,7 +527,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 return;
             }
-            const auto groupId = NetworkGetGroupID(dropdownIndex);
+            const auto groupId = Network::GetGroupID(dropdownIndex);
             const auto windowHandle = std::make_pair(classification, number);
             auto playerSetGroupAction = GameActions::PlayerSetGroupAction(playerId, groupId);
             playerSetGroupAction.SetCallback(
@@ -544,7 +545,7 @@ namespace OpenRCT2::Ui::Windows
         {
             Widget* dropdownWidget;
             int32_t numItems, i;
-            int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+            int32_t player = Network::GetPlayerIndex(static_cast<uint8_t>(number));
             if (player == -1)
             {
                 return;
@@ -552,18 +553,18 @@ namespace OpenRCT2::Ui::Windows
 
             dropdownWidget = widget - 1;
 
-            numItems = NetworkGetNumGroups();
+            numItems = Network::GetNumGroups();
 
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
                 colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
 
-            for (i = 0; i < NetworkGetNumGroups(); i++)
+            for (i = 0; i < Network::GetNumGroups(); i++)
             {
-                gDropdown.items[i] = Dropdown::MenuLabel(NetworkGetGroupName(i));
+                gDropdown.items[i] = Dropdown::MenuLabel(Network::GetGroupName(i));
             }
 
-            gDropdown.items[NetworkGetGroupIndex(NetworkGetPlayerGroup(player))].setChecked(true);
+            gDropdown.items[Network::GetGroupIndex(Network::GetPlayerGroup(player))].setChecked(true);
         }
 
 #pragma endregion
@@ -580,7 +581,7 @@ namespace OpenRCT2::Ui::Windows
             frame_no++;
             InvalidateWidget(WIDX_TAB_1 + page);
 
-            if (NetworkGetPlayerIndex(static_cast<uint8_t>(number)) == -1)
+            if (Network::GetPlayerIndex(static_cast<uint8_t>(number)) == -1)
             {
                 Close();
             }
@@ -602,7 +603,7 @@ namespace OpenRCT2::Ui::Windows
             DrawWidgets(rt);
             DrawTabImages(rt);
 
-            int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
+            int32_t player = Network::GetPlayerIndex(static_cast<uint8_t>(number));
             if (player == -1)
             {
                 return;
@@ -612,13 +613,13 @@ namespace OpenRCT2::Ui::Windows
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
             auto ft = Formatter();
-            ft.Add<uint32_t>(NetworkGetPlayerCommandsRan(player));
+            ft.Add<uint32_t>(Network::GetPlayerCommandsRan(player));
             DrawTextBasic(rt, screenCoords, STR_COMMANDS_RAN, ft);
 
             screenCoords.y += kListRowHeight;
 
             ft = Formatter();
-            ft.Add<uint32_t>(NetworkGetPlayerMoneySpent(player));
+            ft.Add<uint32_t>(Network::GetPlayerMoneySpent(player));
             DrawTextBasic(rt, screenCoords, STR_MONEY_SPENT, ft);
         }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4003,7 +4003,7 @@ namespace OpenRCT2::Ui::Windows
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
 
-            if (Config::Get().general.DebuggingTools && NetworkGetMode() == NETWORK_MODE_NONE)
+            if (Config::Get().general.DebuggingTools && Network::GetMode() == Network::Mode::none)
             {
                 widgets[WIDX_FORCE_BREAKDOWN].type = WidgetType::flatBtn;
             }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2352,7 +2352,7 @@ namespace OpenRCT2::Ui::Windows
             }
             OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::PlaceItem, trackPos);
 
-            if (NetworkGetMode() != NETWORK_MODE_NONE)
+            if (Network::GetMode() != Network::Mode::none)
             {
                 _currentTrackSelectionFlags.set(TrackSelectionFlag::trackPlaceActionQueued);
             }
@@ -4723,7 +4723,7 @@ namespace OpenRCT2::Ui::Windows
                     type = TrackElemType::BeginStation;
                 }
             }
-            if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+            if (Network::GetMode() == Network::Mode::client)
             {
                 // rideConstructionState needs to be set again to the proper value, this only affects the client
                 _rideConstructionState = RideConstructionState::Selected;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -279,7 +279,7 @@ namespace OpenRCT2::Ui::Windows
                     OpenAllRides();
                     break;
                 case WIDX_QUICK_DEMOLISH:
-                    if (NetworkGetMode() != NETWORK_MODE_CLIENT)
+                    if (Network::GetMode() != Network::Mode::client)
                     {
                         _quickDemolishMode = !_quickDemolishMode;
                     }
@@ -470,7 +470,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Open ride window
             const auto selectedRideId = _rideList[index].Id;
-            if (_quickDemolishMode && NetworkGetMode() != NETWORK_MODE_CLIENT)
+            if (_quickDemolishMode && Network::GetMode() != Network::Mode::client)
             {
                 auto gameAction = GameActions::RideDemolishAction(selectedRideId, GameActions::RideModifyType::demolish);
                 GameActions::Execute(&gameAction);
@@ -582,8 +582,8 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_QUICK_DEMOLISH].top = widgets[WIDX_OPEN_CLOSE_ALL].bottom + 3;
             }
             widgets[WIDX_QUICK_DEMOLISH].bottom = widgets[WIDX_QUICK_DEMOLISH].top + 23;
-            widgets[WIDX_QUICK_DEMOLISH].type = NetworkGetMode() != NETWORK_MODE_CLIENT ? WidgetType::flatBtn
-                                                                                        : WidgetType::empty;
+            widgets[WIDX_QUICK_DEMOLISH].type = Network::GetMode() != Network::Mode::client ? WidgetType::flatBtn
+                                                                                            : WidgetType::empty;
         }
 
         /**

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -102,7 +102,7 @@ namespace OpenRCT2::Ui::Windows
             InitScrollWidgets();
 
             // Pause the game if not network play.
-            if (NetworkGetMode() == NETWORK_MODE_NONE)
+            if (Network::GetMode() == Network::Mode::none)
             {
                 gGamePaused |= GAME_PAUSED_MODAL;
                 Audio::StopAll();
@@ -130,7 +130,7 @@ namespace OpenRCT2::Ui::Windows
         void OnClose() override
         {
             // Unpause the game
-            if (NetworkGetMode() == NETWORK_MODE_NONE)
+            if (Network::GetMode() == Network::Mode::none)
             {
                 gGamePaused &= ~GAME_PAUSED_MODAL;
                 Audio::Resume();
@@ -219,7 +219,7 @@ namespace OpenRCT2::Ui::Windows
              * and game_load_or_quit() are not called by the original binary anymore.
              */
 
-            if (gScreenAge < 3840 && NetworkGetMode() == NETWORK_MODE_NONE)
+            if (gScreenAge < 3840 && Network::GetMode() == Network::Mode::none)
             {
                 GameLoadOrQuitNoSavePrompt();
                 return nullptr;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -303,8 +303,8 @@ namespace OpenRCT2::Ui::Windows
                     if (gWindowSceneryScatterEnabled)
                         windowMgr->CloseByClass(WindowClass::SceneryScatter);
                     else if (
-                        NetworkGetMode() != NETWORK_MODE_CLIENT
-                        || NetworkCanPerformCommand(NetworkGetCurrentPlayerGroupIndex(), -2))
+                        Network::GetMode() != Network::Mode::client
+                        || Network::CanPerformCommand(Network::GetCurrentPlayerGroupIndex(), -2))
                     {
                         SceneryScatterOpen();
                     }
@@ -2970,8 +2970,8 @@ namespace OpenRCT2::Ui::Windows
 
                     int32_t quantity = 1;
                     bool isCluster = gWindowSceneryScatterEnabled
-                        && (NetworkGetMode() != NETWORK_MODE_CLIENT
-                            || NetworkCanPerformCommand(NetworkGetCurrentPlayerGroupIndex(), -2));
+                        && (Network::GetMode() != Network::Mode::client
+                            || Network::CanPerformCommand(Network::GetCurrentPlayerGroupIndex(), -2));
 
                     if (isCluster)
                     {

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -547,7 +547,7 @@ namespace OpenRCT2::Ui::Windows
 
     void JoinServer(std::string address)
     {
-        int32_t port = Network::kNetworkDefaultPort;
+        int32_t port = Network::kDefaultPort;
         auto endBracketIndex = address.find(']');
         auto colonIndex = address.find_last_of(':');
         if (colonIndex != std::string::npos)

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -78,8 +78,8 @@ namespace OpenRCT2::Ui::Windows
     {
     private:
         u8string _playerName;
-        ServerList _serverList;
-        std::future<std::tuple<std::vector<ServerListEntry>, StringId>> _fetchFuture;
+        Network::ServerList _serverList;
+        std::future<std::pair<std::vector<Network::ServerListEntry>, StringId>> _fetchFuture;
         uint32_t _numPlayersOnline = 0;
         StringId _statusText = STR_SERVER_LIST_CONNECTING;
 
@@ -283,7 +283,7 @@ namespace OpenRCT2::Ui::Windows
 
                 case WIDX_ADD_SERVER:
                 {
-                    ServerListEntry entry;
+                    Network::ServerListEntry entry;
                     entry.Address = text;
                     entry.Name = text;
                     entry.Favourite = true;
@@ -311,7 +311,7 @@ namespace OpenRCT2::Ui::Windows
                 { COLOUR_WHITE });
 
             // Draw version number
-            std::string version = NetworkGetVersion();
+            std::string version = Network::GetVersion();
             auto ft = Formatter();
             ft.Add<const char*>(version.c_str());
             DrawTextBasic(
@@ -399,7 +399,7 @@ namespace OpenRCT2::Ui::Windows
                 else
                 {
                     // Server online... check version
-                    bool correctVersion = serverDetails.Version == NetworkGetVersion();
+                    bool correctVersion = serverDetails.Version == Network::GetVersion();
                     compatibilitySpriteId = correctVersion ? SPR_G2_RCT1_OPEN_BUTTON_2 : SPR_G2_RCT1_CLOSE_BUTTON_2;
                 }
                 GfxDrawSprite(rt, ImageId(compatibilitySpriteId), { right, screenCoords.y + 1 });
@@ -442,7 +442,7 @@ namespace OpenRCT2::Ui::Windows
                 auto wanF = _serverList.FetchOnlineServerListAsync();
 
                 // Merge or deal with errors
-                std::vector<ServerListEntry> allEntries;
+                std::vector<Network::ServerListEntry> allEntries;
                 try
                 {
                     auto entries = lanF.get();
@@ -461,7 +461,7 @@ namespace OpenRCT2::Ui::Windows
                     allEntries.reserve(allEntries.capacity() + entries.size());
                     allEntries.insert(allEntries.end(), entries.begin(), entries.end());
                 }
-                catch (const MasterServerException& e)
+                catch (const Network::MasterServerException& e)
                 {
                     status = e.StatusText;
                 }
@@ -470,7 +470,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     status = STR_SERVER_LIST_NO_CONNECTION;
                 }
-                return std::make_tuple(allEntries, status);
+                return std::make_pair(allEntries, status);
             });
         }
 
@@ -493,7 +493,7 @@ namespace OpenRCT2::Ui::Windows
                             _statusText = statusText;
                         }
                     }
-                    catch (const MasterServerException& e)
+                    catch (const Network::MasterServerException& e)
                     {
                         _statusText = e.StatusText;
                     }
@@ -547,7 +547,7 @@ namespace OpenRCT2::Ui::Windows
 
     void JoinServer(std::string address)
     {
-        int32_t port = kNetworkDefaultPort;
+        int32_t port = Network::kNetworkDefaultPort;
         auto endBracketIndex = address.find(']');
         auto colonIndex = address.find_last_of(':');
         if (colonIndex != std::string::npos)
@@ -569,7 +569,7 @@ namespace OpenRCT2::Ui::Windows
             address = address.substr(beginBracketIndex + 1, endBracketIndex - beginBracketIndex - 1);
         }
 
-        if (!NetworkBeginClient(address, port))
+        if (!Network::BeginClient(address, port))
         {
             ContextShowError(STR_UNABLE_TO_CONNECT_TO_SERVER, kStringIdNone, {});
         }

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::Ui::Windows
                     WindowStartTextbox(*this, widgetIndex, _name, 64);
                     break;
                 case WIDX_DESCRIPTION_INPUT:
-                    WindowStartTextbox(*this, widgetIndex, _description, kMaxServerDescriptionLength);
+                    WindowStartTextbox(*this, widgetIndex, _description, Network::kMaxServerDescriptionLength);
                     break;
                 case WIDX_GREETING_INPUT:
                     WindowStartTextbox(*this, widgetIndex, _greeting, kChatInputSize);
@@ -127,11 +127,11 @@ namespace OpenRCT2::Ui::Windows
                     Invalidate();
                     break;
                 case WIDX_START_SERVER:
-                    NetworkSetPassword(_password);
+                    Network::SetPassword(_password);
                     ScenarioselectOpen(ScenarioSelectCallback);
                     break;
                 case WIDX_LOAD_SERVER:
-                    NetworkSetPassword(_password);
+                    Network::SetPassword(_password);
                     auto intent = Intent(WindowClass::Loadsave);
                     intent.PutEnumExtra<LoadSaveAction>(INTENT_EXTRA_LOADSAVE_ACTION, LoadSaveAction::load);
                     intent.PutEnumExtra<LoadSaveType>(INTENT_EXTRA_LOADSAVE_TYPE, LoadSaveType::park);
@@ -249,7 +249,7 @@ namespace OpenRCT2::Ui::Windows
     private:
         char _port[7];
         char _name[65];
-        char _description[kMaxServerDescriptionLength];
+        char _description[Network::kMaxServerDescriptionLength];
         char _greeting[kChatInputSize];
         char _password[33];
         static void ScenarioSelectCallback(const utf8* path)
@@ -257,7 +257,7 @@ namespace OpenRCT2::Ui::Windows
             GameNotifyMapChange();
             if (GetContext()->LoadParkFromFile(path, false, true))
             {
-                NetworkBeginServer(Config::Get().network.DefaultPort, Config::Get().network.ListenAddress);
+                Network::BeginServer(Config::Get().network.DefaultPort, Config::Get().network.ListenAddress);
             }
         }
 
@@ -267,7 +267,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 GameNotifyMapChange();
                 GetContext()->LoadParkFromFile(path);
-                NetworkBeginServer(Config::Get().network.DefaultPort, Config::Get().network.ListenAddress);
+                Network::BeginServer(Config::Get().network.DefaultPort, Config::Get().network.ListenAddress);
             }
         }
     };

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -384,7 +384,7 @@ namespace OpenRCT2::Ui::Windows
                     nullLoc.SetNull();
                     GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Pickup,
                                                                 EntityId::FromUnderlying(number), nullLoc,
-                                                                NetworkGetCurrentPlayerId() };
+                                                                Network::GetCurrentPlayerId() };
                     pickupAction.SetCallback(
                         [peepnum = number](const GameActions::GameAction* ga, const GameActions::Result* result) {
                             if (result->Error != GameActions::Status::Ok)
@@ -712,7 +712,7 @@ namespace OpenRCT2::Ui::Windows
             GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Place,
                                                         staffEntityId,
                                                         { destCoords, tileElement->GetBaseZ() },
-                                                        NetworkGetCurrentPlayerId() };
+                                                        Network::GetCurrentPlayerId() };
             pickupAction.SetCallback([](const GameActions::GameAction* ga, const GameActions::Result* result) {
                 if (result->Error != GameActions::Status::Ok)
                     return;
@@ -730,7 +730,7 @@ namespace OpenRCT2::Ui::Windows
             GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Cancel,
                                                         EntityId::FromUnderlying(number),
                                                         { _pickedPeepOldX, 0, 0 },
-                                                        NetworkGetCurrentPlayerId() };
+                                                        Network::GetCurrentPlayerId() };
             GameActions::Execute(&pickupAction);
         }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -554,7 +554,7 @@ namespace OpenRCT2::Ui::Windows
                     nullLoc.SetNull();
 
                     GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Pickup, staff->Id, nullLoc,
-                                                                NetworkGetCurrentPlayerId() };
+                                                                Network::GetCurrentPlayerId() };
                     pickupAction.SetCallback(
                         [staffId = staff->Id](const GameActions::GameAction* ga, const GameActions::Result* result) {
                             if (result->Error != GameActions::Status::Ok)

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -306,7 +306,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_PAUSE:
-                    if (NetworkGetMode() != NETWORK_MODE_CLIENT)
+                    if (Network::GetMode() != Network::Mode::client)
                     {
                         auto pauseToggleAction = GameActions::PauseToggleAction();
                         GameActions::Execute(&pauseToggleAction);
@@ -699,16 +699,16 @@ namespace OpenRCT2::Ui::Windows
 
         void ApplyNetworkMode()
         {
-            switch (NetworkGetMode())
+            switch (Network::GetMode())
             {
-                case NETWORK_MODE_NONE:
+                case Network::Mode::none:
                     widgets[WIDX_NETWORK].type = WidgetType::empty;
                     widgets[WIDX_CHAT].type = WidgetType::empty;
                     break;
-                case NETWORK_MODE_CLIENT:
+                case Network::Mode::client:
                     widgets[WIDX_PAUSE].type = WidgetType::empty;
                     [[fallthrough]];
-                case NETWORK_MODE_SERVER:
+                case Network::Mode::server:
                     widgets[WIDX_FASTFORWARD].type = WidgetType::empty;
                     break;
             }
@@ -983,12 +983,12 @@ namespace OpenRCT2::Ui::Windows
                     screenPos.y++;
 
                 // Draw (de)sync icon.
-                imgId = (NetworkIsDesynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
+                imgId = (Network::IsDesynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
                 GfxDrawSprite(rt, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
 
                 // Draw number of players.
                 auto ft = Formatter();
-                ft.Add<int32_t>(NetworkGetNumVisiblePlayers());
+                ft.Add<int32_t>(Network::GetNumVisiblePlayers());
                 auto colour = ColourWithFlags{ COLOUR_WHITE }.withFlag(ColourFlag::withOutline, true);
                 DrawTextBasic(rt, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, { colour, TextAlignment::RIGHT });
             }
@@ -1395,7 +1395,7 @@ namespace OpenRCT2::Ui::Windows
             colours[0].withFlag(ColourFlag::translucent, true), Dropdown::Flag::StayOpen, TOP_TOOLBAR_CHEATS_COUNT);
 
         // Disable items that are not yet available in multiplayer
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             gDropdown.items[DDIDX_OBJECT_SELECTION].setDisabled(true);
             gDropdown.items[DDIDX_INVENTIONS_LIST].setDisabled(true);
@@ -1514,7 +1514,7 @@ namespace OpenRCT2::Ui::Windows
             { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height() + 1,
             colours[0].withFlag(ColourFlag::translucent, true), 0, TOP_TOOLBAR_NETWORK_COUNT);
 
-        gDropdown.items[DDIDX_MULTIPLAYER_RECONNECT].setDisabled(!NetworkIsDesynchronised());
+        gDropdown.items[DDIDX_MULTIPLAYER_RECONNECT].setDisabled(!Network::IsDesynchronised());
 
         gDropdown.defaultIndex = DDIDX_MULTIPLAYER;
     }
@@ -1530,7 +1530,7 @@ namespace OpenRCT2::Ui::Windows
                     ContextOpenWindow(WindowClass::Multiplayer);
                     break;
                 case DDIDX_MULTIPLAYER_RECONNECT:
-                    NetworkReconnect();
+                    Network::Reconnect();
                     break;
             }
         }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -117,14 +117,14 @@ namespace OpenRCT2
         std::unique_ptr<IGameStateSnapshots> _gameStateSnapshots;
         std::unique_ptr<AssetPackManager> _assetPackManager;
 #ifdef __ENABLE_DISCORD__
-        std::unique_ptr<DiscordService> _discordService;
+        std::unique_ptr<Network::DiscordService> _discordService;
 #endif
         StdInOutConsole _stdInOutConsole;
 #ifdef ENABLE_SCRIPTING
         ScriptEngine _scriptEngine;
 #endif
 #ifndef DISABLE_NETWORK
-        NetworkBase _network;
+        Network::NetworkBase _network;
 #endif
 
         // Scenes
@@ -303,7 +303,7 @@ namespace OpenRCT2
         }
 
 #ifndef DISABLE_NETWORK
-        NetworkBase& GetNetwork() override
+        Network::NetworkBase& GetNetwork() override
         {
             return _network;
         }
@@ -476,7 +476,7 @@ namespace OpenRCT2
 #ifdef __ENABLE_DISCORD__
             if (!gOpenRCT2Headless)
             {
-                _discordService = std::make_unique<DiscordService>();
+                _discordService = std::make_unique<Network::DiscordService>();
             }
 #endif
 
@@ -842,14 +842,14 @@ namespace OpenRCT2
                 if (!asScenario && (info.Type == FileType::park || info.Type == FileType::savedGame))
                 {
 #ifndef DISABLE_NETWORK
-                    if (_network.GetMode() == NETWORK_MODE_CLIENT)
+                    if (_network.GetMode() == Network::Mode::client)
                     {
                         _network.Close();
                     }
 #endif
                     GameLoadInit();
 #ifndef DISABLE_NETWORK
-                    if (_network.GetMode() == NETWORK_MODE_SERVER)
+                    if (_network.GetMode() == Network::Mode::server)
                     {
                         sendMap = true;
                     }
@@ -859,11 +859,11 @@ namespace OpenRCT2
                 {
                     ScenarioBegin(gameState);
 #ifndef DISABLE_NETWORK
-                    if (_network.GetMode() == NETWORK_MODE_SERVER)
+                    if (_network.GetMode() == Network::Mode::server)
                     {
                         sendMap = true;
                     }
-                    if (_network.GetMode() == NETWORK_MODE_CLIENT)
+                    if (_network.GetMode() == Network::Mode::client)
                     {
                         _network.Close();
                     }
@@ -880,7 +880,7 @@ namespace OpenRCT2
 #endif
 
 #ifdef USE_BREAKPAD
-                if (_network.GetMode() == NETWORK_MODE_NONE)
+                if (_network.GetMode() == Network::Mode::none)
                 {
                     StartSilentRecord();
                 }
@@ -1155,7 +1155,7 @@ namespace OpenRCT2
             if (isGameScene)
             {
 #ifndef DISABLE_NETWORK
-                if (gNetworkStart == NETWORK_MODE_SERVER)
+                if (gNetworkStart == Network::Mode::server)
                 {
                     if (gNetworkStartPort == 0)
                     {
@@ -1186,7 +1186,7 @@ namespace OpenRCT2
             }
 
 #ifndef DISABLE_NETWORK
-            else if (gNetworkStart == NETWORK_MODE_CLIENT)
+            else if (gNetworkStart == Network::Mode::client)
             {
                 if (gNetworkStartPort == 0)
                 {

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -77,8 +77,6 @@ enum
     CURSOR_PRESSED = CURSOR_DOWN | CURSOR_CHANGED,
 };
 
-class NetworkBase;
-
 namespace OpenRCT2
 {
     class AssetPackManager;
@@ -100,6 +98,11 @@ namespace OpenRCT2
     namespace Localisation
     {
         class LocalisationService;
+    }
+
+    namespace Network
+    {
+        class NetworkBase;
     }
 
     namespace Scripting
@@ -142,7 +145,7 @@ namespace OpenRCT2
         virtual Drawing::IDrawingEngine* GetDrawingEngine() = 0;
         virtual Paint::Painter* GetPainter() = 0;
 #ifndef DISABLE_NETWORK
-        virtual NetworkBase& GetNetwork() = 0;
+        virtual Network::NetworkBase& GetNetwork() = 0;
 #endif
 
         virtual IScene* GetPreloaderScene() = 0;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -370,7 +370,7 @@ void GameLoadInit()
     auto& gameState = getGameState();
     windowManager->SetMainView(gameState.savedView, gameState.savedViewZoom, gameState.savedViewRotation);
 
-    if (NetworkGetMode() != NETWORK_MODE_CLIENT)
+    if (Network::GetMode() != Network::Mode::client)
     {
         GameActions::ClearQueue();
     }

--- a/src/openrct2/OpenRCT2.h
+++ b/src/openrct2/OpenRCT2.h
@@ -51,7 +51,12 @@ extern u8string gSilentRecordingName;
 extern bool gSilentReplays;
 
 #ifndef DISABLE_NETWORK
-extern int32_t gNetworkStart;
+namespace OpenRCT2::Network
+{
+    enum class Mode : int32_t;
+}
+
+extern OpenRCT2::Network::Mode gNetworkStart;
 extern std::string gNetworkStartHost;
 extern int32_t gNetworkStartPort;
 extern std::string gNetworkStartAddress;

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -249,7 +249,7 @@ namespace OpenRCT2
             auto replayData = std::make_unique<ReplayRecordData>();
             replayData->magic = kReplayMagic;
             replayData->version = kReplayVersion;
-            replayData->networkId = NetworkGetVersion();
+            replayData->networkId = Network::GetVersion();
             replayData->name = name;
             replayData->tickStart = currentTicks;
             if (maxTicks != k_MaxReplayTicks)
@@ -715,11 +715,11 @@ namespace OpenRCT2
             serialiser << data.networkId;
 #ifndef DISABLE_NETWORK
             // NOTE: This does not mean the replay will not function, only a warning.
-            if (data.networkId != NetworkGetVersion())
+            if (data.networkId != Network::GetVersion())
             {
                 LOG_WARNING(
                     "Replay network version mismatch: '%s', expected: '%s'", data.networkId.c_str(),
-                    NetworkGetVersion().c_str());
+                    Network::GetVersion().c_str());
             }
 #endif
 

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -279,7 +279,7 @@ namespace OpenRCT2::GameActions
             }
         }
 
-        if (NetworkGetMode() == NETWORK_MODE_NONE)
+        if (Network::GetMode() == Network::Mode::none)
         {
             Config::Save();
         }

--- a/src/openrct2/actions/CheatSetAction.h
+++ b/src/openrct2/actions/CheatSetAction.h
@@ -18,7 +18,7 @@ namespace OpenRCT2::GameActions
         using ParametersRange = std::pair<std::pair<int64_t, int64_t>, std::pair<int64_t, int64_t>>;
 
     private:
-        NetworkCheatType_t _cheatType{ EnumValue(CheatType::Count) };
+        Network::CheatType_t _cheatType{ EnumValue(CheatType::Count) };
         int64_t _param1{};
         int64_t _param2{};
 

--- a/src/openrct2/actions/GameAction.cpp
+++ b/src/openrct2/actions/GameAction.cpp
@@ -82,11 +82,11 @@ namespace OpenRCT2::GameActions
 
     void Enqueue(GameAction::Ptr&& ga, uint32_t tick)
     {
-        if (ga->GetPlayer() == -1 && NetworkGetMode() != NETWORK_MODE_NONE)
+        if (ga->GetPlayer() == -1 && Network::GetMode() != Network::Mode::none)
         {
             // Server can directly invoke actions and will have no player id assigned
             // as that normally happens when receiving them over network.
-            ga->SetPlayer(NetworkGetCurrentPlayerId());
+            ga->SetPlayer(Network::GetCurrentPlayerId());
         }
         _actionQueue.emplace(tick, std::move(ga), _nextUniqueId++);
     }
@@ -106,7 +106,7 @@ namespace OpenRCT2::GameActions
             // run all the game commands at the current tick
             const QueuedGameAction& queued = *_actionQueue.begin();
 
-            if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+            if (Network::GetMode() == Network::Mode::client)
             {
                 if (queued.tick < currentTick)
                 {
@@ -143,10 +143,10 @@ namespace OpenRCT2::GameActions
             Guard::Assert(action != nullptr);
 
             Result result = Execute(action);
-            if (result.Error == Status::Ok && NetworkGetMode() == NETWORK_MODE_SERVER)
+            if (result.Error == Status::Ok && Network::GetMode() == Network::Mode::server)
             {
                 // Relay this action to all other clients.
-                NetworkSendGameAction(action);
+                Network::SendGameAction(action);
             }
 
             _actionQueue.erase(_actionQueue.begin());
@@ -231,9 +231,9 @@ namespace OpenRCT2::GameActions
 
     static const char* GetRealm()
     {
-        if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+        if (Network::GetMode() == Network::Mode::client)
             return "cl";
-        if (NetworkGetMode() == NETWORK_MODE_SERVER)
+        if (Network::GetMode() == Network::Mode::server)
             return "sv";
         return "sp";
     }
@@ -280,7 +280,7 @@ namespace OpenRCT2::GameActions
         const char* text = static_cast<const char*>(output.GetData());
         LOG_VERBOSE("%s", text);
 
-        NetworkAppendServerLog(text);
+        Network::AppendServerLog(text);
     }
 
     static Result ExecuteInternal(const GameAction* action, bool topLevel)
@@ -311,7 +311,8 @@ namespace OpenRCT2::GameActions
 
         Result result = QueryInternal(action, topLevel);
 #ifdef ENABLE_SCRIPTING
-        if (result.Error == Status::Ok && ((NetworkGetMode() == NETWORK_MODE_NONE) || (flags & GAME_COMMAND_FLAG_NETWORKED)))
+        if (result.Error == Status::Ok
+            && ((Network::GetMode() == Network::Mode::none) || (flags & GAME_COMMAND_FLAG_NETWORKED)))
         {
             auto& scriptEngine = GetContext()->GetScriptEngine();
             scriptEngine.RunGameActionHooks(*action, result, false);
@@ -323,18 +324,18 @@ namespace OpenRCT2::GameActions
             if (topLevel)
             {
                 // Networked games send actions to the server to be run
-                if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+                if (Network::GetMode() == Network::Mode::client)
                 {
                     // As a client we have to wait or send it first.
                     if (!(actionFlags & Flags::ClientOnly) && !(flags & GAME_COMMAND_FLAG_NETWORKED))
                     {
                         LOG_VERBOSE("[%s] GameAction::Execute %s (Out)", GetRealm(), action->GetName());
-                        NetworkSendGameAction(action);
+                        Network::SendGameAction(action);
 
                         return result;
                     }
                 }
-                else if (NetworkGetMode() == NETWORK_MODE_SERVER || !gInUpdateCode)
+                else if (Network::GetMode() == Network::Mode::server || !gInUpdateCode)
                 {
                     // If player is the server it would execute right away as where clients execute the commands
                     // at the beginning of the frame, so we have to put them into the queue.
@@ -378,24 +379,24 @@ namespace OpenRCT2::GameActions
 
             if (!(actionFlags & Flags::ClientOnly) && result.Error == Status::Ok)
             {
-                if (NetworkGetMode() != NETWORK_MODE_NONE)
+                if (Network::GetMode() != Network::Mode::none)
                 {
-                    NetworkPlayerId_t playerId = action->GetPlayer();
+                    Network::PlayerId_t playerId = action->GetPlayer();
 
-                    int32_t playerIndex = NetworkGetPlayerIndex(playerId.id);
+                    int32_t playerIndex = Network::GetPlayerIndex(playerId.id);
                     Guard::Assert(
                         playerIndex != -1, "Unable to find player %u for game action %u", playerId, action->GetType());
 
-                    NetworkSetPlayerLastAction(playerIndex, action->GetType());
-                    NetworkIncrementPlayerNumCommands(playerIndex);
+                    Network::SetPlayerLastAction(playerIndex, action->GetType());
+                    Network::IncrementPlayerNumCommands(playerIndex);
                     if (result.Cost > 0)
                     {
-                        NetworkAddPlayerMoneySpent(playerIndex, result.Cost);
+                        Network::AddPlayerMoneySpent(playerIndex, result.Cost);
                     }
 
                     if (!result.Position.IsNull())
                     {
-                        NetworkSetPlayerLastActionCoord(playerIndex, result.Position);
+                        Network::SetPlayerLastActionCoord(playerIndex, result.Position);
                     }
                 }
                 else
@@ -435,12 +436,12 @@ namespace OpenRCT2::GameActions
         bool shouldShowError = !(flags & GAME_COMMAND_FLAG_GHOST) && !(flags & GAME_COMMAND_FLAG_NO_SPEND) && topLevel;
 
         // In network mode the error should be only shown to the issuer of the action.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             // If the action was never networked and query fails locally the player id is not assigned.
             // So compare only if the action went into the queue otherwise show errors by default.
             const bool isActionFromNetwork = (action->GetFlags() & GAME_COMMAND_FLAG_NETWORKED) != 0;
-            if (isActionFromNetwork && action->GetPlayer() != NetworkGetCurrentPlayerId())
+            if (isActionFromNetwork && action->GetPlayer() != Network::GetCurrentPlayerId())
             {
                 shouldShowError = false;
             }

--- a/src/openrct2/actions/GameAction.h
+++ b/src/openrct2/actions/GameAction.h
@@ -98,7 +98,7 @@ namespace OpenRCT2::GameActions
         }
 
         template<typename T, size_t _TypeID>
-        void Visit(std::string_view name, NetworkObjectId<T, _TypeID>& param)
+        void Visit(std::string_view name, Network::NetworkObjectId<T, _TypeID>& param)
         {
             Visit(name, param.id);
         }
@@ -113,8 +113,8 @@ namespace OpenRCT2::GameActions
     private:
         GameCommand const _type;
 
-        NetworkPlayerId_t _playerId = { -1 }; // Callee
-        uint32_t _flags = 0;                  // GAME_COMMAND_FLAGS
+        Network::PlayerId_t _playerId = { -1 }; // Callee
+        uint32_t _flags = 0;                    // GAME_COMMAND_FLAGS
         uint32_t _networkId = 0;
         Callback_t _callback;
 
@@ -137,12 +137,12 @@ namespace OpenRCT2::GameActions
             visitor.Visit("flags", _flags);
         }
 
-        NetworkPlayerId_t GetPlayer() const
+        Network::PlayerId_t GetPlayer() const
         {
             return _playerId;
         }
 
-        void SetPlayer(NetworkPlayerId_t playerId)
+        void SetPlayer(Network::PlayerId_t playerId)
         {
             _playerId = playerId;
         }

--- a/src/openrct2/actions/NetworkModifyGroupAction.cpp
+++ b/src/openrct2/actions/NetworkModifyGroupAction.cpp
@@ -47,11 +47,11 @@ namespace OpenRCT2::GameActions
 
     Result NetworkModifyGroupAction::Query() const
     {
-        return NetworkModifyGroups(GetPlayer(), _type, _groupId, _name, _permissionIndex, _permissionState, false);
+        return Network::ModifyGroups(GetPlayer(), _type, _groupId, _name, _permissionIndex, _permissionState, false);
     }
 
     Result NetworkModifyGroupAction::Execute() const
     {
-        return NetworkModifyGroups(GetPlayer(), _type, _groupId, _name, _permissionIndex, _permissionState, true);
+        return Network::ModifyGroups(GetPlayer(), _type, _groupId, _name, _permissionIndex, _permissionState, true);
     }
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/PeepPickupAction.h
+++ b/src/openrct2/actions/PeepPickupAction.h
@@ -28,11 +28,11 @@ namespace OpenRCT2::GameActions
         PeepPickupType _type{ PeepPickupType::Count };
         EntityId _entityId{ EntityId::GetNull() };
         CoordsXYZ _loc;
-        NetworkPlayerId_t _owner{ -1 };
+        Network::PlayerId_t _owner{ -1 };
 
     public:
         PeepPickupAction() = default;
-        PeepPickupAction(PeepPickupType type, EntityId entityId, const CoordsXYZ& loc, NetworkPlayerId_t owner);
+        PeepPickupAction(PeepPickupType type, EntityId entityId, const CoordsXYZ& loc, Network::PlayerId_t owner);
 
         void AcceptParameters(GameActionParameterVisitor&) final;
 

--- a/src/openrct2/actions/PlayerKickAction.cpp
+++ b/src/openrct2/actions/PlayerKickAction.cpp
@@ -13,7 +13,7 @@
 
 namespace OpenRCT2::GameActions
 {
-    PlayerKickAction::PlayerKickAction(NetworkPlayerId_t playerId)
+    PlayerKickAction::PlayerKickAction(Network::PlayerId_t playerId)
         : _playerId(playerId)
     {
     }
@@ -36,11 +36,11 @@ namespace OpenRCT2::GameActions
     }
     Result PlayerKickAction::Query() const
     {
-        return NetworkKickPlayer(_playerId, false);
+        return Network::KickPlayer(_playerId, false);
     }
 
     Result PlayerKickAction::Execute() const
     {
-        return NetworkKickPlayer(_playerId, true);
+        return Network::KickPlayer(_playerId, true);
     }
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/PlayerKickAction.h
+++ b/src/openrct2/actions/PlayerKickAction.h
@@ -16,12 +16,12 @@ namespace OpenRCT2::GameActions
     class PlayerKickAction final : public GameActionBase<GameCommand::KickPlayer>
     {
     private:
-        NetworkPlayerId_t _playerId{ -1 };
+        Network::PlayerId_t _playerId{ -1 };
 
     public:
         PlayerKickAction() = default;
 
-        PlayerKickAction(NetworkPlayerId_t playerId);
+        PlayerKickAction(Network::PlayerId_t playerId);
 
         void AcceptParameters(GameActionParameterVisitor&) final;
 

--- a/src/openrct2/actions/PlayerSetGroupAction.cpp
+++ b/src/openrct2/actions/PlayerSetGroupAction.cpp
@@ -13,7 +13,7 @@
 
 namespace OpenRCT2::GameActions
 {
-    PlayerSetGroupAction::PlayerSetGroupAction(NetworkPlayerId_t playerId, uint8_t groupId)
+    PlayerSetGroupAction::PlayerSetGroupAction(Network::PlayerId_t playerId, uint8_t groupId)
         : _playerId(playerId)
         , _groupId(groupId)
     {
@@ -38,11 +38,11 @@ namespace OpenRCT2::GameActions
     }
     Result PlayerSetGroupAction::Query() const
     {
-        return NetworkSetPlayerGroup(GetPlayer(), _playerId, _groupId, false);
+        return Network::SetPlayerGroup(GetPlayer(), _playerId, _groupId, false);
     }
 
     Result PlayerSetGroupAction::Execute() const
     {
-        return NetworkSetPlayerGroup(GetPlayer(), _playerId, _groupId, true);
+        return Network::SetPlayerGroup(GetPlayer(), _playerId, _groupId, true);
     }
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/PlayerSetGroupAction.h
+++ b/src/openrct2/actions/PlayerSetGroupAction.h
@@ -16,12 +16,12 @@ namespace OpenRCT2::GameActions
     class PlayerSetGroupAction final : public GameActionBase<GameCommand::SetPlayerGroup>
     {
     private:
-        NetworkPlayerId_t _playerId{ -1 };
+        Network::PlayerId_t _playerId{ -1 };
         uint8_t _groupId{ std::numeric_limits<uint8_t>::max() };
 
     public:
         PlayerSetGroupAction() = default;
-        PlayerSetGroupAction(NetworkPlayerId_t playerId, uint8_t groupId);
+        PlayerSetGroupAction(Network::PlayerId_t playerId, uint8_t groupId);
 
         void AcceptParameters(GameActionParameterVisitor&) final;
 

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -40,9 +40,9 @@ using namespace OpenRCT2;
 #endif // USE_BREAKPAD
 
 #ifndef DISABLE_NETWORK
-int32_t gNetworkStart = NETWORK_MODE_NONE;
+Network::Mode gNetworkStart = Network::Mode::none;
 std::string gNetworkStartHost;
-int32_t gNetworkStartPort = kNetworkDefaultPort;
+int32_t gNetworkStartPort = Network::kNetworkDefaultPort;
 std::string gNetworkStartAddress;
 
 static uint32_t _port = 0;
@@ -304,7 +304,7 @@ exitcode_t HandleCommandHost(CommandLineArgEnumerator* enumerator)
     gOpenRCT2StartupAction = StartupAction::Open;
     String::set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
 
-    gNetworkStart = NETWORK_MODE_SERVER;
+    gNetworkStart = Network::Mode::server;
     gNetworkStartPort = _port;
     gNetworkStartAddress = String::toStd(_address);
 
@@ -326,7 +326,7 @@ exitcode_t HandleCommandJoin(CommandLineArgEnumerator* enumerator)
         return EXITCODE_FAIL;
     }
 
-    gNetworkStart = NETWORK_MODE_CLIENT;
+    gNetworkStart = Network::Mode::client;
     gNetworkStartPort = _port;
     gNetworkStartHost = hostname;
     return EXITCODE_CONTINUE;
@@ -452,7 +452,7 @@ static void PrintVersion()
     Console::WriteLine(versionInfo.c_str());
     Console::WriteFormat("%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);
     Console::WriteLine();
-    Console::WriteFormat("Network version: %s", NetworkGetVersion().c_str());
+    Console::WriteFormat("Network version: %s", Network::GetVersion().c_str());
     Console::WriteLine();
 #ifdef ENABLE_SCRIPTING
     Console::WriteFormat("Plugin API version: %d", OpenRCT2::Scripting::kPluginApiVersion);

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -42,7 +42,7 @@ using namespace OpenRCT2;
 #ifndef DISABLE_NETWORK
 Network::Mode gNetworkStart = Network::Mode::none;
 std::string gNetworkStartHost;
-int32_t gNetworkStartPort = Network::kNetworkDefaultPort;
+int32_t gNetworkStartPort = Network::kDefaultPort;
 std::string gNetworkStartAddress;
 
 static uint32_t _port = 0;

--- a/src/openrct2/command_line/SimulateCommands.cpp
+++ b/src/openrct2/command_line/SimulateCommands.cpp
@@ -57,7 +57,7 @@ static exitcode_t HandleSimulate(CommandLineArgEnumerator* argEnumerator)
     gOpenRCT2Headless = true;
 
 #ifndef DISABLE_NETWORK
-    gNetworkStart = NETWORK_MODE_SERVER;
+    gNetworkStart = Network::Mode::server;
 #endif
 
     std::unique_ptr<IContext> context(CreateContext());

--- a/src/openrct2/command_line/UriHandler.cpp
+++ b/src/openrct2/command_line/UriHandler.cpp
@@ -62,7 +62,7 @@ static exitcode_t HandleUriJoin(const std::vector<std::string>& args)
 {
     std::string hostname;
     int32_t port;
-    if (args.size() > 1 && TryParseHostnamePort(args[1], &hostname, &port, Network::kNetworkDefaultPort))
+    if (args.size() > 1 && TryParseHostnamePort(args[1], &hostname, &port, Network::kDefaultPort))
     {
         // Set the network start configuration
         gNetworkStart = Network::Mode::client;

--- a/src/openrct2/command_line/UriHandler.cpp
+++ b/src/openrct2/command_line/UriHandler.cpp
@@ -62,10 +62,10 @@ static exitcode_t HandleUriJoin(const std::vector<std::string>& args)
 {
     std::string hostname;
     int32_t port;
-    if (args.size() > 1 && TryParseHostnamePort(args[1], &hostname, &port, kNetworkDefaultPort))
+    if (args.size() > 1 && TryParseHostnamePort(args[1], &hostname, &port, Network::kNetworkDefaultPort))
     {
         // Set the network start configuration
-        gNetworkStart = NETWORK_MODE_CLIENT;
+        gNetworkStart = Network::Mode::client;
         gNetworkStartHost = std::move(hostname);
         gNetworkStartPort = port;
         return EXITCODE_CONTINUE;

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -473,7 +473,7 @@ namespace OpenRCT2::Config
 
             auto model = &_config.network;
             model->PlayerName = std::move(playerName);
-            model->DefaultPort = reader->GetInt32("default_port", ::Network::kNetworkDefaultPort);
+            model->DefaultPort = reader->GetInt32("default_port", ::Network::kDefaultPort);
             model->ListenAddress = reader->GetString("listen_address", "");
             model->DefaultPassword = reader->GetString("default_password", "");
             model->StayConnected = reader->GetBoolean("stay_connected", true);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -473,7 +473,7 @@ namespace OpenRCT2::Config
 
             auto model = &_config.network;
             model->PlayerName = std::move(playerName);
-            model->DefaultPort = reader->GetInt32("default_port", kNetworkDefaultPort);
+            model->DefaultPort = reader->GetInt32("default_port", ::Network::kNetworkDefaultPort);
             model->ListenAddress = reader->GetString("listen_address", "");
             model->DefaultPassword = reader->GetString("default_password", "");
             model->StayConnected = reader->GetBoolean("stay_connected", true);

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -186,27 +186,27 @@ struct DataSerializerTraitsT<std::string>
 };
 
 template<>
-struct DataSerializerTraitsT<NetworkPlayerId_t>
+struct DataSerializerTraitsT<OpenRCT2::Network::PlayerId_t>
 {
-    static void encode(OpenRCT2::IStream* stream, const NetworkPlayerId_t& val)
+    static void encode(OpenRCT2::IStream* stream, const OpenRCT2::Network::PlayerId_t& val)
     {
         stream->WriteValue(ByteSwapBE(val.id));
     }
-    static void decode(OpenRCT2::IStream* stream, NetworkPlayerId_t& val)
+    static void decode(OpenRCT2::IStream* stream, OpenRCT2::Network::PlayerId_t& val)
     {
         val.id = ByteSwapBE(stream->ReadValue<int32_t>());
     }
-    static void log(OpenRCT2::IStream* stream, const NetworkPlayerId_t& val)
+    static void log(OpenRCT2::IStream* stream, const OpenRCT2::Network::PlayerId_t& val)
     {
         char playerId[28] = {};
         snprintf(playerId, sizeof(playerId), "%u", val.id);
 
         stream->Write(playerId, strlen(playerId));
 
-        int32_t playerIndex = NetworkGetPlayerIndex(val.id);
+        int32_t playerIndex = OpenRCT2::Network::GetPlayerIndex(val.id);
         if (playerIndex != -1)
         {
-            const char* playerName = NetworkGetPlayerName(playerIndex);
+            const char* playerName = OpenRCT2::Network::GetPlayerName(playerIndex);
             if (playerName != nullptr)
             {
                 stream->Write(" \"", 2);
@@ -591,17 +591,17 @@ struct DataSerializerTraitsT<CoordsXYZD>
 };
 
 template<>
-struct DataSerializerTraitsT<NetworkCheatType_t>
+struct DataSerializerTraitsT<OpenRCT2::Network::CheatType_t>
 {
-    static void encode(OpenRCT2::IStream* stream, const NetworkCheatType_t& val)
+    static void encode(OpenRCT2::IStream* stream, const OpenRCT2::Network::CheatType_t& val)
     {
         stream->WriteValue(ByteSwapBE(val.id));
     }
-    static void decode(OpenRCT2::IStream* stream, NetworkCheatType_t& val)
+    static void decode(OpenRCT2::IStream* stream, OpenRCT2::Network::CheatType_t& val)
     {
         val.id = ByteSwapBE(stream->ReadValue<int32_t>());
     }
-    static void log(OpenRCT2::IStream* stream, const NetworkCheatType_t& val)
+    static void log(OpenRCT2::IStream* stream, const OpenRCT2::Network::CheatType_t& val)
     {
         const char* cheatName = CheatsGetName(static_cast<CheatType>(val.id));
         stream->Write(cheatName, strlen(cheatName));

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -6430,7 +6430,7 @@ static bool PeepShouldWatchRide(TileElement* tileElement)
 {
     // Ghosts are purely this-client-side and should not cause any interaction,
     // as that may lead to a desync.
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         if (tileElement->IsGhost())
             return false;
@@ -6543,7 +6543,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6582,7 +6582,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6609,7 +6609,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6654,7 +6654,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6701,7 +6701,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6727,7 +6727,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6771,7 +6771,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6817,7 +6817,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;
@@ -6843,7 +6843,7 @@ static bool GuestFindRideToLookAt(Guest& guest, uint8_t edge, RideId* rideToView
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -68,7 +68,7 @@ void MoneyEffect::Create(money64 value, const CoordsXYZ& loc)
     {
         // If game actions return no valid location of the action we can not use the screen
         // coordinates as every client will have different ones.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             LOG_WARNING("Attempted to create money effect without a valid location in multiplayer");
             return;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -44,8 +44,8 @@ static int32_t ChatHistoryDrawString(RenderTarget& rt, const char* text, const S
 
 bool ChatAvailable()
 {
-    return NetworkGetMode() != NETWORK_MODE_NONE && NetworkGetStatus() == NETWORK_STATUS_CONNECTED
-        && NetworkGetAuthstatus() == NetworkAuth::Ok;
+    return Network::GetMode() != Network::Mode::none && Network::GetStatus() == Network::Status::connected
+        && Network::GetAuthstatus() == Network::Auth::ok;
 }
 
 void ChatOpen()
@@ -243,7 +243,7 @@ void ChatAddHistory(std::string_view s)
     _chatHistoryTime.push_front(Platform::GetTicks());
 
     // Log to file (src only as logging does its own timestamp)
-    NetworkAppendChatLog(s);
+    Network::AppendChatLog(s);
 
     CreateAudioChannel(SoundId::NewsItem, 0, kMixerVolumeMax, 0.5f, 1.5f, true);
 }
@@ -255,7 +255,7 @@ void ChatInput(enum ChatInput input)
         case ChatInput::Send:
             if (!_chatCurrentLine.empty())
             {
-                NetworkSendChat(_chatCurrentLine.c_str());
+                Network::SendChat(_chatCurrentLine.c_str());
             }
             ChatClearInput();
             ChatClose();

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1176,7 +1176,7 @@ static void ConsoleCommandOpen(InteractiveConsole& console, const arguments_t& a
         bool invalidTitle = false;
         if (argv[0] == "object_selection" && InvalidArguments(&invalidTitle, !title))
         {
-            if (NetworkGetMode() != NETWORK_MODE_NONE)
+            if (Network::GetMode() != Network::Mode::none)
             {
                 console.WriteLineError("Cannot open this window in multiplayer mode.");
             }
@@ -1190,7 +1190,7 @@ static void ConsoleCommandOpen(InteractiveConsole& console, const arguments_t& a
         }
         else if (argv[0] == "inventions_list" && InvalidArguments(&invalidTitle, !title))
         {
-            if (NetworkGetMode() != NETWORK_MODE_NONE)
+            if (Network::GetMode() != Network::Mode::none)
             {
                 console.WriteLineError("Cannot open this window in multiplayer mode.");
             }
@@ -1362,8 +1362,8 @@ static void ConsoleCommandSavePark([[maybe_unused]] InteractiveConsole& console,
 
 static void ConsoleCommandSay(InteractiveConsole& console, const arguments_t& argv)
 {
-    if (NetworkGetMode() == NETWORK_MODE_NONE || NetworkGetStatus() != NETWORK_STATUS_CONNECTED
-        || NetworkGetAuthstatus() != NetworkAuth::Ok)
+    if (Network::GetMode() == Network::Mode::none || Network::GetStatus() != Network::Status::connected
+        || Network::GetAuthstatus() != Network::Auth::ok)
     {
         console.WriteFormatLine("This command only works in multiplayer mode.");
         return;
@@ -1371,7 +1371,7 @@ static void ConsoleCommandSay(InteractiveConsole& console, const arguments_t& ar
 
     if (!argv.empty())
     {
-        NetworkSendChat(argv[0].c_str());
+        Network::SendChat(argv[0].c_str());
         return;
     }
 
@@ -1380,7 +1380,7 @@ static void ConsoleCommandSay(InteractiveConsole& console, const arguments_t& ar
 
 static void ConsoleCommandReplayStartRecord(InteractiveConsole& console, const arguments_t& argv)
 {
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
         return;
@@ -1423,7 +1423,7 @@ static void ConsoleCommandReplayStartRecord(InteractiveConsole& console, const a
 
 static void ConsoleCommandReplayStopRecord(InteractiveConsole& console, const arguments_t& argv)
 {
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
         return;
@@ -1454,7 +1454,7 @@ static void ConsoleCommandReplayStopRecord(InteractiveConsole& console, const ar
 
 static void ConsoleCommandReplayStart(InteractiveConsole& console, const arguments_t& argv)
 {
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
         return;
@@ -1492,7 +1492,7 @@ static void ConsoleCommandReplayStart(InteractiveConsole& console, const argumen
 
 static void ConsoleCommandReplayStop(InteractiveConsole& console, const arguments_t& argv)
 {
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
         return;
@@ -1507,7 +1507,7 @@ static void ConsoleCommandReplayStop(InteractiveConsole& console, const argument
 
 static void ConsoleCommandReplayNormalise(InteractiveConsole& console, const arguments_t& argv)
 {
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         console.WriteFormatLine("This command is currently not supported in multiplayer mode.");
     }

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::Network
                 }
                 else
                 {
-                    OpenRCT2::FmtString fmtServerName(NetworkGetServerName());
+                    FmtString fmtServerName(NetworkGetServerName());
                     std::string serverName;
                     for (const auto& token : fmtServerName)
                     {

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -91,13 +91,13 @@ namespace OpenRCT2::Network
         {
             default:
                 details = GetParkName();
-                if (NetworkGetMode() == NETWORK_MODE_NONE)
+                if (Network::GetMode() == Network::Mode::none)
                 {
                     state = "Playing Solo";
                 }
                 else
                 {
-                    FmtString fmtServerName(NetworkGetServerName());
+                    FmtString fmtServerName(Network::GetServerName());
                     std::string serverName;
                     for (const auto& token : fmtServerName)
                     {
@@ -115,10 +115,10 @@ namespace OpenRCT2::Network
                     }
                     state = serverName;
 
-                    partyId = NetworkGetServerName();
+                    partyId = Network::GetServerName();
                     // NOTE: the party size is displayed next to state
                     discordPresence.partyId = partyId.c_str();
-                    discordPresence.partySize = NetworkGetNumPlayers();
+                    discordPresence.partySize = Network::GetNumPlayers();
                     discordPresence.partyMax = 256;
 
                     // TODO generate secrets for the server

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -24,130 +24,128 @@
     #include <chrono>
     #include <discord_rpc.h>
 
-using namespace OpenRCT2;
-
-namespace
+namespace OpenRCT2::Network
 {
     using namespace std::chrono_literals;
 
     constexpr const char* kApplicationID = "378612438200877056";
     constexpr const char* kSteamAppID = nullptr;
     constexpr auto kRefreshInterval = 5.0s;
-} // namespace
 
-static void OnReady([[maybe_unused]] const DiscordUser* request)
-{
-    LOG_VERBOSE("DiscordService::OnReady()");
-}
-
-static void OnDisconnected(int errorCode, const char* message)
-{
-    Console::Error::WriteLine("DiscordService::OnDisconnected(%d, %s)", errorCode, message);
-}
-
-static void OnErrored(int errorCode, const char* message)
-{
-    Console::Error::WriteLine("DiscordService::OnErrored(%d, %s)", errorCode, message);
-}
-
-DiscordService::DiscordService()
-{
-    DiscordEventHandlers handlers = {};
-    handlers.ready = OnReady;
-    handlers.disconnected = OnDisconnected;
-    handlers.errored = OnErrored;
-    Discord_Initialize(kApplicationID, &handlers, 1, kSteamAppID);
-}
-
-DiscordService::~DiscordService()
-{
-    Discord_Shutdown();
-}
-
-static std::string GetParkName()
-{
-    auto& gameState = getGameState();
-    return gameState.park.name;
-}
-
-void DiscordService::Tick()
-{
-    Discord_RunCallbacks();
-
-    if (_updateTimer.GetElapsedTime() < kRefreshInterval)
-        return;
-
-    RefreshPresence();
-    _updateTimer.Restart();
-}
-
-void DiscordService::RefreshPresence() const
-{
-    DiscordRichPresence discordPresence = {};
-    discordPresence.largeImageKey = "logo";
-
-    std::string state;
-    std::string details;
-    std::string partyId;
-
-    switch (gLegacyScene)
+    static void OnReady([[maybe_unused]] const DiscordUser* request)
     {
-        default:
-            details = GetParkName();
-            if (NetworkGetMode() == NETWORK_MODE_NONE)
-            {
-                state = "Playing Solo";
-            }
-            else
-            {
-                OpenRCT2::FmtString fmtServerName(NetworkGetServerName());
-                std::string serverName;
-                for (const auto& token : fmtServerName)
-                {
-                    if (token.IsLiteral())
-                    {
-                        serverName += token.text;
-                    }
-                    else if (token.IsCodepoint())
-                    {
-                        auto codepoint = token.GetCodepoint();
-                        char buffer[8]{};
-                        UTF8WriteCodepoint(buffer, codepoint);
-                        serverName += buffer;
-                    }
-                }
-                state = serverName;
-
-                partyId = NetworkGetServerName();
-                // NOTE: the party size is displayed next to state
-                discordPresence.partyId = partyId.c_str();
-                discordPresence.partySize = NetworkGetNumPlayers();
-                discordPresence.partyMax = 256;
-
-                // TODO generate secrets for the server
-                discordPresence.matchSecret = nullptr;
-                discordPresence.spectateSecret = nullptr;
-                discordPresence.instance = 1;
-            }
-            break;
-        case LegacyScene::titleSequence:
-            details = "In Menus";
-            break;
-        case LegacyScene::scenarioEditor:
-            details = "In Scenario Editor";
-            break;
-        case LegacyScene::trackDesigner:
-            details = "In Track Designer";
-            break;
-        case LegacyScene::trackDesignsManager:
-            details = "In Track Designs Manager";
-            break;
+        LOG_VERBOSE("DiscordService::OnReady()");
     }
 
-    discordPresence.state = state.c_str();
-    discordPresence.details = details.c_str();
+    static void OnDisconnected(int errorCode, const char* message)
+    {
+        Console::Error::WriteLine("DiscordService::OnDisconnected(%d, %s)", errorCode, message);
+    }
 
-    Discord_UpdatePresence(&discordPresence);
-}
+    static void OnErrored(int errorCode, const char* message)
+    {
+        Console::Error::WriteLine("DiscordService::OnErrored(%d, %s)", errorCode, message);
+    }
+
+    DiscordService::DiscordService()
+    {
+        DiscordEventHandlers handlers = {};
+        handlers.ready = OnReady;
+        handlers.disconnected = OnDisconnected;
+        handlers.errored = OnErrored;
+        Discord_Initialize(kApplicationID, &handlers, 1, kSteamAppID);
+    }
+
+    DiscordService::~DiscordService()
+    {
+        Discord_Shutdown();
+    }
+
+    static std::string GetParkName()
+    {
+        auto& gameState = getGameState();
+        return gameState.park.name;
+    }
+
+    void DiscordService::Tick()
+    {
+        Discord_RunCallbacks();
+
+        if (_updateTimer.GetElapsedTime() < kRefreshInterval)
+            return;
+
+        RefreshPresence();
+        _updateTimer.Restart();
+    }
+
+    void DiscordService::RefreshPresence() const
+    {
+        DiscordRichPresence discordPresence = {};
+        discordPresence.largeImageKey = "logo";
+
+        std::string state;
+        std::string details;
+        std::string partyId;
+
+        switch (gLegacyScene)
+        {
+            default:
+                details = GetParkName();
+                if (NetworkGetMode() == NETWORK_MODE_NONE)
+                {
+                    state = "Playing Solo";
+                }
+                else
+                {
+                    OpenRCT2::FmtString fmtServerName(NetworkGetServerName());
+                    std::string serverName;
+                    for (const auto& token : fmtServerName)
+                    {
+                        if (token.IsLiteral())
+                        {
+                            serverName += token.text;
+                        }
+                        else if (token.IsCodepoint())
+                        {
+                            auto codepoint = token.GetCodepoint();
+                            char buffer[8]{};
+                            UTF8WriteCodepoint(buffer, codepoint);
+                            serverName += buffer;
+                        }
+                    }
+                    state = serverName;
+
+                    partyId = NetworkGetServerName();
+                    // NOTE: the party size is displayed next to state
+                    discordPresence.partyId = partyId.c_str();
+                    discordPresence.partySize = NetworkGetNumPlayers();
+                    discordPresence.partyMax = 256;
+
+                    // TODO generate secrets for the server
+                    discordPresence.matchSecret = nullptr;
+                    discordPresence.spectateSecret = nullptr;
+                    discordPresence.instance = 1;
+                }
+                break;
+            case LegacyScene::titleSequence:
+                details = "In Menus";
+                break;
+            case LegacyScene::scenarioEditor:
+                details = "In Scenario Editor";
+                break;
+            case LegacyScene::trackDesigner:
+                details = "In Track Designer";
+                break;
+            case LegacyScene::trackDesignsManager:
+                details = "In Track Designs Manager";
+                break;
+        }
+
+        discordPresence.state = state.c_str();
+        discordPresence.details = details.c_str();
+
+        Discord_UpdatePresence(&discordPresence);
+    }
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/DiscordService.h
+++ b/src/openrct2/network/DiscordService.h
@@ -20,7 +20,7 @@ namespace OpenRCT2::Network
     class DiscordService final
     {
     private:
-        OpenRCT2::Timer _updateTimer;
+        Timer _updateTimer;
 
     public:
         DiscordService();

--- a/src/openrct2/network/DiscordService.h
+++ b/src/openrct2/network/DiscordService.h
@@ -15,19 +15,22 @@
 
     #include <limits>
 
-class DiscordService final
+namespace OpenRCT2::Network
 {
-private:
-    OpenRCT2::Timer _updateTimer;
+    class DiscordService final
+    {
+    private:
+        OpenRCT2::Timer _updateTimer;
 
-public:
-    DiscordService();
-    ~DiscordService();
+    public:
+        DiscordService();
+        ~DiscordService();
 
-    void Tick();
+        void Tick();
 
-private:
-    void RefreshPresence() const;
-};
+    private:
+        void RefreshPresence() const;
+    };
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/Network.h
+++ b/src/openrct2/network/Network.h
@@ -32,9 +32,9 @@ namespace OpenRCT2::GameActions
 
 namespace OpenRCT2::Network
 {
-    constexpr uint16_t kNetworkDefaultPort = 11753;
-    constexpr uint16_t kNetworkLanBroadcastPort = 11754;
-    constexpr const char* kNetworkLanBroadcastMsg = "openrct2.server.query";
+    constexpr uint16_t kDefaultPort = 11753;
+    constexpr uint16_t kLanBroadcastPort = 11754;
+    constexpr const char* kLanBroadcastMsg = "openrct2.server.query";
     constexpr const char* kMasterServerURL = "https://servers.openrct2.io";
     constexpr uint16_t kMaxServerDescriptionLength = 256;
 

--- a/src/openrct2/network/Network.h
+++ b/src/openrct2/network/Network.h
@@ -38,86 +38,86 @@ namespace OpenRCT2::Network
     constexpr const char* kMasterServerURL = "https://servers.openrct2.io";
     constexpr uint16_t kMaxServerDescriptionLength = 256;
 
-    enum class NetworkPermission : uint32_t;
+    enum class Permission : uint32_t;
 
-    void NetworkReconnect();
-    void NetworkShutdownClient();
-    int32_t NetworkBeginClient(const std::string& host, int32_t port);
-    int32_t NetworkBeginServer(int32_t port, const std::string& address);
+    void Reconnect();
+    void ShutdownClient();
+    int32_t BeginClient(const std::string& host, int32_t port);
+    int32_t BeginServer(int32_t port, const std::string& address);
 
-    [[nodiscard]] int32_t NetworkGetMode();
-    [[nodiscard]] int32_t NetworkGetStatus();
-    bool NetworkIsDesynchronised();
-    bool NetworkCheckDesynchronisation();
-    void NetworkRequestGamestateSnapshot();
-    void NetworkSendTick();
-    bool NetworkGamestateSnapshotsEnabled();
-    void NetworkUpdate();
-    void NetworkProcessPending();
-    void NetworkFlush();
+    [[nodiscard]] Mode GetMode();
+    [[nodiscard]] Status GetStatus();
+    bool IsDesynchronised();
+    bool CheckDesynchronisation();
+    void RequestGamestateSnapshot();
+    void SendTick();
+    bool GamestateSnapshotsEnabled();
+    void Update();
+    void ProcessPending();
+    void Flush();
 
-    [[nodiscard]] NetworkAuth NetworkGetAuthstatus();
-    [[nodiscard]] uint32_t NetworkGetServerTick();
-    [[nodiscard]] uint8_t NetworkGetCurrentPlayerId();
-    [[nodiscard]] int32_t NetworkGetNumPlayers();
-    [[nodiscard]] int32_t NetworkGetNumVisiblePlayers();
-    [[nodiscard]] const char* NetworkGetPlayerName(uint32_t index);
-    [[nodiscard]] uint32_t NetworkGetPlayerFlags(uint32_t index);
-    [[nodiscard]] int32_t NetworkGetPlayerPing(uint32_t index);
-    [[nodiscard]] int32_t NetworkGetPlayerID(uint32_t index);
-    [[nodiscard]] money64 NetworkGetPlayerMoneySpent(uint32_t index);
-    [[nodiscard]] std::string NetworkGetPlayerIPAddress(uint32_t id);
-    [[nodiscard]] std::string NetworkGetPlayerPublicKeyHash(uint32_t id);
-    void NetworkIncrementPlayerNumCommands(uint32_t playerIndex);
-    void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost);
-    [[nodiscard]] int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time);
-    void NetworkSetPlayerLastAction(uint32_t index, GameCommand command);
-    [[nodiscard]] CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index);
-    void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord);
-    [[nodiscard]] uint32_t NetworkGetPlayerCommandsRan(uint32_t index);
-    [[nodiscard]] int32_t NetworkGetPlayerIndex(uint32_t id);
-    [[nodiscard]] uint8_t NetworkGetPlayerGroup(uint32_t index);
-    void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex);
-    [[nodiscard]] int32_t NetworkGetGroupIndex(uint8_t id);
-    [[nodiscard]] int32_t NetworkGetCurrentPlayerGroupIndex();
-    [[nodiscard]] uint8_t NetworkGetGroupID(uint32_t index);
-    [[nodiscard]] int32_t NetworkGetNumGroups();
-    [[nodiscard]] const char* NetworkGetGroupName(uint32_t index);
-    [[nodiscard]] GameActions::Result NetworkSetPlayerGroup(
-        NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting);
-    [[nodiscard]] GameActions::Result NetworkModifyGroups(
-        NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+    [[nodiscard]] Auth GetAuthstatus();
+    [[nodiscard]] uint32_t GetServerTick();
+    [[nodiscard]] uint8_t GetCurrentPlayerId();
+    [[nodiscard]] int32_t GetNumPlayers();
+    [[nodiscard]] int32_t GetNumVisiblePlayers();
+    [[nodiscard]] const char* GetPlayerName(uint32_t index);
+    [[nodiscard]] uint32_t GetPlayerFlags(uint32_t index);
+    [[nodiscard]] int32_t GetPlayerPing(uint32_t index);
+    [[nodiscard]] int32_t GetPlayerID(uint32_t index);
+    [[nodiscard]] money64 GetPlayerMoneySpent(uint32_t index);
+    [[nodiscard]] std::string GetPlayerIPAddress(uint32_t id);
+    [[nodiscard]] std::string GetPlayerPublicKeyHash(uint32_t id);
+    void IncrementPlayerNumCommands(uint32_t playerIndex);
+    void AddPlayerMoneySpent(uint32_t index, money64 cost);
+    [[nodiscard]] int32_t GetPlayerLastAction(uint32_t index, int32_t time);
+    void SetPlayerLastAction(uint32_t index, GameCommand command);
+    [[nodiscard]] CoordsXYZ GetPlayerLastActionCoord(uint32_t index);
+    void SetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord);
+    [[nodiscard]] uint32_t GetPlayerCommandsRan(uint32_t index);
+    [[nodiscard]] int32_t GetPlayerIndex(uint32_t id);
+    [[nodiscard]] uint8_t GetPlayerGroup(uint32_t index);
+    void SetPlayerGroup(uint32_t index, uint32_t groupindex);
+    [[nodiscard]] int32_t GetGroupIndex(uint8_t id);
+    [[nodiscard]] int32_t GetCurrentPlayerGroupIndex();
+    [[nodiscard]] uint8_t GetGroupID(uint32_t index);
+    [[nodiscard]] int32_t GetNumGroups();
+    [[nodiscard]] const char* GetGroupName(uint32_t index);
+    [[nodiscard]] GameActions::Result SetPlayerGroup(
+        PlayerId_t actionPlayerId, PlayerId_t playerId, uint8_t groupId, bool isExecuting);
+    [[nodiscard]] GameActions::Result ModifyGroups(
+        PlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
         uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting);
-    [[nodiscard]] GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting);
-    [[nodiscard]] uint8_t NetworkGetDefaultGroup();
-    [[nodiscard]] int32_t NetworkGetNumActions();
-    [[nodiscard]] StringId NetworkGetActionNameStringID(uint32_t index);
-    [[nodiscard]] int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index);
-    [[nodiscard]] int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index);
-    void NetworkSetPickupPeep(uint8_t playerid, Peep* peep);
-    [[nodiscard]] Peep* NetworkGetPickupPeep(uint8_t playerid);
-    void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x);
-    [[nodiscard]] int32_t NetworkGetPickupPeepOldX(uint8_t playerid);
-    [[nodiscard]] bool NetworkIsServerPlayerInvisible();
+    [[nodiscard]] GameActions::Result KickPlayer(PlayerId_t playerId, bool isExecuting);
+    [[nodiscard]] uint8_t GetDefaultGroup();
+    [[nodiscard]] int32_t GetNumActions();
+    [[nodiscard]] StringId GetActionNameStringID(uint32_t index);
+    [[nodiscard]] int32_t CanPerformAction(uint32_t groupindex, Permission index);
+    [[nodiscard]] int32_t CanPerformCommand(uint32_t groupindex, int32_t index);
+    void SetPickupPeep(uint8_t playerid, Peep* peep);
+    [[nodiscard]] Peep* GetPickupPeep(uint8_t playerid);
+    void SetPickupPeepOldX(uint8_t playerid, int32_t x);
+    [[nodiscard]] int32_t GetPickupPeepOldX(uint8_t playerid);
+    [[nodiscard]] bool IsServerPlayerInvisible();
 
-    void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
-    void NetworkSendGameAction(const GameActions::GameAction* action);
-    void NetworkSendPassword(const std::string& password);
+    void SendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
+    void SendGameAction(const GameActions::GameAction* action);
+    void SendPassword(const std::string& password);
 
-    void NetworkSetPassword(const char* password);
+    void SetPassword(const char* password);
 
-    void NetworkAppendChatLog(std::string_view text);
-    void NetworkAppendServerLog(const utf8* text);
-    [[nodiscard]] u8string NetworkGetServerName();
-    [[nodiscard]] u8string NetworkGetServerDescription();
-    [[nodiscard]] u8string NetworkGetServerGreeting();
-    [[nodiscard]] u8string NetworkGetServerProviderName();
-    [[nodiscard]] u8string NetworkGetServerProviderEmail();
-    [[nodiscard]] u8string NetworkGetServerProviderWebsite();
+    void AppendChatLog(std::string_view text);
+    void AppendServerLog(const utf8* text);
+    [[nodiscard]] u8string GetServerName();
+    [[nodiscard]] u8string GetServerDescription();
+    [[nodiscard]] u8string GetServerGreeting();
+    [[nodiscard]] u8string GetServerProviderName();
+    [[nodiscard]] u8string GetServerProviderEmail();
+    [[nodiscard]] u8string GetServerProviderWebsite();
 
-    [[nodiscard]] std::string NetworkGetVersion();
+    [[nodiscard]] std::string GetVersion();
 
-    [[nodiscard]] NetworkStats NetworkGetStats();
-    [[nodiscard]] NetworkServerState NetworkGetServerState();
-    [[nodiscard]] json_t NetworkGetServerInfoAsJson();
+    [[nodiscard]] Stats GetStats();
+    [[nodiscard]] ServerState GetServerState();
+    [[nodiscard]] json_t GetServerInfoAsJson();
 } // namespace OpenRCT2::Network

--- a/src/openrct2/network/Network.h
+++ b/src/openrct2/network/Network.h
@@ -19,12 +19,6 @@
 #include <string_view>
 #include <vector>
 
-constexpr uint16_t kNetworkDefaultPort = 11753;
-constexpr uint16_t kNetworkLanBroadcastPort = 11754;
-constexpr const char* kNetworkLanBroadcastMsg = "openrct2.server.query";
-constexpr const char* kMasterServerURL = "https://servers.openrct2.io";
-constexpr uint16_t kMaxServerDescriptionLength = 256;
-
 struct Peep;
 struct CoordsXYZ;
 
@@ -36,85 +30,94 @@ namespace OpenRCT2::GameActions
     class Result;
 } // namespace OpenRCT2::GameActions
 
-enum class NetworkPermission : uint32_t;
+namespace OpenRCT2::Network
+{
+    constexpr uint16_t kNetworkDefaultPort = 11753;
+    constexpr uint16_t kNetworkLanBroadcastPort = 11754;
+    constexpr const char* kNetworkLanBroadcastMsg = "openrct2.server.query";
+    constexpr const char* kMasterServerURL = "https://servers.openrct2.io";
+    constexpr uint16_t kMaxServerDescriptionLength = 256;
 
-void NetworkReconnect();
-void NetworkShutdownClient();
-int32_t NetworkBeginClient(const std::string& host, int32_t port);
-int32_t NetworkBeginServer(int32_t port, const std::string& address);
+    enum class NetworkPermission : uint32_t;
 
-[[nodiscard]] int32_t NetworkGetMode();
-[[nodiscard]] int32_t NetworkGetStatus();
-bool NetworkIsDesynchronised();
-bool NetworkCheckDesynchronisation();
-void NetworkRequestGamestateSnapshot();
-void NetworkSendTick();
-bool NetworkGamestateSnapshotsEnabled();
-void NetworkUpdate();
-void NetworkProcessPending();
-void NetworkFlush();
+    void NetworkReconnect();
+    void NetworkShutdownClient();
+    int32_t NetworkBeginClient(const std::string& host, int32_t port);
+    int32_t NetworkBeginServer(int32_t port, const std::string& address);
 
-[[nodiscard]] NetworkAuth NetworkGetAuthstatus();
-[[nodiscard]] uint32_t NetworkGetServerTick();
-[[nodiscard]] uint8_t NetworkGetCurrentPlayerId();
-[[nodiscard]] int32_t NetworkGetNumPlayers();
-[[nodiscard]] int32_t NetworkGetNumVisiblePlayers();
-[[nodiscard]] const char* NetworkGetPlayerName(uint32_t index);
-[[nodiscard]] uint32_t NetworkGetPlayerFlags(uint32_t index);
-[[nodiscard]] int32_t NetworkGetPlayerPing(uint32_t index);
-[[nodiscard]] int32_t NetworkGetPlayerID(uint32_t index);
-[[nodiscard]] money64 NetworkGetPlayerMoneySpent(uint32_t index);
-[[nodiscard]] std::string NetworkGetPlayerIPAddress(uint32_t id);
-[[nodiscard]] std::string NetworkGetPlayerPublicKeyHash(uint32_t id);
-void NetworkIncrementPlayerNumCommands(uint32_t playerIndex);
-void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost);
-[[nodiscard]] int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time);
-void NetworkSetPlayerLastAction(uint32_t index, GameCommand command);
-[[nodiscard]] CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index);
-void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord);
-[[nodiscard]] uint32_t NetworkGetPlayerCommandsRan(uint32_t index);
-[[nodiscard]] int32_t NetworkGetPlayerIndex(uint32_t id);
-[[nodiscard]] uint8_t NetworkGetPlayerGroup(uint32_t index);
-void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex);
-[[nodiscard]] int32_t NetworkGetGroupIndex(uint8_t id);
-[[nodiscard]] int32_t NetworkGetCurrentPlayerGroupIndex();
-[[nodiscard]] uint8_t NetworkGetGroupID(uint32_t index);
-[[nodiscard]] int32_t NetworkGetNumGroups();
-[[nodiscard]] const char* NetworkGetGroupName(uint32_t index);
-[[nodiscard]] OpenRCT2::GameActions::Result NetworkSetPlayerGroup(
-    NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting);
-[[nodiscard]] OpenRCT2::GameActions::Result NetworkModifyGroups(
-    NetworkPlayerId_t actionPlayerId, OpenRCT2::GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
-    uint32_t permissionIndex, OpenRCT2::GameActions::PermissionState permissionState, bool isExecuting);
-[[nodiscard]] OpenRCT2::GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting);
-[[nodiscard]] uint8_t NetworkGetDefaultGroup();
-[[nodiscard]] int32_t NetworkGetNumActions();
-[[nodiscard]] StringId NetworkGetActionNameStringID(uint32_t index);
-[[nodiscard]] int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index);
-[[nodiscard]] int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index);
-void NetworkSetPickupPeep(uint8_t playerid, Peep* peep);
-[[nodiscard]] Peep* NetworkGetPickupPeep(uint8_t playerid);
-void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x);
-[[nodiscard]] int32_t NetworkGetPickupPeepOldX(uint8_t playerid);
-[[nodiscard]] bool NetworkIsServerPlayerInvisible();
+    [[nodiscard]] int32_t NetworkGetMode();
+    [[nodiscard]] int32_t NetworkGetStatus();
+    bool NetworkIsDesynchronised();
+    bool NetworkCheckDesynchronisation();
+    void NetworkRequestGamestateSnapshot();
+    void NetworkSendTick();
+    bool NetworkGamestateSnapshotsEnabled();
+    void NetworkUpdate();
+    void NetworkProcessPending();
+    void NetworkFlush();
 
-void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
-void NetworkSendGameAction(const OpenRCT2::GameActions::GameAction* action);
-void NetworkSendPassword(const std::string& password);
+    [[nodiscard]] NetworkAuth NetworkGetAuthstatus();
+    [[nodiscard]] uint32_t NetworkGetServerTick();
+    [[nodiscard]] uint8_t NetworkGetCurrentPlayerId();
+    [[nodiscard]] int32_t NetworkGetNumPlayers();
+    [[nodiscard]] int32_t NetworkGetNumVisiblePlayers();
+    [[nodiscard]] const char* NetworkGetPlayerName(uint32_t index);
+    [[nodiscard]] uint32_t NetworkGetPlayerFlags(uint32_t index);
+    [[nodiscard]] int32_t NetworkGetPlayerPing(uint32_t index);
+    [[nodiscard]] int32_t NetworkGetPlayerID(uint32_t index);
+    [[nodiscard]] money64 NetworkGetPlayerMoneySpent(uint32_t index);
+    [[nodiscard]] std::string NetworkGetPlayerIPAddress(uint32_t id);
+    [[nodiscard]] std::string NetworkGetPlayerPublicKeyHash(uint32_t id);
+    void NetworkIncrementPlayerNumCommands(uint32_t playerIndex);
+    void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost);
+    [[nodiscard]] int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time);
+    void NetworkSetPlayerLastAction(uint32_t index, GameCommand command);
+    [[nodiscard]] CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index);
+    void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord);
+    [[nodiscard]] uint32_t NetworkGetPlayerCommandsRan(uint32_t index);
+    [[nodiscard]] int32_t NetworkGetPlayerIndex(uint32_t id);
+    [[nodiscard]] uint8_t NetworkGetPlayerGroup(uint32_t index);
+    void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex);
+    [[nodiscard]] int32_t NetworkGetGroupIndex(uint8_t id);
+    [[nodiscard]] int32_t NetworkGetCurrentPlayerGroupIndex();
+    [[nodiscard]] uint8_t NetworkGetGroupID(uint32_t index);
+    [[nodiscard]] int32_t NetworkGetNumGroups();
+    [[nodiscard]] const char* NetworkGetGroupName(uint32_t index);
+    [[nodiscard]] OpenRCT2::GameActions::Result NetworkSetPlayerGroup(
+        NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting);
+    [[nodiscard]] OpenRCT2::GameActions::Result NetworkModifyGroups(
+        NetworkPlayerId_t actionPlayerId, OpenRCT2::GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+        uint32_t permissionIndex, OpenRCT2::GameActions::PermissionState permissionState, bool isExecuting);
+    [[nodiscard]] OpenRCT2::GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting);
+    [[nodiscard]] uint8_t NetworkGetDefaultGroup();
+    [[nodiscard]] int32_t NetworkGetNumActions();
+    [[nodiscard]] StringId NetworkGetActionNameStringID(uint32_t index);
+    [[nodiscard]] int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index);
+    [[nodiscard]] int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index);
+    void NetworkSetPickupPeep(uint8_t playerid, Peep* peep);
+    [[nodiscard]] Peep* NetworkGetPickupPeep(uint8_t playerid);
+    void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x);
+    [[nodiscard]] int32_t NetworkGetPickupPeepOldX(uint8_t playerid);
+    [[nodiscard]] bool NetworkIsServerPlayerInvisible();
 
-void NetworkSetPassword(const char* password);
+    void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
+    void NetworkSendGameAction(const OpenRCT2::GameActions::GameAction* action);
+    void NetworkSendPassword(const std::string& password);
 
-void NetworkAppendChatLog(std::string_view text);
-void NetworkAppendServerLog(const utf8* text);
-[[nodiscard]] u8string NetworkGetServerName();
-[[nodiscard]] u8string NetworkGetServerDescription();
-[[nodiscard]] u8string NetworkGetServerGreeting();
-[[nodiscard]] u8string NetworkGetServerProviderName();
-[[nodiscard]] u8string NetworkGetServerProviderEmail();
-[[nodiscard]] u8string NetworkGetServerProviderWebsite();
+    void NetworkSetPassword(const char* password);
 
-[[nodiscard]] std::string NetworkGetVersion();
+    void NetworkAppendChatLog(std::string_view text);
+    void NetworkAppendServerLog(const utf8* text);
+    [[nodiscard]] u8string NetworkGetServerName();
+    [[nodiscard]] u8string NetworkGetServerDescription();
+    [[nodiscard]] u8string NetworkGetServerGreeting();
+    [[nodiscard]] u8string NetworkGetServerProviderName();
+    [[nodiscard]] u8string NetworkGetServerProviderEmail();
+    [[nodiscard]] u8string NetworkGetServerProviderWebsite();
 
-[[nodiscard]] NetworkStats NetworkGetStats();
-[[nodiscard]] NetworkServerState NetworkGetServerState();
-[[nodiscard]] json_t NetworkGetServerInfoAsJson();
+    [[nodiscard]] std::string NetworkGetVersion();
+
+    [[nodiscard]] NetworkStats NetworkGetStats();
+    [[nodiscard]] NetworkServerState NetworkGetServerState();
+    [[nodiscard]] json_t NetworkGetServerInfoAsJson();
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/Network.h
+++ b/src/openrct2/network/Network.h
@@ -83,12 +83,12 @@ namespace OpenRCT2::Network
     [[nodiscard]] uint8_t NetworkGetGroupID(uint32_t index);
     [[nodiscard]] int32_t NetworkGetNumGroups();
     [[nodiscard]] const char* NetworkGetGroupName(uint32_t index);
-    [[nodiscard]] OpenRCT2::GameActions::Result NetworkSetPlayerGroup(
+    [[nodiscard]] GameActions::Result NetworkSetPlayerGroup(
         NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting);
-    [[nodiscard]] OpenRCT2::GameActions::Result NetworkModifyGroups(
-        NetworkPlayerId_t actionPlayerId, OpenRCT2::GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
-        uint32_t permissionIndex, OpenRCT2::GameActions::PermissionState permissionState, bool isExecuting);
-    [[nodiscard]] OpenRCT2::GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting);
+    [[nodiscard]] GameActions::Result NetworkModifyGroups(
+        NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+        uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting);
+    [[nodiscard]] GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting);
     [[nodiscard]] uint8_t NetworkGetDefaultGroup();
     [[nodiscard]] int32_t NetworkGetNumActions();
     [[nodiscard]] StringId NetworkGetActionNameStringID(uint32_t index);
@@ -101,7 +101,7 @@ namespace OpenRCT2::Network
     [[nodiscard]] bool NetworkIsServerPlayerInvisible();
 
     void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
-    void NetworkSendGameAction(const OpenRCT2::GameActions::GameAction* action);
+    void NetworkSendGameAction(const GameActions::GameAction* action);
     void NetworkSendPassword(const std::string& password);
 
     void NetworkSetPassword(const char* password);

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -18,7 +18,7 @@
 
 namespace OpenRCT2::Network
 {
-    NetworkPermission NetworkActions::FindCommand(GameCommand command)
+    Permission NetworkActions::FindCommand(GameCommand command)
     {
         auto it = std::find_if(Actions.begin(), Actions.end(), [&command](NetworkAction const& action) {
             for (GameCommand currentCommand : action.Commands)
@@ -32,24 +32,24 @@ namespace OpenRCT2::Network
         });
         if (it != Actions.end())
         {
-            return static_cast<NetworkPermission>(it - Actions.begin());
+            return static_cast<Permission>(it - Actions.begin());
         }
-        return NetworkPermission::Count;
+        return Permission::Count;
     }
 
-    NetworkPermission NetworkActions::FindCommandByPermissionName(const std::string& permission_name)
+    Permission NetworkActions::FindCommandByPermissionName(const std::string& permission_name)
     {
         auto it = std::find_if(Actions.begin(), Actions.end(), [&permission_name](NetworkAction const& action) {
             return action.PermissionName == permission_name;
         });
         if (it != Actions.end())
         {
-            return static_cast<NetworkPermission>(it - Actions.begin());
+            return static_cast<Permission>(it - Actions.begin());
         }
-        return NetworkPermission::Count;
+        return Permission::Count;
     }
 
-    const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> NetworkActions::Actions = {
+    const std::array<NetworkAction, static_cast<size_t>(Permission::Count)> NetworkActions::Actions = {
         NetworkAction{
             STR_ACTION_CHAT,
             "PERMISSION_CHAT",

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -16,254 +16,257 @@
 
     #include <algorithm>
 
-NetworkPermission NetworkActions::FindCommand(GameCommand command)
+namespace OpenRCT2::Network
 {
-    auto it = std::find_if(Actions.begin(), Actions.end(), [&command](NetworkAction const& action) {
-        for (GameCommand currentCommand : action.Commands)
-        {
-            if (currentCommand == command)
+    NetworkPermission NetworkActions::FindCommand(GameCommand command)
+    {
+        auto it = std::find_if(Actions.begin(), Actions.end(), [&command](NetworkAction const& action) {
+            for (GameCommand currentCommand : action.Commands)
             {
-                return true;
+                if (currentCommand == command)
+                {
+                    return true;
+                }
             }
+            return false;
+        });
+        if (it != Actions.end())
+        {
+            return static_cast<NetworkPermission>(it - Actions.begin());
         }
-        return false;
-    });
-    if (it != Actions.end())
-    {
-        return static_cast<NetworkPermission>(it - Actions.begin());
+        return NetworkPermission::Count;
     }
-    return NetworkPermission::Count;
-}
 
-NetworkPermission NetworkActions::FindCommandByPermissionName(const std::string& permission_name)
-{
-    auto it = std::find_if(Actions.begin(), Actions.end(), [&permission_name](NetworkAction const& action) {
-        return action.PermissionName == permission_name;
-    });
-    if (it != Actions.end())
+    NetworkPermission NetworkActions::FindCommandByPermissionName(const std::string& permission_name)
     {
-        return static_cast<NetworkPermission>(it - Actions.begin());
+        auto it = std::find_if(Actions.begin(), Actions.end(), [&permission_name](NetworkAction const& action) {
+            return action.PermissionName == permission_name;
+        });
+        if (it != Actions.end())
+        {
+            return static_cast<NetworkPermission>(it - Actions.begin());
+        }
+        return NetworkPermission::Count;
     }
-    return NetworkPermission::Count;
-}
 
-const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> NetworkActions::Actions = {
-    NetworkAction{
-        STR_ACTION_CHAT,
-        "PERMISSION_CHAT",
-        {},
-    },
-    NetworkAction{
-        STR_ACTION_TERRAFORM,
-        "PERMISSION_TERRAFORM",
-        {
-            GameCommand::SetLandHeight,
-            GameCommand::RaiseLand,
-            GameCommand::LowerLand,
-            GameCommand::EditLandSmooth,
-            GameCommand::ChangeSurfaceStyle,
+    const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> NetworkActions::Actions = {
+        NetworkAction{
+            STR_ACTION_CHAT,
+            "PERMISSION_CHAT",
+            {},
         },
-    },
-    NetworkAction{
-        STR_ACTION_SET_WATER_LEVEL,
-        "PERMISSION_SET_WATER_LEVEL",
-        {
-            GameCommand::SetWaterHeight,
-            GameCommand::RaiseWater,
-            GameCommand::LowerWater,
+        NetworkAction{
+            STR_ACTION_TERRAFORM,
+            "PERMISSION_TERRAFORM",
+            {
+                GameCommand::SetLandHeight,
+                GameCommand::RaiseLand,
+                GameCommand::LowerLand,
+                GameCommand::EditLandSmooth,
+                GameCommand::ChangeSurfaceStyle,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_TOGGLE_PAUSE,
-        "PERMISSION_TOGGLE_PAUSE",
-        {
-            GameCommand::TogglePause,
+        NetworkAction{
+            STR_ACTION_SET_WATER_LEVEL,
+            "PERMISSION_SET_WATER_LEVEL",
+            {
+                GameCommand::SetWaterHeight,
+                GameCommand::RaiseWater,
+                GameCommand::LowerWater,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_CREATE_RIDE,
-        "PERMISSION_CREATE_RIDE",
-        {
-            GameCommand::CreateRide,
+        NetworkAction{
+            STR_ACTION_TOGGLE_PAUSE,
+            "PERMISSION_TOGGLE_PAUSE",
+            {
+                GameCommand::TogglePause,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_REMOVE_RIDE,
-        "PERMISSION_REMOVE_RIDE",
-        {
-            GameCommand::DemolishRide,
+        NetworkAction{
+            STR_ACTION_CREATE_RIDE,
+            "PERMISSION_CREATE_RIDE",
+            {
+                GameCommand::CreateRide,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_BUILD_RIDE,
-        "PERMISSION_BUILD_RIDE",
-        {
-            GameCommand::PlaceTrack,
-            GameCommand::RemoveTrack,
-            GameCommand::SetMazeTrack,
-            GameCommand::PlaceTrackDesign,
-            GameCommand::PlaceMazeDesign,
-            GameCommand::PlaceRideEntranceOrExit,
-            GameCommand::RemoveRideEntranceOrExit,
+        NetworkAction{
+            STR_ACTION_REMOVE_RIDE,
+            "PERMISSION_REMOVE_RIDE",
+            {
+                GameCommand::DemolishRide,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_RIDE_PROPERTIES,
-        "PERMISSION_RIDE_PROPERTIES",
-        {
-            GameCommand::SetRideName,
-            GameCommand::SetRideAppearance,
-            GameCommand::SetRideStatus,
-            GameCommand::SetRideVehicles,
-            GameCommand::SetRideSetting,
-            GameCommand::SetRidePrice,
-            GameCommand::SetBrakesSpeed,
-            GameCommand::SetColourScheme,
+        NetworkAction{
+            STR_ACTION_BUILD_RIDE,
+            "PERMISSION_BUILD_RIDE",
+            {
+                GameCommand::PlaceTrack,
+                GameCommand::RemoveTrack,
+                GameCommand::SetMazeTrack,
+                GameCommand::PlaceTrackDesign,
+                GameCommand::PlaceMazeDesign,
+                GameCommand::PlaceRideEntranceOrExit,
+                GameCommand::RemoveRideEntranceOrExit,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_SCENERY,
-        "PERMISSION_SCENERY",
-        {
-            GameCommand::RemoveScenery,
-            GameCommand::PlaceScenery,
-            GameCommand::SetBrakesSpeed,
-            GameCommand::RemoveWall,
-            GameCommand::PlaceWall,
-            GameCommand::RemoveLargeScenery,
-            GameCommand::PlaceLargeScenery,
-            GameCommand::PlaceBanner,
-            GameCommand::RemoveBanner,
-            GameCommand::SetSceneryColour,
-            GameCommand::SetWallColour,
-            GameCommand::SetLargeSceneryColour,
-            GameCommand::SetBannerColour,
-            GameCommand::SetBannerName,
-            GameCommand::SetSignName,
-            GameCommand::SetBannerStyle,
-            GameCommand::SetSignStyle,
+        NetworkAction{
+            STR_ACTION_RIDE_PROPERTIES,
+            "PERMISSION_RIDE_PROPERTIES",
+            {
+                GameCommand::SetRideName,
+                GameCommand::SetRideAppearance,
+                GameCommand::SetRideStatus,
+                GameCommand::SetRideVehicles,
+                GameCommand::SetRideSetting,
+                GameCommand::SetRidePrice,
+                GameCommand::SetBrakesSpeed,
+                GameCommand::SetColourScheme,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_PATH,
-        "PERMISSION_PATH",
-        {
-            GameCommand::PlacePath,
-            GameCommand::PlacePathLayout,
-            GameCommand::RemovePath,
-            GameCommand::PlaceFootpathAddition,
-            GameCommand::RemoveFootpathAddition,
+        NetworkAction{
+            STR_ACTION_SCENERY,
+            "PERMISSION_SCENERY",
+            {
+                GameCommand::RemoveScenery,
+                GameCommand::PlaceScenery,
+                GameCommand::SetBrakesSpeed,
+                GameCommand::RemoveWall,
+                GameCommand::PlaceWall,
+                GameCommand::RemoveLargeScenery,
+                GameCommand::PlaceLargeScenery,
+                GameCommand::PlaceBanner,
+                GameCommand::RemoveBanner,
+                GameCommand::SetSceneryColour,
+                GameCommand::SetWallColour,
+                GameCommand::SetLargeSceneryColour,
+                GameCommand::SetBannerColour,
+                GameCommand::SetBannerName,
+                GameCommand::SetSignName,
+                GameCommand::SetBannerStyle,
+                GameCommand::SetSignStyle,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_CLEAR_LANDSCAPE,
-        "PERMISSION_CLEAR_LANDSCAPE",
-        {
-            GameCommand::ClearScenery,
+        NetworkAction{
+            STR_ACTION_PATH,
+            "PERMISSION_PATH",
+            {
+                GameCommand::PlacePath,
+                GameCommand::PlacePathLayout,
+                GameCommand::RemovePath,
+                GameCommand::PlaceFootpathAddition,
+                GameCommand::RemoveFootpathAddition,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_GUEST,
-        "PERMISSION_GUEST",
-        {
-            GameCommand::SetGuestName,
-            GameCommand::PickupGuest,
-            GameCommand::BalloonPress,
-            GameCommand::GuestSetFlags,
+        NetworkAction{
+            STR_ACTION_CLEAR_LANDSCAPE,
+            "PERMISSION_CLEAR_LANDSCAPE",
+            {
+                GameCommand::ClearScenery,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_STAFF,
-        "PERMISSION_STAFF",
-        {
-            GameCommand::HireNewStaffMember,
-            GameCommand::SetStaffPatrol,
-            GameCommand::FireStaffMember,
-            GameCommand::SetStaffOrders,
-            GameCommand::SetStaffCostume,
-            GameCommand::SetStaffColour,
-            GameCommand::SetStaffName,
-            GameCommand::PickupStaff,
+        NetworkAction{
+            STR_ACTION_GUEST,
+            "PERMISSION_GUEST",
+            {
+                GameCommand::SetGuestName,
+                GameCommand::PickupGuest,
+                GameCommand::BalloonPress,
+                GameCommand::GuestSetFlags,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_PARK_PROPERTIES,
-        "PERMISSION_PARK_PROPERTIES",
-        {
-            GameCommand::SetParkName,
-            GameCommand::SetParkOpen,
-            GameCommand::SetParkEntranceFee,
-            GameCommand::SetLandOwnership,
-            GameCommand::BuyLandRights,
-            GameCommand::PlaceParkEntrance,
-            GameCommand::RemoveParkEntrance,
-            GameCommand::PlacePeepSpawn,
-            GameCommand::ChangeMapSize,
+        NetworkAction{
+            STR_ACTION_STAFF,
+            "PERMISSION_STAFF",
+            {
+                GameCommand::HireNewStaffMember,
+                GameCommand::SetStaffPatrol,
+                GameCommand::FireStaffMember,
+                GameCommand::SetStaffOrders,
+                GameCommand::SetStaffCostume,
+                GameCommand::SetStaffColour,
+                GameCommand::SetStaffName,
+                GameCommand::PickupStaff,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_PARK_FUNDING,
-        "PERMISSION_PARK_FUNDING",
-        {
-            GameCommand::SetCurrentLoan,
-            GameCommand::SetResearchFunding,
-            GameCommand::StartMarketingCampaign,
+        NetworkAction{
+            STR_ACTION_PARK_PROPERTIES,
+            "PERMISSION_PARK_PROPERTIES",
+            {
+                GameCommand::SetParkName,
+                GameCommand::SetParkOpen,
+                GameCommand::SetParkEntranceFee,
+                GameCommand::SetLandOwnership,
+                GameCommand::BuyLandRights,
+                GameCommand::PlaceParkEntrance,
+                GameCommand::RemoveParkEntrance,
+                GameCommand::PlacePeepSpawn,
+                GameCommand::ChangeMapSize,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_KICK_PLAYER,
-        "PERMISSION_KICK_PLAYER",
-        {
-            GameCommand::KickPlayer,
+        NetworkAction{
+            STR_ACTION_PARK_FUNDING,
+            "PERMISSION_PARK_FUNDING",
+            {
+                GameCommand::SetCurrentLoan,
+                GameCommand::SetResearchFunding,
+                GameCommand::StartMarketingCampaign,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_MODIFY_GROUPS,
-        "PERMISSION_MODIFY_GROUPS",
-        {
-            GameCommand::ModifyGroups,
+        NetworkAction{
+            STR_ACTION_KICK_PLAYER,
+            "PERMISSION_KICK_PLAYER",
+            {
+                GameCommand::KickPlayer,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_SET_PLAYER_GROUP,
-        "PERMISSION_SET_PLAYER_GROUP",
-        {
-            GameCommand::SetPlayerGroup,
+        NetworkAction{
+            STR_ACTION_MODIFY_GROUPS,
+            "PERMISSION_MODIFY_GROUPS",
+            {
+                GameCommand::ModifyGroups,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_CHEAT,
-        "PERMISSION_CHEAT",
-        {
-            GameCommand::Cheat,
-            GameCommand::SetDate,
-            GameCommand::FreezeRideRating,
+        NetworkAction{
+            STR_ACTION_SET_PLAYER_GROUP,
+            "PERMISSION_SET_PLAYER_GROUP",
+            {
+                GameCommand::SetPlayerGroup,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_TOGGLE_SCENERY_CLUSTER,
-        "PERMISSION_TOGGLE_SCENERY_CLUSTER",
-        {},
-    },
-    NetworkAction{
-        STR_ACTION_PASSWORDLESS_LOGIN,
-        "PERMISSION_PASSWORDLESS_LOGIN",
-        {},
-    },
-    NetworkAction{
-        STR_ACTION_MODIFY_TILE,
-        "PERMISSION_MODIFY_TILE",
-        {
-            GameCommand::ModifyTile,
+        NetworkAction{
+            STR_ACTION_CHEAT,
+            "PERMISSION_CHEAT",
+            {
+                GameCommand::Cheat,
+                GameCommand::SetDate,
+                GameCommand::FreezeRideRating,
+            },
         },
-    },
-    NetworkAction{
-        STR_ACTION_EDIT_SCENARIO_OPTIONS,
-        "PERMISSION_EDIT_SCENARIO_OPTIONS",
-        {
-            GameCommand::EditScenarioOptions,
+        NetworkAction{
+            STR_ACTION_TOGGLE_SCENERY_CLUSTER,
+            "PERMISSION_TOGGLE_SCENERY_CLUSTER",
+            {},
         },
-    },
-};
+        NetworkAction{
+            STR_ACTION_PASSWORDLESS_LOGIN,
+            "PERMISSION_PASSWORDLESS_LOGIN",
+            {},
+        },
+        NetworkAction{
+            STR_ACTION_MODIFY_TILE,
+            "PERMISSION_MODIFY_TILE",
+            {
+                GameCommand::ModifyTile,
+            },
+        },
+        NetworkAction{
+            STR_ACTION_EDIT_SCENARIO_OPTIONS,
+            "PERMISSION_EDIT_SCENARIO_OPTIONS",
+            {
+                GameCommand::EditScenarioOptions,
+            },
+        },
+    };
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/NetworkAction.h
+++ b/src/openrct2/network/NetworkAction.h
@@ -16,48 +16,51 @@
 #include <string>
 #include <vector>
 
-enum class NetworkPermission : uint32_t
+namespace OpenRCT2::Network
 {
-    Chat,
-    Terraform,
-    SetWaterLevel,
-    TogglePause,
-    CreateRide,
-    RemoveRide,
-    BuildRide,
-    RideProperties,
-    Scenery,
-    Path,
-    ClearLandscape,
-    Guest,
-    Staff,
-    ParkProperties,
-    ParkFunding,
-    KickPlayer,
-    ModifyGroups,
-    SetPlayerGroup,
-    Cheat,
-    ToggleSceneryCluster,
-    PasswordlessLogin,
-    ModifyTile,
-    EditScenarioOptions,
+    enum class NetworkPermission : uint32_t
+    {
+        Chat,
+        Terraform,
+        SetWaterLevel,
+        TogglePause,
+        CreateRide,
+        RemoveRide,
+        BuildRide,
+        RideProperties,
+        Scenery,
+        Path,
+        ClearLandscape,
+        Guest,
+        Staff,
+        ParkProperties,
+        ParkFunding,
+        KickPlayer,
+        ModifyGroups,
+        SetPlayerGroup,
+        Cheat,
+        ToggleSceneryCluster,
+        PasswordlessLogin,
+        ModifyTile,
+        EditScenarioOptions,
 
-    Count
-};
+        Count
+    };
 
-class NetworkAction final
-{
-public:
-    StringId Name;
-    std::string PermissionName;
-    std::vector<GameCommand> Commands;
-};
+    class NetworkAction final
+    {
+    public:
+        StringId Name;
+        std::string PermissionName;
+        std::vector<GameCommand> Commands;
+    };
 
-class NetworkActions final
-{
-public:
-    static const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> Actions;
+    class NetworkActions final
+    {
+    public:
+        static const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> Actions;
 
-    static NetworkPermission FindCommand(GameCommand command);
-    static NetworkPermission FindCommandByPermissionName(const std::string& permission_name);
-};
+        static NetworkPermission FindCommand(GameCommand command);
+        static NetworkPermission FindCommandByPermissionName(const std::string& permission_name);
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkAction.h
+++ b/src/openrct2/network/NetworkAction.h
@@ -18,7 +18,7 @@
 
 namespace OpenRCT2::Network
 {
-    enum class NetworkPermission : uint32_t
+    enum class Permission : uint32_t
     {
         Chat,
         Terraform,
@@ -58,9 +58,9 @@ namespace OpenRCT2::Network
     class NetworkActions final
     {
     public:
-        static const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> Actions;
+        static const std::array<NetworkAction, static_cast<size_t>(Permission::Count)> Actions;
 
-        static NetworkPermission FindCommand(GameCommand command);
-        static NetworkPermission FindCommandByPermissionName(const std::string& permission_name);
+        static Permission FindCommand(GameCommand command);
+        static Permission FindCommandByPermissionName(const std::string& permission_name);
     };
 } // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,8 +43,6 @@
 #include <iterator>
 #include <stdexcept>
 
-using namespace OpenRCT2;
-
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
@@ -104,4253 +102,4270 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     #include <string>
     #include <vector>
 
-using namespace OpenRCT2;
+    using namespace OpenRCT2;
 
-static void NetworkChatShowConnectedMessage();
-static void NetworkChatShowServerGreeting();
-static u8string NetworkGetKeysDirectory();
-static u8string NetworkGetPrivateKeyPath(u8string_view playerName);
-static u8string NetworkGetPublicKeyPath(u8string_view playerName, u8string_view hash);
+    static void NetworkChatShowConnectedMessage();
+    static void NetworkChatShowServerGreeting();
+    static u8string NetworkGetKeysDirectory();
+    static u8string NetworkGetPrivateKeyPath(u8string_view playerName);
+    static u8string NetworkGetPublicKeyPath(u8string_view playerName, u8string_view hash);
 
-NetworkBase::NetworkBase(IContext& context)
-    : System(context)
-{
-    mode = NETWORK_MODE_NONE;
-    status = NETWORK_STATUS_NONE;
-    last_ping_sent_time = 0;
-    _actionId = 0;
-
-    client_command_handlers[NetworkCommand::Auth] = &NetworkBase::Client_Handle_AUTH;
-    client_command_handlers[NetworkCommand::Map] = &NetworkBase::Client_Handle_MAP;
-    client_command_handlers[NetworkCommand::Chat] = &NetworkBase::Client_Handle_CHAT;
-    client_command_handlers[NetworkCommand::GameAction] = &NetworkBase::Client_Handle_GAME_ACTION;
-    client_command_handlers[NetworkCommand::Tick] = &NetworkBase::Client_Handle_TICK;
-    client_command_handlers[NetworkCommand::PlayerList] = &NetworkBase::Client_Handle_PLAYERLIST;
-    client_command_handlers[NetworkCommand::PlayerInfo] = &NetworkBase::Client_Handle_PLAYERINFO;
-    client_command_handlers[NetworkCommand::Ping] = &NetworkBase::Client_Handle_PING;
-    client_command_handlers[NetworkCommand::PingList] = &NetworkBase::Client_Handle_PINGLIST;
-    client_command_handlers[NetworkCommand::DisconnectMessage] = &NetworkBase::Client_Handle_SETDISCONNECTMSG;
-    client_command_handlers[NetworkCommand::ShowError] = &NetworkBase::Client_Handle_SHOWERROR;
-    client_command_handlers[NetworkCommand::GroupList] = &NetworkBase::Client_Handle_GROUPLIST;
-    client_command_handlers[NetworkCommand::Event] = &NetworkBase::Client_Handle_EVENT;
-    client_command_handlers[NetworkCommand::GameInfo] = &NetworkBase::Client_Handle_GAMEINFO;
-    client_command_handlers[NetworkCommand::Token] = &NetworkBase::Client_Handle_TOKEN;
-    client_command_handlers[NetworkCommand::ObjectsList] = &NetworkBase::Client_Handle_OBJECTS_LIST;
-    client_command_handlers[NetworkCommand::ScriptsHeader] = &NetworkBase::Client_Handle_SCRIPTS_HEADER;
-    client_command_handlers[NetworkCommand::ScriptsData] = &NetworkBase::Client_Handle_SCRIPTS_DATA;
-    client_command_handlers[NetworkCommand::GameState] = &NetworkBase::Client_Handle_GAMESTATE;
-
-    server_command_handlers[NetworkCommand::Auth] = &NetworkBase::ServerHandleAuth;
-    server_command_handlers[NetworkCommand::Chat] = &NetworkBase::ServerHandleChat;
-    server_command_handlers[NetworkCommand::GameAction] = &NetworkBase::ServerHandleGameAction;
-    server_command_handlers[NetworkCommand::Ping] = &NetworkBase::ServerHandlePing;
-    server_command_handlers[NetworkCommand::GameInfo] = &NetworkBase::ServerHandleGameInfo;
-    server_command_handlers[NetworkCommand::Token] = &NetworkBase::ServerHandleToken;
-    server_command_handlers[NetworkCommand::MapRequest] = &NetworkBase::ServerHandleMapRequest;
-    server_command_handlers[NetworkCommand::RequestGameState] = &NetworkBase::ServerHandleRequestGamestate;
-    server_command_handlers[NetworkCommand::Heartbeat] = &NetworkBase::ServerHandleHeartbeat;
-
-    _chat_log_fs << std::unitbuf;
-    _server_log_fs << std::unitbuf;
-}
-
-bool NetworkBase::Init()
-{
-    status = NETWORK_STATUS_READY;
-
-    ServerName.clear();
-    ServerDescription.clear();
-    ServerGreeting.clear();
-    ServerProviderName.clear();
-    ServerProviderEmail.clear();
-    ServerProviderWebsite.clear();
-    return true;
-}
-
-void NetworkBase::Reconnect()
-{
-    if (status != NETWORK_STATUS_NONE)
+    NetworkBase::NetworkBase(IContext& context)
+        : System(context)
     {
-        Close();
-    }
-    if (_requireClose)
-    {
-        _requireReconnect = true;
-        return;
-    }
-    BeginClient(_host, _port);
-}
+        mode = NETWORK_MODE_NONE;
+        status = NETWORK_STATUS_NONE;
+        last_ping_sent_time = 0;
+        _actionId = 0;
 
-void NetworkBase::Close()
-{
-    if (status != NETWORK_STATUS_NONE)
-    {
-        // HACK Because Close() is closed all over the place, it sometimes gets called inside an Update
-        //      call. This then causes disposed data to be accessed. Therefore, save closing until the
-        //      end of the update loop.
-        if (_closeLock)
-        {
-            _requireClose = true;
-            return;
-        }
+        client_command_handlers[NetworkCommand::Auth] = &NetworkBase::Client_Handle_AUTH;
+        client_command_handlers[NetworkCommand::Map] = &NetworkBase::Client_Handle_MAP;
+        client_command_handlers[NetworkCommand::Chat] = &NetworkBase::Client_Handle_CHAT;
+        client_command_handlers[NetworkCommand::GameAction] = &NetworkBase::Client_Handle_GAME_ACTION;
+        client_command_handlers[NetworkCommand::Tick] = &NetworkBase::Client_Handle_TICK;
+        client_command_handlers[NetworkCommand::PlayerList] = &NetworkBase::Client_Handle_PLAYERLIST;
+        client_command_handlers[NetworkCommand::PlayerInfo] = &NetworkBase::Client_Handle_PLAYERINFO;
+        client_command_handlers[NetworkCommand::Ping] = &NetworkBase::Client_Handle_PING;
+        client_command_handlers[NetworkCommand::PingList] = &NetworkBase::Client_Handle_PINGLIST;
+        client_command_handlers[NetworkCommand::DisconnectMessage] = &NetworkBase::Client_Handle_SETDISCONNECTMSG;
+        client_command_handlers[NetworkCommand::ShowError] = &NetworkBase::Client_Handle_SHOWERROR;
+        client_command_handlers[NetworkCommand::GroupList] = &NetworkBase::Client_Handle_GROUPLIST;
+        client_command_handlers[NetworkCommand::Event] = &NetworkBase::Client_Handle_EVENT;
+        client_command_handlers[NetworkCommand::GameInfo] = &NetworkBase::Client_Handle_GAMEINFO;
+        client_command_handlers[NetworkCommand::Token] = &NetworkBase::Client_Handle_TOKEN;
+        client_command_handlers[NetworkCommand::ObjectsList] = &NetworkBase::Client_Handle_OBJECTS_LIST;
+        client_command_handlers[NetworkCommand::ScriptsHeader] = &NetworkBase::Client_Handle_SCRIPTS_HEADER;
+        client_command_handlers[NetworkCommand::ScriptsData] = &NetworkBase::Client_Handle_SCRIPTS_DATA;
+        client_command_handlers[NetworkCommand::GameState] = &NetworkBase::Client_Handle_GAMESTATE;
 
-        CloseChatLog();
-        CloseServerLog();
-        CloseConnection();
+        server_command_handlers[NetworkCommand::Auth] = &NetworkBase::ServerHandleAuth;
+        server_command_handlers[NetworkCommand::Chat] = &NetworkBase::ServerHandleChat;
+        server_command_handlers[NetworkCommand::GameAction] = &NetworkBase::ServerHandleGameAction;
+        server_command_handlers[NetworkCommand::Ping] = &NetworkBase::ServerHandlePing;
+        server_command_handlers[NetworkCommand::GameInfo] = &NetworkBase::ServerHandleGameInfo;
+        server_command_handlers[NetworkCommand::Token] = &NetworkBase::ServerHandleToken;
+        server_command_handlers[NetworkCommand::MapRequest] = &NetworkBase::ServerHandleMapRequest;
+        server_command_handlers[NetworkCommand::RequestGameState] = &NetworkBase::ServerHandleRequestGamestate;
+        server_command_handlers[NetworkCommand::Heartbeat] = &NetworkBase::ServerHandleHeartbeat;
 
-        client_connection_list.clear();
-        GameActions::ClearQueue();
-        GameActions::ResumeQueue();
-        player_list.clear();
-        group_list.clear();
-        _serverTickData.clear();
-        _pendingPlayerLists.clear();
-        _pendingPlayerInfo.clear();
-
-    #ifdef ENABLE_SCRIPTING
-        auto& scriptEngine = GetContext().GetScriptEngine();
-        scriptEngine.RemoveNetworkPlugins();
-    #endif
-
-        GfxInvalidateScreen();
-
-        _requireClose = false;
-    }
-}
-
-void NetworkBase::DecayCooldown(NetworkPlayer* player)
-{
-    if (player == nullptr)
-        return; // No valid connection yet.
-
-    for (auto it = std::begin(player->CooldownTime); it != std::end(player->CooldownTime);)
-    {
-        it->second -= _currentDeltaTime;
-        if (it->second <= 0)
-            it = player->CooldownTime.erase(it);
-        else
-            it++;
-    }
-}
-
-void NetworkBase::CloseConnection()
-{
-    if (mode == NETWORK_MODE_CLIENT)
-    {
-        _serverConnection.reset();
-    }
-    else if (mode == NETWORK_MODE_SERVER)
-    {
-        _listenSocket.reset();
-        _advertiser.reset();
+        _chat_log_fs << std::unitbuf;
+        _server_log_fs << std::unitbuf;
     }
 
-    mode = NETWORK_MODE_NONE;
-    status = NETWORK_STATUS_NONE;
-    _lastConnectStatus = SocketStatus::Closed;
-}
-
-bool NetworkBase::BeginClient(const std::string& host, uint16_t port)
-{
-    if (GetMode() != NETWORK_MODE_NONE)
+    bool NetworkBase::Init()
     {
-        return false;
-    }
-
-    Close();
-    if (!Init())
-        return false;
-
-    mode = NETWORK_MODE_CLIENT;
-
-    LOG_INFO("Connecting to %s:%u", host.c_str(), port);
-    _host = host;
-    _port = port;
-
-    _serverConnection = std::make_unique<NetworkConnection>();
-    _serverConnection->Socket = CreateTcpSocket();
-    _serverConnection->Socket->ConnectAsync(host, port);
-    _serverState.gamestateSnapshotsEnabled = false;
-
-    status = NETWORK_STATUS_CONNECTING;
-    _lastConnectStatus = SocketStatus::Closed;
-    _clientMapLoaded = false;
-    _serverTickData.clear();
-
-    BeginChatLog();
-    BeginServerLog();
-
-    // We need to wait for the map load before we execute any actions.
-    // If the client has the title screen running then there's a potential
-    // risk of tick collision with the server map and title screen map.
-    GameActions::SuspendQueue();
-
-    auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
-    if (!File::Exists(keyPath))
-    {
-        Console::WriteLine("Generating key... This may take a while");
-        Console::WriteLine("Need to collect enough entropy from the system");
-        _key.Generate();
-        Console::WriteLine("Key generated, saving private bits as %s", keyPath.c_str());
-
-        const auto keysDirectory = NetworkGetKeysDirectory();
-        if (!Path::CreateDirectory(keysDirectory))
-        {
-            LOG_ERROR("Unable to create directory %s.", keysDirectory.c_str());
-            return false;
-        }
-
-        try
-        {
-            auto fs = FileStream(keyPath, FileMode::write);
-            _key.SavePrivate(&fs);
-        }
-        catch (const std::exception&)
-        {
-            LOG_ERROR("Unable to save private key at %s.", keyPath.c_str());
-            return false;
-        }
-
-        const std::string hash = _key.PublicKeyHash();
-        const utf8* publicKeyHash = hash.c_str();
-        keyPath = NetworkGetPublicKeyPath(Config::Get().network.PlayerName, publicKeyHash);
-        Console::WriteLine("Key generated, saving public bits as %s", keyPath.c_str());
-
-        try
-        {
-            auto fs = FileStream(keyPath, FileMode::write);
-            _key.SavePublic(&fs);
-        }
-        catch (const std::exception&)
-        {
-            LOG_ERROR("Unable to save public key at %s.", keyPath.c_str());
-            return false;
-        }
-    }
-    else
-    {
-        // LoadPrivate returns validity of loaded key
-        bool ok = false;
-        try
-        {
-            LOG_VERBOSE("Loading key from %s", keyPath.c_str());
-            auto fs = FileStream(keyPath, FileMode::open);
-            ok = _key.LoadPrivate(&fs);
-        }
-        catch (const std::exception&)
-        {
-            LOG_ERROR("Unable to read private key from %s.", keyPath.c_str());
-            return false;
-        }
-
-        // Don't store private key in memory when it's not in use.
-        _key.Unload();
-        return ok;
-    }
-
-    return true;
-}
-
-bool NetworkBase::BeginServer(uint16_t port, const std::string& address)
-{
-    Close();
-    if (!Init())
-        return false;
-
-    mode = NETWORK_MODE_SERVER;
-
-    _userManager.Load();
-
-    LOG_VERBOSE("Begin listening for clients");
-
-    _listenSocket = CreateTcpSocket();
-    try
-    {
-        _listenSocket->Listen(address, port);
-    }
-    catch (const std::exception& ex)
-    {
-        Console::Error::WriteLine(ex.what());
-        Close();
-        return false;
-    }
-
-    ServerName = Config::Get().network.ServerName;
-    ServerDescription = Config::Get().network.ServerDescription;
-    ServerGreeting = Config::Get().network.ServerGreeting;
-    ServerProviderName = Config::Get().network.ProviderName;
-    ServerProviderEmail = Config::Get().network.ProviderEmail;
-    ServerProviderWebsite = Config::Get().network.ProviderWebsite;
-
-    IsServerPlayerInvisible = gOpenRCT2Headless;
-
-    LoadGroups();
-    BeginChatLog();
-    BeginServerLog();
-
-    NetworkPlayer* player = AddPlayer(Config::Get().network.PlayerName, "");
-    player->Flags |= NETWORK_PLAYER_FLAG_ISSERVER;
-    player->Group = 0;
-    player_id = player->Id;
-
-    if (NetworkGetMode() == NETWORK_MODE_SERVER)
-    {
-        // Add SERVER to users.json and save.
-        NetworkUser* networkUser = _userManager.GetOrAddUser(player->KeyHash);
-        networkUser->GroupId = player->Group;
-        networkUser->Name = player->Name;
-        _userManager.Save();
-    }
-
-    auto* szAddress = address.empty() ? "*" : address.c_str();
-    Console::WriteLine("Listening for clients on %s:%hu", szAddress, port);
-    NetworkChatShowConnectedMessage();
-    NetworkChatShowServerGreeting();
-
-    status = NETWORK_STATUS_CONNECTED;
-    listening_port = port;
-    _serverState.gamestateSnapshotsEnabled = Config::Get().network.DesyncDebugging;
-    _advertiser = CreateServerAdvertiser(listening_port);
-
-    GameLoadScripts();
-    GameNotifyMapChanged();
-
-    return true;
-}
-
-int32_t NetworkBase::GetMode() const noexcept
-{
-    return mode;
-}
-
-int32_t NetworkBase::GetStatus() const noexcept
-{
-    return status;
-}
-
-NetworkAuth NetworkBase::GetAuthStatus()
-{
-    if (GetMode() == NETWORK_MODE_CLIENT)
-    {
-        return _serverConnection->AuthStatus;
-    }
-    if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        return NetworkAuth::Ok;
-    }
-    return NetworkAuth::None;
-}
-
-uint32_t NetworkBase::GetServerTick() const noexcept
-{
-    return _serverState.tick;
-}
-
-uint8_t NetworkBase::GetPlayerID() const noexcept
-{
-    return player_id;
-}
-
-NetworkConnection* NetworkBase::GetPlayerConnection(uint8_t id) const
-{
-    auto player = GetPlayerByID(id);
-    if (player != nullptr)
-    {
-        auto clientIt = std::find_if(
-            client_connection_list.begin(), client_connection_list.end(),
-            [player](const auto& conn) -> bool { return conn->Player == player; });
-        return clientIt != client_connection_list.end() ? clientIt->get() : nullptr;
-    }
-    return nullptr;
-}
-
-void NetworkBase::Update()
-{
-    _closeLock = true;
-
-    // Update is not necessarily called per game tick, maintain our own delta time
-    uint32_t ticks = Platform::GetTicks();
-    _currentDeltaTime = std::max<uint32_t>(ticks - _lastUpdateTime, 1);
-    _lastUpdateTime = ticks;
-
-    switch (GetMode())
-    {
-        case NETWORK_MODE_SERVER:
-            UpdateServer();
-            break;
-        case NETWORK_MODE_CLIENT:
-            UpdateClient();
-            break;
-    }
-
-    // If the Close() was called during the update, close it for real
-    _closeLock = false;
-    if (_requireClose)
-    {
-        Close();
-        if (_requireReconnect)
-        {
-            Reconnect();
-        }
-    }
-}
-
-void NetworkBase::Flush()
-{
-    if (GetMode() == NETWORK_MODE_CLIENT)
-    {
-        _serverConnection->SendQueuedData();
-    }
-    else
-    {
-        for (auto& it : client_connection_list)
-        {
-            it->SendQueuedData();
-        }
-    }
-}
-
-void NetworkBase::UpdateServer()
-{
-    for (auto& connection : client_connection_list)
-    {
-        // This can be called multiple times before the connection is removed.
-        if (!connection->IsValid())
-            continue;
-
-        if (!ProcessConnection(*connection))
-        {
-            connection->Disconnect();
-        }
-        else
-        {
-            DecayCooldown(connection->Player);
-        }
-    }
-
-    uint32_t ticks = Platform::GetTicks();
-    if (ticks > last_ping_sent_time + 3000)
-    {
-        ServerSendPing();
-        ServerSendPingList();
-    }
-
-    if (_advertiser != nullptr)
-    {
-        _advertiser->Update();
-    }
-
-    std::unique_ptr<ITcpSocket> tcpSocket = _listenSocket->Accept();
-    if (tcpSocket != nullptr)
-    {
-        AddClient(std::move(tcpSocket));
-    }
-}
-
-void NetworkBase::UpdateClient()
-{
-    assert(_serverConnection != nullptr);
-
-    switch (status)
-    {
-        case NETWORK_STATUS_CONNECTING:
-        {
-            switch (_serverConnection->Socket->GetStatus())
-            {
-                case SocketStatus::Resolving:
-                {
-                    if (_lastConnectStatus != SocketStatus::Resolving)
-                    {
-                        _lastConnectStatus = SocketStatus::Resolving;
-                        char str_resolving[256];
-                        FormatStringLegacy(str_resolving, 256, STR_MULTIPLAYER_RESOLVING, nullptr);
-
-                        auto intent = Intent(WindowClass::NetworkStatus);
-                        intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_resolving });
-                        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
-                        ContextOpenIntent(&intent);
-                    }
-                    break;
-                }
-                case SocketStatus::Connecting:
-                {
-                    if (_lastConnectStatus != SocketStatus::Connecting)
-                    {
-                        _lastConnectStatus = SocketStatus::Connecting;
-                        char str_connecting[256];
-                        FormatStringLegacy(str_connecting, 256, STR_MULTIPLAYER_CONNECTING, nullptr);
-
-                        auto intent = Intent(WindowClass::NetworkStatus);
-                        intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_connecting });
-                        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
-                        ContextOpenIntent(&intent);
-
-                        server_connect_time = Platform::GetTicks();
-                    }
-                    break;
-                }
-                case SocketStatus::Connected:
-                {
-                    status = NETWORK_STATUS_CONNECTED;
-                    _serverConnection->ResetLastPacketTime();
-                    Client_Send_TOKEN();
-                    char str_authenticating[256];
-                    FormatStringLegacy(str_authenticating, 256, STR_MULTIPLAYER_AUTHENTICATING, nullptr);
-
-                    auto intent = Intent(WindowClass::NetworkStatus);
-                    intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_authenticating });
-                    intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
-                    ContextOpenIntent(&intent);
-                    break;
-                }
-                default:
-                {
-                    const char* error = _serverConnection->Socket->GetError();
-                    if (error != nullptr)
-                    {
-                        Console::Error::WriteLine(error);
-                    }
-
-                    Close();
-                    ContextForceCloseWindowByClass(WindowClass::NetworkStatus);
-                    ContextShowError(STR_UNABLE_TO_CONNECT_TO_SERVER, kStringIdNone, {});
-                    break;
-                }
-            }
-            break;
-        }
-        case NETWORK_STATUS_CONNECTED:
-        {
-            if (!ProcessConnection(*_serverConnection))
-            {
-                // Do not show disconnect message window when password window closed/canceled
-                if (_serverConnection->AuthStatus == NetworkAuth::RequirePassword)
-                {
-                    ContextForceCloseWindowByClass(WindowClass::NetworkStatus);
-                }
-                else
-                {
-                    char str_disconnected[256];
-
-                    if (_serverConnection->GetLastDisconnectReason())
-                    {
-                        const char* disconnect_reason = _serverConnection->GetLastDisconnectReason();
-                        FormatStringLegacy(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_WITH_REASON, &disconnect_reason);
-                    }
-                    else
-                    {
-                        FormatStringLegacy(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_NO_REASON, nullptr);
-                    }
-
-                    auto intent = Intent(WindowClass::NetworkStatus);
-                    intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_disconnected });
-                    ContextOpenIntent(&intent);
-                }
-
-                auto* windowMgr = Ui::GetWindowManager();
-                windowMgr->CloseByClass(WindowClass::Multiplayer);
-                Close();
-            }
-            else
-            {
-                uint32_t ticks = Platform::GetTicks();
-                if (ticks - _lastSentHeartbeat >= 3000)
-                {
-                    Client_Send_HEARTBEAT(*_serverConnection);
-                    _lastSentHeartbeat = ticks;
-                }
-            }
-
-            break;
-        }
-    }
-}
-
-auto NetworkBase::GetPlayerIteratorByID(uint8_t id) const
-{
-    return std::find_if(player_list.begin(), player_list.end(), [id](std::unique_ptr<NetworkPlayer> const& player) {
-        return player->Id == id;
-    });
-}
-
-NetworkPlayer* NetworkBase::GetPlayerByID(uint8_t id) const
-{
-    auto it = GetPlayerIteratorByID(id);
-    if (it != player_list.end())
-    {
-        return it->get();
-    }
-    return nullptr;
-}
-
-auto NetworkBase::GetGroupIteratorByID(uint8_t id) const
-{
-    return std::find_if(
-        group_list.begin(), group_list.end(), [id](std::unique_ptr<NetworkGroup> const& group) { return group->Id == id; });
-}
-
-NetworkGroup* NetworkBase::GetGroupByID(uint8_t id) const
-{
-    auto it = GetGroupIteratorByID(id);
-    if (it != group_list.end())
-    {
-        return it->get();
-    }
-    return nullptr;
-}
-
-int32_t NetworkBase::GetTotalNumPlayers() const noexcept
-{
-    return static_cast<int32_t>(player_list.size());
-}
-
-int32_t NetworkBase::GetNumVisiblePlayers() const noexcept
-{
-    if (IsServerPlayerInvisible)
-        return static_cast<int32_t>(player_list.size() - 1);
-    return static_cast<int32_t>(player_list.size());
-}
-
-const char* NetworkBase::FormatChat(NetworkPlayer* fromPlayer, const char* text)
-{
-    static std::string formatted;
-    formatted.clear();
-
-    if (fromPlayer != nullptr)
-    {
-        auto& network = OpenRCT2::GetContext()->GetNetwork();
-        auto it = network.GetGroupByID(fromPlayer->Id);
-        std::string groupName = "";
-        std::vector<std::string> colours;
-        if (it != nullptr)
-        {
-            groupName = it->GetName();
-            if (groupName[0] != '{')
-            {
-                colours.push_back("{WHITE}");
-            }
-        }
-
-        for (size_t i = 0; i < groupName.size(); ++i)
-        {
-            if (groupName[i] == '{')
-            {
-                std::string colour = "{";
-                ++i;
-                while (i < groupName.size() && groupName[i] != '}' && groupName[i] != '{')
-                {
-                    colour += groupName[i];
-                    ++i;
-                }
-                colour += '}';
-                if (groupName[i] == '}' && i < groupName.size())
-                {
-                    colours.push_back(colour);
-                }
-            }
-        }
-
-        if (colours.size() == 0 || (colours.size() == 1 && colours[0] == "{WHITE}"))
-        {
-            formatted += "{BABYBLUE}";
-            formatted += fromPlayer->Name;
-        }
-        else
-        {
-            size_t j = 0;
-            size_t proportionalSize = fromPlayer->Name.size() / colours.size();
-            for (size_t i = 0; i < colours.size(); ++i)
-            {
-                formatted += colours[i];
-                size_t numCharacters = proportionalSize + j;
-                for (; j < numCharacters && j < fromPlayer->Name.size(); ++j)
-                {
-                    formatted += fromPlayer->Name[j];
-                }
-            }
-            while (j < fromPlayer->Name.size())
-            {
-                formatted += fromPlayer->Name[j];
-                j++;
-            }
-        }
-
-        formatted += ": ";
-    }
-    formatted += "{WHITE}";
-    formatted += text;
-    return formatted.c_str();
-}
-
-void NetworkBase::SendPacketToClients(const NetworkPacket& packet, bool front, bool gameCmd) const
-{
-    for (auto& client_connection : client_connection_list)
-    {
-        if (gameCmd)
-        {
-            // If marked as game command we can not send the packet to connections that are not fully connected.
-            // Sending the packet would cause the client to store a command that is behind the tick where he starts,
-            // which would be essentially never executed. The clients do not require commands before the server has not sent the
-            // map data.
-            if (client_connection->Player == nullptr)
-            {
-                continue;
-            }
-        }
-        client_connection->QueuePacket(packet, front);
-    }
-}
-
-bool NetworkBase::CheckSRAND(uint32_t tick, uint32_t srand0)
-{
-    // We have to wait for the map to be loaded first, ticks may match current loaded map.
-    if (!_clientMapLoaded)
+        status = NETWORK_STATUS_READY;
+
+        ServerName.clear();
+        ServerDescription.clear();
+        ServerGreeting.clear();
+        ServerProviderName.clear();
+        ServerProviderEmail.clear();
+        ServerProviderWebsite.clear();
         return true;
-
-    auto itTickData = _serverTickData.find(tick);
-    if (itTickData == std::end(_serverTickData))
-        return true;
-
-    const ServerTickData storedTick = itTickData->second;
-    _serverTickData.erase(itTickData);
-
-    if (storedTick.srand0 != srand0)
-    {
-        LOG_INFO("Srand0 mismatch, client = %08X, server = %08X", srand0, storedTick.srand0);
-        return false;
     }
 
-    if (!storedTick.spriteHash.empty())
+    void NetworkBase::Reconnect()
     {
-        EntitiesChecksum checksum = getGameState().entities.GetAllEntitiesChecksum();
-        std::string clientSpriteHash = checksum.ToString();
-        if (clientSpriteHash != storedTick.spriteHash)
-        {
-            LOG_INFO("Sprite hash mismatch, client = %s, server = %s", clientSpriteHash.c_str(), storedTick.spriteHash.c_str());
-            return false;
-        }
-    }
-
-    return true;
-}
-
-bool NetworkBase::IsDesynchronised() const noexcept
-{
-    return _serverState.state == NetworkServerStatus::Desynced;
-}
-
-bool NetworkBase::CheckDesynchronizaton()
-{
-    const auto currentTicks = getGameState().currentTicks;
-
-    // Check synchronisation
-    if (GetMode() == NETWORK_MODE_CLIENT && _serverState.state != NetworkServerStatus::Desynced
-        && !CheckSRAND(currentTicks, ScenarioRandState().s0))
-    {
-        _serverState.state = NetworkServerStatus::Desynced;
-        _serverState.desyncTick = currentTicks;
-
-        char str_desync[256];
-        FormatStringLegacy(str_desync, 256, STR_MULTIPLAYER_DESYNC, nullptr);
-
-        auto intent = Intent(WindowClass::NetworkStatus);
-        intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_desync });
-        ContextOpenIntent(&intent);
-
-        if (!Config::Get().network.StayConnected)
+        if (status != NETWORK_STATUS_NONE)
         {
             Close();
         }
+        if (_requireClose)
+        {
+            _requireReconnect = true;
+            return;
+        }
+        BeginClient(_host, _port);
+    }
+
+    void NetworkBase::Close()
+    {
+        if (status != NETWORK_STATUS_NONE)
+        {
+            // HACK Because Close() is closed all over the place, it sometimes gets called inside an Update
+            //      call. This then causes disposed data to be accessed. Therefore, save closing until the
+            //      end of the update loop.
+            if (_closeLock)
+            {
+                _requireClose = true;
+                return;
+            }
+
+            CloseChatLog();
+            CloseServerLog();
+            CloseConnection();
+
+            client_connection_list.clear();
+            GameActions::ClearQueue();
+            GameActions::ResumeQueue();
+            player_list.clear();
+            group_list.clear();
+            _serverTickData.clear();
+            _pendingPlayerLists.clear();
+            _pendingPlayerInfo.clear();
+
+    #ifdef ENABLE_SCRIPTING
+            auto& scriptEngine = GetContext().GetScriptEngine();
+            scriptEngine.RemoveNetworkPlugins();
+    #endif
+
+            GfxInvalidateScreen();
+
+            _requireClose = false;
+        }
+    }
+
+    void NetworkBase::DecayCooldown(NetworkPlayer* player)
+    {
+        if (player == nullptr)
+            return; // No valid connection yet.
+
+        for (auto it = std::begin(player->CooldownTime); it != std::end(player->CooldownTime);)
+        {
+            it->second -= _currentDeltaTime;
+            if (it->second <= 0)
+                it = player->CooldownTime.erase(it);
+            else
+                it++;
+        }
+    }
+
+    void NetworkBase::CloseConnection()
+    {
+        if (mode == NETWORK_MODE_CLIENT)
+        {
+            _serverConnection.reset();
+        }
+        else if (mode == NETWORK_MODE_SERVER)
+        {
+            _listenSocket.reset();
+            _advertiser.reset();
+        }
+
+        mode = NETWORK_MODE_NONE;
+        status = NETWORK_STATUS_NONE;
+        _lastConnectStatus = SocketStatus::Closed;
+    }
+
+    bool NetworkBase::BeginClient(const std::string& host, uint16_t port)
+    {
+        if (GetMode() != NETWORK_MODE_NONE)
+        {
+            return false;
+        }
+
+        Close();
+        if (!Init())
+            return false;
+
+        mode = NETWORK_MODE_CLIENT;
+
+        LOG_INFO("Connecting to %s:%u", host.c_str(), port);
+        _host = host;
+        _port = port;
+
+        _serverConnection = std::make_unique<NetworkConnection>();
+        _serverConnection->Socket = CreateTcpSocket();
+        _serverConnection->Socket->ConnectAsync(host, port);
+        _serverState.gamestateSnapshotsEnabled = false;
+
+        status = NETWORK_STATUS_CONNECTING;
+        _lastConnectStatus = SocketStatus::Closed;
+        _clientMapLoaded = false;
+        _serverTickData.clear();
+
+        BeginChatLog();
+        BeginServerLog();
+
+        // We need to wait for the map load before we execute any actions.
+        // If the client has the title screen running then there's a potential
+        // risk of tick collision with the server map and title screen map.
+        GameActions::SuspendQueue();
+
+        auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
+        if (!File::Exists(keyPath))
+        {
+            Console::WriteLine("Generating key... This may take a while");
+            Console::WriteLine("Need to collect enough entropy from the system");
+            _key.Generate();
+            Console::WriteLine("Key generated, saving private bits as %s", keyPath.c_str());
+
+            const auto keysDirectory = NetworkGetKeysDirectory();
+            if (!Path::CreateDirectory(keysDirectory))
+            {
+                LOG_ERROR("Unable to create directory %s.", keysDirectory.c_str());
+                return false;
+            }
+
+            try
+            {
+                auto fs = FileStream(keyPath, FileMode::write);
+                _key.SavePrivate(&fs);
+            }
+            catch (const std::exception&)
+            {
+                LOG_ERROR("Unable to save private key at %s.", keyPath.c_str());
+                return false;
+            }
+
+            const std::string hash = _key.PublicKeyHash();
+            const utf8* publicKeyHash = hash.c_str();
+            keyPath = NetworkGetPublicKeyPath(Config::Get().network.PlayerName, publicKeyHash);
+            Console::WriteLine("Key generated, saving public bits as %s", keyPath.c_str());
+
+            try
+            {
+                auto fs = FileStream(keyPath, FileMode::write);
+                _key.SavePublic(&fs);
+            }
+            catch (const std::exception&)
+            {
+                LOG_ERROR("Unable to save public key at %s.", keyPath.c_str());
+                return false;
+            }
+        }
+        else
+        {
+            // LoadPrivate returns validity of loaded key
+            bool ok = false;
+            try
+            {
+                LOG_VERBOSE("Loading key from %s", keyPath.c_str());
+                auto fs = FileStream(keyPath, FileMode::open);
+                ok = _key.LoadPrivate(&fs);
+            }
+            catch (const std::exception&)
+            {
+                LOG_ERROR("Unable to read private key from %s.", keyPath.c_str());
+                return false;
+            }
+
+            // Don't store private key in memory when it's not in use.
+            _key.Unload();
+            return ok;
+        }
 
         return true;
     }
 
-    return false;
-}
-
-void NetworkBase::RequestStateSnapshot()
-{
-    LOG_INFO("Requesting game state for tick %u", _serverState.desyncTick);
-
-    Client_Send_RequestGameState(_serverState.desyncTick);
-}
-
-NetworkServerState NetworkBase::GetServerState() const noexcept
-{
-    return _serverState;
-}
-
-void NetworkBase::KickPlayer(int32_t playerId)
-{
-    for (auto& client_connection : client_connection_list)
+    bool NetworkBase::BeginServer(uint16_t port, const std::string& address)
     {
-        if (client_connection->Player->Id == playerId)
-        {
-            // Disconnect the client gracefully
-            client_connection->SetLastDisconnectReason(STR_MULTIPLAYER_KICKED);
-            char str_disconnect_msg[256];
-            FormatStringLegacy(str_disconnect_msg, 256, STR_MULTIPLAYER_KICKED_REASON, nullptr);
-            ServerSendSetDisconnectMsg(*client_connection, str_disconnect_msg);
-            client_connection->Disconnect();
-            break;
-        }
-    }
-}
+        Close();
+        if (!Init())
+            return false;
 
-void NetworkBase::SetPassword(u8string_view password)
-{
-    _password = password;
-}
+        mode = NETWORK_MODE_SERVER;
 
-void NetworkBase::ServerClientDisconnected()
-{
-    if (GetMode() == NETWORK_MODE_CLIENT)
-    {
-        _serverConnection->Disconnect();
-    }
-}
+        _userManager.Load();
 
-std::string NetworkBase::GenerateAdvertiseKey()
-{
-    // Generate a string of 16 random hex characters (64-integer key as a hex formatted string)
-    static char hexChars[] = {
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
-    };
-    char key[17];
-    for (int32_t i = 0; i < 16; i++)
-    {
-        int32_t hexCharIndex = UtilRand() % std::size(hexChars);
-        key[i] = hexChars[hexCharIndex];
-    }
-    key[std::size(key) - 1] = 0;
+        LOG_VERBOSE("Begin listening for clients");
 
-    return key;
-}
-
-std::string NetworkBase::GetMasterServerUrl()
-{
-    if (Config::Get().network.MasterServerUrl.empty())
-    {
-        return kMasterServerURL;
-    }
-
-    return Config::Get().network.MasterServerUrl;
-}
-
-NetworkGroup* NetworkBase::AddGroup()
-{
-    NetworkGroup* addedgroup = nullptr;
-    int32_t newid = -1;
-    // Find first unused group id
-    for (int32_t id = 0; id < 255; id++)
-    {
-        if (std::find_if(
-                group_list.begin(), group_list.end(),
-                [&id](std::unique_ptr<NetworkGroup> const& group) { return group->Id == id; })
-            == group_list.end())
-        {
-            newid = id;
-            break;
-        }
-    }
-    if (newid != -1)
-    {
-        auto group = std::make_unique<NetworkGroup>();
-        group->Id = newid;
-        group->SetName("Group #" + std::to_string(newid));
-        addedgroup = group.get();
-        group_list.push_back(std::move(group));
-    }
-    return addedgroup;
-}
-
-void NetworkBase::RemoveGroup(uint8_t id)
-{
-    auto group = GetGroupIteratorByID(id);
-    if (group != group_list.end())
-    {
-        group_list.erase(group);
-    }
-
-    if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        _userManager.UnsetUsersOfGroup(id);
-        _userManager.Save();
-    }
-}
-
-uint8_t NetworkBase::GetGroupIDByHash(const std::string& keyhash)
-{
-    const NetworkUser* networkUser = _userManager.GetUserByHash(keyhash);
-
-    uint8_t groupId = GetDefaultGroup();
-    if (networkUser != nullptr && networkUser->GroupId.has_value())
-    {
-        const uint8_t assignedGroup = *networkUser->GroupId;
-        if (GetGroupByID(assignedGroup) != nullptr)
-        {
-            groupId = assignedGroup;
-        }
-        else
-        {
-            LOG_WARNING(
-                "User %s is assigned to non-existent group %u. Assigning to default group (%u)", keyhash.c_str(), assignedGroup,
-                groupId);
-        }
-    }
-    return groupId;
-}
-
-uint8_t NetworkBase::GetDefaultGroup() const noexcept
-{
-    return default_group;
-}
-
-void NetworkBase::SetDefaultGroup(uint8_t id)
-{
-    if (GetGroupByID(id) != nullptr)
-    {
-        default_group = id;
-    }
-}
-
-void NetworkBase::SaveGroups()
-{
-    if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        auto& env = GetContext().GetPlatformEnvironment();
-        auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
-
-        json_t jsonGroups = json_t::array();
-        for (auto& group : group_list)
-        {
-            jsonGroups.push_back(group->ToJson());
-        }
-        json_t jsonGroupsCfg = {
-            { "default_group", default_group },
-            { "groups", jsonGroups },
-        };
+        _listenSocket = CreateTcpSocket();
         try
         {
-            Json::WriteToFile(path, jsonGroupsCfg);
+            _listenSocket->Listen(address, port);
         }
         catch (const std::exception& ex)
         {
-            LOG_ERROR("Unable to save %s: %s", path.c_str(), ex.what());
+            Console::Error::WriteLine(ex.what());
+            Close();
+            return false;
         }
-    }
-}
 
-void NetworkBase::SetupDefaultGroups()
-{
-    // Admin group
-    auto admin = std::make_unique<NetworkGroup>();
-    admin->SetName("Admin");
-    admin->ActionsAllowed.fill(0xFF);
-    admin->Id = 0;
-    group_list.push_back(std::move(admin));
+        ServerName = Config::Get().network.ServerName;
+        ServerDescription = Config::Get().network.ServerDescription;
+        ServerGreeting = Config::Get().network.ServerGreeting;
+        ServerProviderName = Config::Get().network.ProviderName;
+        ServerProviderEmail = Config::Get().network.ProviderEmail;
+        ServerProviderWebsite = Config::Get().network.ProviderWebsite;
 
-    // Spectator group
-    auto spectator = std::make_unique<NetworkGroup>();
-    spectator->SetName("Spectator");
-    spectator->ToggleActionPermission(NetworkPermission::Chat);
-    spectator->Id = 1;
-    group_list.push_back(std::move(spectator));
+        IsServerPlayerInvisible = gOpenRCT2Headless;
 
-    // User group
-    auto user = std::make_unique<NetworkGroup>();
-    user->SetName("User");
-    user->ActionsAllowed.fill(0xFF);
-    user->ToggleActionPermission(NetworkPermission::KickPlayer);
-    user->ToggleActionPermission(NetworkPermission::ModifyGroups);
-    user->ToggleActionPermission(NetworkPermission::SetPlayerGroup);
-    user->ToggleActionPermission(NetworkPermission::Cheat);
-    user->ToggleActionPermission(NetworkPermission::PasswordlessLogin);
-    user->ToggleActionPermission(NetworkPermission::ModifyTile);
-    user->ToggleActionPermission(NetworkPermission::EditScenarioOptions);
-    user->Id = 2;
-    group_list.push_back(std::move(user));
+        LoadGroups();
+        BeginChatLog();
+        BeginServerLog();
 
-    SetDefaultGroup(1);
-}
+        NetworkPlayer* player = AddPlayer(Config::Get().network.PlayerName, "");
+        player->Flags |= NETWORK_PLAYER_FLAG_ISSERVER;
+        player->Group = 0;
+        player_id = player->Id;
 
-void NetworkBase::LoadGroups()
-{
-    group_list.clear();
-
-    auto& env = GetContext().GetPlatformEnvironment();
-    auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
-
-    json_t jsonGroupConfig;
-    if (File::Exists(path))
-    {
-        try
+        if (NetworkGetMode() == NETWORK_MODE_SERVER)
         {
-            jsonGroupConfig = Json::ReadFromFile(path);
+            // Add SERVER to users.json and save.
+            NetworkUser* networkUser = _userManager.GetOrAddUser(player->KeyHash);
+            networkUser->GroupId = player->Group;
+            networkUser->Name = player->Name;
+            _userManager.Save();
         }
-        catch (const std::exception& e)
-        {
-            LOG_ERROR("Failed to read %s as JSON. Setting default groups. %s", path.c_str(), e.what());
-        }
+
+        auto* szAddress = address.empty() ? "*" : address.c_str();
+        Console::WriteLine("Listening for clients on %s:%hu", szAddress, port);
+        NetworkChatShowConnectedMessage();
+        NetworkChatShowServerGreeting();
+
+        status = NETWORK_STATUS_CONNECTED;
+        listening_port = port;
+        _serverState.gamestateSnapshotsEnabled = Config::Get().network.DesyncDebugging;
+        _advertiser = CreateServerAdvertiser(listening_port);
+
+        GameLoadScripts();
+        GameNotifyMapChanged();
+
+        return true;
     }
 
-    if (!jsonGroupConfig.is_object())
+    int32_t NetworkBase::GetMode() const noexcept
     {
-        SetupDefaultGroups();
+        return mode;
     }
-    else
+
+    int32_t NetworkBase::GetStatus() const noexcept
     {
-        json_t jsonGroups = jsonGroupConfig["groups"];
-        if (jsonGroups.is_array())
+        return status;
+    }
+
+    NetworkAuth NetworkBase::GetAuthStatus()
+    {
+        if (GetMode() == NETWORK_MODE_CLIENT)
         {
-            for (auto& jsonGroup : jsonGroups)
+            return _serverConnection->AuthStatus;
+        }
+        if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            return NetworkAuth::Ok;
+        }
+        return NetworkAuth::None;
+    }
+
+    uint32_t NetworkBase::GetServerTick() const noexcept
+    {
+        return _serverState.tick;
+    }
+
+    uint8_t NetworkBase::GetPlayerID() const noexcept
+    {
+        return player_id;
+    }
+
+    NetworkConnection* NetworkBase::GetPlayerConnection(uint8_t id) const
+    {
+        auto player = GetPlayerByID(id);
+        if (player != nullptr)
+        {
+            auto clientIt = std::find_if(
+                client_connection_list.begin(), client_connection_list.end(),
+                [player](const auto& conn) -> bool { return conn->Player == player; });
+            return clientIt != client_connection_list.end() ? clientIt->get() : nullptr;
+        }
+        return nullptr;
+    }
+
+    void NetworkBase::Update()
+    {
+        _closeLock = true;
+
+        // Update is not necessarily called per game tick, maintain our own delta time
+        uint32_t ticks = Platform::GetTicks();
+        _currentDeltaTime = std::max<uint32_t>(ticks - _lastUpdateTime, 1);
+        _lastUpdateTime = ticks;
+
+        switch (GetMode())
+        {
+            case NETWORK_MODE_SERVER:
+                UpdateServer();
+                break;
+            case NETWORK_MODE_CLIENT:
+                UpdateClient();
+                break;
+        }
+
+        // If the Close() was called during the update, close it for real
+        _closeLock = false;
+        if (_requireClose)
+        {
+            Close();
+            if (_requireReconnect)
             {
-                group_list.emplace_back(std::make_unique<NetworkGroup>(NetworkGroup::FromJson(jsonGroup)));
+                Reconnect();
             }
         }
+    }
 
-        default_group = Json::GetNumber<uint8_t>(jsonGroupConfig["default_group"]);
-        if (GetGroupByID(default_group) == nullptr)
+    void NetworkBase::Flush()
+    {
+        if (GetMode() == NETWORK_MODE_CLIENT)
         {
-            default_group = 0;
-        }
-    }
-
-    // Host group should always contain all permissions.
-    group_list.at(0)->ActionsAllowed.fill(0xFF);
-}
-
-std::string NetworkBase::BeginLog(const std::string& directory, const std::string& midName, const std::string& filenameFormat)
-{
-    utf8 filename[256];
-    time_t timer;
-    time(&timer);
-    auto tmInfo = localtime(&timer);
-    if (strftime(filename, sizeof(filename), filenameFormat.c_str(), tmInfo) == 0)
-    {
-        throw std::runtime_error("strftime failed");
-    }
-
-    auto directoryMidName = Path::Combine(directory, midName);
-    Path::CreateDirectory(directoryMidName);
-    return Path::Combine(directoryMidName, filename);
-}
-
-void NetworkBase::AppendLog(std::ostream& fs, std::string_view s)
-{
-    if (fs.fail())
-    {
-        LOG_ERROR("bad ostream failed to append log");
-        return;
-    }
-    try
-    {
-        utf8 buffer[1024];
-        time_t timer;
-        time(&timer);
-        auto tmInfo = localtime(&timer);
-        if (strftime(buffer, sizeof(buffer), "[%Y/%m/%d %H:%M:%S] ", tmInfo) != 0)
-        {
-            String::append(buffer, sizeof(buffer), std::string(s).c_str());
-            String::append(buffer, sizeof(buffer), PLATFORM_NEWLINE);
-
-            fs.write(buffer, strlen(buffer));
-        }
-    }
-    catch (const std::exception& ex)
-    {
-        LOG_ERROR("%s", ex.what());
-    }
-}
-
-void NetworkBase::BeginChatLog()
-{
-    auto& env = GetContext().GetPlatformEnvironment();
-    auto directory = env.GetDirectoryPath(DirBase::user, DirId::chatLogs);
-    _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
-    _chat_log_fs.open(fs::u8path(_chatLogPath), std::ios::out | std::ios::app);
-}
-
-void NetworkBase::AppendChatLog(std::string_view s)
-{
-    if (Config::Get().network.LogChat && _chat_log_fs.is_open())
-    {
-        AppendLog(_chat_log_fs, s);
-    }
-}
-
-void NetworkBase::CloseChatLog()
-{
-    _chat_log_fs.close();
-}
-
-void NetworkBase::BeginServerLog()
-{
-    auto& env = GetContext().GetPlatformEnvironment();
-    auto directory = env.GetDirectoryPath(DirBase::user, DirId::serverLogs);
-    _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
-    _server_log_fs.open(fs::u8path(_serverLogPath), std::ios::out | std::ios::app | std::ios::binary);
-
-    // Log server start event
-    utf8 logMessage[256];
-    if (GetMode() == NETWORK_MODE_CLIENT)
-    {
-        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STARTED, nullptr);
-    }
-    else if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STARTED, nullptr);
-    }
-    else
-    {
-        logMessage[0] = '\0';
-        Guard::Assert(false, "Unknown network mode!");
-    }
-    AppendServerLog(logMessage);
-}
-
-void NetworkBase::AppendServerLog(const std::string& s)
-{
-    if (Config::Get().network.LogServerActions && _server_log_fs.is_open())
-    {
-        AppendLog(_server_log_fs, s);
-    }
-}
-
-void NetworkBase::CloseServerLog()
-{
-    // Log server stopped event
-    char logMessage[256];
-    if (GetMode() == NETWORK_MODE_CLIENT)
-    {
-        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STOPPED, nullptr);
-    }
-    else if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STOPPED, nullptr);
-    }
-    else
-    {
-        logMessage[0] = '\0';
-        Guard::Assert(false, "Unknown network mode!");
-    }
-    AppendServerLog(logMessage);
-    _server_log_fs.close();
-}
-
-void NetworkBase::Client_Send_RequestGameState(uint32_t tick)
-{
-    if (_serverState.gamestateSnapshotsEnabled == false)
-    {
-        LOG_VERBOSE("Server does not store a gamestate history");
-        return;
-    }
-
-    LOG_VERBOSE("Requesting gamestate from server for tick %u", tick);
-
-    NetworkPacket packet(NetworkCommand::RequestGameState);
-    packet << tick;
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::Client_Send_TOKEN()
-{
-    LOG_VERBOSE("requesting token");
-    NetworkPacket packet(NetworkCommand::Token);
-    _serverConnection->AuthStatus = NetworkAuth::Requested;
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::Client_Send_AUTH(
-    const std::string& name, const std::string& password, const std::string& pubkey, const std::vector<uint8_t>& signature)
-{
-    NetworkPacket packet(NetworkCommand::Auth);
-    packet.WriteString(NetworkGetVersion());
-    packet.WriteString(name);
-    packet.WriteString(password);
-    packet.WriteString(pubkey);
-    assert(signature.size() <= static_cast<size_t>(UINT32_MAX));
-    packet << static_cast<uint32_t>(signature.size());
-    packet.Write(signature.data(), signature.size());
-    _serverConnection->AuthStatus = NetworkAuth::Requested;
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::Client_Send_MAPREQUEST(const std::vector<ObjectEntryDescriptor>& objects)
-{
-    LOG_VERBOSE("client requests %u objects", uint32_t(objects.size()));
-    NetworkPacket packet(NetworkCommand::MapRequest);
-    packet << static_cast<uint32_t>(objects.size());
-    for (const auto& object : objects)
-    {
-        std::string name(object.GetName());
-        LOG_VERBOSE("client requests object %s", name.c_str());
-        if (object.Generation == ObjectGeneration::DAT)
-        {
-            packet << static_cast<uint8_t>(0);
-            packet.Write(&object.Entry, sizeof(RCTObjectEntry));
+            _serverConnection->SendQueuedData();
         }
         else
         {
-            packet << static_cast<uint8_t>(1);
-            packet.WriteString(name);
+            for (auto& it : client_connection_list)
+            {
+                it->SendQueuedData();
+            }
         }
     }
-    _serverConnection->QueuePacket(std::move(packet));
-}
 
-void NetworkBase::ServerSendToken(NetworkConnection& connection)
-{
-    NetworkPacket packet(NetworkCommand::Token);
-    packet << static_cast<uint32_t>(connection.Challenge.size());
-    packet.Write(connection.Challenge.data(), connection.Challenge.size());
-    connection.QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendObjectsList(
-    NetworkConnection& connection, const std::vector<const ObjectRepositoryItem*>& objects) const
-{
-    LOG_VERBOSE("Server sends objects list with %u items", objects.size());
-
-    if (objects.empty())
-    {
-        NetworkPacket packet(NetworkCommand::ObjectsList);
-        packet << static_cast<uint32_t>(0) << static_cast<uint32_t>(objects.size());
-
-        connection.QueuePacket(std::move(packet));
-    }
-    else
-    {
-        for (size_t i = 0; i < objects.size(); ++i)
-        {
-            const auto* object = objects[i];
-
-            NetworkPacket packet(NetworkCommand::ObjectsList);
-            packet << static_cast<uint32_t>(i) << static_cast<uint32_t>(objects.size());
-
-            if (object->Identifier.empty())
-            {
-                // DAT
-                LOG_VERBOSE("Object %.8s (checksum %x)", object->ObjectEntry.name, object->ObjectEntry.checksum);
-                packet << static_cast<uint8_t>(0);
-                packet.Write(&object->ObjectEntry, sizeof(RCTObjectEntry));
-            }
-            else
-            {
-                // JSON
-                LOG_VERBOSE("Object %s", object->Identifier.c_str());
-                packet << static_cast<uint8_t>(1);
-                packet.WriteString(object->Identifier);
-            }
-
-            connection.QueuePacket(std::move(packet));
-        }
-    }
-}
-
-void NetworkBase::ServerSendScripts(NetworkConnection& connection)
-{
-    #ifdef ENABLE_SCRIPTING
-    using namespace OpenRCT2::Scripting;
-
-    auto& scriptEngine = GetContext().GetScriptEngine();
-
-    // Get remote plugin list.
-    const auto remotePlugins = scriptEngine.GetRemotePlugins();
-    LOG_VERBOSE("Server sends %zu scripts", remotePlugins.size());
-
-    // Build the data contents for each plugin.
-    MemoryStream pluginData;
-    for (auto& plugin : remotePlugins)
-    {
-        const auto& code = plugin->GetCode();
-
-        const auto codeSize = static_cast<uint32_t>(code.size());
-        pluginData.WriteValue(codeSize);
-        pluginData.WriteArray(code.c_str(), code.size());
-    }
-
-    // Send the header packet.
-    NetworkPacket packetScriptHeader(NetworkCommand::ScriptsHeader);
-    packetScriptHeader << static_cast<uint32_t>(remotePlugins.size());
-    packetScriptHeader << static_cast<uint32_t>(pluginData.GetLength());
-    connection.QueuePacket(std::move(packetScriptHeader));
-
-    // Segment the plugin data into chunks and send them.
-    const uint8_t* pluginDataBuffer = static_cast<const uint8_t*>(pluginData.GetData());
-    uint32_t dataOffset = 0;
-    while (dataOffset < pluginData.GetLength())
-    {
-        const uint32_t chunkSize = std::min<uint32_t>(pluginData.GetLength() - dataOffset, kChunkSize);
-
-        NetworkPacket packet(NetworkCommand::ScriptsData);
-        packet << chunkSize;
-        packet.Write(pluginDataBuffer + dataOffset, chunkSize);
-
-        connection.QueuePacket(std::move(packet));
-
-        dataOffset += chunkSize;
-    }
-    Guard::Assert(dataOffset == pluginData.GetLength());
-
-    #else
-    NetworkPacket packetScriptHeader(NetworkCommand::ScriptsHeader);
-    packetScriptHeader << static_cast<uint32_t>(0u);
-    packetScriptHeader << static_cast<uint32_t>(0u);
-    #endif
-}
-
-void NetworkBase::Client_Send_HEARTBEAT(NetworkConnection& connection) const
-{
-    LOG_VERBOSE("Sending heartbeat");
-
-    NetworkPacket packet(NetworkCommand::Heartbeat);
-    connection.QueuePacket(std::move(packet));
-}
-
-NetworkStats NetworkBase::GetStats() const
-{
-    NetworkStats stats = {};
-    if (mode == NETWORK_MODE_CLIENT)
-    {
-        stats = _serverConnection->Stats;
-    }
-    else
+    void NetworkBase::UpdateServer()
     {
         for (auto& connection : client_connection_list)
         {
-            for (size_t n = 0; n < EnumValue(NetworkStatisticsGroup::Max); n++)
+            // This can be called multiple times before the connection is removed.
+            if (!connection->IsValid())
+                continue;
+
+            if (!ProcessConnection(*connection))
             {
-                stats.bytesReceived[n] += connection->Stats.bytesReceived[n];
-                stats.bytesSent[n] += connection->Stats.bytesSent[n];
+                connection->Disconnect();
+            }
+            else
+            {
+                DecayCooldown(connection->Player);
             }
         }
-    }
-    return stats;
-}
 
-void NetworkBase::ServerSendAuth(NetworkConnection& connection)
-{
-    uint8_t new_playerid = 0;
-    if (connection.Player != nullptr)
-    {
-        new_playerid = connection.Player->Id;
-    }
-    NetworkPacket packet(NetworkCommand::Auth);
-    packet << static_cast<uint32_t>(connection.AuthStatus) << new_playerid;
-    if (connection.AuthStatus == NetworkAuth::BadVersion)
-    {
-        packet.WriteString(NetworkGetVersion());
-    }
-    connection.QueuePacket(std::move(packet));
-    if (connection.AuthStatus != NetworkAuth::Ok && connection.AuthStatus != NetworkAuth::RequirePassword)
-    {
-        connection.Disconnect();
-    }
-}
-
-void NetworkBase::ServerSendMap(NetworkConnection* connection)
-{
-    std::vector<const ObjectRepositoryItem*> objects;
-    if (connection != nullptr)
-    {
-        objects = connection->RequestedObjects;
-    }
-    else
-    {
-        // This will send all custom objects to connected clients
-        // TODO: fix it so custom objects negotiation is performed even in this case.
-        auto& context = GetContext();
-        auto& objManager = context.GetObjectManager();
-        objects = objManager.GetPackableObjects();
-    }
-
-    auto header = SaveForNetwork(objects);
-    if (header.empty())
-    {
-        if (connection != nullptr)
+        uint32_t ticks = Platform::GetTicks();
+        if (ticks > last_ping_sent_time + 3000)
         {
-            connection->SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
-            connection->Disconnect();
+            ServerSendPing();
+            ServerSendPingList();
         }
-        return;
-    }
-    size_t chunksize = kChunkSize;
-    for (size_t i = 0; i < header.size(); i += chunksize)
-    {
-        size_t datasize = std::min(chunksize, header.size() - i);
-        NetworkPacket packet(NetworkCommand::Map);
-        packet << static_cast<uint32_t>(header.size()) << static_cast<uint32_t>(i);
-        packet.Write(&header[i], datasize);
-        if (connection != nullptr)
+
+        if (_advertiser != nullptr)
         {
-            connection->QueuePacket(std::move(packet));
+            _advertiser->Update();
         }
-        else
+
+        std::unique_ptr<ITcpSocket> tcpSocket = _listenSocket->Accept();
+        if (tcpSocket != nullptr)
         {
-            SendPacketToClients(packet);
+            AddClient(std::move(tcpSocket));
         }
     }
-}
 
-std::vector<uint8_t> NetworkBase::SaveForNetwork(const std::vector<const ObjectRepositoryItem*>& objects) const
-{
-    std::vector<uint8_t> result;
-    auto ms = MemoryStream();
-    if (SaveMap(&ms, objects))
+    void NetworkBase::UpdateClient()
     {
-        result.resize(ms.GetLength());
-        std::memcpy(result.data(), ms.GetData(), result.size());
-    }
-    else
-    {
-        LOG_WARNING("Failed to export map.");
-    }
-    return result;
-}
+        assert(_serverConnection != nullptr);
 
-void NetworkBase::Client_Send_CHAT(const char* text)
-{
-    NetworkPacket packet(NetworkCommand::Chat);
-    packet.WriteString(text);
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds)
-{
-    NetworkPacket packet(NetworkCommand::Chat);
-    packet.WriteString(text);
-
-    if (playerIds.empty())
-    {
-        // Empty players / default value means send to all players
-        SendPacketToClients(packet);
-    }
-    else
-    {
-        for (auto playerId : playerIds)
+        switch (status)
         {
-            auto conn = GetPlayerConnection(playerId);
-            if (conn != nullptr)
+            case NETWORK_STATUS_CONNECTING:
             {
-                conn->QueuePacket(packet);
-            }
-        }
-    }
-}
-
-void NetworkBase::Client_Send_GAME_ACTION(const GameActions::GameAction* action)
-{
-    NetworkPacket packet(NetworkCommand::GameAction);
-
-    uint32_t networkId = 0;
-    networkId = ++_actionId;
-
-    // I know its ugly, want basic functionality for now.
-    const_cast<GameActions::GameAction*>(action)->SetNetworkId(networkId);
-    if (action->GetCallback())
-    {
-        _gameActionCallbacks.insert(std::make_pair(networkId, action->GetCallback()));
-    }
-
-    DataSerialiser stream(true);
-    action->Serialise(stream);
-
-    packet << getGameState().currentTicks << action->GetType() << stream;
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendGameAction(const GameActions::GameAction* action)
-{
-    NetworkPacket packet(NetworkCommand::GameAction);
-
-    DataSerialiser stream(true);
-    action->Serialise(stream);
-
-    packet << getGameState().currentTicks << action->GetType() << stream;
-
-    SendPacketToClients(packet);
-}
-
-void NetworkBase::ServerSendTick()
-{
-    NetworkPacket packet(NetworkCommand::Tick);
-    packet << getGameState().currentTicks << ScenarioRandState().s0;
-    uint32_t flags = 0;
-    // Simple counter which limits how often a sprite checksum gets sent.
-    // This can get somewhat expensive, so we don't want to push it every tick in release,
-    // but debug version can check more often.
-    static int32_t checksum_counter = 0;
-    checksum_counter++;
-    if (checksum_counter >= 100)
-    {
-        checksum_counter = 0;
-        flags |= NETWORK_TICK_FLAG_CHECKSUMS;
-    }
-    // Send flags always, so we can understand packet structure on the other end,
-    // and allow for some expansion.
-    packet << flags;
-    if (flags & NETWORK_TICK_FLAG_CHECKSUMS)
-    {
-        EntitiesChecksum checksum = getGameState().entities.GetAllEntitiesChecksum();
-        packet.WriteString(checksum.ToString());
-    }
-
-    SendPacketToClients(packet);
-}
-
-void NetworkBase::ServerSendPlayerInfo(int32_t playerId)
-{
-    NetworkPacket packet(NetworkCommand::PlayerInfo);
-    packet << getGameState().currentTicks;
-
-    auto* player = GetPlayerByID(playerId);
-    if (player == nullptr)
-        return;
-
-    player->Write(packet);
-    SendPacketToClients(packet);
-}
-
-void NetworkBase::ServerSendPlayerList()
-{
-    NetworkPacket packet(NetworkCommand::PlayerList);
-    packet << getGameState().currentTicks << static_cast<uint8_t>(player_list.size());
-    for (auto& player : player_list)
-    {
-        player->Write(packet);
-    }
-    SendPacketToClients(packet);
-}
-
-void NetworkBase::Client_Send_PING()
-{
-    NetworkPacket packet(NetworkCommand::Ping);
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendPing()
-{
-    last_ping_sent_time = Platform::GetTicks();
-    NetworkPacket packet(NetworkCommand::Ping);
-    for (auto& client_connection : client_connection_list)
-    {
-        client_connection->PingTime = Platform::GetTicks();
-    }
-    SendPacketToClients(packet, true);
-}
-
-void NetworkBase::ServerSendPingList()
-{
-    NetworkPacket packet(NetworkCommand::PingList);
-    packet << static_cast<uint8_t>(player_list.size());
-    for (auto& player : player_list)
-    {
-        packet << player->Id << player->Ping;
-    }
-    SendPacketToClients(packet);
-}
-
-void NetworkBase::ServerSendSetDisconnectMsg(NetworkConnection& connection, const char* msg)
-{
-    NetworkPacket packet(NetworkCommand::DisconnectMessage);
-    packet.WriteString(msg);
-    connection.QueuePacket(std::move(packet));
-}
-
-json_t NetworkBase::GetServerInfoAsJson() const
-{
-    json_t jsonObj = {
-        { "name", Config::Get().network.ServerName },
-        { "requiresPassword", _password.size() > 0 },
-        { "version", NetworkGetVersion() },
-        { "players", GetNumVisiblePlayers() },
-        { "maxPlayers", Config::Get().network.Maxplayers },
-        { "description", Config::Get().network.ServerDescription },
-        { "greeting", Config::Get().network.ServerGreeting },
-        { "dedicated", gOpenRCT2Headless },
-    };
-    return jsonObj;
-}
-
-void NetworkBase::ServerSendGameInfo(NetworkConnection& connection)
-{
-    NetworkPacket packet(NetworkCommand::GameInfo);
-    #ifndef DISABLE_HTTP
-    json_t jsonObj = GetServerInfoAsJson();
-
-    // Provider details
-    json_t jsonProvider = {
-        { "name", Config::Get().network.ProviderName },
-        { "email", Config::Get().network.ProviderEmail },
-        { "website", Config::Get().network.ProviderWebsite },
-    };
-
-    jsonObj["provider"] = jsonProvider;
-
-    packet.WriteString(jsonObj.dump());
-    packet << _serverState.gamestateSnapshotsEnabled;
-    packet << IsServerPlayerInvisible;
-
-    #endif
-    connection.QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendShowError(NetworkConnection& connection, StringId title, StringId message)
-{
-    NetworkPacket packet(NetworkCommand::ShowError);
-    packet << title << message;
-    connection.QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendGroupList(NetworkConnection& connection)
-{
-    NetworkPacket packet(NetworkCommand::GroupList);
-    packet << static_cast<uint8_t>(group_list.size()) << default_group;
-    for (auto& group : group_list)
-    {
-        group->Write(packet);
-    }
-    connection.QueuePacket(std::move(packet));
-}
-
-void NetworkBase::ServerSendEventPlayerJoined(const char* playerName)
-{
-    NetworkPacket packet(NetworkCommand::Event);
-    packet << static_cast<uint16_t>(SERVER_EVENT_PLAYER_JOINED);
-    packet.WriteString(playerName);
-    SendPacketToClients(packet);
-}
-
-void NetworkBase::ServerSendEventPlayerDisconnected(const char* playerName, const char* reason)
-{
-    NetworkPacket packet(NetworkCommand::Event);
-    packet << static_cast<uint16_t>(SERVER_EVENT_PLAYER_DISCONNECTED);
-    packet.WriteString(playerName);
-    packet.WriteString(reason);
-    SendPacketToClients(packet);
-}
-
-bool NetworkBase::ProcessConnection(NetworkConnection& connection)
-{
-    NetworkReadPacket packetStatus;
-
-    uint32_t countProcessed = 0;
-    do
-    {
-        countProcessed++;
-        packetStatus = connection.ReadPacket();
-        switch (packetStatus)
-        {
-            case NetworkReadPacket::Disconnected:
-                // closed connection or network error
-                if (!connection.GetLastDisconnectReason())
+                switch (_serverConnection->Socket->GetStatus())
                 {
-                    connection.SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
-                }
-                return false;
-            case NetworkReadPacket::Success:
-                // done reading in packet
-                ProcessPacket(connection, connection.InboundPacket);
-                if (!connection.IsValid())
-                {
-                    return false;
-                }
-                break;
-            case NetworkReadPacket::MoreData:
-                // more data required to be read
-                break;
-            case NetworkReadPacket::NoData:
-                // could not read anything from socket
-                break;
-        }
-    } while (packetStatus == NetworkReadPacket::Success && countProcessed < kMaxPacketsPerUpdate);
-
-    if (!connection.ReceivedPacketRecently())
-    {
-        if (!connection.GetLastDisconnectReason())
-        {
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_NO_DATA);
-        }
-        return false;
-    }
-
-    return true;
-}
-
-void NetworkBase::ProcessPacket(NetworkConnection& connection, NetworkPacket& packet)
-{
-    const auto& handlerList = GetMode() == NETWORK_MODE_SERVER ? server_command_handlers : client_command_handlers;
-
-    auto it = handlerList.find(packet.GetCommand());
-    if (it != handlerList.end())
-    {
-        auto commandHandler = it->second;
-        if (connection.AuthStatus == NetworkAuth::Ok || !packet.CommandRequiresAuth())
-        {
-            try
-            {
-                (this->*commandHandler)(connection, packet);
-            }
-            catch (const std::exception& ex)
-            {
-                LOG_VERBOSE("Exception during packet processing: %s", ex.what());
-            }
-        }
-    }
-
-    packet.Clear();
-}
-
-// This is called at the end of each game tick, this where things should be processed that affects the game state.
-void NetworkBase::ProcessPending()
-{
-    if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        ProcessDisconnectedClients();
-    }
-    else if (GetMode() == NETWORK_MODE_CLIENT)
-    {
-        ProcessPlayerInfo();
-    }
-    ProcessPlayerList();
-}
-
-static bool ProcessPlayerAuthenticatePluginHooks(
-    const NetworkConnection& connection, std::string_view name, std::string_view publicKeyHash)
-{
-    #ifdef ENABLE_SCRIPTING
-    using namespace OpenRCT2::Scripting;
-
-    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(Scripting::HookType::networkAuthenticate))
-    {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-        // Create event args object
-        DukObject eObj(ctx);
-        eObj.Set("name", name);
-        eObj.Set("publicKeyHash", publicKeyHash);
-        eObj.Set("ipAddress", connection.Socket->GetIpAddress());
-        eObj.Set("cancel", false);
-        auto e = eObj.Take();
-
-        // Call the subscriptions
-        hookEngine.Call(Scripting::HookType::networkAuthenticate, e, false);
-
-        // Check if any hook has cancelled the join
-        if (AsOrDefault(e["cancel"], false))
-        {
-            return false;
-        }
-    }
-    #endif
-    return true;
-}
-
-static void ProcessPlayerJoinedPluginHooks(uint8_t playerId)
-{
-    #ifdef ENABLE_SCRIPTING
-    using namespace OpenRCT2::Scripting;
-
-    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(Scripting::HookType::networkJoin))
-    {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-        // Create event args object
-        DukObject eObj(ctx);
-        eObj.Set("player", playerId);
-        auto e = eObj.Take();
-
-        // Call the subscriptions
-        hookEngine.Call(Scripting::HookType::networkJoin, e, false);
-    }
-    #endif
-}
-
-static void ProcessPlayerLeftPluginHooks(uint8_t playerId)
-{
-    #ifdef ENABLE_SCRIPTING
-    using namespace OpenRCT2::Scripting;
-
-    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(Scripting::HookType::networkLeave))
-    {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-        // Create event args object
-        DukObject eObj(ctx);
-        eObj.Set("player", playerId);
-        auto e = eObj.Take();
-
-        // Call the subscriptions
-        hookEngine.Call(Scripting::HookType::networkLeave, e, false);
-    }
-    #endif
-}
-
-void NetworkBase::ProcessPlayerList()
-{
-    if (GetMode() == NETWORK_MODE_SERVER)
-    {
-        // Avoid sending multiple times the player list, we mark the list invalidated on modifications
-        // and then send at the end of the tick the final player list.
-        if (_playerListInvalidated)
-        {
-            _playerListInvalidated = false;
-            ServerSendPlayerList();
-        }
-    }
-    else
-    {
-        // As client we have to keep things in order so the update is tick bound.
-        // Commands/Actions reference players and so this list needs to be in sync with those.
-        auto itPending = _pendingPlayerLists.begin();
-        while (itPending != _pendingPlayerLists.end())
-        {
-            if (itPending->first > getGameState().currentTicks)
-                break;
-
-            // List of active players found in the list.
-            std::vector<uint8_t> activePlayerIds;
-            std::vector<uint8_t> newPlayers;
-            std::vector<uint8_t> removedPlayers;
-
-            for (const auto& pendingPlayer : itPending->second.players)
-            {
-                activePlayerIds.push_back(pendingPlayer.Id);
-
-                auto* player = GetPlayerByID(pendingPlayer.Id);
-                if (player == nullptr)
-                {
-                    // Add new player.
-                    player = AddPlayer("", "");
-                    if (player != nullptr)
+                    case SocketStatus::Resolving:
                     {
-                        *player = pendingPlayer;
-                        if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
+                        if (_lastConnectStatus != SocketStatus::Resolving)
                         {
-                            _serverConnection->Player = player;
+                            _lastConnectStatus = SocketStatus::Resolving;
+                            char str_resolving[256];
+                            FormatStringLegacy(str_resolving, 256, STR_MULTIPLAYER_RESOLVING, nullptr);
+
+                            auto intent = Intent(WindowClass::NetworkStatus);
+                            intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_resolving });
+                            intent.PutExtra(
+                                INTENT_EXTRA_CALLBACK, []() -> void { OpenRCT2::GetContext()->GetNetwork().Close(); });
+                            ContextOpenIntent(&intent);
                         }
-                        newPlayers.push_back(player->Id);
+                        break;
                     }
+                    case SocketStatus::Connecting:
+                    {
+                        if (_lastConnectStatus != SocketStatus::Connecting)
+                        {
+                            _lastConnectStatus = SocketStatus::Connecting;
+                            char str_connecting[256];
+                            FormatStringLegacy(str_connecting, 256, STR_MULTIPLAYER_CONNECTING, nullptr);
+
+                            auto intent = Intent(WindowClass::NetworkStatus);
+                            intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_connecting });
+                            intent.PutExtra(
+                                INTENT_EXTRA_CALLBACK, []() -> void { OpenRCT2::GetContext()->GetNetwork().Close(); });
+                            ContextOpenIntent(&intent);
+
+                            server_connect_time = Platform::GetTicks();
+                        }
+                        break;
+                    }
+                    case SocketStatus::Connected:
+                    {
+                        status = NETWORK_STATUS_CONNECTED;
+                        _serverConnection->ResetLastPacketTime();
+                        Client_Send_TOKEN();
+                        char str_authenticating[256];
+                        FormatStringLegacy(str_authenticating, 256, STR_MULTIPLAYER_AUTHENTICATING, nullptr);
+
+                        auto intent = Intent(WindowClass::NetworkStatus);
+                        intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_authenticating });
+                        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
+                        ContextOpenIntent(&intent);
+                        break;
+                    }
+                    default:
+                    {
+                        const char* error = _serverConnection->Socket->GetError();
+                        if (error != nullptr)
+                        {
+                            Console::Error::WriteLine(error);
+                        }
+
+                        Close();
+                        ContextForceCloseWindowByClass(WindowClass::NetworkStatus);
+                        ContextShowError(STR_UNABLE_TO_CONNECT_TO_SERVER, kStringIdNone, {});
+                        break;
+                    }
+                }
+                break;
+            }
+            case NETWORK_STATUS_CONNECTED:
+            {
+                if (!ProcessConnection(*_serverConnection))
+                {
+                    // Do not show disconnect message window when password window closed/canceled
+                    if (_serverConnection->AuthStatus == NetworkAuth::RequirePassword)
+                    {
+                        ContextForceCloseWindowByClass(WindowClass::NetworkStatus);
+                    }
+                    else
+                    {
+                        char str_disconnected[256];
+
+                        if (_serverConnection->GetLastDisconnectReason())
+                        {
+                            const char* disconnect_reason = _serverConnection->GetLastDisconnectReason();
+                            FormatStringLegacy(
+                                str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_WITH_REASON, &disconnect_reason);
+                        }
+                        else
+                        {
+                            FormatStringLegacy(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_NO_REASON, nullptr);
+                        }
+
+                        auto intent = Intent(WindowClass::NetworkStatus);
+                        intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_disconnected });
+                        ContextOpenIntent(&intent);
+                    }
+
+                    auto* windowMgr = Ui::GetWindowManager();
+                    windowMgr->CloseByClass(WindowClass::Multiplayer);
+                    Close();
                 }
                 else
                 {
-                    // Update.
-                    *player = pendingPlayer;
+                    uint32_t ticks = Platform::GetTicks();
+                    if (ticks - _lastSentHeartbeat >= 3000)
+                    {
+                        Client_Send_HEARTBEAT(*_serverConnection);
+                        _lastSentHeartbeat = ticks;
+                    }
                 }
-            }
 
-            // Remove any players that are not in newly received list
-            for (const auto& player : player_list)
+                break;
+            }
+        }
+    }
+
+    auto NetworkBase::GetPlayerIteratorByID(uint8_t id) const
+    {
+        return std::find_if(player_list.begin(), player_list.end(), [id](std::unique_ptr<NetworkPlayer> const& player) {
+            return player->Id == id;
+        });
+    }
+
+    NetworkPlayer* NetworkBase::GetPlayerByID(uint8_t id) const
+    {
+        auto it = GetPlayerIteratorByID(id);
+        if (it != player_list.end())
+        {
+            return it->get();
+        }
+        return nullptr;
+    }
+
+    auto NetworkBase::GetGroupIteratorByID(uint8_t id) const
+    {
+        return std::find_if(
+            group_list.begin(), group_list.end(), [id](std::unique_ptr<NetworkGroup> const& group) { return group->Id == id; });
+    }
+
+    NetworkGroup* NetworkBase::GetGroupByID(uint8_t id) const
+    {
+        auto it = GetGroupIteratorByID(id);
+        if (it != group_list.end())
+        {
+            return it->get();
+        }
+        return nullptr;
+    }
+
+    int32_t NetworkBase::GetTotalNumPlayers() const noexcept
+    {
+        return static_cast<int32_t>(player_list.size());
+    }
+
+    int32_t NetworkBase::GetNumVisiblePlayers() const noexcept
+    {
+        if (IsServerPlayerInvisible)
+            return static_cast<int32_t>(player_list.size() - 1);
+        return static_cast<int32_t>(player_list.size());
+    }
+
+    const char* NetworkBase::FormatChat(NetworkPlayer* fromPlayer, const char* text)
+    {
+        static std::string formatted;
+        formatted.clear();
+
+        if (fromPlayer != nullptr)
+        {
+            auto& network = OpenRCT2::GetContext()->GetNetwork();
+            auto it = network.GetGroupByID(fromPlayer->Id);
+            std::string groupName = "";
+            std::vector<std::string> colours;
+            if (it != nullptr)
             {
-                if (std::find(activePlayerIds.begin(), activePlayerIds.end(), player->Id) == activePlayerIds.end())
+                groupName = it->GetName();
+                if (groupName[0] != '{')
                 {
-                    removedPlayers.push_back(player->Id);
+                    colours.push_back("{WHITE}");
                 }
             }
 
-            // Run player removed hooks (must be before players removed from list)
-            for (auto playerId : removedPlayers)
+            for (size_t i = 0; i < groupName.size(); ++i)
             {
-                ProcessPlayerLeftPluginHooks(playerId);
+                if (groupName[i] == '{')
+                {
+                    std::string colour = "{";
+                    ++i;
+                    while (i < groupName.size() && groupName[i] != '}' && groupName[i] != '{')
+                    {
+                        colour += groupName[i];
+                        ++i;
+                    }
+                    colour += '}';
+                    if (groupName[i] == '}' && i < groupName.size())
+                    {
+                        colours.push_back(colour);
+                    }
+                }
             }
 
-            // Run player joined hooks (must be after players added to list)
-            for (auto playerId : newPlayers)
+            if (colours.size() == 0 || (colours.size() == 1 && colours[0] == "{WHITE}"))
             {
-                ProcessPlayerJoinedPluginHooks(playerId);
+                formatted += "{BABYBLUE}";
+                formatted += fromPlayer->Name;
+            }
+            else
+            {
+                size_t j = 0;
+                size_t proportionalSize = fromPlayer->Name.size() / colours.size();
+                for (size_t i = 0; i < colours.size(); ++i)
+                {
+                    formatted += colours[i];
+                    size_t numCharacters = proportionalSize + j;
+                    for (; j < numCharacters && j < fromPlayer->Name.size(); ++j)
+                    {
+                        formatted += fromPlayer->Name[j];
+                    }
+                }
+                while (j < fromPlayer->Name.size())
+                {
+                    formatted += fromPlayer->Name[j];
+                    j++;
+                }
             }
 
-            // Now actually remove removed players from player list
-            player_list.erase(
-                std::remove_if(
-                    player_list.begin(), player_list.end(),
-                    [&removedPlayers](const std::unique_ptr<NetworkPlayer>& player) {
-                        return std::find(removedPlayers.begin(), removedPlayers.end(), player->Id) != removedPlayers.end();
-                    }),
-                player_list.end());
-
-            _pendingPlayerLists.erase(itPending);
-            itPending = _pendingPlayerLists.begin();
+            formatted += ": ";
         }
+        formatted += "{WHITE}";
+        formatted += text;
+        return formatted.c_str();
     }
-}
 
-void NetworkBase::ProcessPlayerInfo()
-{
-    const auto currentTicks = getGameState().currentTicks;
-
-    auto range = _pendingPlayerInfo.equal_range(currentTicks);
-    for (auto it = range.first; it != range.second; it++)
+    void NetworkBase::SendPacketToClients(const NetworkPacket& packet, bool front, bool gameCmd) const
     {
-        auto* player = GetPlayerByID(it->second.Id);
-        if (player != nullptr)
+        for (auto& client_connection : client_connection_list)
         {
-            const NetworkPlayer& networkedInfo = it->second;
-            player->Flags = networkedInfo.Flags;
-            player->Group = networkedInfo.Group;
-            player->LastAction = networkedInfo.LastAction;
-            player->LastActionCoord = networkedInfo.LastActionCoord;
-            player->MoneySpent = networkedInfo.MoneySpent;
-            player->CommandsRan = networkedInfo.CommandsRan;
+            if (gameCmd)
+            {
+                // If marked as game command we can not send the packet to connections that are not fully connected.
+                // Sending the packet would cause the client to store a command that is behind the tick where he starts,
+                // which would be essentially never executed. The clients do not require commands before the server has not sent
+                // the map data.
+                if (client_connection->Player == nullptr)
+                {
+                    continue;
+                }
+            }
+            client_connection->QueuePacket(packet, front);
         }
     }
-    _pendingPlayerInfo.erase(currentTicks);
-}
 
-void NetworkBase::ProcessDisconnectedClients()
-{
-    for (auto it = client_connection_list.begin(); it != client_connection_list.end();)
+    bool NetworkBase::CheckSRAND(uint32_t tick, uint32_t srand0)
     {
-        auto& connection = *it;
+        // We have to wait for the map to be loaded first, ticks may match current loaded map.
+        if (!_clientMapLoaded)
+            return true;
 
-        if (!connection->ShouldDisconnect)
+        auto itTickData = _serverTickData.find(tick);
+        if (itTickData == std::end(_serverTickData))
+            return true;
+
+        const ServerTickData storedTick = itTickData->second;
+        _serverTickData.erase(itTickData);
+
+        if (storedTick.srand0 != srand0)
         {
-            it++;
-            continue;
+            LOG_INFO("Srand0 mismatch, client = %08X, server = %08X", srand0, storedTick.srand0);
+            return false;
         }
 
-        // Make sure to send all remaining packets out before disconnecting.
-        connection->SendQueuedData();
-        connection->Socket->Disconnect();
+        if (!storedTick.spriteHash.empty())
+        {
+            EntitiesChecksum checksum = getGameState().entities.GetAllEntitiesChecksum();
+            std::string clientSpriteHash = checksum.ToString();
+            if (clientSpriteHash != storedTick.spriteHash)
+            {
+                LOG_INFO(
+                    "Sprite hash mismatch, client = %s, server = %s", clientSpriteHash.c_str(), storedTick.spriteHash.c_str());
+                return false;
+            }
+        }
 
-        ServerClientDisconnected(connection);
-        RemovePlayer(connection);
-
-        it = client_connection_list.erase(it);
-    }
-}
-
-void NetworkBase::AddClient(std::unique_ptr<ITcpSocket>&& socket)
-{
-    // Log connection info.
-    char addr[128];
-    snprintf(addr, sizeof(addr), "Client joined from %s", socket->GetHostName());
-    AppendServerLog(addr);
-
-    // Store connection
-    auto connection = std::make_unique<NetworkConnection>();
-    connection->Socket = std::move(socket);
-
-    client_connection_list.push_back(std::move(connection));
-}
-
-void NetworkBase::ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection)
-{
-    NetworkPlayer* connection_player = connection->Player;
-    if (connection_player == nullptr)
-        return;
-
-    char text[256];
-    const char* has_disconnected_args[2] = {
-        connection_player->Name.c_str(),
-        connection->GetLastDisconnectReason(),
-    };
-    if (has_disconnected_args[1] != nullptr)
-    {
-        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, has_disconnected_args);
-    }
-    else
-    {
-        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_NO_REASON, &(has_disconnected_args[0]));
+        return true;
     }
 
-    ChatAddHistory(text);
-    Peep* pickup_peep = NetworkGetPickupPeep(connection_player->Id);
-    if (pickup_peep != nullptr)
+    bool NetworkBase::IsDesynchronised() const noexcept
     {
-        GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Cancel,
-                                                    pickup_peep->Id,
-                                                    { NetworkGetPickupPeepOldX(connection_player->Id), 0, 0 },
-                                                    NetworkGetCurrentPlayerId() };
-        auto res = GameActions::Execute(&pickupAction);
+        return _serverState.state == NetworkServerStatus::Desynced;
     }
-    ServerSendEventPlayerDisconnected(
-        const_cast<char*>(connection_player->Name.c_str()), connection->GetLastDisconnectReason());
 
-    // Log player disconnected event
-    AppendServerLog(text);
-
-    ProcessPlayerLeftPluginHooks(connection_player->Id);
-}
-
-void NetworkBase::RemovePlayer(std::unique_ptr<NetworkConnection>& connection)
-{
-    NetworkPlayer* connection_player = connection->Player;
-    if (connection_player == nullptr)
-        return;
-
-    player_list.erase(
-        std::remove_if(
-            player_list.begin(), player_list.end(),
-            [connection_player](std::unique_ptr<NetworkPlayer>& player) { return player.get() == connection_player; }),
-        player_list.end());
-
-    // Send new player list.
-    _playerListInvalidated = true;
-}
-
-NetworkPlayer* NetworkBase::AddPlayer(const std::string& name, const std::string& keyhash)
-{
-    NetworkPlayer* addedplayer = nullptr;
-    int32_t newid = -1;
-    if (GetMode() == NETWORK_MODE_SERVER)
+    bool NetworkBase::CheckDesynchronizaton()
     {
-        // Find first unused player id
+        const auto currentTicks = getGameState().currentTicks;
+
+        // Check synchronisation
+        if (GetMode() == NETWORK_MODE_CLIENT && _serverState.state != NetworkServerStatus::Desynced
+            && !CheckSRAND(currentTicks, ScenarioRandState().s0))
+        {
+            _serverState.state = NetworkServerStatus::Desynced;
+            _serverState.desyncTick = currentTicks;
+
+            char str_desync[256];
+            FormatStringLegacy(str_desync, 256, STR_MULTIPLAYER_DESYNC, nullptr);
+
+            auto intent = Intent(WindowClass::NetworkStatus);
+            intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_desync });
+            ContextOpenIntent(&intent);
+
+            if (!Config::Get().network.StayConnected)
+            {
+                Close();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    void NetworkBase::RequestStateSnapshot()
+    {
+        LOG_INFO("Requesting game state for tick %u", _serverState.desyncTick);
+
+        Client_Send_RequestGameState(_serverState.desyncTick);
+    }
+
+    NetworkServerState NetworkBase::GetServerState() const noexcept
+    {
+        return _serverState;
+    }
+
+    void NetworkBase::KickPlayer(int32_t playerId)
+    {
+        for (auto& client_connection : client_connection_list)
+        {
+            if (client_connection->Player->Id == playerId)
+            {
+                // Disconnect the client gracefully
+                client_connection->SetLastDisconnectReason(STR_MULTIPLAYER_KICKED);
+                char str_disconnect_msg[256];
+                FormatStringLegacy(str_disconnect_msg, 256, STR_MULTIPLAYER_KICKED_REASON, nullptr);
+                ServerSendSetDisconnectMsg(*client_connection, str_disconnect_msg);
+                client_connection->Disconnect();
+                break;
+            }
+        }
+    }
+
+    void NetworkBase::SetPassword(u8string_view password)
+    {
+        _password = password;
+    }
+
+    void NetworkBase::ServerClientDisconnected()
+    {
+        if (GetMode() == NETWORK_MODE_CLIENT)
+        {
+            _serverConnection->Disconnect();
+        }
+    }
+
+    std::string NetworkBase::GenerateAdvertiseKey()
+    {
+        // Generate a string of 16 random hex characters (64-integer key as a hex formatted string)
+        static char hexChars[] = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+        };
+        char key[17];
+        for (int32_t i = 0; i < 16; i++)
+        {
+            int32_t hexCharIndex = UtilRand() % std::size(hexChars);
+            key[i] = hexChars[hexCharIndex];
+        }
+        key[std::size(key) - 1] = 0;
+
+        return key;
+    }
+
+    std::string NetworkBase::GetMasterServerUrl()
+    {
+        if (Config::Get().network.MasterServerUrl.empty())
+        {
+            return kMasterServerURL;
+        }
+
+        return Config::Get().network.MasterServerUrl;
+    }
+
+    NetworkGroup* NetworkBase::AddGroup()
+    {
+        NetworkGroup* addedgroup = nullptr;
+        int32_t newid = -1;
+        // Find first unused group id
         for (int32_t id = 0; id < 255; id++)
         {
             if (std::find_if(
-                    player_list.begin(), player_list.end(),
-                    [&id](std::unique_ptr<NetworkPlayer> const& player) { return player->Id == id; })
-                == player_list.end())
+                    group_list.begin(), group_list.end(),
+                    [&id](std::unique_ptr<NetworkGroup> const& group) { return group->Id == id; })
+                == group_list.end())
             {
                 newid = id;
                 break;
             }
         }
+        if (newid != -1)
+        {
+            auto group = std::make_unique<NetworkGroup>();
+            group->Id = newid;
+            group->SetName("Group #" + std::to_string(newid));
+            addedgroup = group.get();
+            group_list.push_back(std::move(group));
+        }
+        return addedgroup;
     }
-    else
+
+    void NetworkBase::RemoveGroup(uint8_t id)
     {
-        newid = 0;
-    }
-    if (newid != -1)
-    {
-        std::unique_ptr<NetworkPlayer> player;
+        auto group = GetGroupIteratorByID(id);
+        if (group != group_list.end())
+        {
+            group_list.erase(group);
+        }
+
         if (GetMode() == NETWORK_MODE_SERVER)
         {
-            // Load keys host may have added manually
-            _userManager.Load();
+            _userManager.UnsetUsersOfGroup(id);
+            _userManager.Save();
+        }
+    }
 
-            // Check if the key is registered
-            const NetworkUser* networkUser = _userManager.GetUserByHash(keyhash);
+    uint8_t NetworkBase::GetGroupIDByHash(const std::string& keyhash)
+    {
+        const NetworkUser* networkUser = _userManager.GetUserByHash(keyhash);
 
-            player = std::make_unique<NetworkPlayer>();
-            player->Id = newid;
-            player->KeyHash = keyhash;
-            if (networkUser == nullptr)
+        uint8_t groupId = GetDefaultGroup();
+        if (networkUser != nullptr && networkUser->GroupId.has_value())
+        {
+            const uint8_t assignedGroup = *networkUser->GroupId;
+            if (GetGroupByID(assignedGroup) != nullptr)
             {
-                player->Group = GetDefaultGroup();
-                if (!name.empty())
-                {
-                    player->SetName(MakePlayerNameUnique(String::trim(name)));
-                }
+                groupId = assignedGroup;
             }
             else
             {
-                player->Group = networkUser->GroupId.has_value() ? *networkUser->GroupId : GetDefaultGroup();
-                player->SetName(networkUser->Name);
+                LOG_WARNING(
+                    "User %s is assigned to non-existent group %u. Assigning to default group (%u)", keyhash.c_str(),
+                    assignedGroup, groupId);
             }
-
-            // Send new player list.
-            _playerListInvalidated = true;
         }
-        else
-        {
-            player = std::make_unique<NetworkPlayer>();
-            player->Id = newid;
-            player->Group = GetDefaultGroup();
-            player->SetName(String::trim(std::string(name)));
-        }
-
-        addedplayer = player.get();
-        player_list.push_back(std::move(player));
+        return groupId;
     }
-    return addedplayer;
-}
 
-std::string NetworkBase::MakePlayerNameUnique(const std::string& name)
-{
-    // Note: Player names are case-insensitive
-
-    std::string new_name = name.substr(0, 31);
-    int32_t counter = 1;
-    bool unique;
-    do
+    uint8_t NetworkBase::GetDefaultGroup() const noexcept
     {
-        unique = true;
+        return default_group;
+    }
 
-        // Check if there is already a player with this name in the server
-        for (const auto& player : player_list)
+    void NetworkBase::SetDefaultGroup(uint8_t id)
+    {
+        if (GetGroupByID(id) != nullptr)
         {
-            if (String::iequals(player->Name, new_name))
+            default_group = id;
+        }
+    }
+
+    void NetworkBase::SaveGroups()
+    {
+        if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            auto& env = GetContext().GetPlatformEnvironment();
+            auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
+
+            json_t jsonGroups = json_t::array();
+            for (auto& group : group_list)
             {
-                unique = false;
-                break;
+                jsonGroups.push_back(group->ToJson());
             }
-        }
-
-        if (unique)
-        {
-            // Check if there is already a registered player with this name
-            if (_userManager.GetUserByName(new_name) != nullptr)
+            json_t jsonGroupsCfg = {
+                { "default_group", default_group },
+                { "groups", jsonGroups },
+            };
+            try
             {
-                unique = false;
+                Json::WriteToFile(path, jsonGroupsCfg);
             }
-        }
-
-        if (!unique)
-        {
-            // Increment name counter
-            counter++;
-            new_name = name.substr(0, 31) + " #" + std::to_string(counter);
-        }
-    } while (!unique);
-    return new_name;
-}
-
-void NetworkBase::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet)
-{
-    auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
-    if (!File::Exists(keyPath))
-    {
-        LOG_ERROR("Key file (%s) was not found. Restart client to re-generate it.", keyPath.c_str());
-        return;
-    }
-
-    try
-    {
-        auto fs = FileStream(keyPath, FileMode::open);
-        if (!_key.LoadPrivate(&fs))
-        {
-            throw std::runtime_error("Failed to load private key.");
-        }
-    }
-    catch (const std::exception&)
-    {
-        LOG_ERROR("Failed to load key %s", keyPath.c_str());
-        connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
-        connection.Disconnect();
-        return;
-    }
-
-    uint32_t challenge_size;
-    packet >> challenge_size;
-    const char* challenge = reinterpret_cast<const char*>(packet.Read(challenge_size));
-
-    std::vector<uint8_t> signature;
-    const std::string pubkey = _key.PublicKeyString();
-    _challenge.resize(challenge_size);
-    std::memcpy(_challenge.data(), challenge, challenge_size);
-    bool ok = _key.Sign(_challenge.data(), _challenge.size(), signature);
-    if (!ok)
-    {
-        LOG_ERROR("Failed to sign server's challenge.");
-        connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
-        connection.Disconnect();
-        return;
-    }
-    // Don't keep private key in memory. There's no need and it may get leaked
-    // when process dump gets collected at some point in future.
-    _key.Unload();
-
-    Client_Send_AUTH(Config::Get().network.PlayerName, gCustomPassword, pubkey, signature);
-}
-
-void NetworkBase::ServerHandleRequestGamestate(NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t tick;
-    packet >> tick;
-
-    if (_serverState.gamestateSnapshotsEnabled == false)
-    {
-        // Ignore this if this is off.
-        return;
-    }
-
-    IGameStateSnapshots* snapshots = GetContext().GetGameStateSnapshots();
-
-    const GameStateSnapshot_t* snapshot = snapshots->GetLinkedSnapshot(tick);
-    if (snapshot != nullptr)
-    {
-        MemoryStream snapshotMemory;
-        DataSerialiser ds(true, snapshotMemory);
-
-        snapshots->SerialiseSnapshot(const_cast<GameStateSnapshot_t&>(*snapshot), ds);
-
-        uint32_t bytesSent = 0;
-        uint32_t length = static_cast<uint32_t>(snapshotMemory.GetLength());
-        while (bytesSent < length)
-        {
-            uint32_t dataSize = kChunkSize;
-            if (bytesSent + dataSize > snapshotMemory.GetLength())
+            catch (const std::exception& ex)
             {
-                dataSize = snapshotMemory.GetLength() - bytesSent;
-            }
-
-            NetworkPacket packetGameStateChunk(NetworkCommand::GameState);
-            packetGameStateChunk << tick << length << bytesSent << dataSize;
-            packetGameStateChunk.Write(static_cast<const uint8_t*>(snapshotMemory.GetData()) + bytesSent, dataSize);
-
-            connection.QueuePacket(std::move(packetGameStateChunk));
-
-            bytesSent += dataSize;
-        }
-    }
-}
-
-void NetworkBase::ServerHandleHeartbeat(NetworkConnection& connection, NetworkPacket& packet)
-{
-    LOG_VERBOSE("Client %s heartbeat", connection.Socket->GetHostName());
-    connection.ResetLastPacketTime();
-}
-
-void NetworkBase::Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t auth_status;
-    packet >> auth_status >> const_cast<uint8_t&>(player_id);
-    connection.AuthStatus = static_cast<NetworkAuth>(auth_status);
-    switch (connection.AuthStatus)
-    {
-        case NetworkAuth::Ok:
-            Client_Send_GAMEINFO();
-            break;
-        case NetworkAuth::BadName:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_BAD_PLAYER_NAME);
-            connection.Disconnect();
-            break;
-        case NetworkAuth::BadVersion:
-        {
-            auto version = std::string(packet.ReadString());
-            auto versionp = version.c_str();
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_INCORRECT_SOFTWARE_VERSION, &versionp);
-            connection.Disconnect();
-            break;
-        }
-        case NetworkAuth::BadPassword:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_BAD_PASSWORD);
-            connection.Disconnect();
-            break;
-        case NetworkAuth::VerificationFailure:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
-            connection.Disconnect();
-            break;
-        case NetworkAuth::Full:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_SERVER_FULL);
-            connection.Disconnect();
-            break;
-        case NetworkAuth::RequirePassword:
-            ContextOpenWindowView(WV_NETWORK_PASSWORD);
-            break;
-        case NetworkAuth::UnknownKeyDisallowed:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_UNKNOWN_KEY_DISALLOWED);
-            connection.Disconnect();
-            break;
-        default:
-            connection.SetLastDisconnectReason(STR_MULTIPLAYER_RECEIVED_INVALID_DATA);
-            connection.Disconnect();
-            break;
-    }
-}
-
-void NetworkBase::ServerClientJoined(std::string_view name, const std::string& keyhash, NetworkConnection& connection)
-{
-    auto player = AddPlayer(std::string(name), keyhash);
-    connection.Player = player;
-    if (player != nullptr)
-    {
-        char text[256];
-        const char* player_name = static_cast<const char*>(player->Name.c_str());
-        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
-        ChatAddHistory(text);
-
-        auto& context = GetContext();
-        auto& objManager = context.GetObjectManager();
-        auto objects = objManager.GetPackableObjects();
-        ServerSendObjectsList(connection, objects);
-        ServerSendScripts(connection);
-
-        // Log player joining event
-        std::string playerNameHash = player->Name + " (" + keyhash + ")";
-        player_name = static_cast<const char*>(playerNameHash.c_str());
-        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
-        AppendServerLog(text);
-
-        ProcessPlayerJoinedPluginHooks(player->Id);
-    }
-}
-
-void NetworkBase::ServerHandleToken(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
-{
-    uint8_t token_size = 10 + (rand() & 0x7f);
-    connection.Challenge.resize(token_size);
-    for (int32_t i = 0; i < token_size; i++)
-    {
-        connection.Challenge[i] = static_cast<uint8_t>(rand() & 0xff);
-    }
-    ServerSendToken(connection);
-}
-
-static void OpenNetworkProgress(StringId captionStringId)
-{
-    auto captionString = GetContext()->GetLocalisationService().GetString(captionStringId);
-    auto intent = Intent(INTENT_ACTION_PROGRESS_OPEN);
-    intent.PutExtra(INTENT_EXTRA_MESSAGE, captionString);
-    intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
-    ContextOpenIntent(&intent);
-}
-
-void NetworkBase::Client_Handle_OBJECTS_LIST(NetworkConnection& connection, NetworkPacket& packet)
-{
-    auto& repo = GetContext().GetObjectRepository();
-
-    uint32_t index = 0;
-    uint32_t totalObjects = 0;
-    packet >> index >> totalObjects;
-
-    static constexpr uint32_t kObjectStartIndex = 0;
-    if (index == kObjectStartIndex)
-    {
-        _missingObjects.clear();
-    }
-
-    if (totalObjects > 0)
-    {
-        OpenNetworkProgress(STR_MULTIPLAYER_RECEIVING_OBJECTS_LIST);
-        GetContext().SetProgress(index + 1, totalObjects);
-
-        uint8_t objectType{};
-        packet >> objectType;
-
-        if (objectType == 0)
-        {
-            // DAT
-            auto entry = reinterpret_cast<const RCTObjectEntry*>(packet.Read(sizeof(RCTObjectEntry)));
-            if (entry != nullptr)
-            {
-                const auto* object = repo.FindObject(entry);
-                if (object == nullptr)
-                {
-                    auto objectName = std::string(entry->GetName());
-                    LOG_VERBOSE("Requesting object %s with checksum %x from server", objectName.c_str(), entry->checksum);
-                    _missingObjects.push_back(ObjectEntryDescriptor(*entry));
-                }
-                else if (object->ObjectEntry.checksum != entry->checksum || object->ObjectEntry.flags != entry->flags)
-                {
-                    auto objectName = std::string(entry->GetName());
-                    LOG_WARNING(
-                        "Object %s has different checksum/flags (%x/%x) than server (%x/%x).", objectName.c_str(),
-                        object->ObjectEntry.checksum, object->ObjectEntry.flags, entry->checksum, entry->flags);
-                }
-            }
-        }
-        else
-        {
-            // JSON
-            auto identifier = packet.ReadString();
-            if (!identifier.empty())
-            {
-                const auto* object = repo.FindObject(identifier);
-                if (object == nullptr)
-                {
-                    auto objectName = std::string(identifier);
-                    LOG_VERBOSE("Requesting object %s from server", objectName.c_str());
-                    _missingObjects.push_back(ObjectEntryDescriptor(objectName));
-                }
+                LOG_ERROR("Unable to save %s: %s", path.c_str(), ex.what());
             }
         }
     }
 
-    if (index + 1 >= totalObjects)
+    void NetworkBase::SetupDefaultGroups()
     {
-        LOG_VERBOSE("client received object list, it has %u entries", totalObjects);
-        Client_Send_MAPREQUEST(_missingObjects);
-        _missingObjects.clear();
-    }
-}
+        // Admin group
+        auto admin = std::make_unique<NetworkGroup>();
+        admin->SetName("Admin");
+        admin->ActionsAllowed.fill(0xFF);
+        admin->Id = 0;
+        group_list.push_back(std::move(admin));
 
-void NetworkBase::Client_Handle_SCRIPTS_HEADER(NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t numScripts{};
-    uint32_t dataSize{};
-    packet >> numScripts >> dataSize;
+        // Spectator group
+        auto spectator = std::make_unique<NetworkGroup>();
+        spectator->SetName("Spectator");
+        spectator->ToggleActionPermission(NetworkPermission::Chat);
+        spectator->Id = 1;
+        group_list.push_back(std::move(spectator));
 
-    #ifdef ENABLE_SCRIPTING
-    _serverScriptsData.data.Clear();
-    _serverScriptsData.pluginCount = numScripts;
-    _serverScriptsData.dataSize = dataSize;
-    #else
-    if (numScripts > 0)
-    {
-        connection.SetLastDisconnectReason("The client requires plugin support.");
-        Close();
-    }
-    #endif
-}
+        // User group
+        auto user = std::make_unique<NetworkGroup>();
+        user->SetName("User");
+        user->ActionsAllowed.fill(0xFF);
+        user->ToggleActionPermission(NetworkPermission::KickPlayer);
+        user->ToggleActionPermission(NetworkPermission::ModifyGroups);
+        user->ToggleActionPermission(NetworkPermission::SetPlayerGroup);
+        user->ToggleActionPermission(NetworkPermission::Cheat);
+        user->ToggleActionPermission(NetworkPermission::PasswordlessLogin);
+        user->ToggleActionPermission(NetworkPermission::ModifyTile);
+        user->ToggleActionPermission(NetworkPermission::EditScenarioOptions);
+        user->Id = 2;
+        group_list.push_back(std::move(user));
 
-void NetworkBase::Client_Handle_SCRIPTS_DATA(NetworkConnection& connection, NetworkPacket& packet)
-{
-    #ifdef ENABLE_SCRIPTING
-    uint32_t dataSize{};
-    packet >> dataSize;
-    Guard::Assert(dataSize > 0);
-
-    const auto* data = packet.Read(dataSize);
-    Guard::Assert(data != nullptr);
-
-    auto& scriptsData = _serverScriptsData.data;
-    scriptsData.Write(data, dataSize);
-
-    if (scriptsData.GetLength() == _serverScriptsData.dataSize)
-    {
-        auto& scriptEngine = GetContext().GetScriptEngine();
-
-        scriptsData.SetPosition(0);
-        for (uint32_t i = 0; i < _serverScriptsData.pluginCount; ++i)
-        {
-            const auto codeSize = scriptsData.ReadValue<uint32_t>();
-            const auto scriptData = scriptsData.ReadArray<char>(codeSize);
-
-            auto code = std::string_view(reinterpret_cast<const char*>(scriptData.get()), codeSize);
-            scriptEngine.AddNetworkPlugin(code);
-        }
-        Guard::Assert(scriptsData.GetPosition() == scriptsData.GetLength());
-
-        // Empty the current buffer.
-        _serverScriptsData = {};
-    }
-    #else
-    connection.SetLastDisconnectReason("The client requires plugin support.");
-    Close();
-    #endif
-}
-
-void NetworkBase::Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t tick;
-    uint32_t totalSize;
-    uint32_t offset;
-    uint32_t dataSize;
-
-    packet >> tick >> totalSize >> offset >> dataSize;
-
-    if (offset == 0)
-    {
-        // Reset
-        _serverGameState = MemoryStream();
+        SetDefaultGroup(1);
     }
 
-    _serverGameState.SetPosition(offset);
-
-    const uint8_t* data = packet.Read(dataSize);
-    _serverGameState.Write(data, dataSize);
-
-    LOG_VERBOSE(
-        "Received Game State %.02f%%",
-        (static_cast<float>(_serverGameState.GetLength()) / static_cast<float>(totalSize)) * 100.0f);
-
-    if (_serverGameState.GetLength() == totalSize)
+    void NetworkBase::LoadGroups()
     {
-        _serverGameState.SetPosition(0);
-        DataSerialiser ds(false, _serverGameState);
+        group_list.clear();
 
-        IGameStateSnapshots* snapshots = GetContext().GetGameStateSnapshots();
+        auto& env = GetContext().GetPlatformEnvironment();
+        auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
 
-        GameStateSnapshot_t& serverSnapshot = snapshots->CreateSnapshot();
-        snapshots->SerialiseSnapshot(serverSnapshot, ds);
-
-        const GameStateSnapshot_t* desyncSnapshot = snapshots->GetLinkedSnapshot(tick);
-        if (desyncSnapshot != nullptr)
-        {
-            GameStateCompareData cmpData = snapshots->Compare(serverSnapshot, *desyncSnapshot);
-
-            std::string outputPath = GetContext().GetPlatformEnvironment().GetDirectoryPath(DirBase::user, DirId::desyncLogs);
-
-            Path::CreateDirectory(outputPath);
-
-            char uniqueFileName[128] = {};
-            snprintf(
-                uniqueFileName, sizeof(uniqueFileName), "desync_%llu_%u.txt",
-                static_cast<long long unsigned>(Platform::GetDatetimeNowUTC()), tick);
-
-            std::string outputFile = Path::Combine(outputPath, uniqueFileName);
-
-            if (snapshots->LogCompareDataToFile(outputFile, cmpData))
-            {
-                LOG_INFO("Wrote desync report to '%s'", outputFile.c_str());
-
-                auto ft = Formatter();
-                ft.Add<char*>(uniqueFileName);
-
-                char str_desync[1024];
-                FormatStringLegacy(str_desync, sizeof(str_desync), STR_DESYNC_REPORT, ft.Data());
-
-                auto intent = Intent(WindowClass::NetworkStatus);
-                intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_desync });
-                ContextOpenIntent(&intent);
-            }
-        }
-    }
-}
-
-void NetworkBase::ServerHandleMapRequest(NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t size;
-    packet >> size;
-    LOG_VERBOSE("Client requested %u objects", size);
-    auto& repo = GetContext().GetObjectRepository();
-    for (uint32_t i = 0; i < size; i++)
-    {
-        uint8_t generation{};
-        packet >> generation;
-
-        std::string objectName;
-        const ObjectRepositoryItem* item{};
-        if (generation == static_cast<uint8_t>(ObjectGeneration::DAT))
-        {
-            const auto* entry = reinterpret_cast<const RCTObjectEntry*>(packet.Read(sizeof(RCTObjectEntry)));
-            objectName = std::string(entry->GetName());
-            LOG_VERBOSE("Client requested object %s", objectName.c_str());
-            item = repo.FindObject(entry);
-        }
-        else
-        {
-            objectName = std::string(packet.ReadString());
-            LOG_VERBOSE("Client requested object %s", objectName.c_str());
-            item = repo.FindObject(objectName);
-        }
-
-        if (item == nullptr)
-        {
-            LOG_WARNING("Client tried getting non-existent object %s from us.", objectName.c_str());
-        }
-        else
-        {
-            connection.RequestedObjects.push_back(item);
-        }
-    }
-
-    auto player_name = connection.Player->Name.c_str();
-    ServerSendMap(&connection);
-    ServerSendEventPlayerJoined(player_name);
-    ServerSendGroupList(connection);
-}
-
-void NetworkBase::ServerHandleAuth(NetworkConnection& connection, NetworkPacket& packet)
-{
-    if (connection.AuthStatus != NetworkAuth::Ok)
-    {
-        auto* hostName = connection.Socket->GetHostName();
-        auto gameversion = packet.ReadString();
-        auto name = packet.ReadString();
-        auto password = packet.ReadString();
-        auto pubkey = packet.ReadString();
-        uint32_t sigsize;
-        packet >> sigsize;
-        if (pubkey.empty())
-        {
-            connection.AuthStatus = NetworkAuth::VerificationFailure;
-        }
-        else
+        json_t jsonGroupConfig;
+        if (File::Exists(path))
         {
             try
             {
-                // RSA technically supports keys up to 65536 bits, so this is the
-                // maximum signature size for now.
-                constexpr auto MaxRSASignatureSizeInBytes = 8192;
-
-                if (sigsize == 0 || sigsize > MaxRSASignatureSizeInBytes)
-                {
-                    throw std::runtime_error("Invalid signature size");
-                }
-
-                std::vector<uint8_t> signature;
-                signature.resize(sigsize);
-
-                const uint8_t* signatureData = packet.Read(sigsize);
-                if (signatureData == nullptr)
-                {
-                    throw std::runtime_error("Failed to read packet.");
-                }
-
-                std::memcpy(signature.data(), signatureData, sigsize);
-
-                auto ms = MemoryStream(pubkey.data(), pubkey.size());
-                if (!connection.Key.LoadPublic(&ms))
-                {
-                    throw std::runtime_error("Failed to load public key.");
-                }
-
-                bool verified = connection.Key.Verify(connection.Challenge.data(), connection.Challenge.size(), signature);
-                const std::string hash = connection.Key.PublicKeyHash();
-                if (verified)
-                {
-                    LOG_VERBOSE("Connection %s: Signature verification ok. Hash %s", hostName, hash.c_str());
-                    if (Config::Get().network.KnownKeysOnly && _userManager.GetUserByHash(hash) == nullptr)
-                    {
-                        LOG_VERBOSE("Connection %s: Hash %s, not known", hostName, hash.c_str());
-                        connection.AuthStatus = NetworkAuth::UnknownKeyDisallowed;
-                    }
-                    else
-                    {
-                        connection.AuthStatus = NetworkAuth::Verified;
-                    }
-                }
-                else
-                {
-                    connection.AuthStatus = NetworkAuth::VerificationFailure;
-                    LOG_VERBOSE("Connection %s: Signature verification failed!", hostName);
-                }
+                jsonGroupConfig = Json::ReadFromFile(path);
             }
-            catch (const std::exception&)
+            catch (const std::exception& e)
             {
-                connection.AuthStatus = NetworkAuth::VerificationFailure;
-                LOG_VERBOSE("Connection %s: Signature verification failed, invalid data!", hostName);
+                LOG_ERROR("Failed to read %s as JSON. Setting default groups. %s", path.c_str(), e.what());
             }
         }
 
-        bool passwordless = false;
-        if (connection.AuthStatus == NetworkAuth::Verified)
+        if (!jsonGroupConfig.is_object())
         {
-            const NetworkGroup* group = GetGroupByID(GetGroupIDByHash(connection.Key.PublicKeyHash()));
-            if (group != nullptr)
-            {
-                passwordless = group->CanPerformAction(NetworkPermission::PasswordlessLogin);
-            }
-        }
-        if (gameversion != NetworkGetVersion())
-        {
-            connection.AuthStatus = NetworkAuth::BadVersion;
-            LOG_INFO("Connection %s: Bad version.", hostName);
-        }
-        else if (name.empty())
-        {
-            connection.AuthStatus = NetworkAuth::BadName;
-            LOG_INFO("Connection %s: Bad name.", connection.Socket->GetHostName());
-        }
-        else if (!passwordless)
-        {
-            if (password.empty() && !_password.empty())
-            {
-                connection.AuthStatus = NetworkAuth::RequirePassword;
-                LOG_INFO("Connection %s: Requires password.", hostName);
-            }
-            else if (!password.empty() && _password != password)
-            {
-                connection.AuthStatus = NetworkAuth::BadPassword;
-                LOG_INFO("Connection %s: Bad password.", hostName);
-            }
-        }
-
-        if (GetNumVisiblePlayers() >= Config::Get().network.Maxplayers)
-        {
-            connection.AuthStatus = NetworkAuth::Full;
-            LOG_INFO("Connection %s: Server is full.", hostName);
-        }
-        else if (connection.AuthStatus == NetworkAuth::Verified)
-        {
-            const std::string hash = connection.Key.PublicKeyHash();
-            if (ProcessPlayerAuthenticatePluginHooks(connection, name, hash))
-            {
-                connection.AuthStatus = NetworkAuth::Ok;
-                ServerClientJoined(name, hash, connection);
-            }
-            else
-            {
-                connection.AuthStatus = NetworkAuth::VerificationFailure;
-                LOG_INFO("Connection %s: Denied by plugin.", hostName);
-            }
-        }
-
-        ServerSendAuth(connection);
-    }
-}
-
-void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t size, offset;
-    packet >> size >> offset;
-    int32_t chunksize = static_cast<int32_t>(packet.Header.Size - packet.BytesRead);
-    if (chunksize <= 0)
-    {
-        return;
-    }
-    if (offset == 0)
-    {
-        // Start of a new map load, clear the queue now as we have to buffer them
-        // until the map is fully loaded.
-        GameActions::ClearQueue();
-        GameActions::SuspendQueue();
-
-        _serverTickData.clear();
-        _clientMapLoaded = false;
-
-        OpenNetworkProgress(STR_MULTIPLAYER_DOWNLOADING_MAP);
-    }
-    if (size > chunk_buffer.size())
-    {
-        chunk_buffer.resize(size);
-    }
-
-    const auto currentProgressKiB = (offset + chunksize) / 1024;
-    const auto totalSizeKiB = size / 1024;
-
-    GetContext().SetProgress(currentProgressKiB, totalSizeKiB, STR_STRING_M_OF_N_KIB);
-
-    std::memcpy(&chunk_buffer[offset], const_cast<void*>(static_cast<const void*>(packet.Read(chunksize))), chunksize);
-    if (offset + chunksize == size)
-    {
-        // Allow queue processing of game actions again.
-        GameActions::ResumeQueue();
-
-        ContextForceCloseWindowByClass(WindowClass::ProgressWindow);
-        GameUnloadScripts();
-        GameNotifyMapChange();
-
-        bool has_to_free = false;
-        uint8_t* data = &chunk_buffer[0];
-        size_t data_size = size;
-        auto ms = MemoryStream(data, data_size);
-        if (LoadMap(&ms))
-        {
-            GameLoadInit();
-            GameLoadScripts();
-            GameNotifyMapChanged();
-            _serverState.tick = getGameState().currentTicks;
-            // NetworkStatusOpen("Loaded new map from network");
-            _serverState.state = NetworkServerStatus::Ok;
-            _clientMapLoaded = true;
-            gFirstTimeSaving = true;
-
-            // Notify user he is now online and which shortcut key enables chat
-            NetworkChatShowConnectedMessage();
-
-            // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
-            FixInvalidVehicleSpriteSizes();
-
-            // NOTE: Game actions are normally processed before processing the player list.
-            // Given that during map load game actions are buffered we have to process the
-            // player list first to have valid players for the queued game actions.
-            ProcessPlayerList();
+            SetupDefaultGroups();
         }
         else
         {
-            // Something went wrong, game is not loaded. Return to main screen.
-            auto loadOrQuitAction = GameActions::LoadOrQuitAction(
-                GameActions::LoadOrQuitModes::OpenSavePrompt, PromptMode::saveBeforeQuit);
-            GameActions::Execute(&loadOrQuitAction);
-        }
-        if (has_to_free)
-        {
-            free(data);
-        }
-    }
-}
-
-bool NetworkBase::LoadMap(IStream* stream)
-{
-    bool result = false;
-    try
-    {
-        auto& context = GetContext();
-        auto& objManager = context.GetObjectManager();
-        auto importer = ParkImporter::CreateParkFile(context.GetObjectRepository());
-        auto loadResult = importer->LoadFromStream(stream, false);
-        objManager.LoadObjects(loadResult.RequiredObjects);
-
-        MapAnimations::ClearAll();
-        // TODO: Have a separate GameState and exchange once loaded.
-        auto& gameState = getGameState();
-        importer->Import(gameState);
-
-        EntityTweener::Get().Reset();
-        MapAnimations::MarkAllTiles();
-
-        gLastAutoSaveUpdate = kAutosavePause;
-        result = true;
-    }
-    catch (const std::exception& e)
-    {
-        Console::Error::WriteLine("Unable to read map from server: %s", e.what());
-    }
-    return result;
-}
-
-bool NetworkBase::SaveMap(IStream* stream, const std::vector<const ObjectRepositoryItem*>& objects) const
-{
-    bool result = false;
-    PrepareMapForSave();
-    try
-    {
-        auto exporter = std::make_unique<ParkFileExporter>();
-        exporter->ExportObjectsList = objects;
-
-        auto& gameState = getGameState();
-        exporter->Export(gameState, *stream, kParkFileNetCompressionLevel);
-        result = true;
-    }
-    catch (const std::exception& e)
-    {
-        Console::Error::WriteLine("Unable to serialise map: %s", e.what());
-    }
-    return result;
-}
-
-void NetworkBase::Client_Handle_CHAT([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    auto text = packet.ReadString();
-    if (!text.empty())
-    {
-        ChatAddHistory(std::string(text));
-    }
-}
-
-static bool ProcessChatMessagePluginHooks(uint8_t playerId, std::string& text)
-{
-    #ifdef ENABLE_SCRIPTING
-    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(Scripting::HookType::networkChat))
-    {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-
-        // Create event args object
-        auto objIdx = duk_push_object(ctx);
-        duk_push_number(ctx, playerId);
-        duk_put_prop_string(ctx, objIdx, "player");
-        duk_push_string(ctx, text.c_str());
-        duk_put_prop_string(ctx, objIdx, "message");
-        auto e = DukValue::take_from_stack(ctx);
-
-        // Call the subscriptions
-        hookEngine.Call(Scripting::HookType::networkChat, e, false);
-
-        // Update text from object if subscriptions changed it
-        if (e["message"].type() != DukValue::Type::STRING)
-        {
-            // Subscription set text to non-string, do not relay message
-            return false;
-        }
-        text = e["message"].as_string();
-        if (text.empty())
-        {
-            // Subscription set text to empty string, do not relay message
-            return false;
-        }
-    }
-    #endif
-    return true;
-}
-
-void NetworkBase::ServerHandleChat(NetworkConnection& connection, NetworkPacket& packet)
-{
-    auto szText = packet.ReadString();
-    if (szText.empty())
-        return;
-
-    if (connection.Player != nullptr)
-    {
-        NetworkGroup* group = GetGroupByID(connection.Player->Group);
-        if (group == nullptr || !group->CanPerformAction(NetworkPermission::Chat))
-        {
-            return;
-        }
-    }
-
-    std::string text(szText);
-    if (connection.Player != nullptr)
-    {
-        if (!ProcessChatMessagePluginHooks(connection.Player->Id, text))
-        {
-            // Message not to be relayed
-            return;
-        }
-    }
-
-    const char* formatted = FormatChat(connection.Player, text.c_str());
-    ChatAddHistory(formatted);
-    ServerSendChat(formatted);
-}
-
-void NetworkBase::Client_Handle_GAME_ACTION([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t tick;
-    GameCommand actionType;
-    packet >> tick >> actionType;
-
-    MemoryStream stream;
-    const size_t size = packet.Header.Size - packet.BytesRead;
-    stream.WriteArray(packet.Read(size), size);
-    stream.SetPosition(0);
-
-    DataSerialiser ds(false, stream);
-
-    GameActions::GameAction::Ptr action = GameActions::Create(actionType);
-    if (action == nullptr)
-    {
-        LOG_ERROR("Received unregistered game action type: 0x%08X", actionType);
-        return;
-    }
-    action->Serialise(ds);
-
-    if (player_id == action->GetPlayer().id)
-    {
-        // Only execute callbacks that belong to us,
-        // clients can have identical network ids assigned.
-        auto itr = _gameActionCallbacks.find(action->GetNetworkId());
-        if (itr != _gameActionCallbacks.end())
-        {
-            action->SetCallback(itr->second);
-            _gameActionCallbacks.erase(itr);
-        }
-    }
-
-    GameActions::Enqueue(std::move(action), tick);
-}
-
-void NetworkBase::ServerHandleGameAction(NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t tick;
-    GameCommand actionType;
-
-    NetworkPlayer* player = connection.Player;
-    if (player == nullptr)
-    {
-        return;
-    }
-
-    packet >> tick >> actionType;
-
-    // Don't let clients send pause or quit
-    if (actionType == GameCommand::TogglePause || actionType == GameCommand::LoadOrQuit)
-    {
-        return;
-    }
-
-    if (actionType != GameCommand::Custom)
-    {
-        // Check if player's group permission allows command to run
-        NetworkGroup* group = GetGroupByID(connection.Player->Group);
-        if (group == nullptr || group->CanPerformCommand(actionType) == false)
-        {
-            ServerSendShowError(connection, STR_CANT_DO_THIS, STR_PERMISSION_DENIED);
-            return;
-        }
-    }
-
-    // Create and enqueue the action.
-    GameActions::GameAction::Ptr ga = GameActions::Create(actionType);
-    if (ga == nullptr)
-    {
-        LOG_ERROR(
-            "Received unregistered game action type: 0x%08X from player: (%d) %s", actionType, connection.Player->Id,
-            connection.Player->Name.c_str());
-        return;
-    }
-
-    // Player who is hosting is not affected by cooldowns.
-    if ((player->Flags & NETWORK_PLAYER_FLAG_ISSERVER) == 0)
-    {
-        auto cooldownIt = player->CooldownTime.find(actionType);
-        if (cooldownIt != std::end(player->CooldownTime))
-        {
-            if (cooldownIt->second > 0)
+            json_t jsonGroups = jsonGroupConfig["groups"];
+            if (jsonGroups.is_array())
             {
-                ServerSendShowError(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
-                return;
+                for (auto& jsonGroup : jsonGroups)
+                {
+                    group_list.emplace_back(std::make_unique<NetworkGroup>(NetworkGroup::FromJson(jsonGroup)));
+                }
+            }
+
+            default_group = Json::GetNumber<uint8_t>(jsonGroupConfig["default_group"]);
+            if (GetGroupByID(default_group) == nullptr)
+            {
+                default_group = 0;
             }
         }
 
-        uint32_t cooldownTime = ga->GetCooldownTime();
-        if (cooldownTime > 0)
+        // Host group should always contain all permissions.
+        group_list.at(0)->ActionsAllowed.fill(0xFF);
+    }
+
+    std::string NetworkBase::BeginLog(
+        const std::string& directory, const std::string& midName, const std::string& filenameFormat)
+    {
+        utf8 filename[256];
+        time_t timer;
+        time(&timer);
+        auto tmInfo = localtime(&timer);
+        if (strftime(filename, sizeof(filename), filenameFormat.c_str(), tmInfo) == 0)
         {
-            player->CooldownTime[actionType] = cooldownTime;
+            throw std::runtime_error("strftime failed");
         }
+
+        auto directoryMidName = Path::Combine(directory, midName);
+        Path::CreateDirectory(directoryMidName);
+        return Path::Combine(directoryMidName, filename);
     }
 
-    DataSerialiser stream(false);
-    const size_t size = packet.Header.Size - packet.BytesRead;
-    stream.GetStream().WriteArray(packet.Read(size), size);
-    stream.GetStream().SetPosition(0);
-
-    ga->Serialise(stream);
-    // Set player to sender, should be 0 if sent from client.
-    ga->SetPlayer(NetworkPlayerId_t{ connection.Player->Id });
-
-    GameActions::Enqueue(std::move(ga), tick);
-}
-
-void NetworkBase::Client_Handle_TICK([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t srand0;
-    uint32_t flags;
-    uint32_t serverTick;
-
-    packet >> serverTick >> srand0 >> flags;
-
-    ServerTickData tickData;
-    tickData.srand0 = srand0;
-    tickData.tick = serverTick;
-
-    if (flags & NETWORK_TICK_FLAG_CHECKSUMS)
+    void NetworkBase::AppendLog(std::ostream& fs, std::string_view s)
     {
-        auto text = packet.ReadString();
-        if (!text.empty())
+        if (fs.fail())
         {
-            tickData.spriteHash = text;
+            LOG_ERROR("bad ostream failed to append log");
+            return;
         }
-    }
-
-    // Don't let the history grow too much.
-    while (_serverTickData.size() >= 100)
-    {
-        _serverTickData.erase(_serverTickData.begin());
-    }
-
-    _serverState.tick = serverTick;
-    _serverTickData.emplace(serverTick, tickData);
-}
-
-void NetworkBase::Client_Handle_PLAYERINFO([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t tick;
-    packet >> tick;
-
-    NetworkPlayer playerInfo;
-    playerInfo.Read(packet);
-
-    _pendingPlayerInfo.emplace(tick, playerInfo);
-}
-
-void NetworkBase::Client_Handle_PLAYERLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint32_t tick;
-    uint8_t size;
-    packet >> tick >> size;
-
-    auto& pending = _pendingPlayerLists[tick];
-    pending.players.clear();
-
-    for (uint32_t i = 0; i < size; i++)
-    {
-        NetworkPlayer tempplayer;
-        tempplayer.Read(packet);
-
-        pending.players.push_back(std::move(tempplayer));
-    }
-}
-
-void NetworkBase::Client_Handle_PING([[maybe_unused]] NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
-{
-    Client_Send_PING();
-}
-
-void NetworkBase::ServerHandlePing(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
-{
-    int32_t ping = Platform::GetTicks() - connection.PingTime;
-    if (ping < 0)
-    {
-        ping = 0;
-    }
-    if (connection.Player != nullptr)
-    {
-        connection.Player->Ping = ping;
-        auto* windowMgr = Ui::GetWindowManager();
-        windowMgr->InvalidateByNumber(WindowClass::Player, connection.Player->Id);
-    }
-}
-
-void NetworkBase::Client_Handle_PINGLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint8_t size;
-    packet >> size;
-    for (uint32_t i = 0; i < size; i++)
-    {
-        uint8_t id;
-        uint16_t ping;
-        packet >> id >> ping;
-        NetworkPlayer* player = GetPlayerByID(id);
-        if (player != nullptr)
+        try
         {
-            player->Ping = ping;
-        }
-    }
-
-    auto* windowMgr = Ui::GetWindowManager();
-    windowMgr->InvalidateByClass(WindowClass::Player);
-}
-
-void NetworkBase::Client_Handle_SETDISCONNECTMSG(NetworkConnection& connection, NetworkPacket& packet)
-{
-    auto disconnectmsg = packet.ReadString();
-    if (!disconnectmsg.empty())
-    {
-        connection.SetLastDisconnectReason(disconnectmsg);
-    }
-}
-
-void NetworkBase::ServerHandleGameInfo(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
-{
-    ServerSendGameInfo(connection);
-}
-
-void NetworkBase::Client_Handle_SHOWERROR([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    StringId title, message;
-    packet >> title >> message;
-    ContextShowError(title, message, {});
-}
-
-void NetworkBase::Client_Handle_GROUPLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    group_list.clear();
-    uint8_t size;
-    packet >> size >> default_group;
-    for (uint32_t i = 0; i < size; i++)
-    {
-        NetworkGroup group;
-        group.Read(packet);
-        auto newgroup = std::make_unique<NetworkGroup>(group);
-        group_list.push_back(std::move(newgroup));
-    }
-}
-
-void NetworkBase::Client_Handle_EVENT([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    uint16_t eventType;
-    packet >> eventType;
-    switch (eventType)
-    {
-        case SERVER_EVENT_PLAYER_JOINED:
-        {
-            auto playerName = packet.ReadString();
-            auto message = FormatStringID(STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, playerName);
-            ChatAddHistory(message);
-            break;
-        }
-        case SERVER_EVENT_PLAYER_DISCONNECTED:
-        {
-            auto playerName = packet.ReadString();
-            auto reason = packet.ReadString();
-            std::string message;
-            if (reason.empty())
+            utf8 buffer[1024];
+            time_t timer;
+            time(&timer);
+            auto tmInfo = localtime(&timer);
+            if (strftime(buffer, sizeof(buffer), "[%Y/%m/%d %H:%M:%S] ", tmInfo) != 0)
             {
-                message = FormatStringID(STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_NO_REASON, playerName);
+                String::append(buffer, sizeof(buffer), std::string(s).c_str());
+                String::append(buffer, sizeof(buffer), PLATFORM_NEWLINE);
+
+                fs.write(buffer, strlen(buffer));
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            LOG_ERROR("%s", ex.what());
+        }
+    }
+
+    void NetworkBase::BeginChatLog()
+    {
+        auto& env = GetContext().GetPlatformEnvironment();
+        auto directory = env.GetDirectoryPath(DirBase::user, DirId::chatLogs);
+        _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
+        _chat_log_fs.open(fs::u8path(_chatLogPath), std::ios::out | std::ios::app);
+    }
+
+    void NetworkBase::AppendChatLog(std::string_view s)
+    {
+        if (Config::Get().network.LogChat && _chat_log_fs.is_open())
+        {
+            AppendLog(_chat_log_fs, s);
+        }
+    }
+
+    void NetworkBase::CloseChatLog()
+    {
+        _chat_log_fs.close();
+    }
+
+    void NetworkBase::BeginServerLog()
+    {
+        auto& env = GetContext().GetPlatformEnvironment();
+        auto directory = env.GetDirectoryPath(DirBase::user, DirId::serverLogs);
+        _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
+        _server_log_fs.open(fs::u8path(_serverLogPath), std::ios::out | std::ios::app | std::ios::binary);
+
+        // Log server start event
+        utf8 logMessage[256];
+        if (GetMode() == NETWORK_MODE_CLIENT)
+        {
+            FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STARTED, nullptr);
+        }
+        else if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STARTED, nullptr);
+        }
+        else
+        {
+            logMessage[0] = '\0';
+            Guard::Assert(false, "Unknown network mode!");
+        }
+        AppendServerLog(logMessage);
+    }
+
+    void NetworkBase::AppendServerLog(const std::string& s)
+    {
+        if (Config::Get().network.LogServerActions && _server_log_fs.is_open())
+        {
+            AppendLog(_server_log_fs, s);
+        }
+    }
+
+    void NetworkBase::CloseServerLog()
+    {
+        // Log server stopped event
+        char logMessage[256];
+        if (GetMode() == NETWORK_MODE_CLIENT)
+        {
+            FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STOPPED, nullptr);
+        }
+        else if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STOPPED, nullptr);
+        }
+        else
+        {
+            logMessage[0] = '\0';
+            Guard::Assert(false, "Unknown network mode!");
+        }
+        AppendServerLog(logMessage);
+        _server_log_fs.close();
+    }
+
+    void NetworkBase::Client_Send_RequestGameState(uint32_t tick)
+    {
+        if (_serverState.gamestateSnapshotsEnabled == false)
+        {
+            LOG_VERBOSE("Server does not store a gamestate history");
+            return;
+        }
+
+        LOG_VERBOSE("Requesting gamestate from server for tick %u", tick);
+
+        NetworkPacket packet(NetworkCommand::RequestGameState);
+        packet << tick;
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::Client_Send_TOKEN()
+    {
+        LOG_VERBOSE("requesting token");
+        NetworkPacket packet(NetworkCommand::Token);
+        _serverConnection->AuthStatus = NetworkAuth::Requested;
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::Client_Send_AUTH(
+        const std::string& name, const std::string& password, const std::string& pubkey, const std::vector<uint8_t>& signature)
+    {
+        NetworkPacket packet(NetworkCommand::Auth);
+        packet.WriteString(NetworkGetVersion());
+        packet.WriteString(name);
+        packet.WriteString(password);
+        packet.WriteString(pubkey);
+        assert(signature.size() <= static_cast<size_t>(UINT32_MAX));
+        packet << static_cast<uint32_t>(signature.size());
+        packet.Write(signature.data(), signature.size());
+        _serverConnection->AuthStatus = NetworkAuth::Requested;
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::Client_Send_MAPREQUEST(const std::vector<ObjectEntryDescriptor>& objects)
+    {
+        LOG_VERBOSE("client requests %u objects", uint32_t(objects.size()));
+        NetworkPacket packet(NetworkCommand::MapRequest);
+        packet << static_cast<uint32_t>(objects.size());
+        for (const auto& object : objects)
+        {
+            std::string name(object.GetName());
+            LOG_VERBOSE("client requests object %s", name.c_str());
+            if (object.Generation == ObjectGeneration::DAT)
+            {
+                packet << static_cast<uint8_t>(0);
+                packet.Write(&object.Entry, sizeof(RCTObjectEntry));
             }
             else
             {
-                message = FormatStringID(STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, playerName, reason);
+                packet << static_cast<uint8_t>(1);
+                packet.WriteString(name);
             }
-            ChatAddHistory(message);
-            break;
         }
+        _serverConnection->QueuePacket(std::move(packet));
     }
-}
 
-void NetworkBase::Client_Send_GAMEINFO()
-{
-    LOG_VERBOSE("requesting gameinfo");
-    NetworkPacket packet(NetworkCommand::GameInfo);
-    _serverConnection->QueuePacket(std::move(packet));
-}
-
-void NetworkBase::Client_Handle_GAMEINFO([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
-{
-    auto jsonString = packet.ReadString();
-    packet >> _serverState.gamestateSnapshotsEnabled;
-    packet >> IsServerPlayerInvisible;
-
-    json_t jsonData = Json::FromString(jsonString);
-
-    if (jsonData.is_object())
+    void NetworkBase::ServerSendToken(NetworkConnection& connection)
     {
-        ServerName = Json::GetString(jsonData["name"]);
-        ServerDescription = Json::GetString(jsonData["description"]);
-        ServerGreeting = Json::GetString(jsonData["greeting"]);
+        NetworkPacket packet(NetworkCommand::Token);
+        packet << static_cast<uint32_t>(connection.Challenge.size());
+        packet.Write(connection.Challenge.data(), connection.Challenge.size());
+        connection.QueuePacket(std::move(packet));
+    }
 
-        json_t jsonProvider = jsonData["provider"];
-        if (jsonProvider.is_object())
+    void NetworkBase::ServerSendObjectsList(
+        NetworkConnection& connection, const std::vector<const ObjectRepositoryItem*>& objects) const
+    {
+        LOG_VERBOSE("Server sends objects list with %u items", objects.size());
+
+        if (objects.empty())
         {
-            ServerProviderName = Json::GetString(jsonProvider["name"]);
-            ServerProviderEmail = Json::GetString(jsonProvider["email"]);
-            ServerProviderWebsite = Json::GetString(jsonProvider["website"]);
+            NetworkPacket packet(NetworkCommand::ObjectsList);
+            packet << static_cast<uint32_t>(0) << static_cast<uint32_t>(objects.size());
+
+            connection.QueuePacket(std::move(packet));
         }
-    }
-
-    NetworkChatShowServerGreeting();
-}
-
-void NetworkReconnect()
-{
-    GetContext()->GetNetwork().Reconnect();
-}
-
-void NetworkShutdownClient()
-{
-    GetContext()->GetNetwork().ServerClientDisconnected();
-}
-
-int32_t NetworkBeginClient(const std::string& host, int32_t port)
-{
-    return GetContext()->GetNetwork().BeginClient(host, port);
-}
-
-int32_t NetworkBeginServer(int32_t port, const std::string& address)
-{
-    return GetContext()->GetNetwork().BeginServer(port, address);
-}
-
-void NetworkUpdate()
-{
-    GetContext()->GetNetwork().Update();
-}
-
-void NetworkProcessPending()
-{
-    GetContext()->GetNetwork().ProcessPending();
-}
-
-void NetworkFlush()
-{
-    GetContext()->GetNetwork().Flush();
-}
-
-int32_t NetworkGetMode()
-{
-    return GetContext()->GetNetwork().GetMode();
-}
-
-int32_t NetworkGetStatus()
-{
-    return GetContext()->GetNetwork().GetStatus();
-}
-
-bool NetworkIsDesynchronised()
-{
-    return GetContext()->GetNetwork().IsDesynchronised();
-}
-
-bool NetworkCheckDesynchronisation()
-{
-    return GetContext()->GetNetwork().CheckDesynchronizaton();
-}
-
-void NetworkRequestGamestateSnapshot()
-{
-    return GetContext()->GetNetwork().RequestStateSnapshot();
-}
-
-void NetworkSendTick()
-{
-    GetContext()->GetNetwork().ServerSendTick();
-}
-
-NetworkAuth NetworkGetAuthstatus()
-{
-    return GetContext()->GetNetwork().GetAuthStatus();
-}
-
-uint32_t NetworkGetServerTick()
-{
-    return GetContext()->GetNetwork().GetServerTick();
-}
-
-uint8_t NetworkGetCurrentPlayerId()
-{
-    return GetContext()->GetNetwork().GetPlayerID();
-}
-
-int32_t NetworkGetNumPlayers()
-{
-    return GetContext()->GetNetwork().GetTotalNumPlayers();
-}
-
-int32_t NetworkGetNumVisiblePlayers()
-{
-    return GetContext()->GetNetwork().GetNumVisiblePlayers();
-}
-
-const char* NetworkGetPlayerName(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    return static_cast<const char*>(network.player_list[index]->Name.c_str());
-}
-
-uint32_t NetworkGetPlayerFlags(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    return network.player_list[index]->Flags;
-}
-
-int32_t NetworkGetPlayerPing(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    return network.player_list[index]->Ping;
-}
-
-int32_t NetworkGetPlayerID(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    return network.player_list[index]->Id;
-}
-
-money64 NetworkGetPlayerMoneySpent(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    return network.player_list[index]->MoneySpent;
-}
-
-std::string NetworkGetPlayerIPAddress(uint32_t id)
-{
-    auto& network = GetContext()->GetNetwork();
-    auto conn = network.GetPlayerConnection(id);
-    if (conn != nullptr && conn->Socket != nullptr)
-    {
-        return conn->Socket->GetIpAddress();
-    }
-    return {};
-}
-
-std::string NetworkGetPlayerPublicKeyHash(uint32_t id)
-{
-    auto& network = GetContext()->GetNetwork();
-    auto player = network.GetPlayerByID(id);
-    if (player != nullptr)
-    {
-        return player->KeyHash;
-    }
-    return {};
-}
-
-void NetworkIncrementPlayerNumCommands(uint32_t playerIndex)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(playerIndex, network.player_list);
-
-    network.player_list[playerIndex]->IncrementNumCommands();
-}
-
-void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    network.player_list[index]->AddMoneySpent(cost);
-}
-
-int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    if (time && Platform::GetTicks() > network.player_list[index]->LastActionTime + time)
-    {
-        return -999;
-    }
-    return network.player_list[index]->LastAction;
-}
-
-void NetworkSetPlayerLastAction(uint32_t index, GameCommand command)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    network.player_list[index]->LastAction = static_cast<int32_t>(NetworkActions::FindCommand(command));
-    network.player_list[index]->LastActionTime = Platform::GetTicks();
-}
-
-CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, GetContext()->GetNetwork().player_list);
-
-    return network.player_list[index]->LastActionCoord;
-}
-
-void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    if (index < network.player_list.size())
-    {
-        network.player_list[index]->LastActionCoord = coord;
-    }
-}
-
-uint32_t NetworkGetPlayerCommandsRan(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, GetContext()->GetNetwork().player_list);
-
-    return network.player_list[index]->CommandsRan;
-}
-
-int32_t NetworkGetPlayerIndex(uint32_t id)
-{
-    auto& network = GetContext()->GetNetwork();
-    auto it = network.GetPlayerIteratorByID(id);
-    if (it == network.player_list.end())
-    {
-        return -1;
-    }
-    return static_cast<int32_t>(network.GetPlayerIteratorByID(id) - network.player_list.begin());
-}
-
-uint8_t NetworkGetPlayerGroup(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-
-    return network.player_list[index]->Group;
-}
-
-void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.player_list);
-    Guard::IndexInRange(groupindex, network.group_list);
-
-    network.player_list[index]->Group = network.group_list[groupindex]->Id;
-}
-
-int32_t NetworkGetGroupIndex(uint8_t id)
-{
-    auto& network = GetContext()->GetNetwork();
-    auto it = network.GetGroupIteratorByID(id);
-    if (it == network.group_list.end())
-    {
-        return -1;
-    }
-    return static_cast<int32_t>(network.GetGroupIteratorByID(id) - network.group_list.begin());
-}
-
-uint8_t NetworkGetGroupID(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(index, network.group_list);
-
-    return network.group_list[index]->Id;
-}
-
-int32_t NetworkGetNumGroups()
-{
-    auto& network = GetContext()->GetNetwork();
-    return static_cast<int32_t>(network.group_list.size());
-}
-
-const char* NetworkGetGroupName(uint32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.group_list[index]->GetName().c_str();
-}
-
-void NetworkChatShowConnectedMessage()
-{
-    auto windowManager = Ui::GetWindowManager();
-    std::string s = windowManager->GetKeyboardShortcutString("interface.misc.multiplayer_chat");
-    const char* sptr = s.c_str();
-
-    utf8 buffer[256];
-    FormatStringLegacy(buffer, sizeof(buffer), STR_MULTIPLAYER_CONNECTED_CHAT_HINT, &sptr);
-
-    NetworkPlayer server;
-    server.Name = "Server";
-    const char* formatted = NetworkBase::FormatChat(&server, buffer);
-    ChatAddHistory(formatted);
-}
-
-// Display server greeting if one exists
-void NetworkChatShowServerGreeting()
-{
-    const auto& greeting = NetworkGetServerGreeting();
-    if (!greeting.empty())
-    {
-        thread_local std::string greeting_formatted;
-        greeting_formatted.assign("{OUTLINE}{GREEN}");
-        greeting_formatted += greeting;
-        ChatAddHistory(greeting_formatted);
-    }
-}
-
-GameActions::Result NetworkSetPlayerGroup(
-    NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting)
-{
-    auto& network = GetContext()->GetNetwork();
-    NetworkPlayer* player = network.GetPlayerByID(playerId);
-
-    NetworkGroup* fromgroup = network.GetGroupByID(actionPlayerId);
-    if (player == nullptr)
-    {
-        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_DO_THIS, kStringIdNone);
-    }
-
-    if (network.GetGroupByID(groupId) == nullptr)
-    {
-        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_DO_THIS, kStringIdNone);
-    }
-
-    if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
-    {
-        return GameActions::Result(
-            GameActions::Status::InvalidParameters, STR_CANT_CHANGE_GROUP_THAT_THE_HOST_BELONGS_TO, kStringIdNone);
-    }
-
-    if (groupId == 0 && fromgroup != nullptr && fromgroup->Id != 0)
-    {
-        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_SET_TO_THIS_GROUP, kStringIdNone);
-    }
-
-    if (isExecuting)
-    {
-        player->Group = groupId;
-
-        if (NetworkGetMode() == NETWORK_MODE_SERVER)
+        else
         {
-            // Add or update saved user
-            NetworkUserManager& userManager = network._userManager;
-            NetworkUser* networkUser = userManager.GetOrAddUser(player->KeyHash);
-            networkUser->GroupId = groupId;
-            networkUser->Name = player->Name;
-            userManager.Save();
+            for (size_t i = 0; i < objects.size(); ++i)
+            {
+                const auto* object = objects[i];
+
+                NetworkPacket packet(NetworkCommand::ObjectsList);
+                packet << static_cast<uint32_t>(i) << static_cast<uint32_t>(objects.size());
+
+                if (object->Identifier.empty())
+                {
+                    // DAT
+                    LOG_VERBOSE("Object %.8s (checksum %x)", object->ObjectEntry.name, object->ObjectEntry.checksum);
+                    packet << static_cast<uint8_t>(0);
+                    packet.Write(&object->ObjectEntry, sizeof(RCTObjectEntry));
+                }
+                else
+                {
+                    // JSON
+                    LOG_VERBOSE("Object %s", object->Identifier.c_str());
+                    packet << static_cast<uint8_t>(1);
+                    packet.WriteString(object->Identifier);
+                }
+
+                connection.QueuePacket(std::move(packet));
+            }
+        }
+    }
+
+    void NetworkBase::ServerSendScripts(NetworkConnection& connection)
+    {
+    #ifdef ENABLE_SCRIPTING
+        using namespace OpenRCT2::Scripting;
+
+        auto& scriptEngine = GetContext().GetScriptEngine();
+
+        // Get remote plugin list.
+        const auto remotePlugins = scriptEngine.GetRemotePlugins();
+        LOG_VERBOSE("Server sends %zu scripts", remotePlugins.size());
+
+        // Build the data contents for each plugin.
+        MemoryStream pluginData;
+        for (auto& plugin : remotePlugins)
+        {
+            const auto& code = plugin->GetCode();
+
+            const auto codeSize = static_cast<uint32_t>(code.size());
+            pluginData.WriteValue(codeSize);
+            pluginData.WriteArray(code.c_str(), code.size());
         }
 
-        auto* windowMgr = Ui::GetWindowManager();
-        windowMgr->InvalidateByNumber(WindowClass::Player, playerId);
+        // Send the header packet.
+        NetworkPacket packetScriptHeader(NetworkCommand::ScriptsHeader);
+        packetScriptHeader << static_cast<uint32_t>(remotePlugins.size());
+        packetScriptHeader << static_cast<uint32_t>(pluginData.GetLength());
+        connection.QueuePacket(std::move(packetScriptHeader));
 
-        // Log set player group event
-        NetworkPlayer* game_command_player = network.GetPlayerByID(actionPlayerId);
-        NetworkGroup* new_player_group = network.GetGroupByID(groupId);
-        char log_msg[256];
-        const char* args[3] = {
-            player->Name.c_str(),
-            new_player_group->GetName().c_str(),
-            game_command_player->Name.c_str(),
+        // Segment the plugin data into chunks and send them.
+        const uint8_t* pluginDataBuffer = static_cast<const uint8_t*>(pluginData.GetData());
+        uint32_t dataOffset = 0;
+        while (dataOffset < pluginData.GetLength())
+        {
+            const uint32_t chunkSize = std::min<uint32_t>(pluginData.GetLength() - dataOffset, kChunkSize);
+
+            NetworkPacket packet(NetworkCommand::ScriptsData);
+            packet << chunkSize;
+            packet.Write(pluginDataBuffer + dataOffset, chunkSize);
+
+            connection.QueuePacket(std::move(packet));
+
+            dataOffset += chunkSize;
+        }
+        Guard::Assert(dataOffset == pluginData.GetLength());
+
+    #else
+        NetworkPacket packetScriptHeader(NetworkCommand::ScriptsHeader);
+        packetScriptHeader << static_cast<uint32_t>(0u);
+        packetScriptHeader << static_cast<uint32_t>(0u);
+    #endif
+    }
+
+    void NetworkBase::Client_Send_HEARTBEAT(NetworkConnection& connection) const
+    {
+        LOG_VERBOSE("Sending heartbeat");
+
+        NetworkPacket packet(NetworkCommand::Heartbeat);
+        connection.QueuePacket(std::move(packet));
+    }
+
+    NetworkStats NetworkBase::GetStats() const
+    {
+        NetworkStats stats = {};
+        if (mode == NETWORK_MODE_CLIENT)
+        {
+            stats = _serverConnection->Stats;
+        }
+        else
+        {
+            for (auto& connection : client_connection_list)
+            {
+                for (size_t n = 0; n < EnumValue(NetworkStatisticsGroup::Max); n++)
+                {
+                    stats.bytesReceived[n] += connection->Stats.bytesReceived[n];
+                    stats.bytesSent[n] += connection->Stats.bytesSent[n];
+                }
+            }
+        }
+        return stats;
+    }
+
+    void NetworkBase::ServerSendAuth(NetworkConnection& connection)
+    {
+        uint8_t new_playerid = 0;
+        if (connection.Player != nullptr)
+        {
+            new_playerid = connection.Player->Id;
+        }
+        NetworkPacket packet(NetworkCommand::Auth);
+        packet << static_cast<uint32_t>(connection.AuthStatus) << new_playerid;
+        if (connection.AuthStatus == NetworkAuth::BadVersion)
+        {
+            packet.WriteString(NetworkGetVersion());
+        }
+        connection.QueuePacket(std::move(packet));
+        if (connection.AuthStatus != NetworkAuth::Ok && connection.AuthStatus != NetworkAuth::RequirePassword)
+        {
+            connection.Disconnect();
+        }
+    }
+
+    void NetworkBase::ServerSendMap(NetworkConnection* connection)
+    {
+        std::vector<const ObjectRepositoryItem*> objects;
+        if (connection != nullptr)
+        {
+            objects = connection->RequestedObjects;
+        }
+        else
+        {
+            // This will send all custom objects to connected clients
+            // TODO: fix it so custom objects negotiation is performed even in this case.
+            auto& context = GetContext();
+            auto& objManager = context.GetObjectManager();
+            objects = objManager.GetPackableObjects();
+        }
+
+        auto header = SaveForNetwork(objects);
+        if (header.empty())
+        {
+            if (connection != nullptr)
+            {
+                connection->SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
+                connection->Disconnect();
+            }
+            return;
+        }
+        size_t chunksize = kChunkSize;
+        for (size_t i = 0; i < header.size(); i += chunksize)
+        {
+            size_t datasize = std::min(chunksize, header.size() - i);
+            NetworkPacket packet(NetworkCommand::Map);
+            packet << static_cast<uint32_t>(header.size()) << static_cast<uint32_t>(i);
+            packet.Write(&header[i], datasize);
+            if (connection != nullptr)
+            {
+                connection->QueuePacket(std::move(packet));
+            }
+            else
+            {
+                SendPacketToClients(packet);
+            }
+        }
+    }
+
+    std::vector<uint8_t> NetworkBase::SaveForNetwork(const std::vector<const ObjectRepositoryItem*>& objects) const
+    {
+        std::vector<uint8_t> result;
+        auto ms = MemoryStream();
+        if (SaveMap(&ms, objects))
+        {
+            result.resize(ms.GetLength());
+            std::memcpy(result.data(), ms.GetData(), result.size());
+        }
+        else
+        {
+            LOG_WARNING("Failed to export map.");
+        }
+        return result;
+    }
+
+    void NetworkBase::Client_Send_CHAT(const char* text)
+    {
+        NetworkPacket packet(NetworkCommand::Chat);
+        packet.WriteString(text);
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds)
+    {
+        NetworkPacket packet(NetworkCommand::Chat);
+        packet.WriteString(text);
+
+        if (playerIds.empty())
+        {
+            // Empty players / default value means send to all players
+            SendPacketToClients(packet);
+        }
+        else
+        {
+            for (auto playerId : playerIds)
+            {
+                auto conn = GetPlayerConnection(playerId);
+                if (conn != nullptr)
+                {
+                    conn->QueuePacket(packet);
+                }
+            }
+        }
+    }
+
+    void NetworkBase::Client_Send_GAME_ACTION(const GameActions::GameAction* action)
+    {
+        NetworkPacket packet(NetworkCommand::GameAction);
+
+        uint32_t networkId = 0;
+        networkId = ++_actionId;
+
+        // I know its ugly, want basic functionality for now.
+        const_cast<GameActions::GameAction*>(action)->SetNetworkId(networkId);
+        if (action->GetCallback())
+        {
+            _gameActionCallbacks.insert(std::make_pair(networkId, action->GetCallback()));
+        }
+
+        DataSerialiser stream(true);
+        action->Serialise(stream);
+
+        packet << getGameState().currentTicks << action->GetType() << stream;
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::ServerSendGameAction(const GameActions::GameAction* action)
+    {
+        NetworkPacket packet(NetworkCommand::GameAction);
+
+        DataSerialiser stream(true);
+        action->Serialise(stream);
+
+        packet << getGameState().currentTicks << action->GetType() << stream;
+
+        SendPacketToClients(packet);
+    }
+
+    void NetworkBase::ServerSendTick()
+    {
+        NetworkPacket packet(NetworkCommand::Tick);
+        packet << getGameState().currentTicks << ScenarioRandState().s0;
+        uint32_t flags = 0;
+        // Simple counter which limits how often a sprite checksum gets sent.
+        // This can get somewhat expensive, so we don't want to push it every tick in release,
+        // but debug version can check more often.
+        static int32_t checksum_counter = 0;
+        checksum_counter++;
+        if (checksum_counter >= 100)
+        {
+            checksum_counter = 0;
+            flags |= NETWORK_TICK_FLAG_CHECKSUMS;
+        }
+        // Send flags always, so we can understand packet structure on the other end,
+        // and allow for some expansion.
+        packet << flags;
+        if (flags & NETWORK_TICK_FLAG_CHECKSUMS)
+        {
+            EntitiesChecksum checksum = getGameState().entities.GetAllEntitiesChecksum();
+            packet.WriteString(checksum.ToString());
+        }
+
+        SendPacketToClients(packet);
+    }
+
+    void NetworkBase::ServerSendPlayerInfo(int32_t playerId)
+    {
+        NetworkPacket packet(NetworkCommand::PlayerInfo);
+        packet << getGameState().currentTicks;
+
+        auto* player = GetPlayerByID(playerId);
+        if (player == nullptr)
+            return;
+
+        player->Write(packet);
+        SendPacketToClients(packet);
+    }
+
+    void NetworkBase::ServerSendPlayerList()
+    {
+        NetworkPacket packet(NetworkCommand::PlayerList);
+        packet << getGameState().currentTicks << static_cast<uint8_t>(player_list.size());
+        for (auto& player : player_list)
+        {
+            player->Write(packet);
+        }
+        SendPacketToClients(packet);
+    }
+
+    void NetworkBase::Client_Send_PING()
+    {
+        NetworkPacket packet(NetworkCommand::Ping);
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::ServerSendPing()
+    {
+        last_ping_sent_time = Platform::GetTicks();
+        NetworkPacket packet(NetworkCommand::Ping);
+        for (auto& client_connection : client_connection_list)
+        {
+            client_connection->PingTime = Platform::GetTicks();
+        }
+        SendPacketToClients(packet, true);
+    }
+
+    void NetworkBase::ServerSendPingList()
+    {
+        NetworkPacket packet(NetworkCommand::PingList);
+        packet << static_cast<uint8_t>(player_list.size());
+        for (auto& player : player_list)
+        {
+            packet << player->Id << player->Ping;
+        }
+        SendPacketToClients(packet);
+    }
+
+    void NetworkBase::ServerSendSetDisconnectMsg(NetworkConnection& connection, const char* msg)
+    {
+        NetworkPacket packet(NetworkCommand::DisconnectMessage);
+        packet.WriteString(msg);
+        connection.QueuePacket(std::move(packet));
+    }
+
+    json_t NetworkBase::GetServerInfoAsJson() const
+    {
+        json_t jsonObj = {
+            { "name", Config::Get().network.ServerName },
+            { "requiresPassword", _password.size() > 0 },
+            { "version", NetworkGetVersion() },
+            { "players", GetNumVisiblePlayers() },
+            { "maxPlayers", Config::Get().network.Maxplayers },
+            { "description", Config::Get().network.ServerDescription },
+            { "greeting", Config::Get().network.ServerGreeting },
+            { "dedicated", gOpenRCT2Headless },
         };
-        FormatStringLegacy(log_msg, 256, STR_LOG_SET_PLAYER_GROUP, args);
-        NetworkAppendServerLog(log_msg);
+        return jsonObj;
     }
-    return GameActions::Result();
-}
 
-GameActions::Result NetworkModifyGroups(
-    NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
-    uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting)
-{
-    auto& network = GetContext()->GetNetwork();
-    switch (type)
+    void NetworkBase::ServerSendGameInfo(NetworkConnection& connection)
     {
-        case GameActions::ModifyGroupType::AddGroup:
+        NetworkPacket packet(NetworkCommand::GameInfo);
+    #ifndef DISABLE_HTTP
+        json_t jsonObj = GetServerInfoAsJson();
+
+        // Provider details
+        json_t jsonProvider = {
+            { "name", Config::Get().network.ProviderName },
+            { "email", Config::Get().network.ProviderEmail },
+            { "website", Config::Get().network.ProviderWebsite },
+        };
+
+        jsonObj["provider"] = jsonProvider;
+
+        packet.WriteString(jsonObj.dump());
+        packet << _serverState.gamestateSnapshotsEnabled;
+        packet << IsServerPlayerInvisible;
+
+    #endif
+        connection.QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::ServerSendShowError(NetworkConnection& connection, StringId title, StringId message)
+    {
+        NetworkPacket packet(NetworkCommand::ShowError);
+        packet << title << message;
+        connection.QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::ServerSendGroupList(NetworkConnection& connection)
+    {
+        NetworkPacket packet(NetworkCommand::GroupList);
+        packet << static_cast<uint8_t>(group_list.size()) << default_group;
+        for (auto& group : group_list)
         {
-            if (isExecuting)
-            {
-                NetworkGroup* newgroup = network.AddGroup();
-                if (newgroup == nullptr)
-                {
-                    return GameActions::Result(GameActions::Status::Unknown, STR_CANT_DO_THIS, kStringIdNone);
-                }
-            }
+            group->Write(packet);
         }
-        break;
-        case GameActions::ModifyGroupType::RemoveGroup:
+        connection.QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::ServerSendEventPlayerJoined(const char* playerName)
+    {
+        NetworkPacket packet(NetworkCommand::Event);
+        packet << static_cast<uint16_t>(SERVER_EVENT_PLAYER_JOINED);
+        packet.WriteString(playerName);
+        SendPacketToClients(packet);
+    }
+
+    void NetworkBase::ServerSendEventPlayerDisconnected(const char* playerName, const char* reason)
+    {
+        NetworkPacket packet(NetworkCommand::Event);
+        packet << static_cast<uint16_t>(SERVER_EVENT_PLAYER_DISCONNECTED);
+        packet.WriteString(playerName);
+        packet.WriteString(reason);
+        SendPacketToClients(packet);
+    }
+
+    bool NetworkBase::ProcessConnection(NetworkConnection& connection)
+    {
+        NetworkReadPacket packetStatus;
+
+        uint32_t countProcessed = 0;
+        do
         {
-            if (groupId == 0)
+            countProcessed++;
+            packetStatus = connection.ReadPacket();
+            switch (packetStatus)
             {
-                return GameActions::Result(GameActions::Status::Disallowed, STR_THIS_GROUP_CANNOT_BE_MODIFIED, kStringIdNone);
-            }
-            for (const auto& it : network.player_list)
-            {
-                if ((it.get())->Group == groupId)
-                {
-                    return GameActions::Result(
-                        GameActions::Status::Disallowed, STR_CANT_REMOVE_GROUP_THAT_PLAYERS_BELONG_TO, kStringIdNone);
-                }
-            }
-            if (isExecuting)
-            {
-                network.RemoveGroup(groupId);
-            }
-        }
-        break;
-        case GameActions::ModifyGroupType::SetPermissions:
-        {
-            if (groupId == 0)
-            { // can't change admin group permissions
-                return GameActions::Result(GameActions::Status::Disallowed, STR_THIS_GROUP_CANNOT_BE_MODIFIED, kStringIdNone);
-            }
-            NetworkGroup* mygroup = nullptr;
-            NetworkPlayer* player = network.GetPlayerByID(actionPlayerId);
-            auto networkPermission = static_cast<NetworkPermission>(permissionIndex);
-            if (player != nullptr && permissionState == GameActions::PermissionState::Toggle)
-            {
-                mygroup = network.GetGroupByID(player->Group);
-                if (mygroup == nullptr || !mygroup->CanPerformAction(networkPermission))
-                {
-                    return GameActions::Result(
-                        GameActions::Status::Disallowed, STR_CANT_MODIFY_PERMISSION_THAT_YOU_DO_NOT_HAVE_YOURSELF,
-                        kStringIdNone);
-                }
-            }
-            if (isExecuting)
-            {
-                NetworkGroup* group = network.GetGroupByID(groupId);
-                if (group != nullptr)
-                {
-                    if (permissionState != GameActions::PermissionState::Toggle)
+                case NetworkReadPacket::Disconnected:
+                    // closed connection or network error
+                    if (!connection.GetLastDisconnectReason())
                     {
-                        if (mygroup != nullptr)
+                        connection.SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
+                    }
+                    return false;
+                case NetworkReadPacket::Success:
+                    // done reading in packet
+                    ProcessPacket(connection, connection.InboundPacket);
+                    if (!connection.IsValid())
+                    {
+                        return false;
+                    }
+                    break;
+                case NetworkReadPacket::MoreData:
+                    // more data required to be read
+                    break;
+                case NetworkReadPacket::NoData:
+                    // could not read anything from socket
+                    break;
+            }
+        } while (packetStatus == NetworkReadPacket::Success && countProcessed < kMaxPacketsPerUpdate);
+
+        if (!connection.ReceivedPacketRecently())
+        {
+            if (!connection.GetLastDisconnectReason())
+            {
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_NO_DATA);
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    void NetworkBase::ProcessPacket(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        const auto& handlerList = GetMode() == NETWORK_MODE_SERVER ? server_command_handlers : client_command_handlers;
+
+        auto it = handlerList.find(packet.GetCommand());
+        if (it != handlerList.end())
+        {
+            auto commandHandler = it->second;
+            if (connection.AuthStatus == NetworkAuth::Ok || !packet.CommandRequiresAuth())
+            {
+                try
+                {
+                    (this->*commandHandler)(connection, packet);
+                }
+                catch (const std::exception& ex)
+                {
+                    LOG_VERBOSE("Exception during packet processing: %s", ex.what());
+                }
+            }
+        }
+
+        packet.Clear();
+    }
+
+    // This is called at the end of each game tick, this where things should be processed that affects the game state.
+    void NetworkBase::ProcessPending()
+    {
+        if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            ProcessDisconnectedClients();
+        }
+        else if (GetMode() == NETWORK_MODE_CLIENT)
+        {
+            ProcessPlayerInfo();
+        }
+        ProcessPlayerList();
+    }
+
+    static bool ProcessPlayerAuthenticatePluginHooks(
+        const NetworkConnection& connection, std::string_view name, std::string_view publicKeyHash)
+    {
+    #ifdef ENABLE_SCRIPTING
+        using namespace OpenRCT2::Scripting;
+
+        auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+        if (hookEngine.HasSubscriptions(Scripting::HookType::networkAuthenticate))
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+
+            // Create event args object
+            DukObject eObj(ctx);
+            eObj.Set("name", name);
+            eObj.Set("publicKeyHash", publicKeyHash);
+            eObj.Set("ipAddress", connection.Socket->GetIpAddress());
+            eObj.Set("cancel", false);
+            auto e = eObj.Take();
+
+            // Call the subscriptions
+            hookEngine.Call(Scripting::HookType::networkAuthenticate, e, false);
+
+            // Check if any hook has cancelled the join
+            if (AsOrDefault(e["cancel"], false))
+            {
+                return false;
+            }
+        }
+    #endif
+        return true;
+    }
+
+    static void ProcessPlayerJoinedPluginHooks(uint8_t playerId)
+    {
+    #ifdef ENABLE_SCRIPTING
+        using namespace OpenRCT2::Scripting;
+
+        auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+        if (hookEngine.HasSubscriptions(Scripting::HookType::networkJoin))
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+
+            // Create event args object
+            DukObject eObj(ctx);
+            eObj.Set("player", playerId);
+            auto e = eObj.Take();
+
+            // Call the subscriptions
+            hookEngine.Call(Scripting::HookType::networkJoin, e, false);
+        }
+    #endif
+    }
+
+    static void ProcessPlayerLeftPluginHooks(uint8_t playerId)
+    {
+    #ifdef ENABLE_SCRIPTING
+        using namespace OpenRCT2::Scripting;
+
+        auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+        if (hookEngine.HasSubscriptions(Scripting::HookType::networkLeave))
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+
+            // Create event args object
+            DukObject eObj(ctx);
+            eObj.Set("player", playerId);
+            auto e = eObj.Take();
+
+            // Call the subscriptions
+            hookEngine.Call(Scripting::HookType::networkLeave, e, false);
+        }
+    #endif
+    }
+
+    void NetworkBase::ProcessPlayerList()
+    {
+        if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            // Avoid sending multiple times the player list, we mark the list invalidated on modifications
+            // and then send at the end of the tick the final player list.
+            if (_playerListInvalidated)
+            {
+                _playerListInvalidated = false;
+                ServerSendPlayerList();
+            }
+        }
+        else
+        {
+            // As client we have to keep things in order so the update is tick bound.
+            // Commands/Actions reference players and so this list needs to be in sync with those.
+            auto itPending = _pendingPlayerLists.begin();
+            while (itPending != _pendingPlayerLists.end())
+            {
+                if (itPending->first > getGameState().currentTicks)
+                    break;
+
+                // List of active players found in the list.
+                std::vector<uint8_t> activePlayerIds;
+                std::vector<uint8_t> newPlayers;
+                std::vector<uint8_t> removedPlayers;
+
+                for (const auto& pendingPlayer : itPending->second.players)
+                {
+                    activePlayerIds.push_back(pendingPlayer.Id);
+
+                    auto* player = GetPlayerByID(pendingPlayer.Id);
+                    if (player == nullptr)
+                    {
+                        // Add new player.
+                        player = AddPlayer("", "");
+                        if (player != nullptr)
                         {
-                            if (permissionState == GameActions::PermissionState::SetAll)
+                            *player = pendingPlayer;
+                            if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
                             {
-                                group->ActionsAllowed = mygroup->ActionsAllowed;
+                                _serverConnection->Player = player;
                             }
-                            else
-                            {
-                                group->ActionsAllowed.fill(0x00);
-                            }
+                            newPlayers.push_back(player->Id);
                         }
                     }
                     else
                     {
-                        group->ToggleActionPermission(networkPermission);
+                        // Update.
+                        *player = pendingPlayer;
+                    }
+                }
+
+                // Remove any players that are not in newly received list
+                for (const auto& player : player_list)
+                {
+                    if (std::find(activePlayerIds.begin(), activePlayerIds.end(), player->Id) == activePlayerIds.end())
+                    {
+                        removedPlayers.push_back(player->Id);
+                    }
+                }
+
+                // Run player removed hooks (must be before players removed from list)
+                for (auto playerId : removedPlayers)
+                {
+                    ProcessPlayerLeftPluginHooks(playerId);
+                }
+
+                // Run player joined hooks (must be after players added to list)
+                for (auto playerId : newPlayers)
+                {
+                    ProcessPlayerJoinedPluginHooks(playerId);
+                }
+
+                // Now actually remove removed players from player list
+                player_list.erase(
+                    std::remove_if(
+                        player_list.begin(), player_list.end(),
+                        [&removedPlayers](const std::unique_ptr<NetworkPlayer>& player) {
+                            return std::find(removedPlayers.begin(), removedPlayers.end(), player->Id) != removedPlayers.end();
+                        }),
+                    player_list.end());
+
+                _pendingPlayerLists.erase(itPending);
+                itPending = _pendingPlayerLists.begin();
+            }
+        }
+    }
+
+    void NetworkBase::ProcessPlayerInfo()
+    {
+        const auto currentTicks = getGameState().currentTicks;
+
+        auto range = _pendingPlayerInfo.equal_range(currentTicks);
+        for (auto it = range.first; it != range.second; it++)
+        {
+            auto* player = GetPlayerByID(it->second.Id);
+            if (player != nullptr)
+            {
+                const NetworkPlayer& networkedInfo = it->second;
+                player->Flags = networkedInfo.Flags;
+                player->Group = networkedInfo.Group;
+                player->LastAction = networkedInfo.LastAction;
+                player->LastActionCoord = networkedInfo.LastActionCoord;
+                player->MoneySpent = networkedInfo.MoneySpent;
+                player->CommandsRan = networkedInfo.CommandsRan;
+            }
+        }
+        _pendingPlayerInfo.erase(currentTicks);
+    }
+
+    void NetworkBase::ProcessDisconnectedClients()
+    {
+        for (auto it = client_connection_list.begin(); it != client_connection_list.end();)
+        {
+            auto& connection = *it;
+
+            if (!connection->ShouldDisconnect)
+            {
+                it++;
+                continue;
+            }
+
+            // Make sure to send all remaining packets out before disconnecting.
+            connection->SendQueuedData();
+            connection->Socket->Disconnect();
+
+            ServerClientDisconnected(connection);
+            RemovePlayer(connection);
+
+            it = client_connection_list.erase(it);
+        }
+    }
+
+    void NetworkBase::AddClient(std::unique_ptr<ITcpSocket>&& socket)
+    {
+        // Log connection info.
+        char addr[128];
+        snprintf(addr, sizeof(addr), "Client joined from %s", socket->GetHostName());
+        AppendServerLog(addr);
+
+        // Store connection
+        auto connection = std::make_unique<NetworkConnection>();
+        connection->Socket = std::move(socket);
+
+        client_connection_list.push_back(std::move(connection));
+    }
+
+    void NetworkBase::ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection)
+    {
+        NetworkPlayer* connection_player = connection->Player;
+        if (connection_player == nullptr)
+            return;
+
+        char text[256];
+        const char* has_disconnected_args[2] = {
+            connection_player->Name.c_str(),
+            connection->GetLastDisconnectReason(),
+        };
+        if (has_disconnected_args[1] != nullptr)
+        {
+            FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, has_disconnected_args);
+        }
+        else
+        {
+            FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_NO_REASON, &(has_disconnected_args[0]));
+        }
+
+        ChatAddHistory(text);
+        Peep* pickup_peep = NetworkGetPickupPeep(connection_player->Id);
+        if (pickup_peep != nullptr)
+        {
+            GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Cancel,
+                                                        pickup_peep->Id,
+                                                        { NetworkGetPickupPeepOldX(connection_player->Id), 0, 0 },
+                                                        NetworkGetCurrentPlayerId() };
+            auto res = GameActions::Execute(&pickupAction);
+        }
+        ServerSendEventPlayerDisconnected(
+            const_cast<char*>(connection_player->Name.c_str()), connection->GetLastDisconnectReason());
+
+        // Log player disconnected event
+        AppendServerLog(text);
+
+        ProcessPlayerLeftPluginHooks(connection_player->Id);
+    }
+
+    void NetworkBase::RemovePlayer(std::unique_ptr<NetworkConnection>& connection)
+    {
+        NetworkPlayer* connection_player = connection->Player;
+        if (connection_player == nullptr)
+            return;
+
+        player_list.erase(
+            std::remove_if(
+                player_list.begin(), player_list.end(),
+                [connection_player](std::unique_ptr<NetworkPlayer>& player) { return player.get() == connection_player; }),
+            player_list.end());
+
+        // Send new player list.
+        _playerListInvalidated = true;
+    }
+
+    NetworkPlayer* NetworkBase::AddPlayer(const std::string& name, const std::string& keyhash)
+    {
+        NetworkPlayer* addedplayer = nullptr;
+        int32_t newid = -1;
+        if (GetMode() == NETWORK_MODE_SERVER)
+        {
+            // Find first unused player id
+            for (int32_t id = 0; id < 255; id++)
+            {
+                if (std::find_if(
+                        player_list.begin(), player_list.end(),
+                        [&id](std::unique_ptr<NetworkPlayer> const& player) { return player->Id == id; })
+                    == player_list.end())
+                {
+                    newid = id;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            newid = 0;
+        }
+        if (newid != -1)
+        {
+            std::unique_ptr<NetworkPlayer> player;
+            if (GetMode() == NETWORK_MODE_SERVER)
+            {
+                // Load keys host may have added manually
+                _userManager.Load();
+
+                // Check if the key is registered
+                const NetworkUser* networkUser = _userManager.GetUserByHash(keyhash);
+
+                player = std::make_unique<NetworkPlayer>();
+                player->Id = newid;
+                player->KeyHash = keyhash;
+                if (networkUser == nullptr)
+                {
+                    player->Group = GetDefaultGroup();
+                    if (!name.empty())
+                    {
+                        player->SetName(MakePlayerNameUnique(String::trim(name)));
+                    }
+                }
+                else
+                {
+                    player->Group = networkUser->GroupId.has_value() ? *networkUser->GroupId : GetDefaultGroup();
+                    player->SetName(networkUser->Name);
+                }
+
+                // Send new player list.
+                _playerListInvalidated = true;
+            }
+            else
+            {
+                player = std::make_unique<NetworkPlayer>();
+                player->Id = newid;
+                player->Group = GetDefaultGroup();
+                player->SetName(String::trim(std::string(name)));
+            }
+
+            addedplayer = player.get();
+            player_list.push_back(std::move(player));
+        }
+        return addedplayer;
+    }
+
+    std::string NetworkBase::MakePlayerNameUnique(const std::string& name)
+    {
+        // Note: Player names are case-insensitive
+
+        std::string new_name = name.substr(0, 31);
+        int32_t counter = 1;
+        bool unique;
+        do
+        {
+            unique = true;
+
+            // Check if there is already a player with this name in the server
+            for (const auto& player : player_list)
+            {
+                if (String::iequals(player->Name, new_name))
+                {
+                    unique = false;
+                    break;
+                }
+            }
+
+            if (unique)
+            {
+                // Check if there is already a registered player with this name
+                if (_userManager.GetUserByName(new_name) != nullptr)
+                {
+                    unique = false;
+                }
+            }
+
+            if (!unique)
+            {
+                // Increment name counter
+                counter++;
+                new_name = name.substr(0, 31) + " #" + std::to_string(counter);
+            }
+        } while (!unique);
+        return new_name;
+    }
+
+    void NetworkBase::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
+        if (!File::Exists(keyPath))
+        {
+            LOG_ERROR("Key file (%s) was not found. Restart client to re-generate it.", keyPath.c_str());
+            return;
+        }
+
+        try
+        {
+            auto fs = FileStream(keyPath, FileMode::open);
+            if (!_key.LoadPrivate(&fs))
+            {
+                throw std::runtime_error("Failed to load private key.");
+            }
+        }
+        catch (const std::exception&)
+        {
+            LOG_ERROR("Failed to load key %s", keyPath.c_str());
+            connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
+            connection.Disconnect();
+            return;
+        }
+
+        uint32_t challenge_size;
+        packet >> challenge_size;
+        const char* challenge = reinterpret_cast<const char*>(packet.Read(challenge_size));
+
+        std::vector<uint8_t> signature;
+        const std::string pubkey = _key.PublicKeyString();
+        _challenge.resize(challenge_size);
+        std::memcpy(_challenge.data(), challenge, challenge_size);
+        bool ok = _key.Sign(_challenge.data(), _challenge.size(), signature);
+        if (!ok)
+        {
+            LOG_ERROR("Failed to sign server's challenge.");
+            connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
+            connection.Disconnect();
+            return;
+        }
+        // Don't keep private key in memory. There's no need and it may get leaked
+        // when process dump gets collected at some point in future.
+        _key.Unload();
+
+        Client_Send_AUTH(Config::Get().network.PlayerName, gCustomPassword, pubkey, signature);
+    }
+
+    void NetworkBase::ServerHandleRequestGamestate(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t tick;
+        packet >> tick;
+
+        if (_serverState.gamestateSnapshotsEnabled == false)
+        {
+            // Ignore this if this is off.
+            return;
+        }
+
+        IGameStateSnapshots* snapshots = GetContext().GetGameStateSnapshots();
+
+        const GameStateSnapshot_t* snapshot = snapshots->GetLinkedSnapshot(tick);
+        if (snapshot != nullptr)
+        {
+            MemoryStream snapshotMemory;
+            DataSerialiser ds(true, snapshotMemory);
+
+            snapshots->SerialiseSnapshot(const_cast<GameStateSnapshot_t&>(*snapshot), ds);
+
+            uint32_t bytesSent = 0;
+            uint32_t length = static_cast<uint32_t>(snapshotMemory.GetLength());
+            while (bytesSent < length)
+            {
+                uint32_t dataSize = kChunkSize;
+                if (bytesSent + dataSize > snapshotMemory.GetLength())
+                {
+                    dataSize = snapshotMemory.GetLength() - bytesSent;
+                }
+
+                NetworkPacket packetGameStateChunk(NetworkCommand::GameState);
+                packetGameStateChunk << tick << length << bytesSent << dataSize;
+                packetGameStateChunk.Write(static_cast<const uint8_t*>(snapshotMemory.GetData()) + bytesSent, dataSize);
+
+                connection.QueuePacket(std::move(packetGameStateChunk));
+
+                bytesSent += dataSize;
+            }
+        }
+    }
+
+    void NetworkBase::ServerHandleHeartbeat(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        LOG_VERBOSE("Client %s heartbeat", connection.Socket->GetHostName());
+        connection.ResetLastPacketTime();
+    }
+
+    void NetworkBase::Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t auth_status;
+        packet >> auth_status >> const_cast<uint8_t&>(player_id);
+        connection.AuthStatus = static_cast<NetworkAuth>(auth_status);
+        switch (connection.AuthStatus)
+        {
+            case NetworkAuth::Ok:
+                Client_Send_GAMEINFO();
+                break;
+            case NetworkAuth::BadName:
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_BAD_PLAYER_NAME);
+                connection.Disconnect();
+                break;
+            case NetworkAuth::BadVersion:
+            {
+                auto version = std::string(packet.ReadString());
+                auto versionp = version.c_str();
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_INCORRECT_SOFTWARE_VERSION, &versionp);
+                connection.Disconnect();
+                break;
+            }
+            case NetworkAuth::BadPassword:
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_BAD_PASSWORD);
+                connection.Disconnect();
+                break;
+            case NetworkAuth::VerificationFailure:
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
+                connection.Disconnect();
+                break;
+            case NetworkAuth::Full:
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_SERVER_FULL);
+                connection.Disconnect();
+                break;
+            case NetworkAuth::RequirePassword:
+                ContextOpenWindowView(WV_NETWORK_PASSWORD);
+                break;
+            case NetworkAuth::UnknownKeyDisallowed:
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_UNKNOWN_KEY_DISALLOWED);
+                connection.Disconnect();
+                break;
+            default:
+                connection.SetLastDisconnectReason(STR_MULTIPLAYER_RECEIVED_INVALID_DATA);
+                connection.Disconnect();
+                break;
+        }
+    }
+
+    void NetworkBase::ServerClientJoined(std::string_view name, const std::string& keyhash, NetworkConnection& connection)
+    {
+        auto player = AddPlayer(std::string(name), keyhash);
+        connection.Player = player;
+        if (player != nullptr)
+        {
+            char text[256];
+            const char* player_name = static_cast<const char*>(player->Name.c_str());
+            FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
+            ChatAddHistory(text);
+
+            auto& context = GetContext();
+            auto& objManager = context.GetObjectManager();
+            auto objects = objManager.GetPackableObjects();
+            ServerSendObjectsList(connection, objects);
+            ServerSendScripts(connection);
+
+            // Log player joining event
+            std::string playerNameHash = player->Name + " (" + keyhash + ")";
+            player_name = static_cast<const char*>(playerNameHash.c_str());
+            FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
+            AppendServerLog(text);
+
+            ProcessPlayerJoinedPluginHooks(player->Id);
+        }
+    }
+
+    void NetworkBase::ServerHandleToken(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
+    {
+        uint8_t token_size = 10 + (rand() & 0x7f);
+        connection.Challenge.resize(token_size);
+        for (int32_t i = 0; i < token_size; i++)
+        {
+            connection.Challenge[i] = static_cast<uint8_t>(rand() & 0xff);
+        }
+        ServerSendToken(connection);
+    }
+
+    static void OpenNetworkProgress(StringId captionStringId)
+    {
+        auto captionString = GetContext()->GetLocalisationService().GetString(captionStringId);
+        auto intent = Intent(INTENT_ACTION_PROGRESS_OPEN);
+        intent.PutExtra(INTENT_EXTRA_MESSAGE, captionString);
+        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
+        ContextOpenIntent(&intent);
+    }
+
+    void NetworkBase::Client_Handle_OBJECTS_LIST(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        auto& repo = GetContext().GetObjectRepository();
+
+        uint32_t index = 0;
+        uint32_t totalObjects = 0;
+        packet >> index >> totalObjects;
+
+        static constexpr uint32_t kObjectStartIndex = 0;
+        if (index == kObjectStartIndex)
+        {
+            _missingObjects.clear();
+        }
+
+        if (totalObjects > 0)
+        {
+            OpenNetworkProgress(STR_MULTIPLAYER_RECEIVING_OBJECTS_LIST);
+            GetContext().SetProgress(index + 1, totalObjects);
+
+            uint8_t objectType{};
+            packet >> objectType;
+
+            if (objectType == 0)
+            {
+                // DAT
+                auto entry = reinterpret_cast<const RCTObjectEntry*>(packet.Read(sizeof(RCTObjectEntry)));
+                if (entry != nullptr)
+                {
+                    const auto* object = repo.FindObject(entry);
+                    if (object == nullptr)
+                    {
+                        auto objectName = std::string(entry->GetName());
+                        LOG_VERBOSE("Requesting object %s with checksum %x from server", objectName.c_str(), entry->checksum);
+                        _missingObjects.push_back(ObjectEntryDescriptor(*entry));
+                    }
+                    else if (object->ObjectEntry.checksum != entry->checksum || object->ObjectEntry.flags != entry->flags)
+                    {
+                        auto objectName = std::string(entry->GetName());
+                        LOG_WARNING(
+                            "Object %s has different checksum/flags (%x/%x) than server (%x/%x).", objectName.c_str(),
+                            object->ObjectEntry.checksum, object->ObjectEntry.flags, entry->checksum, entry->flags);
+                    }
+                }
+            }
+            else
+            {
+                // JSON
+                auto identifier = packet.ReadString();
+                if (!identifier.empty())
+                {
+                    const auto* object = repo.FindObject(identifier);
+                    if (object == nullptr)
+                    {
+                        auto objectName = std::string(identifier);
+                        LOG_VERBOSE("Requesting object %s from server", objectName.c_str());
+                        _missingObjects.push_back(ObjectEntryDescriptor(objectName));
                     }
                 }
             }
         }
-        break;
-        case GameActions::ModifyGroupType::SetName:
+
+        if (index + 1 >= totalObjects)
         {
-            NetworkGroup* group = network.GetGroupByID(groupId);
-            if (group == nullptr)
+            LOG_VERBOSE("client received object list, it has %u entries", totalObjects);
+            Client_Send_MAPREQUEST(_missingObjects);
+            _missingObjects.clear();
+        }
+    }
+
+    void NetworkBase::Client_Handle_SCRIPTS_HEADER(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t numScripts{};
+        uint32_t dataSize{};
+        packet >> numScripts >> dataSize;
+
+    #ifdef ENABLE_SCRIPTING
+        _serverScriptsData.data.Clear();
+        _serverScriptsData.pluginCount = numScripts;
+        _serverScriptsData.dataSize = dataSize;
+    #else
+        if (numScripts > 0)
+        {
+            connection.SetLastDisconnectReason("The client requires plugin support.");
+            Close();
+        }
+    #endif
+    }
+
+    void NetworkBase::Client_Handle_SCRIPTS_DATA(NetworkConnection& connection, NetworkPacket& packet)
+    {
+    #ifdef ENABLE_SCRIPTING
+        uint32_t dataSize{};
+        packet >> dataSize;
+        Guard::Assert(dataSize > 0);
+
+        const auto* data = packet.Read(dataSize);
+        Guard::Assert(data != nullptr);
+
+        auto& scriptsData = _serverScriptsData.data;
+        scriptsData.Write(data, dataSize);
+
+        if (scriptsData.GetLength() == _serverScriptsData.dataSize)
+        {
+            auto& scriptEngine = GetContext().GetScriptEngine();
+
+            scriptsData.SetPosition(0);
+            for (uint32_t i = 0; i < _serverScriptsData.pluginCount; ++i)
             {
-                return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_RENAME_GROUP, kStringIdNone);
+                const auto codeSize = scriptsData.ReadValue<uint32_t>();
+                const auto scriptData = scriptsData.ReadArray<char>(codeSize);
+
+                auto code = std::string_view(reinterpret_cast<const char*>(scriptData.get()), codeSize);
+                scriptEngine.AddNetworkPlugin(code);
             }
+            Guard::Assert(scriptsData.GetPosition() == scriptsData.GetLength());
 
-            const char* oldName = group->GetName().c_str();
+            // Empty the current buffer.
+            _serverScriptsData = {};
+        }
+    #else
+        connection.SetLastDisconnectReason("The client requires plugin support.");
+        Close();
+    #endif
+    }
 
-            if (strcmp(oldName, name.c_str()) == 0)
+    void NetworkBase::Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t tick;
+        uint32_t totalSize;
+        uint32_t offset;
+        uint32_t dataSize;
+
+        packet >> tick >> totalSize >> offset >> dataSize;
+
+        if (offset == 0)
+        {
+            // Reset
+            _serverGameState = MemoryStream();
+        }
+
+        _serverGameState.SetPosition(offset);
+
+        const uint8_t* data = packet.Read(dataSize);
+        _serverGameState.Write(data, dataSize);
+
+        LOG_VERBOSE(
+            "Received Game State %.02f%%",
+            (static_cast<float>(_serverGameState.GetLength()) / static_cast<float>(totalSize)) * 100.0f);
+
+        if (_serverGameState.GetLength() == totalSize)
+        {
+            _serverGameState.SetPosition(0);
+            DataSerialiser ds(false, _serverGameState);
+
+            IGameStateSnapshots* snapshots = GetContext().GetGameStateSnapshots();
+
+            GameStateSnapshot_t& serverSnapshot = snapshots->CreateSnapshot();
+            snapshots->SerialiseSnapshot(serverSnapshot, ds);
+
+            const GameStateSnapshot_t* desyncSnapshot = snapshots->GetLinkedSnapshot(tick);
+            if (desyncSnapshot != nullptr)
             {
-                return GameActions::Result();
-            }
+                GameStateCompareData cmpData = snapshots->Compare(serverSnapshot, *desyncSnapshot);
 
-            if (name.empty())
-            {
-                return GameActions::Result(
-                    GameActions::Status::InvalidParameters, STR_CANT_RENAME_GROUP, STR_INVALID_GROUP_NAME);
-            }
+                std::string outputPath = GetContext().GetPlatformEnvironment().GetDirectoryPath(
+                    DirBase::user, DirId::desyncLogs);
 
-            if (isExecuting)
-            {
-                if (group != nullptr)
+                Path::CreateDirectory(outputPath);
+
+                char uniqueFileName[128] = {};
+                snprintf(
+                    uniqueFileName, sizeof(uniqueFileName), "desync_%llu_%u.txt",
+                    static_cast<long long unsigned>(Platform::GetDatetimeNowUTC()), tick);
+
+                std::string outputFile = Path::Combine(outputPath, uniqueFileName);
+
+                if (snapshots->LogCompareDataToFile(outputFile, cmpData))
                 {
-                    group->SetName(name);
+                    LOG_INFO("Wrote desync report to '%s'", outputFile.c_str());
+
+                    auto ft = Formatter();
+                    ft.Add<char*>(uniqueFileName);
+
+                    char str_desync[1024];
+                    FormatStringLegacy(str_desync, sizeof(str_desync), STR_DESYNC_REPORT, ft.Data());
+
+                    auto intent = Intent(WindowClass::NetworkStatus);
+                    intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_desync });
+                    ContextOpenIntent(&intent);
                 }
             }
         }
-        break;
-        case GameActions::ModifyGroupType::SetDefault:
+    }
+
+    void NetworkBase::ServerHandleMapRequest(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t size;
+        packet >> size;
+        LOG_VERBOSE("Client requested %u objects", size);
+        auto& repo = GetContext().GetObjectRepository();
+        for (uint32_t i = 0; i < size; i++)
         {
-            if (groupId == 0)
+            uint8_t generation{};
+            packet >> generation;
+
+            std::string objectName;
+            const ObjectRepositoryItem* item{};
+            if (generation == static_cast<uint8_t>(ObjectGeneration::DAT))
             {
-                return GameActions::Result(GameActions::Status::Disallowed, STR_CANT_SET_TO_THIS_GROUP, kStringIdNone);
+                const auto* entry = reinterpret_cast<const RCTObjectEntry*>(packet.Read(sizeof(RCTObjectEntry)));
+                objectName = std::string(entry->GetName());
+                LOG_VERBOSE("Client requested object %s", objectName.c_str());
+                item = repo.FindObject(entry);
             }
-            if (isExecuting)
+            else
             {
-                network.SetDefaultGroup(groupId);
+                objectName = std::string(packet.ReadString());
+                LOG_VERBOSE("Client requested object %s", objectName.c_str());
+                item = repo.FindObject(objectName);
+            }
+
+            if (item == nullptr)
+            {
+                LOG_WARNING("Client tried getting non-existent object %s from us.", objectName.c_str());
+            }
+            else
+            {
+                connection.RequestedObjects.push_back(item);
             }
         }
-        break;
-        default:
-            LOG_ERROR("Invalid Modify Group Type: %u", static_cast<uint8_t>(type));
+
+        auto player_name = connection.Player->Name.c_str();
+        ServerSendMap(&connection);
+        ServerSendEventPlayerJoined(player_name);
+        ServerSendGroupList(connection);
+    }
+
+    void NetworkBase::ServerHandleAuth(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        if (connection.AuthStatus != NetworkAuth::Ok)
+        {
+            auto* hostName = connection.Socket->GetHostName();
+            auto gameversion = packet.ReadString();
+            auto name = packet.ReadString();
+            auto password = packet.ReadString();
+            auto pubkey = packet.ReadString();
+            uint32_t sigsize;
+            packet >> sigsize;
+            if (pubkey.empty())
+            {
+                connection.AuthStatus = NetworkAuth::VerificationFailure;
+            }
+            else
+            {
+                try
+                {
+                    // RSA technically supports keys up to 65536 bits, so this is the
+                    // maximum signature size for now.
+                    constexpr auto MaxRSASignatureSizeInBytes = 8192;
+
+                    if (sigsize == 0 || sigsize > MaxRSASignatureSizeInBytes)
+                    {
+                        throw std::runtime_error("Invalid signature size");
+                    }
+
+                    std::vector<uint8_t> signature;
+                    signature.resize(sigsize);
+
+                    const uint8_t* signatureData = packet.Read(sigsize);
+                    if (signatureData == nullptr)
+                    {
+                        throw std::runtime_error("Failed to read packet.");
+                    }
+
+                    std::memcpy(signature.data(), signatureData, sigsize);
+
+                    auto ms = MemoryStream(pubkey.data(), pubkey.size());
+                    if (!connection.Key.LoadPublic(&ms))
+                    {
+                        throw std::runtime_error("Failed to load public key.");
+                    }
+
+                    bool verified = connection.Key.Verify(connection.Challenge.data(), connection.Challenge.size(), signature);
+                    const std::string hash = connection.Key.PublicKeyHash();
+                    if (verified)
+                    {
+                        LOG_VERBOSE("Connection %s: Signature verification ok. Hash %s", hostName, hash.c_str());
+                        if (Config::Get().network.KnownKeysOnly && _userManager.GetUserByHash(hash) == nullptr)
+                        {
+                            LOG_VERBOSE("Connection %s: Hash %s, not known", hostName, hash.c_str());
+                            connection.AuthStatus = NetworkAuth::UnknownKeyDisallowed;
+                        }
+                        else
+                        {
+                            connection.AuthStatus = NetworkAuth::Verified;
+                        }
+                    }
+                    else
+                    {
+                        connection.AuthStatus = NetworkAuth::VerificationFailure;
+                        LOG_VERBOSE("Connection %s: Signature verification failed!", hostName);
+                    }
+                }
+                catch (const std::exception&)
+                {
+                    connection.AuthStatus = NetworkAuth::VerificationFailure;
+                    LOG_VERBOSE("Connection %s: Signature verification failed, invalid data!", hostName);
+                }
+            }
+
+            bool passwordless = false;
+            if (connection.AuthStatus == NetworkAuth::Verified)
+            {
+                const NetworkGroup* group = GetGroupByID(GetGroupIDByHash(connection.Key.PublicKeyHash()));
+                if (group != nullptr)
+                {
+                    passwordless = group->CanPerformAction(NetworkPermission::PasswordlessLogin);
+                }
+            }
+            if (gameversion != NetworkGetVersion())
+            {
+                connection.AuthStatus = NetworkAuth::BadVersion;
+                LOG_INFO("Connection %s: Bad version.", hostName);
+            }
+            else if (name.empty())
+            {
+                connection.AuthStatus = NetworkAuth::BadName;
+                LOG_INFO("Connection %s: Bad name.", connection.Socket->GetHostName());
+            }
+            else if (!passwordless)
+            {
+                if (password.empty() && !_password.empty())
+                {
+                    connection.AuthStatus = NetworkAuth::RequirePassword;
+                    LOG_INFO("Connection %s: Requires password.", hostName);
+                }
+                else if (!password.empty() && _password != password)
+                {
+                    connection.AuthStatus = NetworkAuth::BadPassword;
+                    LOG_INFO("Connection %s: Bad password.", hostName);
+                }
+            }
+
+            if (GetNumVisiblePlayers() >= Config::Get().network.Maxplayers)
+            {
+                connection.AuthStatus = NetworkAuth::Full;
+                LOG_INFO("Connection %s: Server is full.", hostName);
+            }
+            else if (connection.AuthStatus == NetworkAuth::Verified)
+            {
+                const std::string hash = connection.Key.PublicKeyHash();
+                if (ProcessPlayerAuthenticatePluginHooks(connection, name, hash))
+                {
+                    connection.AuthStatus = NetworkAuth::Ok;
+                    ServerClientJoined(name, hash, connection);
+                }
+                else
+                {
+                    connection.AuthStatus = NetworkAuth::VerificationFailure;
+                    LOG_INFO("Connection %s: Denied by plugin.", hostName);
+                }
+            }
+
+            ServerSendAuth(connection);
+        }
+    }
+
+    void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t size, offset;
+        packet >> size >> offset;
+        int32_t chunksize = static_cast<int32_t>(packet.Header.Size - packet.BytesRead);
+        if (chunksize <= 0)
+        {
+            return;
+        }
+        if (offset == 0)
+        {
+            // Start of a new map load, clear the queue now as we have to buffer them
+            // until the map is fully loaded.
+            GameActions::ClearQueue();
+            GameActions::SuspendQueue();
+
+            _serverTickData.clear();
+            _clientMapLoaded = false;
+
+            OpenNetworkProgress(STR_MULTIPLAYER_DOWNLOADING_MAP);
+        }
+        if (size > chunk_buffer.size())
+        {
+            chunk_buffer.resize(size);
+        }
+
+        const auto currentProgressKiB = (offset + chunksize) / 1024;
+        const auto totalSizeKiB = size / 1024;
+
+        GetContext().SetProgress(currentProgressKiB, totalSizeKiB, STR_STRING_M_OF_N_KIB);
+
+        std::memcpy(&chunk_buffer[offset], const_cast<void*>(static_cast<const void*>(packet.Read(chunksize))), chunksize);
+        if (offset + chunksize == size)
+        {
+            // Allow queue processing of game actions again.
+            GameActions::ResumeQueue();
+
+            ContextForceCloseWindowByClass(WindowClass::ProgressWindow);
+            GameUnloadScripts();
+            GameNotifyMapChange();
+
+            bool has_to_free = false;
+            uint8_t* data = &chunk_buffer[0];
+            size_t data_size = size;
+            auto ms = MemoryStream(data, data_size);
+            if (LoadMap(&ms))
+            {
+                GameLoadInit();
+                GameLoadScripts();
+                GameNotifyMapChanged();
+                _serverState.tick = getGameState().currentTicks;
+                // NetworkStatusOpen("Loaded new map from network");
+                _serverState.state = NetworkServerStatus::Ok;
+                _clientMapLoaded = true;
+                gFirstTimeSaving = true;
+
+                // Notify user he is now online and which shortcut key enables chat
+                NetworkChatShowConnectedMessage();
+
+                // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
+                FixInvalidVehicleSpriteSizes();
+
+                // NOTE: Game actions are normally processed before processing the player list.
+                // Given that during map load game actions are buffered we have to process the
+                // player list first to have valid players for the queued game actions.
+                ProcessPlayerList();
+            }
+            else
+            {
+                // Something went wrong, game is not loaded. Return to main screen.
+                auto loadOrQuitAction = GameActions::LoadOrQuitAction(
+                    GameActions::LoadOrQuitModes::OpenSavePrompt, PromptMode::saveBeforeQuit);
+                GameActions::Execute(&loadOrQuitAction);
+            }
+            if (has_to_free)
+            {
+                free(data);
+            }
+        }
+    }
+
+    bool NetworkBase::LoadMap(IStream* stream)
+    {
+        bool result = false;
+        try
+        {
+            auto& context = GetContext();
+            auto& objManager = context.GetObjectManager();
+            auto importer = ParkImporter::CreateParkFile(context.GetObjectRepository());
+            auto loadResult = importer->LoadFromStream(stream, false);
+            objManager.LoadObjects(loadResult.RequiredObjects);
+
+            MapAnimations::ClearAll();
+            // TODO: Have a separate GameState and exchange once loaded.
+            auto& gameState = getGameState();
+            importer->Import(gameState);
+
+            EntityTweener::Get().Reset();
+            MapAnimations::MarkAllTiles();
+
+            gLastAutoSaveUpdate = kAutosavePause;
+            result = true;
+        }
+        catch (const std::exception& e)
+        {
+            Console::Error::WriteLine("Unable to read map from server: %s", e.what());
+        }
+        return result;
+    }
+
+    bool NetworkBase::SaveMap(IStream* stream, const std::vector<const ObjectRepositoryItem*>& objects) const
+    {
+        bool result = false;
+        PrepareMapForSave();
+        try
+        {
+            auto exporter = std::make_unique<ParkFileExporter>();
+            exporter->ExportObjectsList = objects;
+
+            auto& gameState = getGameState();
+            exporter->Export(gameState, *stream, kParkFileNetCompressionLevel);
+            result = true;
+        }
+        catch (const std::exception& e)
+        {
+            Console::Error::WriteLine("Unable to serialise map: %s", e.what());
+        }
+        return result;
+    }
+
+    void NetworkBase::Client_Handle_CHAT([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        auto text = packet.ReadString();
+        if (!text.empty())
+        {
+            ChatAddHistory(std::string(text));
+        }
+    }
+
+    static bool ProcessChatMessagePluginHooks(uint8_t playerId, std::string& text)
+    {
+    #ifdef ENABLE_SCRIPTING
+        auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+        if (hookEngine.HasSubscriptions(Scripting::HookType::networkChat))
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+
+            // Create event args object
+            auto objIdx = duk_push_object(ctx);
+            duk_push_number(ctx, playerId);
+            duk_put_prop_string(ctx, objIdx, "player");
+            duk_push_string(ctx, text.c_str());
+            duk_put_prop_string(ctx, objIdx, "message");
+            auto e = DukValue::take_from_stack(ctx);
+
+            // Call the subscriptions
+            hookEngine.Call(Scripting::HookType::networkChat, e, false);
+
+            // Update text from object if subscriptions changed it
+            if (e["message"].type() != DukValue::Type::STRING)
+            {
+                // Subscription set text to non-string, do not relay message
+                return false;
+            }
+            text = e["message"].as_string();
+            if (text.empty())
+            {
+                // Subscription set text to empty string, do not relay message
+                return false;
+            }
+        }
+    #endif
+        return true;
+    }
+
+    void NetworkBase::ServerHandleChat(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        auto szText = packet.ReadString();
+        if (szText.empty())
+            return;
+
+        if (connection.Player != nullptr)
+        {
+            NetworkGroup* group = GetGroupByID(connection.Player->Group);
+            if (group == nullptr || !group->CanPerformAction(NetworkPermission::Chat))
+            {
+                return;
+            }
+        }
+
+        std::string text(szText);
+        if (connection.Player != nullptr)
+        {
+            if (!ProcessChatMessagePluginHooks(connection.Player->Id, text))
+            {
+                // Message not to be relayed
+                return;
+            }
+        }
+
+        const char* formatted = FormatChat(connection.Player, text.c_str());
+        ChatAddHistory(formatted);
+        ServerSendChat(formatted);
+    }
+
+    void NetworkBase::Client_Handle_GAME_ACTION([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t tick;
+        GameCommand actionType;
+        packet >> tick >> actionType;
+
+        MemoryStream stream;
+        const size_t size = packet.Header.Size - packet.BytesRead;
+        stream.WriteArray(packet.Read(size), size);
+        stream.SetPosition(0);
+
+        DataSerialiser ds(false, stream);
+
+        GameActions::GameAction::Ptr action = GameActions::Create(actionType);
+        if (action == nullptr)
+        {
+            LOG_ERROR("Received unregistered game action type: 0x%08X", actionType);
+            return;
+        }
+        action->Serialise(ds);
+
+        if (player_id == action->GetPlayer().id)
+        {
+            // Only execute callbacks that belong to us,
+            // clients can have identical network ids assigned.
+            auto itr = _gameActionCallbacks.find(action->GetNetworkId());
+            if (itr != _gameActionCallbacks.end())
+            {
+                action->SetCallback(itr->second);
+                _gameActionCallbacks.erase(itr);
+            }
+        }
+
+        GameActions::Enqueue(std::move(action), tick);
+    }
+
+    void NetworkBase::ServerHandleGameAction(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t tick;
+        GameCommand actionType;
+
+        NetworkPlayer* player = connection.Player;
+        if (player == nullptr)
+        {
+            return;
+        }
+
+        packet >> tick >> actionType;
+
+        // Don't let clients send pause or quit
+        if (actionType == GameCommand::TogglePause || actionType == GameCommand::LoadOrQuit)
+        {
+            return;
+        }
+
+        if (actionType != GameCommand::Custom)
+        {
+            // Check if player's group permission allows command to run
+            NetworkGroup* group = GetGroupByID(connection.Player->Group);
+            if (group == nullptr || group->CanPerformCommand(actionType) == false)
+            {
+                ServerSendShowError(connection, STR_CANT_DO_THIS, STR_PERMISSION_DENIED);
+                return;
+            }
+        }
+
+        // Create and enqueue the action.
+        GameActions::GameAction::Ptr ga = GameActions::Create(actionType);
+        if (ga == nullptr)
+        {
+            LOG_ERROR(
+                "Received unregistered game action type: 0x%08X from player: (%d) %s", actionType, connection.Player->Id,
+                connection.Player->Name.c_str());
+            return;
+        }
+
+        // Player who is hosting is not affected by cooldowns.
+        if ((player->Flags & NETWORK_PLAYER_FLAG_ISSERVER) == 0)
+        {
+            auto cooldownIt = player->CooldownTime.find(actionType);
+            if (cooldownIt != std::end(player->CooldownTime))
+            {
+                if (cooldownIt->second > 0)
+                {
+                    ServerSendShowError(connection, STR_CANT_DO_THIS, STR_NETWORK_ACTION_RATE_LIMIT_MESSAGE);
+                    return;
+                }
+            }
+
+            uint32_t cooldownTime = ga->GetCooldownTime();
+            if (cooldownTime > 0)
+            {
+                player->CooldownTime[actionType] = cooldownTime;
+            }
+        }
+
+        DataSerialiser stream(false);
+        const size_t size = packet.Header.Size - packet.BytesRead;
+        stream.GetStream().WriteArray(packet.Read(size), size);
+        stream.GetStream().SetPosition(0);
+
+        ga->Serialise(stream);
+        // Set player to sender, should be 0 if sent from client.
+        ga->SetPlayer(NetworkPlayerId_t{ connection.Player->Id });
+
+        GameActions::Enqueue(std::move(ga), tick);
+    }
+
+    void NetworkBase::Client_Handle_TICK([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t srand0;
+        uint32_t flags;
+        uint32_t serverTick;
+
+        packet >> serverTick >> srand0 >> flags;
+
+        ServerTickData tickData;
+        tickData.srand0 = srand0;
+        tickData.tick = serverTick;
+
+        if (flags & NETWORK_TICK_FLAG_CHECKSUMS)
+        {
+            auto text = packet.ReadString();
+            if (!text.empty())
+            {
+                tickData.spriteHash = text;
+            }
+        }
+
+        // Don't let the history grow too much.
+        while (_serverTickData.size() >= 100)
+        {
+            _serverTickData.erase(_serverTickData.begin());
+        }
+
+        _serverState.tick = serverTick;
+        _serverTickData.emplace(serverTick, tickData);
+    }
+
+    void NetworkBase::Client_Handle_PLAYERINFO([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t tick;
+        packet >> tick;
+
+        NetworkPlayer playerInfo;
+        playerInfo.Read(packet);
+
+        _pendingPlayerInfo.emplace(tick, playerInfo);
+    }
+
+    void NetworkBase::Client_Handle_PLAYERLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint32_t tick;
+        uint8_t size;
+        packet >> tick >> size;
+
+        auto& pending = _pendingPlayerLists[tick];
+        pending.players.clear();
+
+        for (uint32_t i = 0; i < size; i++)
+        {
+            NetworkPlayer tempplayer;
+            tempplayer.Read(packet);
+
+            pending.players.push_back(std::move(tempplayer));
+        }
+    }
+
+    void NetworkBase::Client_Handle_PING([[maybe_unused]] NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
+    {
+        Client_Send_PING();
+    }
+
+    void NetworkBase::ServerHandlePing(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
+    {
+        int32_t ping = Platform::GetTicks() - connection.PingTime;
+        if (ping < 0)
+        {
+            ping = 0;
+        }
+        if (connection.Player != nullptr)
+        {
+            connection.Player->Ping = ping;
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->InvalidateByNumber(WindowClass::Player, connection.Player->Id);
+        }
+    }
+
+    void NetworkBase::Client_Handle_PINGLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint8_t size;
+        packet >> size;
+        for (uint32_t i = 0; i < size; i++)
+        {
+            uint8_t id;
+            uint16_t ping;
+            packet >> id >> ping;
+            NetworkPlayer* player = GetPlayerByID(id);
+            if (player != nullptr)
+            {
+                player->Ping = ping;
+            }
+        }
+
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->InvalidateByClass(WindowClass::Player);
+    }
+
+    void NetworkBase::Client_Handle_SETDISCONNECTMSG(NetworkConnection& connection, NetworkPacket& packet)
+    {
+        auto disconnectmsg = packet.ReadString();
+        if (!disconnectmsg.empty())
+        {
+            connection.SetLastDisconnectReason(disconnectmsg);
+        }
+    }
+
+    void NetworkBase::ServerHandleGameInfo(NetworkConnection& connection, [[maybe_unused]] NetworkPacket& packet)
+    {
+        ServerSendGameInfo(connection);
+    }
+
+    void NetworkBase::Client_Handle_SHOWERROR([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        StringId title, message;
+        packet >> title >> message;
+        ContextShowError(title, message, {});
+    }
+
+    void NetworkBase::Client_Handle_GROUPLIST([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        group_list.clear();
+        uint8_t size;
+        packet >> size >> default_group;
+        for (uint32_t i = 0; i < size; i++)
+        {
+            NetworkGroup group;
+            group.Read(packet);
+            auto newgroup = std::make_unique<NetworkGroup>(group);
+            group_list.push_back(std::move(newgroup));
+        }
+    }
+
+    void NetworkBase::Client_Handle_EVENT([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        uint16_t eventType;
+        packet >> eventType;
+        switch (eventType)
+        {
+            case SERVER_EVENT_PLAYER_JOINED:
+            {
+                auto playerName = packet.ReadString();
+                auto message = FormatStringID(STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, playerName);
+                ChatAddHistory(message);
+                break;
+            }
+            case SERVER_EVENT_PLAYER_DISCONNECTED:
+            {
+                auto playerName = packet.ReadString();
+                auto reason = packet.ReadString();
+                std::string message;
+                if (reason.empty())
+                {
+                    message = FormatStringID(STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_NO_REASON, playerName);
+                }
+                else
+                {
+                    message = FormatStringID(STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, playerName, reason);
+                }
+                ChatAddHistory(message);
+                break;
+            }
+        }
+    }
+
+    void NetworkBase::Client_Send_GAMEINFO()
+    {
+        LOG_VERBOSE("requesting gameinfo");
+        NetworkPacket packet(NetworkCommand::GameInfo);
+        _serverConnection->QueuePacket(std::move(packet));
+    }
+
+    void NetworkBase::Client_Handle_GAMEINFO([[maybe_unused]] NetworkConnection& connection, NetworkPacket& packet)
+    {
+        auto jsonString = packet.ReadString();
+        packet >> _serverState.gamestateSnapshotsEnabled;
+        packet >> IsServerPlayerInvisible;
+
+        json_t jsonData = Json::FromString(jsonString);
+
+        if (jsonData.is_object())
+        {
+            ServerName = Json::GetString(jsonData["name"]);
+            ServerDescription = Json::GetString(jsonData["description"]);
+            ServerGreeting = Json::GetString(jsonData["greeting"]);
+
+            json_t jsonProvider = jsonData["provider"];
+            if (jsonProvider.is_object())
+            {
+                ServerProviderName = Json::GetString(jsonProvider["name"]);
+                ServerProviderEmail = Json::GetString(jsonProvider["email"]);
+                ServerProviderWebsite = Json::GetString(jsonProvider["website"]);
+            }
+        }
+
+        NetworkChatShowServerGreeting();
+    }
+
+    void NetworkReconnect()
+    {
+        GetContext()->GetNetwork().Reconnect();
+    }
+
+    void NetworkShutdownClient()
+    {
+        GetContext()->GetNetwork().ServerClientDisconnected();
+    }
+
+    int32_t NetworkBeginClient(const std::string& host, int32_t port)
+    {
+        return GetContext()->GetNetwork().BeginClient(host, port);
+    }
+
+    int32_t NetworkBeginServer(int32_t port, const std::string& address)
+    {
+        return GetContext()->GetNetwork().BeginServer(port, address);
+    }
+
+    void NetworkUpdate()
+    {
+        GetContext()->GetNetwork().Update();
+    }
+
+    void NetworkProcessPending()
+    {
+        GetContext()->GetNetwork().ProcessPending();
+    }
+
+    void NetworkFlush()
+    {
+        GetContext()->GetNetwork().Flush();
+    }
+
+    int32_t NetworkGetMode()
+    {
+        return GetContext()->GetNetwork().GetMode();
+    }
+
+    int32_t NetworkGetStatus()
+    {
+        return GetContext()->GetNetwork().GetStatus();
+    }
+
+    bool NetworkIsDesynchronised()
+    {
+        return GetContext()->GetNetwork().IsDesynchronised();
+    }
+
+    bool NetworkCheckDesynchronisation()
+    {
+        return GetContext()->GetNetwork().CheckDesynchronizaton();
+    }
+
+    void NetworkRequestGamestateSnapshot()
+    {
+        return GetContext()->GetNetwork().RequestStateSnapshot();
+    }
+
+    void NetworkSendTick()
+    {
+        GetContext()->GetNetwork().ServerSendTick();
+    }
+
+    NetworkAuth NetworkGetAuthstatus()
+    {
+        return GetContext()->GetNetwork().GetAuthStatus();
+    }
+
+    uint32_t NetworkGetServerTick()
+    {
+        return GetContext()->GetNetwork().GetServerTick();
+    }
+
+    uint8_t NetworkGetCurrentPlayerId()
+    {
+        return GetContext()->GetNetwork().GetPlayerID();
+    }
+
+    int32_t NetworkGetNumPlayers()
+    {
+        return GetContext()->GetNetwork().GetTotalNumPlayers();
+    }
+
+    int32_t NetworkGetNumVisiblePlayers()
+    {
+        return GetContext()->GetNetwork().GetNumVisiblePlayers();
+    }
+
+    const char* NetworkGetPlayerName(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        return static_cast<const char*>(network.player_list[index]->Name.c_str());
+    }
+
+    uint32_t NetworkGetPlayerFlags(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        return network.player_list[index]->Flags;
+    }
+
+    int32_t NetworkGetPlayerPing(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        return network.player_list[index]->Ping;
+    }
+
+    int32_t NetworkGetPlayerID(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        return network.player_list[index]->Id;
+    }
+
+    money64 NetworkGetPlayerMoneySpent(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        return network.player_list[index]->MoneySpent;
+    }
+
+    std::string NetworkGetPlayerIPAddress(uint32_t id)
+    {
+        auto& network = GetContext()->GetNetwork();
+        auto conn = network.GetPlayerConnection(id);
+        if (conn != nullptr && conn->Socket != nullptr)
+        {
+            return conn->Socket->GetIpAddress();
+        }
+        return {};
+    }
+
+    std::string NetworkGetPlayerPublicKeyHash(uint32_t id)
+    {
+        auto& network = GetContext()->GetNetwork();
+        auto player = network.GetPlayerByID(id);
+        if (player != nullptr)
+        {
+            return player->KeyHash;
+        }
+        return {};
+    }
+
+    void NetworkIncrementPlayerNumCommands(uint32_t playerIndex)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(playerIndex, network.player_list);
+
+        network.player_list[playerIndex]->IncrementNumCommands();
+    }
+
+    void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        network.player_list[index]->AddMoneySpent(cost);
+    }
+
+    int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        if (time && Platform::GetTicks() > network.player_list[index]->LastActionTime + time)
+        {
+            return -999;
+        }
+        return network.player_list[index]->LastAction;
+    }
+
+    void NetworkSetPlayerLastAction(uint32_t index, GameCommand command)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        network.player_list[index]->LastAction = static_cast<int32_t>(NetworkActions::FindCommand(command));
+        network.player_list[index]->LastActionTime = Platform::GetTicks();
+    }
+
+    CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, GetContext()->GetNetwork().player_list);
+
+        return network.player_list[index]->LastActionCoord;
+    }
+
+    void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        if (index < network.player_list.size())
+        {
+            network.player_list[index]->LastActionCoord = coord;
+        }
+    }
+
+    uint32_t NetworkGetPlayerCommandsRan(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, GetContext()->GetNetwork().player_list);
+
+        return network.player_list[index]->CommandsRan;
+    }
+
+    int32_t NetworkGetPlayerIndex(uint32_t id)
+    {
+        auto& network = GetContext()->GetNetwork();
+        auto it = network.GetPlayerIteratorByID(id);
+        if (it == network.player_list.end())
+        {
+            return -1;
+        }
+        return static_cast<int32_t>(network.GetPlayerIteratorByID(id) - network.player_list.begin());
+    }
+
+    uint8_t NetworkGetPlayerGroup(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+
+        return network.player_list[index]->Group;
+    }
+
+    void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.player_list);
+        Guard::IndexInRange(groupindex, network.group_list);
+
+        network.player_list[index]->Group = network.group_list[groupindex]->Id;
+    }
+
+    int32_t NetworkGetGroupIndex(uint8_t id)
+    {
+        auto& network = GetContext()->GetNetwork();
+        auto it = network.GetGroupIteratorByID(id);
+        if (it == network.group_list.end())
+        {
+            return -1;
+        }
+        return static_cast<int32_t>(network.GetGroupIteratorByID(id) - network.group_list.begin());
+    }
+
+    uint8_t NetworkGetGroupID(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(index, network.group_list);
+
+        return network.group_list[index]->Id;
+    }
+
+    int32_t NetworkGetNumGroups()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return static_cast<int32_t>(network.group_list.size());
+    }
+
+    const char* NetworkGetGroupName(uint32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.group_list[index]->GetName().c_str();
+    }
+
+    void NetworkChatShowConnectedMessage()
+    {
+        auto windowManager = Ui::GetWindowManager();
+        std::string s = windowManager->GetKeyboardShortcutString("interface.misc.multiplayer_chat");
+        const char* sptr = s.c_str();
+
+        utf8 buffer[256];
+        FormatStringLegacy(buffer, sizeof(buffer), STR_MULTIPLAYER_CONNECTED_CHAT_HINT, &sptr);
+
+        NetworkPlayer server;
+        server.Name = "Server";
+        const char* formatted = NetworkBase::FormatChat(&server, buffer);
+        ChatAddHistory(formatted);
+    }
+
+    // Display server greeting if one exists
+    void NetworkChatShowServerGreeting()
+    {
+        const auto& greeting = NetworkGetServerGreeting();
+        if (!greeting.empty())
+        {
+            thread_local std::string greeting_formatted;
+            greeting_formatted.assign("{OUTLINE}{GREEN}");
+            greeting_formatted += greeting;
+            ChatAddHistory(greeting_formatted);
+        }
+    }
+
+    GameActions::Result NetworkSetPlayerGroup(
+        NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting)
+    {
+        auto& network = GetContext()->GetNetwork();
+        NetworkPlayer* player = network.GetPlayerByID(playerId);
+
+        NetworkGroup* fromgroup = network.GetGroupByID(actionPlayerId);
+        if (player == nullptr)
+        {
+            return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_DO_THIS, kStringIdNone);
+        }
+
+        if (network.GetGroupByID(groupId) == nullptr)
+        {
+            return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_DO_THIS, kStringIdNone);
+        }
+
+        if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
+        {
             return GameActions::Result(
-                GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
-    }
+                GameActions::Status::InvalidParameters, STR_CANT_CHANGE_GROUP_THAT_THE_HOST_BELONGS_TO, kStringIdNone);
+        }
 
-    network.SaveGroups();
-
-    return GameActions::Result();
-}
-
-GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting)
-{
-    auto& network = GetContext()->GetNetwork();
-    NetworkPlayer* player = network.GetPlayerByID(playerId);
-    if (player == nullptr)
-    {
-        // Player might be already removed by the PLAYERLIST command, need to refactor non-game commands executing too
-        // early.
-        return GameActions::Result(GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_PLAYER_NOT_FOUND);
-    }
-
-    if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
-    {
-        return GameActions::Result(GameActions::Status::Disallowed, STR_CANT_KICK_THE_HOST, kStringIdNone);
-    }
-
-    if (isExecuting)
-    {
-        if (network.GetMode() == NETWORK_MODE_SERVER)
+        if (groupId == 0 && fromgroup != nullptr && fromgroup->Id != 0)
         {
-            network.KickPlayer(playerId);
+            return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_SET_TO_THIS_GROUP, kStringIdNone);
+        }
 
-            NetworkUserManager& networkUserManager = network._userManager;
-            networkUserManager.Load();
-            networkUserManager.RemoveUser(player->KeyHash);
-            networkUserManager.Save();
+        if (isExecuting)
+        {
+            player->Group = groupId;
+
+            if (NetworkGetMode() == NETWORK_MODE_SERVER)
+            {
+                // Add or update saved user
+                NetworkUserManager& userManager = network._userManager;
+                NetworkUser* networkUser = userManager.GetOrAddUser(player->KeyHash);
+                networkUser->GroupId = groupId;
+                networkUser->Name = player->Name;
+                userManager.Save();
+            }
+
+            auto* windowMgr = Ui::GetWindowManager();
+            windowMgr->InvalidateByNumber(WindowClass::Player, playerId);
+
+            // Log set player group event
+            NetworkPlayer* game_command_player = network.GetPlayerByID(actionPlayerId);
+            NetworkGroup* new_player_group = network.GetGroupByID(groupId);
+            char log_msg[256];
+            const char* args[3] = {
+                player->Name.c_str(),
+                new_player_group->GetName().c_str(),
+                game_command_player->Name.c_str(),
+            };
+            FormatStringLegacy(log_msg, 256, STR_LOG_SET_PLAYER_GROUP, args);
+            NetworkAppendServerLog(log_msg);
+        }
+        return GameActions::Result();
+    }
+
+    GameActions::Result NetworkModifyGroups(
+        NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+        uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting)
+    {
+        auto& network = GetContext()->GetNetwork();
+        switch (type)
+        {
+            case GameActions::ModifyGroupType::AddGroup:
+            {
+                if (isExecuting)
+                {
+                    NetworkGroup* newgroup = network.AddGroup();
+                    if (newgroup == nullptr)
+                    {
+                        return GameActions::Result(GameActions::Status::Unknown, STR_CANT_DO_THIS, kStringIdNone);
+                    }
+                }
+            }
+            break;
+            case GameActions::ModifyGroupType::RemoveGroup:
+            {
+                if (groupId == 0)
+                {
+                    return GameActions::Result(
+                        GameActions::Status::Disallowed, STR_THIS_GROUP_CANNOT_BE_MODIFIED, kStringIdNone);
+                }
+                for (const auto& it : network.player_list)
+                {
+                    if ((it.get())->Group == groupId)
+                    {
+                        return GameActions::Result(
+                            GameActions::Status::Disallowed, STR_CANT_REMOVE_GROUP_THAT_PLAYERS_BELONG_TO, kStringIdNone);
+                    }
+                }
+                if (isExecuting)
+                {
+                    network.RemoveGroup(groupId);
+                }
+            }
+            break;
+            case GameActions::ModifyGroupType::SetPermissions:
+            {
+                if (groupId == 0)
+                { // can't change admin group permissions
+                    return GameActions::Result(
+                        GameActions::Status::Disallowed, STR_THIS_GROUP_CANNOT_BE_MODIFIED, kStringIdNone);
+                }
+                NetworkGroup* mygroup = nullptr;
+                NetworkPlayer* player = network.GetPlayerByID(actionPlayerId);
+                auto networkPermission = static_cast<NetworkPermission>(permissionIndex);
+                if (player != nullptr && permissionState == GameActions::PermissionState::Toggle)
+                {
+                    mygroup = network.GetGroupByID(player->Group);
+                    if (mygroup == nullptr || !mygroup->CanPerformAction(networkPermission))
+                    {
+                        return GameActions::Result(
+                            GameActions::Status::Disallowed, STR_CANT_MODIFY_PERMISSION_THAT_YOU_DO_NOT_HAVE_YOURSELF,
+                            kStringIdNone);
+                    }
+                }
+                if (isExecuting)
+                {
+                    NetworkGroup* group = network.GetGroupByID(groupId);
+                    if (group != nullptr)
+                    {
+                        if (permissionState != GameActions::PermissionState::Toggle)
+                        {
+                            if (mygroup != nullptr)
+                            {
+                                if (permissionState == GameActions::PermissionState::SetAll)
+                                {
+                                    group->ActionsAllowed = mygroup->ActionsAllowed;
+                                }
+                                else
+                                {
+                                    group->ActionsAllowed.fill(0x00);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            group->ToggleActionPermission(networkPermission);
+                        }
+                    }
+                }
+            }
+            break;
+            case GameActions::ModifyGroupType::SetName:
+            {
+                NetworkGroup* group = network.GetGroupByID(groupId);
+                if (group == nullptr)
+                {
+                    return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_RENAME_GROUP, kStringIdNone);
+                }
+
+                const char* oldName = group->GetName().c_str();
+
+                if (strcmp(oldName, name.c_str()) == 0)
+                {
+                    return GameActions::Result();
+                }
+
+                if (name.empty())
+                {
+                    return GameActions::Result(
+                        GameActions::Status::InvalidParameters, STR_CANT_RENAME_GROUP, STR_INVALID_GROUP_NAME);
+                }
+
+                if (isExecuting)
+                {
+                    if (group != nullptr)
+                    {
+                        group->SetName(name);
+                    }
+                }
+            }
+            break;
+            case GameActions::ModifyGroupType::SetDefault:
+            {
+                if (groupId == 0)
+                {
+                    return GameActions::Result(GameActions::Status::Disallowed, STR_CANT_SET_TO_THIS_GROUP, kStringIdNone);
+                }
+                if (isExecuting)
+                {
+                    network.SetDefaultGroup(groupId);
+                }
+            }
+            break;
+            default:
+                LOG_ERROR("Invalid Modify Group Type: %u", static_cast<uint8_t>(type));
+                return GameActions::Result(
+                    GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
+        }
+
+        network.SaveGroups();
+
+        return GameActions::Result();
+    }
+
+    GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting)
+    {
+        auto& network = GetContext()->GetNetwork();
+        NetworkPlayer* player = network.GetPlayerByID(playerId);
+        if (player == nullptr)
+        {
+            // Player might be already removed by the PLAYERLIST command, need to refactor non-game commands executing too
+            // early.
+            return GameActions::Result(
+                GameActions::Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_PLAYER_NOT_FOUND);
+        }
+
+        if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
+        {
+            return GameActions::Result(GameActions::Status::Disallowed, STR_CANT_KICK_THE_HOST, kStringIdNone);
+        }
+
+        if (isExecuting)
+        {
+            if (network.GetMode() == NETWORK_MODE_SERVER)
+            {
+                network.KickPlayer(playerId);
+
+                NetworkUserManager& networkUserManager = network._userManager;
+                networkUserManager.Load();
+                networkUserManager.RemoveUser(player->KeyHash);
+                networkUserManager.Save();
+            }
+        }
+        return GameActions::Result();
+    }
+
+    uint8_t NetworkGetDefaultGroup()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.GetDefaultGroup();
+    }
+
+    int32_t NetworkGetNumActions()
+    {
+        return static_cast<int32_t>(NetworkActions::Actions.size());
+    }
+
+    StringId NetworkGetActionNameStringID(uint32_t index)
+    {
+        if (index < NetworkActions::Actions.size())
+        {
+            return NetworkActions::Actions[index].Name;
+        }
+
+        return kStringIdNone;
+    }
+
+    int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(groupindex, network.group_list);
+
+        return network.group_list[groupindex]->CanPerformAction(index);
+    }
+
+    int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index)
+    {
+        auto& network = GetContext()->GetNetwork();
+        Guard::IndexInRange(groupindex, network.group_list);
+
+        return network.group_list[groupindex]->CanPerformCommand(static_cast<GameCommand>(index)); // TODO
+    }
+
+    void NetworkSetPickupPeep(uint8_t playerid, Peep* peep)
+    {
+        auto& network = GetContext()->GetNetwork();
+        if (network.GetMode() == NETWORK_MODE_NONE)
+        {
+            _pickup_peep = peep;
+        }
+        else
+        {
+            NetworkPlayer* player = network.GetPlayerByID(playerid);
+            if (player != nullptr)
+            {
+                player->PickupPeep = peep;
+            }
         }
     }
-    return GameActions::Result();
-}
 
-uint8_t NetworkGetDefaultGroup()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.GetDefaultGroup();
-}
-
-int32_t NetworkGetNumActions()
-{
-    return static_cast<int32_t>(NetworkActions::Actions.size());
-}
-
-StringId NetworkGetActionNameStringID(uint32_t index)
-{
-    if (index < NetworkActions::Actions.size())
+    Peep* NetworkGetPickupPeep(uint8_t playerid)
     {
-        return NetworkActions::Actions[index].Name;
+        auto& network = GetContext()->GetNetwork();
+        if (network.GetMode() == NETWORK_MODE_NONE)
+        {
+            return _pickup_peep;
+        }
+
+        NetworkPlayer* player = network.GetPlayerByID(playerid);
+        if (player != nullptr)
+        {
+            return player->PickupPeep;
+        }
+        return nullptr;
     }
 
-    return kStringIdNone;
-}
+    void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x)
+    {
+        auto& network = GetContext()->GetNetwork();
+        if (network.GetMode() == NETWORK_MODE_NONE)
+        {
+            _pickup_peep_old_x = x;
+        }
+        else
+        {
+            NetworkPlayer* player = network.GetPlayerByID(playerid);
+            if (player != nullptr)
+            {
+                player->PickupPeepOldX = x;
+            }
+        }
+    }
 
-int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index)
+    int32_t NetworkGetPickupPeepOldX(uint8_t playerid)
+    {
+        auto& network = GetContext()->GetNetwork();
+        if (network.GetMode() == NETWORK_MODE_NONE)
+        {
+            return _pickup_peep_old_x;
+        }
+
+        NetworkPlayer* player = network.GetPlayerByID(playerid);
+        if (player != nullptr)
+        {
+            return player->PickupPeepOldX;
+        }
+        return -1;
+    }
+
+    bool NetworkIsServerPlayerInvisible()
+    {
+        return GetContext()->GetNetwork().IsServerPlayerInvisible;
+    }
+
+    int32_t NetworkGetCurrentPlayerGroupIndex()
+    {
+        auto& network = GetContext()->GetNetwork();
+        NetworkPlayer* player = network.GetPlayerByID(network.GetPlayerID());
+        if (player != nullptr)
+        {
+            return NetworkGetGroupIndex(player->Group);
+        }
+        return -1;
+    }
+
+    void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds)
+    {
+        auto& network = GetContext()->GetNetwork();
+        if (network.GetMode() == NETWORK_MODE_CLIENT)
+        {
+            network.Client_Send_CHAT(text);
+        }
+        else if (network.GetMode() == NETWORK_MODE_SERVER)
+        {
+            std::string message = text;
+            if (ProcessChatMessagePluginHooks(network.GetPlayerID(), message))
+            {
+                auto player = network.GetPlayerByID(network.GetPlayerID());
+                if (player != nullptr)
+                {
+                    auto formatted = network.FormatChat(player, message.c_str());
+                    if (playerIds.empty()
+                        || std::find(playerIds.begin(), playerIds.end(), network.GetPlayerID()) != playerIds.end())
+                    {
+                        // Server is one of the recipients
+                        ChatAddHistory(formatted);
+                    }
+                    network.ServerSendChat(formatted, playerIds);
+                }
+            }
+        }
+    }
+
+    void NetworkSendGameAction(const GameActions::GameAction* action)
+    {
+        auto& network = GetContext()->GetNetwork();
+        switch (network.GetMode())
+        {
+            case NETWORK_MODE_SERVER:
+                network.ServerSendGameAction(action);
+                break;
+            case NETWORK_MODE_CLIENT:
+                network.Client_Send_GAME_ACTION(action);
+                break;
+        }
+    }
+
+    void NetworkSendPassword(const std::string& password)
+    {
+        auto& network = GetContext()->GetNetwork();
+        const auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
+        if (!File::Exists(keyPath))
+        {
+            LOG_ERROR("Private key %s missing! Restart the game to generate it.", keyPath.c_str());
+            return;
+        }
+        try
+        {
+            auto fs = FileStream(keyPath, FileMode::open);
+            network._key.LoadPrivate(&fs);
+        }
+        catch (const std::exception&)
+        {
+            LOG_ERROR("Error reading private key from %s.", keyPath.c_str());
+            return;
+        }
+        const std::string pubkey = network._key.PublicKeyString();
+
+        std::vector<uint8_t> signature;
+        network._key.Sign(network._challenge.data(), network._challenge.size(), signature);
+        // Don't keep private key in memory. There's no need and it may get leaked
+        // when process dump gets collected at some point in future.
+        network._key.Unload();
+        network.Client_Send_AUTH(Config::Get().network.PlayerName, password, pubkey, signature);
+    }
+
+    void NetworkSetPassword(const char* password)
+    {
+        auto& network = GetContext()->GetNetwork();
+        network.SetPassword(password);
+    }
+
+    void NetworkAppendChatLog(std::string_view text)
+    {
+        auto& network = GetContext()->GetNetwork();
+        network.AppendChatLog(text);
+    }
+
+    void NetworkAppendServerLog(const utf8* text)
+    {
+        auto& network = GetContext()->GetNetwork();
+        network.AppendServerLog(text);
+    }
+
+    static u8string NetworkGetKeysDirectory()
+    {
+        auto& env = GetContext()->GetPlatformEnvironment();
+        return Path::Combine(env.GetDirectoryPath(DirBase::user), u8"keys");
+    }
+
+    static u8string NetworkGetPrivateKeyPath(u8string_view playerName)
+    {
+        return Path::Combine(NetworkGetKeysDirectory(), u8string(playerName) + u8".privkey");
+    }
+
+    static u8string NetworkGetPublicKeyPath(u8string_view playerName, u8string_view hash)
+    {
+        const auto filename = u8string(playerName) + u8"-" + u8string(hash) + u8".pubkey";
+        return Path::Combine(NetworkGetKeysDirectory(), filename);
+    }
+
+    u8string NetworkGetServerName()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.ServerName;
+    }
+    u8string NetworkGetServerDescription()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.ServerDescription;
+    }
+    u8string NetworkGetServerGreeting()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.ServerGreeting;
+    }
+    u8string NetworkGetServerProviderName()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.ServerProviderName;
+    }
+    u8string NetworkGetServerProviderEmail()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.ServerProviderEmail;
+    }
+    u8string NetworkGetServerProviderWebsite()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.ServerProviderWebsite;
+    }
+
+    std::string NetworkGetVersion()
+    {
+        return kNetworkStreamID;
+    }
+
+    NetworkStats NetworkGetStats()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.GetStats();
+    }
+
+    NetworkServerState NetworkGetServerState()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.GetServerState();
+    }
+
+    bool NetworkGamestateSnapshotsEnabled()
+    {
+        return NetworkGetServerState().gamestateSnapshotsEnabled;
+    }
+
+    json_t NetworkGetServerInfoAsJson()
+    {
+        auto& network = GetContext()->GetNetwork();
+        return network.GetServerInfoAsJson();
+    }
+
+} // namespace OpenRCT2::Network
+
+#else // DISABLE_NETWORK
+
+namespace OpenRCT2::Network
 {
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(groupindex, network.group_list);
+    int32_t NetworkGetMode()
+    {
+        return NETWORK_MODE_NONE;
+    }
+    int32_t NetworkGetStatus()
+    {
+        return NETWORK_STATUS_NONE;
+    }
+    NetworkAuth NetworkGetAuthstatus()
+    {
+        return NetworkAuth::None;
+    }
+    uint32_t NetworkGetServerTick()
+    {
+        return getGameState().currentTicks;
+    }
+    void NetworkFlush()
+    {
+    }
+    void NetworkSendTick()
+    {
+    }
+    bool NetworkIsDesynchronised()
+    {
+        return false;
+    }
+    bool NetworkGamestateSnapshotsEnabled()
+    {
+        return false;
+    }
+    bool NetworkCheckDesynchronisation()
+    {
+        return false;
+    }
+    void NetworkRequestGamestateSnapshot()
+    {
+    }
+    void NetworkSendGameAction(const GameActions::GameAction* action)
+    {
+    }
+    void NetworkUpdate()
+    {
+    }
+    void NetworkProcessPending()
+    {
+    }
+    int32_t NetworkBeginClient(const std::string& host, int32_t port)
+    {
+        return 1;
+    }
+    int32_t NetworkBeginServer(int32_t port, const std::string& address)
+    {
+        return 1;
+    }
+    int32_t NetworkGetNumPlayers()
+    {
+        return 1;
+    }
+    int32_t NetworkGetNumVisiblePlayers()
+    {
+        return 1;
+    }
+    const char* NetworkGetPlayerName(uint32_t index)
+    {
+        return "local (OpenRCT2 compiled without MP)";
+    }
+    uint32_t NetworkGetPlayerFlags(uint32_t index)
+    {
+        return 0;
+    }
+    int32_t NetworkGetPlayerPing(uint32_t index)
+    {
+        return 0;
+    }
+    int32_t NetworkGetPlayerID(uint32_t index)
+    {
+        return 0;
+    }
+    money64 NetworkGetPlayerMoneySpent(uint32_t index)
+    {
+        return 0.00_GBP;
+    }
+    std::string NetworkGetPlayerIPAddress(uint32_t id)
+    {
+        return {};
+    }
+    std::string NetworkGetPlayerPublicKeyHash(uint32_t id)
+    {
+        return {};
+    }
+    void NetworkIncrementPlayerNumCommands(uint32_t playerIndex)
+    {
+    }
+    void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost)
+    {
+    }
+    int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time)
+    {
+        return -999;
+    }
+    void NetworkSetPlayerLastAction(uint32_t index, GameCommand command)
+    {
+    }
+    CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index)
+    {
+        return { 0, 0, 0 };
+    }
+    void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
+    {
+    }
+    uint32_t NetworkGetPlayerCommandsRan(uint32_t index)
+    {
+        return 0;
+    }
+    int32_t NetworkGetPlayerIndex(uint32_t id)
+    {
+        return -1;
+    }
+    uint8_t NetworkGetPlayerGroup(uint32_t index)
+    {
+        return 0;
+    }
+    void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex)
+    {
+    }
+    int32_t NetworkGetGroupIndex(uint8_t id)
+    {
+        return -1;
+    }
+    uint8_t NetworkGetGroupID(uint32_t index)
+    {
+        return 0;
+    }
+    int32_t NetworkGetNumGroups()
+    {
+        return 0;
+    }
+    const char* NetworkGetGroupName(uint32_t index)
+    {
+        return "";
+    };
 
-    return network.group_list[groupindex]->CanPerformAction(index);
-}
-
-int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index)
-{
-    auto& network = GetContext()->GetNetwork();
-    Guard::IndexInRange(groupindex, network.group_list);
-
-    return network.group_list[groupindex]->CanPerformCommand(static_cast<GameCommand>(index)); // TODO
-}
-
-void NetworkSetPickupPeep(uint8_t playerid, Peep* peep)
-{
-    auto& network = GetContext()->GetNetwork();
-    if (network.GetMode() == NETWORK_MODE_NONE)
+    GameActions::Result NetworkSetPlayerGroup(
+        NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting)
+    {
+        return GameActions::Result();
+    }
+    GameActions::Result NetworkModifyGroups(
+        NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+        uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting)
+    {
+        return GameActions::Result();
+    }
+    GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting)
+    {
+        return GameActions::Result();
+    }
+    uint8_t NetworkGetDefaultGroup()
+    {
+        return 0;
+    }
+    int32_t NetworkGetNumActions()
+    {
+        return 0;
+    }
+    StringId NetworkGetActionNameStringID(uint32_t index)
+    {
+        return -1;
+    }
+    int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index)
+    {
+        return 0;
+    }
+    int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index)
+    {
+        return 0;
+    }
+    void NetworkSetPickupPeep(uint8_t playerid, Peep* peep)
     {
         _pickup_peep = peep;
     }
-    else
-    {
-        NetworkPlayer* player = network.GetPlayerByID(playerid);
-        if (player != nullptr)
-        {
-            player->PickupPeep = peep;
-        }
-    }
-}
-
-Peep* NetworkGetPickupPeep(uint8_t playerid)
-{
-    auto& network = GetContext()->GetNetwork();
-    if (network.GetMode() == NETWORK_MODE_NONE)
+    Peep* NetworkGetPickupPeep(uint8_t playerid)
     {
         return _pickup_peep;
     }
-
-    NetworkPlayer* player = network.GetPlayerByID(playerid);
-    if (player != nullptr)
-    {
-        return player->PickupPeep;
-    }
-    return nullptr;
-}
-
-void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x)
-{
-    auto& network = GetContext()->GetNetwork();
-    if (network.GetMode() == NETWORK_MODE_NONE)
+    void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x)
     {
         _pickup_peep_old_x = x;
     }
-    else
-    {
-        NetworkPlayer* player = network.GetPlayerByID(playerid);
-        if (player != nullptr)
-        {
-            player->PickupPeepOldX = x;
-        }
-    }
-}
-
-int32_t NetworkGetPickupPeepOldX(uint8_t playerid)
-{
-    auto& network = GetContext()->GetNetwork();
-    if (network.GetMode() == NETWORK_MODE_NONE)
+    int32_t NetworkGetPickupPeepOldX(uint8_t playerid)
     {
         return _pickup_peep_old_x;
     }
-
-    NetworkPlayer* player = network.GetPlayerByID(playerid);
-    if (player != nullptr)
+    void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds)
     {
-        return player->PickupPeepOldX;
     }
-    return -1;
-}
-
-bool NetworkIsServerPlayerInvisible()
-{
-    return GetContext()->GetNetwork().IsServerPlayerInvisible;
-}
-
-int32_t NetworkGetCurrentPlayerGroupIndex()
-{
-    auto& network = GetContext()->GetNetwork();
-    NetworkPlayer* player = network.GetPlayerByID(network.GetPlayerID());
-    if (player != nullptr)
+    void NetworkSendPassword(const std::string& password)
     {
-        return NetworkGetGroupIndex(player->Group);
     }
-    return -1;
-}
-
-void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds)
-{
-    auto& network = GetContext()->GetNetwork();
-    if (network.GetMode() == NETWORK_MODE_CLIENT)
+    void NetworkReconnect()
     {
-        network.Client_Send_CHAT(text);
     }
-    else if (network.GetMode() == NETWORK_MODE_SERVER)
+    void NetworkShutdownClient()
     {
-        std::string message = text;
-        if (ProcessChatMessagePluginHooks(network.GetPlayerID(), message))
-        {
-            auto player = network.GetPlayerByID(network.GetPlayerID());
-            if (player != nullptr)
-            {
-                auto formatted = network.FormatChat(player, message.c_str());
-                if (playerIds.empty()
-                    || std::find(playerIds.begin(), playerIds.end(), network.GetPlayerID()) != playerIds.end())
-                {
-                    // Server is one of the recipients
-                    ChatAddHistory(formatted);
-                }
-                network.ServerSendChat(formatted, playerIds);
-            }
-        }
     }
-}
-
-void NetworkSendGameAction(const GameActions::GameAction* action)
-{
-    auto& network = GetContext()->GetNetwork();
-    switch (network.GetMode())
+    void NetworkSetPassword(const char* password)
     {
-        case NETWORK_MODE_SERVER:
-            network.ServerSendGameAction(action);
-            break;
-        case NETWORK_MODE_CLIENT:
-            network.Client_Send_GAME_ACTION(action);
-            break;
     }
-}
-
-void NetworkSendPassword(const std::string& password)
-{
-    auto& network = GetContext()->GetNetwork();
-    const auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
-    if (!File::Exists(keyPath))
+    uint8_t NetworkGetCurrentPlayerId()
     {
-        LOG_ERROR("Private key %s missing! Restart the game to generate it.", keyPath.c_str());
-        return;
+        return 0;
     }
-    try
+    int32_t NetworkGetCurrentPlayerGroupIndex()
     {
-        auto fs = FileStream(keyPath, FileMode::open);
-        network._key.LoadPrivate(&fs);
+        return 0;
     }
-    catch (const std::exception&)
+    bool NetworkIsServerPlayerInvisible()
     {
-        LOG_ERROR("Error reading private key from %s.", keyPath.c_str());
-        return;
+        return false;
     }
-    const std::string pubkey = network._key.PublicKeyString();
+    void NetworkAppendChatLog(std::string_view)
+    {
+    }
+    void NetworkAppendServerLog(const utf8* text)
+    {
+    }
+    u8string NetworkGetServerName()
+    {
+        return u8string();
+    }
+    u8string NetworkGetServerDescription()
+    {
+        return u8string();
+    }
+    u8string NetworkGetServerGreeting()
+    {
+        return u8string();
+    }
+    u8string NetworkGetServerProviderName()
+    {
+        return u8string();
+    }
+    u8string NetworkGetServerProviderEmail()
+    {
+        return u8string();
+    }
+    u8string NetworkGetServerProviderWebsite()
+    {
+        return u8string();
+    }
+    std::string NetworkGetVersion()
+    {
+        return "Multiplayer disabled";
+    }
+    NetworkStats NetworkGetStats()
+    {
+        return NetworkStats{};
+    }
+    NetworkServerState NetworkGetServerState()
+    {
+        return NetworkServerState{};
+    }
+    json_t NetworkGetServerInfoAsJson()
+    {
+        return {};
+    }
+} // namespace OpenRCT2::Network
 
-    std::vector<uint8_t> signature;
-    network._key.Sign(network._challenge.data(), network._challenge.size(), signature);
-    // Don't keep private key in memory. There's no need and it may get leaked
-    // when process dump gets collected at some point in future.
-    network._key.Unload();
-    network.Client_Send_AUTH(Config::Get().network.PlayerName, password, pubkey, signature);
-}
-
-void NetworkSetPassword(const char* password)
-{
-    auto& network = GetContext()->GetNetwork();
-    network.SetPassword(password);
-}
-
-void NetworkAppendChatLog(std::string_view text)
-{
-    auto& network = GetContext()->GetNetwork();
-    network.AppendChatLog(text);
-}
-
-void NetworkAppendServerLog(const utf8* text)
-{
-    auto& network = GetContext()->GetNetwork();
-    network.AppendServerLog(text);
-}
-
-static u8string NetworkGetKeysDirectory()
-{
-    auto& env = GetContext()->GetPlatformEnvironment();
-    return Path::Combine(env.GetDirectoryPath(DirBase::user), u8"keys");
-}
-
-static u8string NetworkGetPrivateKeyPath(u8string_view playerName)
-{
-    return Path::Combine(NetworkGetKeysDirectory(), u8string(playerName) + u8".privkey");
-}
-
-static u8string NetworkGetPublicKeyPath(u8string_view playerName, u8string_view hash)
-{
-    const auto filename = u8string(playerName) + u8"-" + u8string(hash) + u8".pubkey";
-    return Path::Combine(NetworkGetKeysDirectory(), filename);
-}
-
-u8string NetworkGetServerName()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.ServerName;
-}
-u8string NetworkGetServerDescription()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.ServerDescription;
-}
-u8string NetworkGetServerGreeting()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.ServerGreeting;
-}
-u8string NetworkGetServerProviderName()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.ServerProviderName;
-}
-u8string NetworkGetServerProviderEmail()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.ServerProviderEmail;
-}
-u8string NetworkGetServerProviderWebsite()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.ServerProviderWebsite;
-}
-
-std::string NetworkGetVersion()
-{
-    return kNetworkStreamID;
-}
-
-NetworkStats NetworkGetStats()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.GetStats();
-}
-
-NetworkServerState NetworkGetServerState()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.GetServerState();
-}
-
-bool NetworkGamestateSnapshotsEnabled()
-{
-    return NetworkGetServerState().gamestateSnapshotsEnabled;
-}
-
-json_t NetworkGetServerInfoAsJson()
-{
-    auto& network = GetContext()->GetNetwork();
-    return network.GetServerInfoAsJson();
-}
-#else
-int32_t NetworkGetMode()
-{
-    return NETWORK_MODE_NONE;
-}
-int32_t NetworkGetStatus()
-{
-    return NETWORK_STATUS_NONE;
-}
-NetworkAuth NetworkGetAuthstatus()
-{
-    return NetworkAuth::None;
-}
-uint32_t NetworkGetServerTick()
-{
-    return getGameState().currentTicks;
-}
-void NetworkFlush()
-{
-}
-void NetworkSendTick()
-{
-}
-bool NetworkIsDesynchronised()
-{
-    return false;
-}
-bool NetworkGamestateSnapshotsEnabled()
-{
-    return false;
-}
-bool NetworkCheckDesynchronisation()
-{
-    return false;
-}
-void NetworkRequestGamestateSnapshot()
-{
-}
-void NetworkSendGameAction(const GameActions::GameAction* action)
-{
-}
-void NetworkUpdate()
-{
-}
-void NetworkProcessPending()
-{
-}
-int32_t NetworkBeginClient(const std::string& host, int32_t port)
-{
-    return 1;
-}
-int32_t NetworkBeginServer(int32_t port, const std::string& address)
-{
-    return 1;
-}
-int32_t NetworkGetNumPlayers()
-{
-    return 1;
-}
-int32_t NetworkGetNumVisiblePlayers()
-{
-    return 1;
-}
-const char* NetworkGetPlayerName(uint32_t index)
-{
-    return "local (OpenRCT2 compiled without MP)";
-}
-uint32_t NetworkGetPlayerFlags(uint32_t index)
-{
-    return 0;
-}
-int32_t NetworkGetPlayerPing(uint32_t index)
-{
-    return 0;
-}
-int32_t NetworkGetPlayerID(uint32_t index)
-{
-    return 0;
-}
-money64 NetworkGetPlayerMoneySpent(uint32_t index)
-{
-    return 0.00_GBP;
-}
-std::string NetworkGetPlayerIPAddress(uint32_t id)
-{
-    return {};
-}
-std::string NetworkGetPlayerPublicKeyHash(uint32_t id)
-{
-    return {};
-}
-void NetworkIncrementPlayerNumCommands(uint32_t playerIndex)
-{
-}
-void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost)
-{
-}
-int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time)
-{
-    return -999;
-}
-void NetworkSetPlayerLastAction(uint32_t index, GameCommand command)
-{
-}
-CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index)
-{
-    return { 0, 0, 0 };
-}
-void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
-{
-}
-uint32_t NetworkGetPlayerCommandsRan(uint32_t index)
-{
-    return 0;
-}
-int32_t NetworkGetPlayerIndex(uint32_t id)
-{
-    return -1;
-}
-uint8_t NetworkGetPlayerGroup(uint32_t index)
-{
-    return 0;
-}
-void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex)
-{
-}
-int32_t NetworkGetGroupIndex(uint8_t id)
-{
-    return -1;
-}
-uint8_t NetworkGetGroupID(uint32_t index)
-{
-    return 0;
-}
-int32_t NetworkGetNumGroups()
-{
-    return 0;
-}
-const char* NetworkGetGroupName(uint32_t index)
-{
-    return "";
-};
-
-GameActions::Result NetworkSetPlayerGroup(
-    NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting)
-{
-    return GameActions::Result();
-}
-GameActions::Result NetworkModifyGroups(
-    NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
-    uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting)
-{
-    return GameActions::Result();
-}
-GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting)
-{
-    return GameActions::Result();
-}
-uint8_t NetworkGetDefaultGroup()
-{
-    return 0;
-}
-int32_t NetworkGetNumActions()
-{
-    return 0;
-}
-StringId NetworkGetActionNameStringID(uint32_t index)
-{
-    return -1;
-}
-int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index)
-{
-    return 0;
-}
-int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index)
-{
-    return 0;
-}
-void NetworkSetPickupPeep(uint8_t playerid, Peep* peep)
-{
-    _pickup_peep = peep;
-}
-Peep* NetworkGetPickupPeep(uint8_t playerid)
-{
-    return _pickup_peep;
-}
-void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x)
-{
-    _pickup_peep_old_x = x;
-}
-int32_t NetworkGetPickupPeepOldX(uint8_t playerid)
-{
-    return _pickup_peep_old_x;
-}
-void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds)
-{
-}
-void NetworkSendPassword(const std::string& password)
-{
-}
-void NetworkReconnect()
-{
-}
-void NetworkShutdownClient()
-{
-}
-void NetworkSetPassword(const char* password)
-{
-}
-uint8_t NetworkGetCurrentPlayerId()
-{
-    return 0;
-}
-int32_t NetworkGetCurrentPlayerGroupIndex()
-{
-    return 0;
-}
-bool NetworkIsServerPlayerInvisible()
-{
-    return false;
-}
-void NetworkAppendChatLog(std::string_view)
-{
-}
-void NetworkAppendServerLog(const utf8* text)
-{
-}
-u8string NetworkGetServerName()
-{
-    return u8string();
-}
-u8string NetworkGetServerDescription()
-{
-    return u8string();
-}
-u8string NetworkGetServerGreeting()
-{
-    return u8string();
-}
-u8string NetworkGetServerProviderName()
-{
-    return u8string();
-}
-u8string NetworkGetServerProviderEmail()
-{
-    return u8string();
-}
-u8string NetworkGetServerProviderWebsite()
-{
-    return u8string();
-}
-std::string NetworkGetVersion()
-{
-    return "Multiplayer disabled";
-}
-NetworkStats NetworkGetStats()
-{
-    return NetworkStats{};
-}
-NetworkServerState NetworkGetServerState()
-{
-    return NetworkServerState{};
-}
-json_t NetworkGetServerInfoAsJson()
-{
-    return {};
-}
 #endif /* DISABLE_NETWORK */

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,9 +47,9 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kNetworkStreamVersion = 1;
+constexpr uint8_t kStreamVersion = 1;
 
-const std::string kNetworkStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kNetworkStreamVersion);
+const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 
 static Peep* _pickup_peep = nullptr;
 static int32_t _pickup_peep_old_x = kLocationNull;
@@ -4073,7 +4073,7 @@ namespace OpenRCT2::Network
 
     std::string GetVersion()
     {
-        return kNetworkStreamID;
+        return kStreamID;
     }
 
     Stats GetStats()

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -102,51 +102,51 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     #include <string>
     #include <vector>
 
-    using namespace OpenRCT2;
-
-    static void NetworkChatShowConnectedMessage();
-    static void NetworkChatShowServerGreeting();
-    static u8string NetworkGetKeysDirectory();
-    static u8string NetworkGetPrivateKeyPath(u8string_view playerName);
-    static u8string NetworkGetPublicKeyPath(u8string_view playerName, u8string_view hash);
+namespace OpenRCT2::Network
+{
+    static void ChatShowConnectedMessage();
+    static void ChatShowServerGreeting();
+    static u8string GetKeysDirectory();
+    static u8string GetPrivateKeyPath(u8string_view playerName);
+    static u8string GetPublicKeyPath(u8string_view playerName, u8string_view hash);
 
     NetworkBase::NetworkBase(IContext& context)
         : System(context)
     {
-        mode = NETWORK_MODE_NONE;
-        status = NETWORK_STATUS_NONE;
+        mode = Mode::none;
+        status = Status::none;
         last_ping_sent_time = 0;
         _actionId = 0;
 
-        client_command_handlers[NetworkCommand::Auth] = &NetworkBase::Client_Handle_AUTH;
-        client_command_handlers[NetworkCommand::Map] = &NetworkBase::Client_Handle_MAP;
-        client_command_handlers[NetworkCommand::Chat] = &NetworkBase::Client_Handle_CHAT;
-        client_command_handlers[NetworkCommand::GameAction] = &NetworkBase::Client_Handle_GAME_ACTION;
-        client_command_handlers[NetworkCommand::Tick] = &NetworkBase::Client_Handle_TICK;
-        client_command_handlers[NetworkCommand::PlayerList] = &NetworkBase::Client_Handle_PLAYERLIST;
-        client_command_handlers[NetworkCommand::PlayerInfo] = &NetworkBase::Client_Handle_PLAYERINFO;
-        client_command_handlers[NetworkCommand::Ping] = &NetworkBase::Client_Handle_PING;
-        client_command_handlers[NetworkCommand::PingList] = &NetworkBase::Client_Handle_PINGLIST;
-        client_command_handlers[NetworkCommand::DisconnectMessage] = &NetworkBase::Client_Handle_SETDISCONNECTMSG;
-        client_command_handlers[NetworkCommand::ShowError] = &NetworkBase::Client_Handle_SHOWERROR;
-        client_command_handlers[NetworkCommand::GroupList] = &NetworkBase::Client_Handle_GROUPLIST;
-        client_command_handlers[NetworkCommand::Event] = &NetworkBase::Client_Handle_EVENT;
-        client_command_handlers[NetworkCommand::GameInfo] = &NetworkBase::Client_Handle_GAMEINFO;
-        client_command_handlers[NetworkCommand::Token] = &NetworkBase::Client_Handle_TOKEN;
-        client_command_handlers[NetworkCommand::ObjectsList] = &NetworkBase::Client_Handle_OBJECTS_LIST;
-        client_command_handlers[NetworkCommand::ScriptsHeader] = &NetworkBase::Client_Handle_SCRIPTS_HEADER;
-        client_command_handlers[NetworkCommand::ScriptsData] = &NetworkBase::Client_Handle_SCRIPTS_DATA;
-        client_command_handlers[NetworkCommand::GameState] = &NetworkBase::Client_Handle_GAMESTATE;
+        client_command_handlers[Command::auth] = &NetworkBase::Client_Handle_AUTH;
+        client_command_handlers[Command::map] = &NetworkBase::Client_Handle_MAP;
+        client_command_handlers[Command::chat] = &NetworkBase::Client_Handle_CHAT;
+        client_command_handlers[Command::gameAction] = &NetworkBase::Client_Handle_GAME_ACTION;
+        client_command_handlers[Command::tick] = &NetworkBase::Client_Handle_TICK;
+        client_command_handlers[Command::playerList] = &NetworkBase::Client_Handle_PLAYERLIST;
+        client_command_handlers[Command::playerInfo] = &NetworkBase::Client_Handle_PLAYERINFO;
+        client_command_handlers[Command::ping] = &NetworkBase::Client_Handle_PING;
+        client_command_handlers[Command::pingList] = &NetworkBase::Client_Handle_PINGLIST;
+        client_command_handlers[Command::disconnectMessage] = &NetworkBase::Client_Handle_SETDISCONNECTMSG;
+        client_command_handlers[Command::showError] = &NetworkBase::Client_Handle_SHOWERROR;
+        client_command_handlers[Command::groupList] = &NetworkBase::Client_Handle_GROUPLIST;
+        client_command_handlers[Command::event] = &NetworkBase::Client_Handle_EVENT;
+        client_command_handlers[Command::gameInfo] = &NetworkBase::Client_Handle_GAMEINFO;
+        client_command_handlers[Command::token] = &NetworkBase::Client_Handle_TOKEN;
+        client_command_handlers[Command::objectsList] = &NetworkBase::Client_Handle_OBJECTS_LIST;
+        client_command_handlers[Command::scriptsHeader] = &NetworkBase::Client_Handle_SCRIPTS_HEADER;
+        client_command_handlers[Command::scriptsData] = &NetworkBase::Client_Handle_SCRIPTS_DATA;
+        client_command_handlers[Command::gameState] = &NetworkBase::Client_Handle_GAMESTATE;
 
-        server_command_handlers[NetworkCommand::Auth] = &NetworkBase::ServerHandleAuth;
-        server_command_handlers[NetworkCommand::Chat] = &NetworkBase::ServerHandleChat;
-        server_command_handlers[NetworkCommand::GameAction] = &NetworkBase::ServerHandleGameAction;
-        server_command_handlers[NetworkCommand::Ping] = &NetworkBase::ServerHandlePing;
-        server_command_handlers[NetworkCommand::GameInfo] = &NetworkBase::ServerHandleGameInfo;
-        server_command_handlers[NetworkCommand::Token] = &NetworkBase::ServerHandleToken;
-        server_command_handlers[NetworkCommand::MapRequest] = &NetworkBase::ServerHandleMapRequest;
-        server_command_handlers[NetworkCommand::RequestGameState] = &NetworkBase::ServerHandleRequestGamestate;
-        server_command_handlers[NetworkCommand::Heartbeat] = &NetworkBase::ServerHandleHeartbeat;
+        server_command_handlers[Command::auth] = &NetworkBase::ServerHandleAuth;
+        server_command_handlers[Command::chat] = &NetworkBase::ServerHandleChat;
+        server_command_handlers[Command::gameAction] = &NetworkBase::ServerHandleGameAction;
+        server_command_handlers[Command::ping] = &NetworkBase::ServerHandlePing;
+        server_command_handlers[Command::gameInfo] = &NetworkBase::ServerHandleGameInfo;
+        server_command_handlers[Command::token] = &NetworkBase::ServerHandleToken;
+        server_command_handlers[Command::mapRequest] = &NetworkBase::ServerHandleMapRequest;
+        server_command_handlers[Command::requestGameState] = &NetworkBase::ServerHandleRequestGamestate;
+        server_command_handlers[Command::heartbeat] = &NetworkBase::ServerHandleHeartbeat;
 
         _chat_log_fs << std::unitbuf;
         _server_log_fs << std::unitbuf;
@@ -154,7 +154,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     bool NetworkBase::Init()
     {
-        status = NETWORK_STATUS_READY;
+        status = Status::ready;
 
         ServerName.clear();
         ServerDescription.clear();
@@ -167,7 +167,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Reconnect()
     {
-        if (status != NETWORK_STATUS_NONE)
+        if (status != Status::none)
         {
             Close();
         }
@@ -181,7 +181,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Close()
     {
-        if (status != NETWORK_STATUS_NONE)
+        if (status != Status::none)
         {
             // HACK Because Close() is closed all over the place, it sometimes gets called inside an Update
             //      call. This then causes disposed data to be accessed. Therefore, save closing until the
@@ -216,7 +216,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
     }
 
-    void NetworkBase::DecayCooldown(NetworkPlayer* player)
+    void NetworkBase::DecayCooldown(Player* player)
     {
         if (player == nullptr)
             return; // No valid connection yet.
@@ -233,24 +233,24 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::CloseConnection()
     {
-        if (mode == NETWORK_MODE_CLIENT)
+        if (mode == Mode::client)
         {
             _serverConnection.reset();
         }
-        else if (mode == NETWORK_MODE_SERVER)
+        else if (mode == Mode::server)
         {
             _listenSocket.reset();
             _advertiser.reset();
         }
 
-        mode = NETWORK_MODE_NONE;
-        status = NETWORK_STATUS_NONE;
-        _lastConnectStatus = SocketStatus::Closed;
+        mode = Mode::none;
+        status = Status::none;
+        _lastConnectStatus = SocketStatus::closed;
     }
 
     bool NetworkBase::BeginClient(const std::string& host, uint16_t port)
     {
-        if (GetMode() != NETWORK_MODE_NONE)
+        if (GetMode() != Mode::none)
         {
             return false;
         }
@@ -259,7 +259,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         if (!Init())
             return false;
 
-        mode = NETWORK_MODE_CLIENT;
+        mode = Mode::client;
 
         LOG_INFO("Connecting to %s:%u", host.c_str(), port);
         _host = host;
@@ -270,8 +270,8 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         _serverConnection->Socket->ConnectAsync(host, port);
         _serverState.gamestateSnapshotsEnabled = false;
 
-        status = NETWORK_STATUS_CONNECTING;
-        _lastConnectStatus = SocketStatus::Closed;
+        status = Status::connecting;
+        _lastConnectStatus = SocketStatus::closed;
         _clientMapLoaded = false;
         _serverTickData.clear();
 
@@ -283,7 +283,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         // risk of tick collision with the server map and title screen map.
         GameActions::SuspendQueue();
 
-        auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
+        auto keyPath = GetPrivateKeyPath(Config::Get().network.PlayerName);
         if (!File::Exists(keyPath))
         {
             Console::WriteLine("Generating key... This may take a while");
@@ -291,7 +291,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             _key.Generate();
             Console::WriteLine("Key generated, saving private bits as %s", keyPath.c_str());
 
-            const auto keysDirectory = NetworkGetKeysDirectory();
+            const auto keysDirectory = GetKeysDirectory();
             if (!Path::CreateDirectory(keysDirectory))
             {
                 LOG_ERROR("Unable to create directory %s.", keysDirectory.c_str());
@@ -311,7 +311,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
             const std::string hash = _key.PublicKeyHash();
             const utf8* publicKeyHash = hash.c_str();
-            keyPath = NetworkGetPublicKeyPath(Config::Get().network.PlayerName, publicKeyHash);
+            keyPath = GetPublicKeyPath(Config::Get().network.PlayerName, publicKeyHash);
             Console::WriteLine("Key generated, saving public bits as %s", keyPath.c_str());
 
             try
@@ -355,7 +355,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         if (!Init())
             return false;
 
-        mode = NETWORK_MODE_SERVER;
+        mode = Mode::server;
 
         _userManager.Load();
 
@@ -386,12 +386,12 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         BeginChatLog();
         BeginServerLog();
 
-        NetworkPlayer* player = AddPlayer(Config::Get().network.PlayerName, "");
+        Player* player = AddPlayer(Config::Get().network.PlayerName, "");
         player->Flags |= NETWORK_PLAYER_FLAG_ISSERVER;
         player->Group = 0;
         player_id = player->Id;
 
-        if (NetworkGetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
             // Add SERVER to users.json and save.
             NetworkUser* networkUser = _userManager.GetOrAddUser(player->KeyHash);
@@ -402,10 +402,10 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         auto* szAddress = address.empty() ? "*" : address.c_str();
         Console::WriteLine("Listening for clients on %s:%hu", szAddress, port);
-        NetworkChatShowConnectedMessage();
-        NetworkChatShowServerGreeting();
+        ChatShowConnectedMessage();
+        ChatShowServerGreeting();
 
-        status = NETWORK_STATUS_CONNECTED;
+        status = Status::connected;
         listening_port = port;
         _serverState.gamestateSnapshotsEnabled = Config::Get().network.DesyncDebugging;
         _advertiser = CreateServerAdvertiser(listening_port);
@@ -416,27 +416,27 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return true;
     }
 
-    int32_t NetworkBase::GetMode() const noexcept
+    Mode NetworkBase::GetMode() const noexcept
     {
         return mode;
     }
 
-    int32_t NetworkBase::GetStatus() const noexcept
+    Status NetworkBase::GetStatus() const noexcept
     {
         return status;
     }
 
-    NetworkAuth NetworkBase::GetAuthStatus()
+    Auth NetworkBase::GetAuthStatus()
     {
-        if (GetMode() == NETWORK_MODE_CLIENT)
+        if (GetMode() == Mode::client)
         {
             return _serverConnection->AuthStatus;
         }
-        if (GetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
-            return NetworkAuth::Ok;
+            return Auth::ok;
         }
-        return NetworkAuth::None;
+        return Auth::none;
     }
 
     uint32_t NetworkBase::GetServerTick() const noexcept
@@ -444,7 +444,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return _serverState.tick;
     }
 
-    uint8_t NetworkBase::GetPlayerID() const noexcept
+    PlayerId_t NetworkBase::GetPlayerID() const noexcept
     {
         return player_id;
     }
@@ -456,7 +456,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         {
             auto clientIt = std::find_if(
                 client_connection_list.begin(), client_connection_list.end(),
-                [player](const auto& conn) -> bool { return conn->Player == player; });
+                [player](const auto& conn) -> bool { return conn->player == player; });
             return clientIt != client_connection_list.end() ? clientIt->get() : nullptr;
         }
         return nullptr;
@@ -473,11 +473,13 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         switch (GetMode())
         {
-            case NETWORK_MODE_SERVER:
+            case Mode::server:
                 UpdateServer();
                 break;
-            case NETWORK_MODE_CLIENT:
+            case Mode::client:
                 UpdateClient();
+                break;
+            default:
                 break;
         }
 
@@ -495,7 +497,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Flush()
     {
-        if (GetMode() == NETWORK_MODE_CLIENT)
+        if (GetMode() == Mode::client)
         {
             _serverConnection->SendQueuedData();
         }
@@ -522,7 +524,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             }
             else
             {
-                DecayCooldown(connection->Player);
+                DecayCooldown(connection->player);
             }
         }
 
@@ -551,15 +553,15 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         switch (status)
         {
-            case NETWORK_STATUS_CONNECTING:
+            case Status::connecting:
             {
                 switch (_serverConnection->Socket->GetStatus())
                 {
-                    case SocketStatus::Resolving:
+                    case SocketStatus::resolving:
                     {
-                        if (_lastConnectStatus != SocketStatus::Resolving)
+                        if (_lastConnectStatus != SocketStatus::resolving)
                         {
-                            _lastConnectStatus = SocketStatus::Resolving;
+                            _lastConnectStatus = SocketStatus::resolving;
                             char str_resolving[256];
                             FormatStringLegacy(str_resolving, 256, STR_MULTIPLAYER_RESOLVING, nullptr);
 
@@ -571,11 +573,11 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                         }
                         break;
                     }
-                    case SocketStatus::Connecting:
+                    case SocketStatus::connecting:
                     {
-                        if (_lastConnectStatus != SocketStatus::Connecting)
+                        if (_lastConnectStatus != SocketStatus::connecting)
                         {
-                            _lastConnectStatus = SocketStatus::Connecting;
+                            _lastConnectStatus = SocketStatus::connecting;
                             char str_connecting[256];
                             FormatStringLegacy(str_connecting, 256, STR_MULTIPLAYER_CONNECTING, nullptr);
 
@@ -589,9 +591,9 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                         }
                         break;
                     }
-                    case SocketStatus::Connected:
+                    case SocketStatus::connected:
                     {
-                        status = NETWORK_STATUS_CONNECTED;
+                        status = Status::connected;
                         _serverConnection->ResetLastPacketTime();
                         Client_Send_TOKEN();
                         char str_authenticating[256];
@@ -599,7 +601,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
                         auto intent = Intent(WindowClass::NetworkStatus);
                         intent.PutExtra(INTENT_EXTRA_MESSAGE, std::string{ str_authenticating });
-                        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
+                        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { OpenRCT2::GetContext()->GetNetwork().Close(); });
                         ContextOpenIntent(&intent);
                         break;
                     }
@@ -619,12 +621,12 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 }
                 break;
             }
-            case NETWORK_STATUS_CONNECTED:
+            case Status::connected:
             {
                 if (!ProcessConnection(*_serverConnection))
                 {
                     // Do not show disconnect message window when password window closed/canceled
-                    if (_serverConnection->AuthStatus == NetworkAuth::RequirePassword)
+                    if (_serverConnection->AuthStatus == Auth::requirePassword)
                     {
                         ContextForceCloseWindowByClass(WindowClass::NetworkStatus);
                     }
@@ -664,17 +666,19 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
                 break;
             }
+
+            default:
+                break;
         }
     }
 
     auto NetworkBase::GetPlayerIteratorByID(uint8_t id) const
     {
-        return std::find_if(player_list.begin(), player_list.end(), [id](std::unique_ptr<NetworkPlayer> const& player) {
-            return player->Id == id;
-        });
+        return std::find_if(
+            player_list.begin(), player_list.end(), [id](std::unique_ptr<Player> const& player) { return player->Id == id; });
     }
 
-    NetworkPlayer* NetworkBase::GetPlayerByID(uint8_t id) const
+    Player* NetworkBase::GetPlayerByID(uint8_t id) const
     {
         auto it = GetPlayerIteratorByID(id);
         if (it != player_list.end())
@@ -712,14 +716,14 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return static_cast<int32_t>(player_list.size());
     }
 
-    const char* NetworkBase::FormatChat(NetworkPlayer* fromPlayer, const char* text)
+    const char* NetworkBase::FormatChat(Player* fromPlayer, const char* text)
     {
         static std::string formatted;
         formatted.clear();
 
         if (fromPlayer != nullptr)
         {
-            auto& network = GetContext()->GetNetwork();
+            auto& network = OpenRCT2::GetContext()->GetNetwork();
             auto it = network.GetGroupByID(fromPlayer->Id);
             std::string groupName = "";
             std::vector<std::string> colours;
@@ -793,7 +797,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 // Sending the packet would cause the client to store a command that is behind the tick where he starts,
                 // which would be essentially never executed. The clients do not require commands before the server has not sent
                 // the map data.
-                if (client_connection->Player == nullptr)
+                if (client_connection->player == nullptr)
                 {
                     continue;
                 }
@@ -838,7 +842,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     bool NetworkBase::IsDesynchronised() const noexcept
     {
-        return _serverState.state == NetworkServerStatus::Desynced;
+        return _serverState.state == ServerStatus::desynced;
     }
 
     bool NetworkBase::CheckDesynchronizaton()
@@ -846,10 +850,10 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         const auto currentTicks = getGameState().currentTicks;
 
         // Check synchronisation
-        if (GetMode() == NETWORK_MODE_CLIENT && _serverState.state != NetworkServerStatus::Desynced
+        if (GetMode() == Mode::client && _serverState.state != ServerStatus::desynced
             && !CheckSRAND(currentTicks, ScenarioRandState().s0))
         {
-            _serverState.state = NetworkServerStatus::Desynced;
+            _serverState.state = ServerStatus::desynced;
             _serverState.desyncTick = currentTicks;
 
             char str_desync[256];
@@ -877,7 +881,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         Client_Send_RequestGameState(_serverState.desyncTick);
     }
 
-    NetworkServerState NetworkBase::GetServerState() const noexcept
+    ServerState NetworkBase::GetServerState() const noexcept
     {
         return _serverState;
     }
@@ -886,7 +890,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     {
         for (auto& client_connection : client_connection_list)
         {
-            if (client_connection->Player->Id == playerId)
+            if (client_connection->player->Id == playerId)
             {
                 // Disconnect the client gracefully
                 client_connection->SetLastDisconnectReason(STR_MULTIPLAYER_KICKED);
@@ -906,7 +910,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerClientDisconnected()
     {
-        if (GetMode() == NETWORK_MODE_CLIENT)
+        if (GetMode() == Mode::client)
         {
             _serverConnection->Disconnect();
         }
@@ -974,7 +978,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             group_list.erase(group);
         }
 
-        if (GetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
             _userManager.UnsetUsersOfGroup(id);
             _userManager.Save();
@@ -1018,7 +1022,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::SaveGroups()
     {
-        if (GetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
             auto& env = GetContext().GetPlatformEnvironment();
             auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"groups.json");
@@ -1055,7 +1059,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         // Spectator group
         auto spectator = std::make_unique<NetworkGroup>();
         spectator->SetName("Spectator");
-        spectator->ToggleActionPermission(NetworkPermission::Chat);
+        spectator->ToggleActionPermission(Permission::Chat);
         spectator->Id = 1;
         group_list.push_back(std::move(spectator));
 
@@ -1063,13 +1067,13 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         auto user = std::make_unique<NetworkGroup>();
         user->SetName("User");
         user->ActionsAllowed.fill(0xFF);
-        user->ToggleActionPermission(NetworkPermission::KickPlayer);
-        user->ToggleActionPermission(NetworkPermission::ModifyGroups);
-        user->ToggleActionPermission(NetworkPermission::SetPlayerGroup);
-        user->ToggleActionPermission(NetworkPermission::Cheat);
-        user->ToggleActionPermission(NetworkPermission::PasswordlessLogin);
-        user->ToggleActionPermission(NetworkPermission::ModifyTile);
-        user->ToggleActionPermission(NetworkPermission::EditScenarioOptions);
+        user->ToggleActionPermission(Permission::KickPlayer);
+        user->ToggleActionPermission(Permission::ModifyGroups);
+        user->ToggleActionPermission(Permission::SetPlayerGroup);
+        user->ToggleActionPermission(Permission::Cheat);
+        user->ToggleActionPermission(Permission::PasswordlessLogin);
+        user->ToggleActionPermission(Permission::ModifyTile);
+        user->ToggleActionPermission(Permission::EditScenarioOptions);
         user->Id = 2;
         group_list.push_back(std::move(user));
 
@@ -1196,11 +1200,11 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         // Log server start event
         utf8 logMessage[256];
-        if (GetMode() == NETWORK_MODE_CLIENT)
+        if (GetMode() == Mode::client)
         {
             FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STARTED, nullptr);
         }
-        else if (GetMode() == NETWORK_MODE_SERVER)
+        else if (GetMode() == Mode::server)
         {
             FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STARTED, nullptr);
         }
@@ -1224,11 +1228,11 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     {
         // Log server stopped event
         char logMessage[256];
-        if (GetMode() == NETWORK_MODE_CLIENT)
+        if (GetMode() == Mode::client)
         {
             FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STOPPED, nullptr);
         }
-        else if (GetMode() == NETWORK_MODE_SERVER)
+        else if (GetMode() == Mode::server)
         {
             FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STOPPED, nullptr);
         }
@@ -1251,7 +1255,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         LOG_VERBOSE("Requesting gamestate from server for tick %u", tick);
 
-        NetworkPacket packet(NetworkCommand::RequestGameState);
+        NetworkPacket packet(Command::requestGameState);
         packet << tick;
         _serverConnection->QueuePacket(std::move(packet));
     }
@@ -1259,30 +1263,30 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     void NetworkBase::Client_Send_TOKEN()
     {
         LOG_VERBOSE("requesting token");
-        NetworkPacket packet(NetworkCommand::Token);
-        _serverConnection->AuthStatus = NetworkAuth::Requested;
+        NetworkPacket packet(Command::token);
+        _serverConnection->AuthStatus = Auth::requested;
         _serverConnection->QueuePacket(std::move(packet));
     }
 
     void NetworkBase::Client_Send_AUTH(
         const std::string& name, const std::string& password, const std::string& pubkey, const std::vector<uint8_t>& signature)
     {
-        NetworkPacket packet(NetworkCommand::Auth);
-        packet.WriteString(NetworkGetVersion());
+        NetworkPacket packet(Command::auth);
+        packet.WriteString(GetVersion());
         packet.WriteString(name);
         packet.WriteString(password);
         packet.WriteString(pubkey);
         assert(signature.size() <= static_cast<size_t>(UINT32_MAX));
         packet << static_cast<uint32_t>(signature.size());
         packet.Write(signature.data(), signature.size());
-        _serverConnection->AuthStatus = NetworkAuth::Requested;
+        _serverConnection->AuthStatus = Auth::requested;
         _serverConnection->QueuePacket(std::move(packet));
     }
 
     void NetworkBase::Client_Send_MAPREQUEST(const std::vector<ObjectEntryDescriptor>& objects)
     {
         LOG_VERBOSE("client requests %u objects", uint32_t(objects.size()));
-        NetworkPacket packet(NetworkCommand::MapRequest);
+        NetworkPacket packet(Command::mapRequest);
         packet << static_cast<uint32_t>(objects.size());
         for (const auto& object : objects)
         {
@@ -1304,7 +1308,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendToken(NetworkConnection& connection)
     {
-        NetworkPacket packet(NetworkCommand::Token);
+        NetworkPacket packet(Command::token);
         packet << static_cast<uint32_t>(connection.Challenge.size());
         packet.Write(connection.Challenge.data(), connection.Challenge.size());
         connection.QueuePacket(std::move(packet));
@@ -1317,7 +1321,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         if (objects.empty())
         {
-            NetworkPacket packet(NetworkCommand::ObjectsList);
+            NetworkPacket packet(Command::objectsList);
             packet << static_cast<uint32_t>(0) << static_cast<uint32_t>(objects.size());
 
             connection.QueuePacket(std::move(packet));
@@ -1328,7 +1332,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             {
                 const auto* object = objects[i];
 
-                NetworkPacket packet(NetworkCommand::ObjectsList);
+                NetworkPacket packet(Command::objectsList);
                 packet << static_cast<uint32_t>(i) << static_cast<uint32_t>(objects.size());
 
                 if (object->Identifier.empty())
@@ -1374,7 +1378,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
 
         // Send the header packet.
-        NetworkPacket packetScriptHeader(NetworkCommand::ScriptsHeader);
+        NetworkPacket packetScriptHeader(Command::scriptsHeader);
         packetScriptHeader << static_cast<uint32_t>(remotePlugins.size());
         packetScriptHeader << static_cast<uint32_t>(pluginData.GetLength());
         connection.QueuePacket(std::move(packetScriptHeader));
@@ -1386,7 +1390,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         {
             const uint32_t chunkSize = std::min<uint32_t>(pluginData.GetLength() - dataOffset, kChunkSize);
 
-            NetworkPacket packet(NetworkCommand::ScriptsData);
+            NetworkPacket packet(Command::scriptsData);
             packet << chunkSize;
             packet.Write(pluginDataBuffer + dataOffset, chunkSize);
 
@@ -1397,7 +1401,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         Guard::Assert(dataOffset == pluginData.GetLength());
 
     #else
-        NetworkPacket packetScriptHeader(NetworkCommand::ScriptsHeader);
+        NetworkPacket packetScriptHeader(Command::scriptsHeader);
         packetScriptHeader << static_cast<uint32_t>(0u);
         packetScriptHeader << static_cast<uint32_t>(0u);
     #endif
@@ -1407,25 +1411,25 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     {
         LOG_VERBOSE("Sending heartbeat");
 
-        NetworkPacket packet(NetworkCommand::Heartbeat);
+        NetworkPacket packet(Command::heartbeat);
         connection.QueuePacket(std::move(packet));
     }
 
-    NetworkStats NetworkBase::GetStats() const
+    Stats NetworkBase::GetStats() const
     {
-        NetworkStats stats = {};
-        if (mode == NETWORK_MODE_CLIENT)
+        Stats stats = {};
+        if (mode == Mode::client)
         {
-            stats = _serverConnection->Stats;
+            stats = _serverConnection->stats;
         }
         else
         {
             for (auto& connection : client_connection_list)
             {
-                for (size_t n = 0; n < EnumValue(NetworkStatisticsGroup::Max); n++)
+                for (size_t n = 0; n < EnumValue(StatisticsGroup::Max); n++)
                 {
-                    stats.bytesReceived[n] += connection->Stats.bytesReceived[n];
-                    stats.bytesSent[n] += connection->Stats.bytesSent[n];
+                    stats.bytesReceived[n] += connection->stats.bytesReceived[n];
+                    stats.bytesSent[n] += connection->stats.bytesSent[n];
                 }
             }
         }
@@ -1435,18 +1439,18 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     void NetworkBase::ServerSendAuth(NetworkConnection& connection)
     {
         uint8_t new_playerid = 0;
-        if (connection.Player != nullptr)
+        if (connection.player != nullptr)
         {
-            new_playerid = connection.Player->Id;
+            new_playerid = connection.player->Id;
         }
-        NetworkPacket packet(NetworkCommand::Auth);
+        NetworkPacket packet(Command::auth);
         packet << static_cast<uint32_t>(connection.AuthStatus) << new_playerid;
-        if (connection.AuthStatus == NetworkAuth::BadVersion)
+        if (connection.AuthStatus == Auth::badVersion)
         {
-            packet.WriteString(NetworkGetVersion());
+            packet.WriteString(GetVersion());
         }
         connection.QueuePacket(std::move(packet));
-        if (connection.AuthStatus != NetworkAuth::Ok && connection.AuthStatus != NetworkAuth::RequirePassword)
+        if (connection.AuthStatus != Auth::ok && connection.AuthStatus != Auth::requirePassword)
         {
             connection.Disconnect();
         }
@@ -1482,7 +1486,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         for (size_t i = 0; i < header.size(); i += chunksize)
         {
             size_t datasize = std::min(chunksize, header.size() - i);
-            NetworkPacket packet(NetworkCommand::Map);
+            NetworkPacket packet(Command::map);
             packet << static_cast<uint32_t>(header.size()) << static_cast<uint32_t>(i);
             packet.Write(&header[i], datasize);
             if (connection != nullptr)
@@ -1514,14 +1518,14 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Client_Send_CHAT(const char* text)
     {
-        NetworkPacket packet(NetworkCommand::Chat);
+        NetworkPacket packet(Command::chat);
         packet.WriteString(text);
         _serverConnection->QueuePacket(std::move(packet));
     }
 
     void NetworkBase::ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds)
     {
-        NetworkPacket packet(NetworkCommand::Chat);
+        NetworkPacket packet(Command::chat);
         packet.WriteString(text);
 
         if (playerIds.empty())
@@ -1544,7 +1548,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Client_Send_GAME_ACTION(const GameActions::GameAction* action)
     {
-        NetworkPacket packet(NetworkCommand::GameAction);
+        NetworkPacket packet(Command::gameAction);
 
         uint32_t networkId = 0;
         networkId = ++_actionId;
@@ -1565,7 +1569,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendGameAction(const GameActions::GameAction* action)
     {
-        NetworkPacket packet(NetworkCommand::GameAction);
+        NetworkPacket packet(Command::gameAction);
 
         DataSerialiser stream(true);
         action->Serialise(stream);
@@ -1577,7 +1581,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendTick()
     {
-        NetworkPacket packet(NetworkCommand::Tick);
+        NetworkPacket packet(Command::tick);
         packet << getGameState().currentTicks << ScenarioRandState().s0;
         uint32_t flags = 0;
         // Simple counter which limits how often a sprite checksum gets sent.
@@ -1604,7 +1608,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendPlayerInfo(int32_t playerId)
     {
-        NetworkPacket packet(NetworkCommand::PlayerInfo);
+        NetworkPacket packet(Command::playerInfo);
         packet << getGameState().currentTicks;
 
         auto* player = GetPlayerByID(playerId);
@@ -1617,7 +1621,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendPlayerList()
     {
-        NetworkPacket packet(NetworkCommand::PlayerList);
+        NetworkPacket packet(Command::playerList);
         packet << getGameState().currentTicks << static_cast<uint8_t>(player_list.size());
         for (auto& player : player_list)
         {
@@ -1628,14 +1632,14 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Client_Send_PING()
     {
-        NetworkPacket packet(NetworkCommand::Ping);
+        NetworkPacket packet(Command::ping);
         _serverConnection->QueuePacket(std::move(packet));
     }
 
     void NetworkBase::ServerSendPing()
     {
         last_ping_sent_time = Platform::GetTicks();
-        NetworkPacket packet(NetworkCommand::Ping);
+        NetworkPacket packet(Command::ping);
         for (auto& client_connection : client_connection_list)
         {
             client_connection->PingTime = Platform::GetTicks();
@@ -1645,7 +1649,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendPingList()
     {
-        NetworkPacket packet(NetworkCommand::PingList);
+        NetworkPacket packet(Command::pingList);
         packet << static_cast<uint8_t>(player_list.size());
         for (auto& player : player_list)
         {
@@ -1656,7 +1660,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendSetDisconnectMsg(NetworkConnection& connection, const char* msg)
     {
-        NetworkPacket packet(NetworkCommand::DisconnectMessage);
+        NetworkPacket packet(Command::disconnectMessage);
         packet.WriteString(msg);
         connection.QueuePacket(std::move(packet));
     }
@@ -1666,7 +1670,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         json_t jsonObj = {
             { "name", Config::Get().network.ServerName },
             { "requiresPassword", _password.size() > 0 },
-            { "version", NetworkGetVersion() },
+            { "version", GetVersion() },
             { "players", GetNumVisiblePlayers() },
             { "maxPlayers", Config::Get().network.Maxplayers },
             { "description", Config::Get().network.ServerDescription },
@@ -1678,7 +1682,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendGameInfo(NetworkConnection& connection)
     {
-        NetworkPacket packet(NetworkCommand::GameInfo);
+        NetworkPacket packet(Command::gameInfo);
     #ifndef DISABLE_HTTP
         json_t jsonObj = GetServerInfoAsJson();
 
@@ -1701,14 +1705,14 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendShowError(NetworkConnection& connection, StringId title, StringId message)
     {
-        NetworkPacket packet(NetworkCommand::ShowError);
+        NetworkPacket packet(Command::showError);
         packet << title << message;
         connection.QueuePacket(std::move(packet));
     }
 
     void NetworkBase::ServerSendGroupList(NetworkConnection& connection)
     {
-        NetworkPacket packet(NetworkCommand::GroupList);
+        NetworkPacket packet(Command::groupList);
         packet << static_cast<uint8_t>(group_list.size()) << default_group;
         for (auto& group : group_list)
         {
@@ -1719,7 +1723,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendEventPlayerJoined(const char* playerName)
     {
-        NetworkPacket packet(NetworkCommand::Event);
+        NetworkPacket packet(Command::event);
         packet << static_cast<uint16_t>(SERVER_EVENT_PLAYER_JOINED);
         packet.WriteString(playerName);
         SendPacketToClients(packet);
@@ -1727,7 +1731,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerSendEventPlayerDisconnected(const char* playerName, const char* reason)
     {
-        NetworkPacket packet(NetworkCommand::Event);
+        NetworkPacket packet(Command::event);
         packet << static_cast<uint16_t>(SERVER_EVENT_PLAYER_DISCONNECTED);
         packet.WriteString(playerName);
         packet.WriteString(reason);
@@ -1745,14 +1749,14 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             packetStatus = connection.ReadPacket();
             switch (packetStatus)
             {
-                case NetworkReadPacket::Disconnected:
+                case NetworkReadPacket::disconnected:
                     // closed connection or network error
                     if (!connection.GetLastDisconnectReason())
                     {
                         connection.SetLastDisconnectReason(STR_MULTIPLAYER_CONNECTION_CLOSED);
                     }
                     return false;
-                case NetworkReadPacket::Success:
+                case NetworkReadPacket::success:
                     // done reading in packet
                     ProcessPacket(connection, connection.InboundPacket);
                     if (!connection.IsValid())
@@ -1760,14 +1764,14 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                         return false;
                     }
                     break;
-                case NetworkReadPacket::MoreData:
+                case NetworkReadPacket::moreData:
                     // more data required to be read
                     break;
-                case NetworkReadPacket::NoData:
+                case NetworkReadPacket::noData:
                     // could not read anything from socket
                     break;
             }
-        } while (packetStatus == NetworkReadPacket::Success && countProcessed < kMaxPacketsPerUpdate);
+        } while (packetStatus == NetworkReadPacket::success && countProcessed < kMaxPacketsPerUpdate);
 
         if (!connection.ReceivedPacketRecently())
         {
@@ -1783,13 +1787,13 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ProcessPacket(NetworkConnection& connection, NetworkPacket& packet)
     {
-        const auto& handlerList = GetMode() == NETWORK_MODE_SERVER ? server_command_handlers : client_command_handlers;
+        const auto& handlerList = GetMode() == Mode::server ? server_command_handlers : client_command_handlers;
 
         auto it = handlerList.find(packet.GetCommand());
         if (it != handlerList.end())
         {
             auto commandHandler = it->second;
-            if (connection.AuthStatus == NetworkAuth::Ok || !packet.CommandRequiresAuth())
+            if (connection.AuthStatus == Auth::ok || !packet.CommandRequiresAuth())
             {
                 try
                 {
@@ -1808,11 +1812,11 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     // This is called at the end of each game tick, this where things should be processed that affects the game state.
     void NetworkBase::ProcessPending()
     {
-        if (GetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
             ProcessDisconnectedClients();
         }
-        else if (GetMode() == NETWORK_MODE_CLIENT)
+        else if (GetMode() == Mode::client)
         {
             ProcessPlayerInfo();
         }
@@ -1895,7 +1899,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ProcessPlayerList()
     {
-        if (GetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
             // Avoid sending multiple times the player list, we mark the list invalidated on modifications
             // and then send at the end of the tick the final player list.
@@ -1934,7 +1938,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                             *player = pendingPlayer;
                             if (player->Flags & NETWORK_PLAYER_FLAG_ISSERVER)
                             {
-                                _serverConnection->Player = player;
+                                _serverConnection->player = player;
                             }
                             newPlayers.push_back(player->Id);
                         }
@@ -1971,7 +1975,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 player_list.erase(
                     std::remove_if(
                         player_list.begin(), player_list.end(),
-                        [&removedPlayers](const std::unique_ptr<NetworkPlayer>& player) {
+                        [&removedPlayers](const std::unique_ptr<Player>& player) {
                             return std::find(removedPlayers.begin(), removedPlayers.end(), player->Id) != removedPlayers.end();
                         }),
                     player_list.end());
@@ -1992,7 +1996,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             auto* player = GetPlayerByID(it->second.Id);
             if (player != nullptr)
             {
-                const NetworkPlayer& networkedInfo = it->second;
+                const Player& networkedInfo = it->second;
                 player->Flags = networkedInfo.Flags;
                 player->Group = networkedInfo.Group;
                 player->LastAction = networkedInfo.LastAction;
@@ -2043,7 +2047,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection)
     {
-        NetworkPlayer* connection_player = connection->Player;
+        Player* connection_player = connection->player;
         if (connection_player == nullptr)
             return;
 
@@ -2062,13 +2066,13 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
 
         ChatAddHistory(text);
-        Peep* pickup_peep = NetworkGetPickupPeep(connection_player->Id);
+        Peep* pickup_peep = GetPickupPeep(connection_player->Id);
         if (pickup_peep != nullptr)
         {
             GameActions::PeepPickupAction pickupAction{ GameActions::PeepPickupType::Cancel,
                                                         pickup_peep->Id,
-                                                        { NetworkGetPickupPeepOldX(connection_player->Id), 0, 0 },
-                                                        NetworkGetCurrentPlayerId() };
+                                                        { GetPickupPeepOldX(connection_player->Id), 0, 0 },
+                                                        GetCurrentPlayerId() };
             auto res = GameActions::Execute(&pickupAction);
         }
         ServerSendEventPlayerDisconnected(
@@ -2082,32 +2086,32 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::RemovePlayer(std::unique_ptr<NetworkConnection>& connection)
     {
-        NetworkPlayer* connection_player = connection->Player;
+        Player* connection_player = connection->player;
         if (connection_player == nullptr)
             return;
 
         player_list.erase(
             std::remove_if(
                 player_list.begin(), player_list.end(),
-                [connection_player](std::unique_ptr<NetworkPlayer>& player) { return player.get() == connection_player; }),
+                [connection_player](std::unique_ptr<Player>& player) { return player.get() == connection_player; }),
             player_list.end());
 
         // Send new player list.
         _playerListInvalidated = true;
     }
 
-    NetworkPlayer* NetworkBase::AddPlayer(const std::string& name, const std::string& keyhash)
+    Player* NetworkBase::AddPlayer(const std::string& name, const std::string& keyhash)
     {
-        NetworkPlayer* addedplayer = nullptr;
+        Player* addedplayer = nullptr;
         int32_t newid = -1;
-        if (GetMode() == NETWORK_MODE_SERVER)
+        if (GetMode() == Mode::server)
         {
             // Find first unused player id
             for (int32_t id = 0; id < 255; id++)
             {
                 if (std::find_if(
                         player_list.begin(), player_list.end(),
-                        [&id](std::unique_ptr<NetworkPlayer> const& player) { return player->Id == id; })
+                        [&id](std::unique_ptr<Player> const& player) { return player->Id == id; })
                     == player_list.end())
                 {
                     newid = id;
@@ -2121,8 +2125,8 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
         if (newid != -1)
         {
-            std::unique_ptr<NetworkPlayer> player;
-            if (GetMode() == NETWORK_MODE_SERVER)
+            std::unique_ptr<Player> player;
+            if (GetMode() == Mode::server)
             {
                 // Load keys host may have added manually
                 _userManager.Load();
@@ -2130,7 +2134,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 // Check if the key is registered
                 const NetworkUser* networkUser = _userManager.GetUserByHash(keyhash);
 
-                player = std::make_unique<NetworkPlayer>();
+                player = std::make_unique<Player>();
                 player->Id = newid;
                 player->KeyHash = keyhash;
                 if (networkUser == nullptr)
@@ -2152,7 +2156,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             }
             else
             {
-                player = std::make_unique<NetworkPlayer>();
+                player = std::make_unique<Player>();
                 player->Id = newid;
                 player->Group = GetDefaultGroup();
                 player->SetName(String::trim(std::string(name)));
@@ -2206,7 +2210,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet)
     {
-        auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
+        auto keyPath = GetPrivateKeyPath(Config::Get().network.PlayerName);
         if (!File::Exists(keyPath))
         {
             LOG_ERROR("Key file (%s) was not found. Restart client to re-generate it.", keyPath.c_str());
@@ -2283,7 +2287,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                     dataSize = snapshotMemory.GetLength() - bytesSent;
                 }
 
-                NetworkPacket packetGameStateChunk(NetworkCommand::GameState);
+                NetworkPacket packetGameStateChunk(Command::gameState);
                 packetGameStateChunk << tick << length << bytesSent << dataSize;
                 packetGameStateChunk.Write(static_cast<const uint8_t*>(snapshotMemory.GetData()) + bytesSent, dataSize);
 
@@ -2304,17 +2308,17 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     {
         uint32_t auth_status;
         packet >> auth_status >> const_cast<uint8_t&>(player_id);
-        connection.AuthStatus = static_cast<NetworkAuth>(auth_status);
+        connection.AuthStatus = static_cast<Auth>(auth_status);
         switch (connection.AuthStatus)
         {
-            case NetworkAuth::Ok:
+            case Auth::ok:
                 Client_Send_GAMEINFO();
                 break;
-            case NetworkAuth::BadName:
+            case Auth::badName:
                 connection.SetLastDisconnectReason(STR_MULTIPLAYER_BAD_PLAYER_NAME);
                 connection.Disconnect();
                 break;
-            case NetworkAuth::BadVersion:
+            case Auth::badVersion:
             {
                 auto version = std::string(packet.ReadString());
                 auto versionp = version.c_str();
@@ -2322,22 +2326,22 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 connection.Disconnect();
                 break;
             }
-            case NetworkAuth::BadPassword:
+            case Auth::badPassword:
                 connection.SetLastDisconnectReason(STR_MULTIPLAYER_BAD_PASSWORD);
                 connection.Disconnect();
                 break;
-            case NetworkAuth::VerificationFailure:
+            case Auth::verificationFailure:
                 connection.SetLastDisconnectReason(STR_MULTIPLAYER_VERIFICATION_FAILURE);
                 connection.Disconnect();
                 break;
-            case NetworkAuth::Full:
+            case Auth::full:
                 connection.SetLastDisconnectReason(STR_MULTIPLAYER_SERVER_FULL);
                 connection.Disconnect();
                 break;
-            case NetworkAuth::RequirePassword:
+            case Auth::requirePassword:
                 ContextOpenWindowView(WV_NETWORK_PASSWORD);
                 break;
-            case NetworkAuth::UnknownKeyDisallowed:
+            case Auth::unknownKeyDisallowed:
                 connection.SetLastDisconnectReason(STR_MULTIPLAYER_UNKNOWN_KEY_DISALLOWED);
                 connection.Disconnect();
                 break;
@@ -2351,7 +2355,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     void NetworkBase::ServerClientJoined(std::string_view name, const std::string& keyhash, NetworkConnection& connection)
     {
         auto player = AddPlayer(std::string(name), keyhash);
-        connection.Player = player;
+        connection.player = player;
         if (player != nullptr)
         {
             char text[256];
@@ -2391,7 +2395,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         auto captionString = GetContext()->GetLocalisationService().GetString(captionStringId);
         auto intent = Intent(INTENT_ACTION_PROGRESS_OPEN);
         intent.PutExtra(INTENT_EXTRA_MESSAGE, captionString);
-        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { ::GetContext()->GetNetwork().Close(); });
+        intent.PutExtra(INTENT_EXTRA_CALLBACK, []() -> void { OpenRCT2::GetContext()->GetNetwork().Close(); });
         ContextOpenIntent(&intent);
     }
 
@@ -2626,7 +2630,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             }
         }
 
-        auto player_name = connection.Player->Name.c_str();
+        auto player_name = connection.player->Name.c_str();
         ServerSendMap(&connection);
         ServerSendEventPlayerJoined(player_name);
         ServerSendGroupList(connection);
@@ -2634,7 +2638,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
     void NetworkBase::ServerHandleAuth(NetworkConnection& connection, NetworkPacket& packet)
     {
-        if (connection.AuthStatus != NetworkAuth::Ok)
+        if (connection.AuthStatus != Auth::ok)
         {
             auto* hostName = connection.Socket->GetHostName();
             auto gameversion = packet.ReadString();
@@ -2645,7 +2649,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             packet >> sigsize;
             if (pubkey.empty())
             {
-                connection.AuthStatus = NetworkAuth::VerificationFailure;
+                connection.AuthStatus = Auth::verificationFailure;
             }
             else
             {
@@ -2685,75 +2689,75 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                         if (Config::Get().network.KnownKeysOnly && _userManager.GetUserByHash(hash) == nullptr)
                         {
                             LOG_VERBOSE("Connection %s: Hash %s, not known", hostName, hash.c_str());
-                            connection.AuthStatus = NetworkAuth::UnknownKeyDisallowed;
+                            connection.AuthStatus = Auth::unknownKeyDisallowed;
                         }
                         else
                         {
-                            connection.AuthStatus = NetworkAuth::Verified;
+                            connection.AuthStatus = Auth::verified;
                         }
                     }
                     else
                     {
-                        connection.AuthStatus = NetworkAuth::VerificationFailure;
+                        connection.AuthStatus = Auth::verificationFailure;
                         LOG_VERBOSE("Connection %s: Signature verification failed!", hostName);
                     }
                 }
                 catch (const std::exception&)
                 {
-                    connection.AuthStatus = NetworkAuth::VerificationFailure;
+                    connection.AuthStatus = Auth::verificationFailure;
                     LOG_VERBOSE("Connection %s: Signature verification failed, invalid data!", hostName);
                 }
             }
 
             bool passwordless = false;
-            if (connection.AuthStatus == NetworkAuth::Verified)
+            if (connection.AuthStatus == Auth::verified)
             {
                 const NetworkGroup* group = GetGroupByID(GetGroupIDByHash(connection.Key.PublicKeyHash()));
                 if (group != nullptr)
                 {
-                    passwordless = group->CanPerformAction(NetworkPermission::PasswordlessLogin);
+                    passwordless = group->CanPerformAction(Permission::PasswordlessLogin);
                 }
             }
-            if (gameversion != NetworkGetVersion())
+            if (gameversion != GetVersion())
             {
-                connection.AuthStatus = NetworkAuth::BadVersion;
+                connection.AuthStatus = Auth::badVersion;
                 LOG_INFO("Connection %s: Bad version.", hostName);
             }
             else if (name.empty())
             {
-                connection.AuthStatus = NetworkAuth::BadName;
+                connection.AuthStatus = Auth::badName;
                 LOG_INFO("Connection %s: Bad name.", connection.Socket->GetHostName());
             }
             else if (!passwordless)
             {
                 if (password.empty() && !_password.empty())
                 {
-                    connection.AuthStatus = NetworkAuth::RequirePassword;
+                    connection.AuthStatus = Auth::requirePassword;
                     LOG_INFO("Connection %s: Requires password.", hostName);
                 }
                 else if (!password.empty() && _password != password)
                 {
-                    connection.AuthStatus = NetworkAuth::BadPassword;
+                    connection.AuthStatus = Auth::badPassword;
                     LOG_INFO("Connection %s: Bad password.", hostName);
                 }
             }
 
             if (GetNumVisiblePlayers() >= Config::Get().network.Maxplayers)
             {
-                connection.AuthStatus = NetworkAuth::Full;
+                connection.AuthStatus = Auth::full;
                 LOG_INFO("Connection %s: Server is full.", hostName);
             }
-            else if (connection.AuthStatus == NetworkAuth::Verified)
+            else if (connection.AuthStatus == Auth::verified)
             {
                 const std::string hash = connection.Key.PublicKeyHash();
                 if (ProcessPlayerAuthenticatePluginHooks(connection, name, hash))
                 {
-                    connection.AuthStatus = NetworkAuth::Ok;
+                    connection.AuthStatus = Auth::ok;
                     ServerClientJoined(name, hash, connection);
                 }
                 else
                 {
-                    connection.AuthStatus = NetworkAuth::VerificationFailure;
+                    connection.AuthStatus = Auth::verificationFailure;
                     LOG_INFO("Connection %s: Denied by plugin.", hostName);
                 }
             }
@@ -2814,12 +2818,12 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 GameNotifyMapChanged();
                 _serverState.tick = getGameState().currentTicks;
                 // NetworkStatusOpen("Loaded new map from network");
-                _serverState.state = NetworkServerStatus::Ok;
+                _serverState.state = ServerStatus::ok;
                 _clientMapLoaded = true;
                 gFirstTimeSaving = true;
 
                 // Notify user he is now online and which shortcut key enables chat
-                NetworkChatShowConnectedMessage();
+                ChatShowConnectedMessage();
 
                 // Fix invalid vehicle sprite sizes, thus preventing visual corruption of sprites
                 FixInvalidVehicleSpriteSizes();
@@ -2943,26 +2947,26 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         if (szText.empty())
             return;
 
-        if (connection.Player != nullptr)
+        if (connection.player != nullptr)
         {
-            NetworkGroup* group = GetGroupByID(connection.Player->Group);
-            if (group == nullptr || !group->CanPerformAction(NetworkPermission::Chat))
+            NetworkGroup* group = GetGroupByID(connection.player->Group);
+            if (group == nullptr || !group->CanPerformAction(Permission::Chat))
             {
                 return;
             }
         }
 
         std::string text(szText);
-        if (connection.Player != nullptr)
+        if (connection.player != nullptr)
         {
-            if (!ProcessChatMessagePluginHooks(connection.Player->Id, text))
+            if (!ProcessChatMessagePluginHooks(connection.player->Id, text))
             {
                 // Message not to be relayed
                 return;
             }
         }
 
-        const char* formatted = FormatChat(connection.Player, text.c_str());
+        const char* formatted = FormatChat(connection.player, text.c_str());
         ChatAddHistory(formatted);
         ServerSendChat(formatted);
     }
@@ -3008,7 +3012,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         uint32_t tick;
         GameCommand actionType;
 
-        NetworkPlayer* player = connection.Player;
+        Player* player = connection.player;
         if (player == nullptr)
         {
             return;
@@ -3025,7 +3029,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         if (actionType != GameCommand::Custom)
         {
             // Check if player's group permission allows command to run
-            NetworkGroup* group = GetGroupByID(connection.Player->Group);
+            NetworkGroup* group = GetGroupByID(connection.player->Group);
             if (group == nullptr || group->CanPerformCommand(actionType) == false)
             {
                 ServerSendShowError(connection, STR_CANT_DO_THIS, STR_PERMISSION_DENIED);
@@ -3038,8 +3042,8 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         if (ga == nullptr)
         {
             LOG_ERROR(
-                "Received unregistered game action type: 0x%08X from player: (%d) %s", actionType, connection.Player->Id,
-                connection.Player->Name.c_str());
+                "Received unregistered game action type: 0x%08X from player: (%d) %s", actionType, connection.player->Id,
+                connection.player->Name.c_str());
             return;
         }
 
@@ -3070,7 +3074,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         ga->Serialise(stream);
         // Set player to sender, should be 0 if sent from client.
-        ga->SetPlayer(NetworkPlayerId_t{ connection.Player->Id });
+        ga->SetPlayer(PlayerId_t{ connection.player->Id });
 
         GameActions::Enqueue(std::move(ga), tick);
     }
@@ -3111,7 +3115,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         uint32_t tick;
         packet >> tick;
 
-        NetworkPlayer playerInfo;
+        Player playerInfo;
         playerInfo.Read(packet);
 
         _pendingPlayerInfo.emplace(tick, playerInfo);
@@ -3128,7 +3132,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         for (uint32_t i = 0; i < size; i++)
         {
-            NetworkPlayer tempplayer;
+            Player tempplayer;
             tempplayer.Read(packet);
 
             pending.players.push_back(std::move(tempplayer));
@@ -3147,11 +3151,11 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         {
             ping = 0;
         }
-        if (connection.Player != nullptr)
+        if (connection.player != nullptr)
         {
-            connection.Player->Ping = ping;
+            connection.player->Ping = ping;
             auto* windowMgr = Ui::GetWindowManager();
-            windowMgr->InvalidateByNumber(WindowClass::Player, connection.Player->Id);
+            windowMgr->InvalidateByNumber(WindowClass::Player, connection.player->Id);
         }
     }
 
@@ -3164,7 +3168,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             uint8_t id;
             uint16_t ping;
             packet >> id >> ping;
-            NetworkPlayer* player = GetPlayerByID(id);
+            Player* player = GetPlayerByID(id);
             if (player != nullptr)
             {
                 player->Ping = ping;
@@ -3245,7 +3249,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
     void NetworkBase::Client_Send_GAMEINFO()
     {
         LOG_VERBOSE("requesting gameinfo");
-        NetworkPacket packet(NetworkCommand::GameInfo);
+        NetworkPacket packet(Command::gameInfo);
         _serverConnection->QueuePacket(std::move(packet));
     }
 
@@ -3272,100 +3276,100 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             }
         }
 
-        NetworkChatShowServerGreeting();
+        ChatShowServerGreeting();
     }
 
-    void NetworkReconnect()
+    void Reconnect()
     {
         GetContext()->GetNetwork().Reconnect();
     }
 
-    void NetworkShutdownClient()
+    void ShutdownClient()
     {
         GetContext()->GetNetwork().ServerClientDisconnected();
     }
 
-    int32_t NetworkBeginClient(const std::string& host, int32_t port)
+    int32_t BeginClient(const std::string& host, int32_t port)
     {
         return GetContext()->GetNetwork().BeginClient(host, port);
     }
 
-    int32_t NetworkBeginServer(int32_t port, const std::string& address)
+    int32_t BeginServer(int32_t port, const std::string& address)
     {
         return GetContext()->GetNetwork().BeginServer(port, address);
     }
 
-    void NetworkUpdate()
+    void Update()
     {
         GetContext()->GetNetwork().Update();
     }
 
-    void NetworkProcessPending()
+    void ProcessPending()
     {
         GetContext()->GetNetwork().ProcessPending();
     }
 
-    void NetworkFlush()
+    void Flush()
     {
         GetContext()->GetNetwork().Flush();
     }
 
-    int32_t NetworkGetMode()
+    Mode GetMode()
     {
         return GetContext()->GetNetwork().GetMode();
     }
 
-    int32_t NetworkGetStatus()
+    Status GetStatus()
     {
         return GetContext()->GetNetwork().GetStatus();
     }
 
-    bool NetworkIsDesynchronised()
+    bool IsDesynchronised()
     {
         return GetContext()->GetNetwork().IsDesynchronised();
     }
 
-    bool NetworkCheckDesynchronisation()
+    bool CheckDesynchronisation()
     {
         return GetContext()->GetNetwork().CheckDesynchronizaton();
     }
 
-    void NetworkRequestGamestateSnapshot()
+    void RequestGamestateSnapshot()
     {
         return GetContext()->GetNetwork().RequestStateSnapshot();
     }
 
-    void NetworkSendTick()
+    void SendTick()
     {
         GetContext()->GetNetwork().ServerSendTick();
     }
 
-    NetworkAuth NetworkGetAuthstatus()
+    Auth GetAuthstatus()
     {
         return GetContext()->GetNetwork().GetAuthStatus();
     }
 
-    uint32_t NetworkGetServerTick()
+    uint32_t GetServerTick()
     {
         return GetContext()->GetNetwork().GetServerTick();
     }
 
-    uint8_t NetworkGetCurrentPlayerId()
+    uint8_t GetCurrentPlayerId()
     {
         return GetContext()->GetNetwork().GetPlayerID();
     }
 
-    int32_t NetworkGetNumPlayers()
+    int32_t GetNumPlayers()
     {
         return GetContext()->GetNetwork().GetTotalNumPlayers();
     }
 
-    int32_t NetworkGetNumVisiblePlayers()
+    int32_t GetNumVisiblePlayers()
     {
         return GetContext()->GetNetwork().GetNumVisiblePlayers();
     }
 
-    const char* NetworkGetPlayerName(uint32_t index)
+    const char* GetPlayerName(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3373,7 +3377,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return static_cast<const char*>(network.player_list[index]->Name.c_str());
     }
 
-    uint32_t NetworkGetPlayerFlags(uint32_t index)
+    uint32_t GetPlayerFlags(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3381,7 +3385,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->Flags;
     }
 
-    int32_t NetworkGetPlayerPing(uint32_t index)
+    int32_t GetPlayerPing(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3389,7 +3393,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->Ping;
     }
 
-    int32_t NetworkGetPlayerID(uint32_t index)
+    int32_t GetPlayerID(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3397,7 +3401,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->Id;
     }
 
-    money64 NetworkGetPlayerMoneySpent(uint32_t index)
+    money64 GetPlayerMoneySpent(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3405,7 +3409,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->MoneySpent;
     }
 
-    std::string NetworkGetPlayerIPAddress(uint32_t id)
+    std::string GetPlayerIPAddress(uint32_t id)
     {
         auto& network = GetContext()->GetNetwork();
         auto conn = network.GetPlayerConnection(id);
@@ -3416,7 +3420,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return {};
     }
 
-    std::string NetworkGetPlayerPublicKeyHash(uint32_t id)
+    std::string GetPlayerPublicKeyHash(uint32_t id)
     {
         auto& network = GetContext()->GetNetwork();
         auto player = network.GetPlayerByID(id);
@@ -3427,7 +3431,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return {};
     }
 
-    void NetworkIncrementPlayerNumCommands(uint32_t playerIndex)
+    void IncrementPlayerNumCommands(uint32_t playerIndex)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(playerIndex, network.player_list);
@@ -3435,7 +3439,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         network.player_list[playerIndex]->IncrementNumCommands();
     }
 
-    void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost)
+    void AddPlayerMoneySpent(uint32_t index, money64 cost)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3443,7 +3447,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         network.player_list[index]->AddMoneySpent(cost);
     }
 
-    int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time)
+    int32_t GetPlayerLastAction(uint32_t index, int32_t time)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3455,7 +3459,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->LastAction;
     }
 
-    void NetworkSetPlayerLastAction(uint32_t index, GameCommand command)
+    void SetPlayerLastAction(uint32_t index, GameCommand command)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3464,7 +3468,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         network.player_list[index]->LastActionTime = Platform::GetTicks();
     }
 
-    CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index)
+    CoordsXYZ GetPlayerLastActionCoord(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, GetContext()->GetNetwork().player_list);
@@ -3472,7 +3476,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->LastActionCoord;
     }
 
-    void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
+    void SetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3483,7 +3487,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
     }
 
-    uint32_t NetworkGetPlayerCommandsRan(uint32_t index)
+    uint32_t GetPlayerCommandsRan(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, GetContext()->GetNetwork().player_list);
@@ -3491,7 +3495,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->CommandsRan;
     }
 
-    int32_t NetworkGetPlayerIndex(uint32_t id)
+    int32_t GetPlayerIndex(uint32_t id)
     {
         auto& network = GetContext()->GetNetwork();
         auto it = network.GetPlayerIteratorByID(id);
@@ -3502,7 +3506,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return static_cast<int32_t>(network.GetPlayerIteratorByID(id) - network.player_list.begin());
     }
 
-    uint8_t NetworkGetPlayerGroup(uint32_t index)
+    uint8_t GetPlayerGroup(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3510,7 +3514,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.player_list[index]->Group;
     }
 
-    void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex)
+    void SetPlayerGroup(uint32_t index, uint32_t groupindex)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.player_list);
@@ -3519,7 +3523,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         network.player_list[index]->Group = network.group_list[groupindex]->Id;
     }
 
-    int32_t NetworkGetGroupIndex(uint8_t id)
+    int32_t GetGroupIndex(uint8_t id)
     {
         auto& network = GetContext()->GetNetwork();
         auto it = network.GetGroupIteratorByID(id);
@@ -3530,7 +3534,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return static_cast<int32_t>(network.GetGroupIteratorByID(id) - network.group_list.begin());
     }
 
-    uint8_t NetworkGetGroupID(uint32_t index)
+    uint8_t GetGroupID(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(index, network.group_list);
@@ -3538,19 +3542,19 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.group_list[index]->Id;
     }
 
-    int32_t NetworkGetNumGroups()
+    int32_t GetNumGroups()
     {
         auto& network = GetContext()->GetNetwork();
         return static_cast<int32_t>(network.group_list.size());
     }
 
-    const char* NetworkGetGroupName(uint32_t index)
+    const char* GetGroupName(uint32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         return network.group_list[index]->GetName().c_str();
     }
 
-    void NetworkChatShowConnectedMessage()
+    void ChatShowConnectedMessage()
     {
         auto windowManager = Ui::GetWindowManager();
         std::string s = windowManager->GetKeyboardShortcutString("interface.misc.multiplayer_chat");
@@ -3559,16 +3563,16 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         utf8 buffer[256];
         FormatStringLegacy(buffer, sizeof(buffer), STR_MULTIPLAYER_CONNECTED_CHAT_HINT, &sptr);
 
-        NetworkPlayer server;
+        Player server;
         server.Name = "Server";
         const char* formatted = NetworkBase::FormatChat(&server, buffer);
         ChatAddHistory(formatted);
     }
 
     // Display server greeting if one exists
-    void NetworkChatShowServerGreeting()
+    void ChatShowServerGreeting()
     {
-        const auto& greeting = NetworkGetServerGreeting();
+        const auto& greeting = GetServerGreeting();
         if (!greeting.empty())
         {
             thread_local std::string greeting_formatted;
@@ -3578,11 +3582,10 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
     }
 
-    GameActions::Result NetworkSetPlayerGroup(
-        NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting)
+    GameActions::Result SetPlayerGroup(PlayerId_t actionPlayerId, PlayerId_t playerId, uint8_t groupId, bool isExecuting)
     {
         auto& network = GetContext()->GetNetwork();
-        NetworkPlayer* player = network.GetPlayerByID(playerId);
+        Player* player = network.GetPlayerByID(playerId);
 
         NetworkGroup* fromgroup = network.GetGroupByID(actionPlayerId);
         if (player == nullptr)
@@ -3610,7 +3613,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         {
             player->Group = groupId;
 
-            if (NetworkGetMode() == NETWORK_MODE_SERVER)
+            if (GetMode() == Mode::server)
             {
                 // Add or update saved user
                 NetworkUserManager& userManager = network._userManager;
@@ -3624,7 +3627,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
             windowMgr->InvalidateByNumber(WindowClass::Player, playerId);
 
             // Log set player group event
-            NetworkPlayer* game_command_player = network.GetPlayerByID(actionPlayerId);
+            Player* game_command_player = network.GetPlayerByID(actionPlayerId);
             NetworkGroup* new_player_group = network.GetGroupByID(groupId);
             char log_msg[256];
             const char* args[3] = {
@@ -3633,13 +3636,13 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                 game_command_player->Name.c_str(),
             };
             FormatStringLegacy(log_msg, 256, STR_LOG_SET_PLAYER_GROUP, args);
-            NetworkAppendServerLog(log_msg);
+            AppendServerLog(log_msg);
         }
         return GameActions::Result();
     }
 
-    GameActions::Result NetworkModifyGroups(
-        NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+    GameActions::Result ModifyGroups(
+        PlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
         uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting)
     {
         auto& network = GetContext()->GetNetwork();
@@ -3686,8 +3689,8 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
                         GameActions::Status::Disallowed, STR_THIS_GROUP_CANNOT_BE_MODIFIED, kStringIdNone);
                 }
                 NetworkGroup* mygroup = nullptr;
-                NetworkPlayer* player = network.GetPlayerByID(actionPlayerId);
-                auto networkPermission = static_cast<NetworkPermission>(permissionIndex);
+                Player* player = network.GetPlayerByID(actionPlayerId);
+                auto networkPermission = static_cast<Permission>(permissionIndex);
                 if (player != nullptr && permissionState == GameActions::PermissionState::Toggle)
                 {
                     mygroup = network.GetGroupByID(player->Group);
@@ -3778,10 +3781,10 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return GameActions::Result();
     }
 
-    GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting)
+    GameActions::Result KickPlayer(PlayerId_t playerId, bool isExecuting)
     {
         auto& network = GetContext()->GetNetwork();
-        NetworkPlayer* player = network.GetPlayerByID(playerId);
+        Player* player = network.GetPlayerByID(playerId);
         if (player == nullptr)
         {
             // Player might be already removed by the PLAYERLIST command, need to refactor non-game commands executing too
@@ -3797,7 +3800,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         if (isExecuting)
         {
-            if (network.GetMode() == NETWORK_MODE_SERVER)
+            if (network.GetMode() == Mode::server)
             {
                 network.KickPlayer(playerId);
 
@@ -3810,18 +3813,18 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return GameActions::Result();
     }
 
-    uint8_t NetworkGetDefaultGroup()
+    uint8_t GetDefaultGroup()
     {
         auto& network = GetContext()->GetNetwork();
         return network.GetDefaultGroup();
     }
 
-    int32_t NetworkGetNumActions()
+    int32_t GetNumActions()
     {
         return static_cast<int32_t>(NetworkActions::Actions.size());
     }
 
-    StringId NetworkGetActionNameStringID(uint32_t index)
+    StringId GetActionNameStringID(uint32_t index)
     {
         if (index < NetworkActions::Actions.size())
         {
@@ -3831,7 +3834,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return kStringIdNone;
     }
 
-    int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index)
+    int32_t CanPerformAction(uint32_t groupindex, Permission index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(groupindex, network.group_list);
@@ -3839,7 +3842,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.group_list[groupindex]->CanPerformAction(index);
     }
 
-    int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index)
+    int32_t CanPerformCommand(uint32_t groupindex, int32_t index)
     {
         auto& network = GetContext()->GetNetwork();
         Guard::IndexInRange(groupindex, network.group_list);
@@ -3847,16 +3850,16 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return network.group_list[groupindex]->CanPerformCommand(static_cast<GameCommand>(index)); // TODO
     }
 
-    void NetworkSetPickupPeep(uint8_t playerid, Peep* peep)
+    void SetPickupPeep(uint8_t playerid, Peep* peep)
     {
         auto& network = GetContext()->GetNetwork();
-        if (network.GetMode() == NETWORK_MODE_NONE)
+        if (network.GetMode() == Mode::none)
         {
             _pickup_peep = peep;
         }
         else
         {
-            NetworkPlayer* player = network.GetPlayerByID(playerid);
+            Player* player = network.GetPlayerByID(playerid);
             if (player != nullptr)
             {
                 player->PickupPeep = peep;
@@ -3864,15 +3867,15 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
     }
 
-    Peep* NetworkGetPickupPeep(uint8_t playerid)
+    Peep* GetPickupPeep(uint8_t playerid)
     {
         auto& network = GetContext()->GetNetwork();
-        if (network.GetMode() == NETWORK_MODE_NONE)
+        if (network.GetMode() == Mode::none)
         {
             return _pickup_peep;
         }
 
-        NetworkPlayer* player = network.GetPlayerByID(playerid);
+        Player* player = network.GetPlayerByID(playerid);
         if (player != nullptr)
         {
             return player->PickupPeep;
@@ -3880,16 +3883,16 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return nullptr;
     }
 
-    void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x)
+    void SetPickupPeepOldX(uint8_t playerid, int32_t x)
     {
         auto& network = GetContext()->GetNetwork();
-        if (network.GetMode() == NETWORK_MODE_NONE)
+        if (network.GetMode() == Mode::none)
         {
             _pickup_peep_old_x = x;
         }
         else
         {
-            NetworkPlayer* player = network.GetPlayerByID(playerid);
+            Player* player = network.GetPlayerByID(playerid);
             if (player != nullptr)
             {
                 player->PickupPeepOldX = x;
@@ -3897,15 +3900,15 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
     }
 
-    int32_t NetworkGetPickupPeepOldX(uint8_t playerid)
+    int32_t GetPickupPeepOldX(uint8_t playerid)
     {
         auto& network = GetContext()->GetNetwork();
-        if (network.GetMode() == NETWORK_MODE_NONE)
+        if (network.GetMode() == Mode::none)
         {
             return _pickup_peep_old_x;
         }
 
-        NetworkPlayer* player = network.GetPlayerByID(playerid);
+        Player* player = network.GetPlayerByID(playerid);
         if (player != nullptr)
         {
             return player->PickupPeepOldX;
@@ -3913,30 +3916,30 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         return -1;
     }
 
-    bool NetworkIsServerPlayerInvisible()
+    bool IsServerPlayerInvisible()
     {
         return GetContext()->GetNetwork().IsServerPlayerInvisible;
     }
 
-    int32_t NetworkGetCurrentPlayerGroupIndex()
+    int32_t GetCurrentPlayerGroupIndex()
     {
         auto& network = GetContext()->GetNetwork();
-        NetworkPlayer* player = network.GetPlayerByID(network.GetPlayerID());
+        Player* player = network.GetPlayerByID(network.GetPlayerID());
         if (player != nullptr)
         {
-            return NetworkGetGroupIndex(player->Group);
+            return GetGroupIndex(player->Group);
         }
         return -1;
     }
 
-    void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds)
+    void SendChat(const char* text, const std::vector<uint8_t>& playerIds)
     {
         auto& network = GetContext()->GetNetwork();
-        if (network.GetMode() == NETWORK_MODE_CLIENT)
+        if (network.GetMode() == Mode::client)
         {
             network.Client_Send_CHAT(text);
         }
-        else if (network.GetMode() == NETWORK_MODE_SERVER)
+        else if (network.GetMode() == Mode::server)
         {
             std::string message = text;
             if (ProcessChatMessagePluginHooks(network.GetPlayerID(), message))
@@ -3957,24 +3960,26 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         }
     }
 
-    void NetworkSendGameAction(const GameActions::GameAction* action)
+    void SendGameAction(const GameActions::GameAction* action)
     {
         auto& network = GetContext()->GetNetwork();
         switch (network.GetMode())
         {
-            case NETWORK_MODE_SERVER:
+            case Mode::server:
                 network.ServerSendGameAction(action);
                 break;
-            case NETWORK_MODE_CLIENT:
+            case Mode::client:
                 network.Client_Send_GAME_ACTION(action);
+                break;
+            default:
                 break;
         }
     }
 
-    void NetworkSendPassword(const std::string& password)
+    void SendPassword(const std::string& password)
     {
         auto& network = GetContext()->GetNetwork();
-        const auto keyPath = NetworkGetPrivateKeyPath(Config::Get().network.PlayerName);
+        const auto keyPath = GetPrivateKeyPath(Config::Get().network.PlayerName);
         if (!File::Exists(keyPath))
         {
             LOG_ERROR("Private key %s missing! Restart the game to generate it.", keyPath.c_str());
@@ -4000,95 +4005,95 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
         network.Client_Send_AUTH(Config::Get().network.PlayerName, password, pubkey, signature);
     }
 
-    void NetworkSetPassword(const char* password)
+    void SetPassword(const char* password)
     {
         auto& network = GetContext()->GetNetwork();
         network.SetPassword(password);
     }
 
-    void NetworkAppendChatLog(std::string_view text)
+    void AppendChatLog(std::string_view text)
     {
         auto& network = GetContext()->GetNetwork();
         network.AppendChatLog(text);
     }
 
-    void NetworkAppendServerLog(const utf8* text)
+    void AppendServerLog(const utf8* text)
     {
         auto& network = GetContext()->GetNetwork();
         network.AppendServerLog(text);
     }
 
-    static u8string NetworkGetKeysDirectory()
+    static u8string GetKeysDirectory()
     {
         auto& env = GetContext()->GetPlatformEnvironment();
         return Path::Combine(env.GetDirectoryPath(DirBase::user), u8"keys");
     }
 
-    static u8string NetworkGetPrivateKeyPath(u8string_view playerName)
+    static u8string GetPrivateKeyPath(u8string_view playerName)
     {
-        return Path::Combine(NetworkGetKeysDirectory(), u8string(playerName) + u8".privkey");
+        return Path::Combine(GetKeysDirectory(), u8string(playerName) + u8".privkey");
     }
 
-    static u8string NetworkGetPublicKeyPath(u8string_view playerName, u8string_view hash)
+    static u8string GetPublicKeyPath(u8string_view playerName, u8string_view hash)
     {
         const auto filename = u8string(playerName) + u8"-" + u8string(hash) + u8".pubkey";
-        return Path::Combine(NetworkGetKeysDirectory(), filename);
+        return Path::Combine(GetKeysDirectory(), filename);
     }
 
-    u8string NetworkGetServerName()
+    u8string GetServerName()
     {
         auto& network = GetContext()->GetNetwork();
         return network.ServerName;
     }
-    u8string NetworkGetServerDescription()
+    u8string GetServerDescription()
     {
         auto& network = GetContext()->GetNetwork();
         return network.ServerDescription;
     }
-    u8string NetworkGetServerGreeting()
+    u8string GetServerGreeting()
     {
         auto& network = GetContext()->GetNetwork();
         return network.ServerGreeting;
     }
-    u8string NetworkGetServerProviderName()
+    u8string GetServerProviderName()
     {
         auto& network = GetContext()->GetNetwork();
         return network.ServerProviderName;
     }
-    u8string NetworkGetServerProviderEmail()
+    u8string GetServerProviderEmail()
     {
         auto& network = GetContext()->GetNetwork();
         return network.ServerProviderEmail;
     }
-    u8string NetworkGetServerProviderWebsite()
+    u8string GetServerProviderWebsite()
     {
         auto& network = GetContext()->GetNetwork();
         return network.ServerProviderWebsite;
     }
 
-    std::string NetworkGetVersion()
+    std::string GetVersion()
     {
         return kNetworkStreamID;
     }
 
-    NetworkStats NetworkGetStats()
+    Stats GetStats()
     {
         auto& network = GetContext()->GetNetwork();
         return network.GetStats();
     }
 
-    NetworkServerState NetworkGetServerState()
+    ServerState GetServerState()
     {
         auto& network = GetContext()->GetNetwork();
         return network.GetServerState();
     }
 
-    bool NetworkGamestateSnapshotsEnabled()
+    bool GamestateSnapshotsEnabled()
     {
-        return NetworkGetServerState().gamestateSnapshotsEnabled;
+        return GetServerState().gamestateSnapshotsEnabled;
     }
 
-    json_t NetworkGetServerInfoAsJson()
+    json_t GetServerInfoAsJson()
     {
         auto& network = GetContext()->GetNetwork();
         return network.GetServerInfoAsJson();
@@ -4100,269 +4105,268 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
 namespace OpenRCT2::Network
 {
-    int32_t NetworkGetMode()
+    Mode GetMode()
     {
-        return NETWORK_MODE_NONE;
+        return Mode::none;
     }
-    int32_t NetworkGetStatus()
+    Status GetStatus()
     {
-        return NETWORK_STATUS_NONE;
+        return Status::none;
     }
-    NetworkAuth NetworkGetAuthstatus()
+    Auth GetAuthstatus()
     {
-        return NetworkAuth::None;
+        return Auth::none;
     }
-    uint32_t NetworkGetServerTick()
+    uint32_t GetServerTick()
     {
         return getGameState().currentTicks;
     }
-    void NetworkFlush()
+    void Flush()
     {
     }
-    void NetworkSendTick()
+    void SendTick()
     {
     }
-    bool NetworkIsDesynchronised()
-    {
-        return false;
-    }
-    bool NetworkGamestateSnapshotsEnabled()
+    bool IsDesynchronised()
     {
         return false;
     }
-    bool NetworkCheckDesynchronisation()
+    bool GamestateSnapshotsEnabled()
     {
         return false;
     }
-    void NetworkRequestGamestateSnapshot()
+    bool CheckDesynchronisation()
+    {
+        return false;
+    }
+    void RequestGamestateSnapshot()
     {
     }
-    void NetworkSendGameAction(const GameActions::GameAction* action)
+    void SendGameAction(const GameActions::GameAction* action)
     {
     }
-    void NetworkUpdate()
+    void Update()
     {
     }
-    void NetworkProcessPending()
+    void ProcessPending()
     {
     }
-    int32_t NetworkBeginClient(const std::string& host, int32_t port)
-    {
-        return 1;
-    }
-    int32_t NetworkBeginServer(int32_t port, const std::string& address)
-    {
-        return 1;
-    }
-    int32_t NetworkGetNumPlayers()
+    int32_t BeginClient(const std::string& host, int32_t port)
     {
         return 1;
     }
-    int32_t NetworkGetNumVisiblePlayers()
+    int32_t BeginServer(int32_t port, const std::string& address)
     {
         return 1;
     }
-    const char* NetworkGetPlayerName(uint32_t index)
+    int32_t GetNumPlayers()
+    {
+        return 1;
+    }
+    int32_t GetNumVisiblePlayers()
+    {
+        return 1;
+    }
+    const char* GetPlayerName(uint32_t index)
     {
         return "local (OpenRCT2 compiled without MP)";
     }
-    uint32_t NetworkGetPlayerFlags(uint32_t index)
+    uint32_t GetPlayerFlags(uint32_t index)
     {
         return 0;
     }
-    int32_t NetworkGetPlayerPing(uint32_t index)
+    int32_t GetPlayerPing(uint32_t index)
     {
         return 0;
     }
-    int32_t NetworkGetPlayerID(uint32_t index)
+    int32_t GetPlayerID(uint32_t index)
     {
         return 0;
     }
-    money64 NetworkGetPlayerMoneySpent(uint32_t index)
+    money64 GetPlayerMoneySpent(uint32_t index)
     {
         return 0.00_GBP;
     }
-    std::string NetworkGetPlayerIPAddress(uint32_t id)
+    std::string GetPlayerIPAddress(uint32_t id)
     {
         return {};
     }
-    std::string NetworkGetPlayerPublicKeyHash(uint32_t id)
+    std::string GetPlayerPublicKeyHash(uint32_t id)
     {
         return {};
     }
-    void NetworkIncrementPlayerNumCommands(uint32_t playerIndex)
+    void IncrementPlayerNumCommands(uint32_t playerIndex)
     {
     }
-    void NetworkAddPlayerMoneySpent(uint32_t index, money64 cost)
+    void AddPlayerMoneySpent(uint32_t index, money64 cost)
     {
     }
-    int32_t NetworkGetPlayerLastAction(uint32_t index, int32_t time)
+    int32_t GetPlayerLastAction(uint32_t index, int32_t time)
     {
         return -999;
     }
-    void NetworkSetPlayerLastAction(uint32_t index, GameCommand command)
+    void SetPlayerLastAction(uint32_t index, GameCommand command)
     {
     }
-    CoordsXYZ NetworkGetPlayerLastActionCoord(uint32_t index)
+    CoordsXYZ GetPlayerLastActionCoord(uint32_t index)
     {
         return { 0, 0, 0 };
     }
-    void NetworkSetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
+    void SetPlayerLastActionCoord(uint32_t index, const CoordsXYZ& coord)
     {
     }
-    uint32_t NetworkGetPlayerCommandsRan(uint32_t index)
+    uint32_t GetPlayerCommandsRan(uint32_t index)
     {
         return 0;
     }
-    int32_t NetworkGetPlayerIndex(uint32_t id)
+    int32_t GetPlayerIndex(uint32_t id)
     {
         return -1;
     }
-    uint8_t NetworkGetPlayerGroup(uint32_t index)
+    uint8_t GetPlayerGroup(uint32_t index)
     {
         return 0;
     }
-    void NetworkSetPlayerGroup(uint32_t index, uint32_t groupindex)
+    void SetPlayerGroup(uint32_t index, uint32_t groupindex)
     {
     }
-    int32_t NetworkGetGroupIndex(uint8_t id)
+    int32_t GetGroupIndex(uint8_t id)
     {
         return -1;
     }
-    uint8_t NetworkGetGroupID(uint32_t index)
+    uint8_t GetGroupID(uint32_t index)
     {
         return 0;
     }
-    int32_t NetworkGetNumGroups()
+    int32_t GetNumGroups()
     {
         return 0;
     }
-    const char* NetworkGetGroupName(uint32_t index)
+    const char* GetGroupName(uint32_t index)
     {
         return "";
     };
 
-    GameActions::Result NetworkSetPlayerGroup(
-        NetworkPlayerId_t actionPlayerId, NetworkPlayerId_t playerId, uint8_t groupId, bool isExecuting)
+    GameActions::Result SetPlayerGroup(PlayerId_t actionPlayerId, PlayerId_t playerId, uint8_t groupId, bool isExecuting)
     {
         return GameActions::Result();
     }
-    GameActions::Result NetworkModifyGroups(
-        NetworkPlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
+    GameActions::Result ModifyGroups(
+        PlayerId_t actionPlayerId, GameActions::ModifyGroupType type, uint8_t groupId, const std::string& name,
         uint32_t permissionIndex, GameActions::PermissionState permissionState, bool isExecuting)
     {
         return GameActions::Result();
     }
-    GameActions::Result NetworkKickPlayer(NetworkPlayerId_t playerId, bool isExecuting)
+    GameActions::Result KickPlayer(PlayerId_t playerId, bool isExecuting)
     {
         return GameActions::Result();
     }
-    uint8_t NetworkGetDefaultGroup()
+    uint8_t GetDefaultGroup()
     {
         return 0;
     }
-    int32_t NetworkGetNumActions()
+    int32_t GetNumActions()
     {
         return 0;
     }
-    StringId NetworkGetActionNameStringID(uint32_t index)
+    StringId GetActionNameStringID(uint32_t index)
     {
         return -1;
     }
-    int32_t NetworkCanPerformAction(uint32_t groupindex, NetworkPermission index)
+    int32_t CanPerformAction(uint32_t groupindex, Permission index)
     {
         return 0;
     }
-    int32_t NetworkCanPerformCommand(uint32_t groupindex, int32_t index)
+    int32_t CanPerformCommand(uint32_t groupindex, int32_t index)
     {
         return 0;
     }
-    void NetworkSetPickupPeep(uint8_t playerid, Peep* peep)
+    void SetPickupPeep(uint8_t playerid, Peep* peep)
     {
         _pickup_peep = peep;
     }
-    Peep* NetworkGetPickupPeep(uint8_t playerid)
+    Peep* GetPickupPeep(uint8_t playerid)
     {
         return _pickup_peep;
     }
-    void NetworkSetPickupPeepOldX(uint8_t playerid, int32_t x)
+    void SetPickupPeepOldX(uint8_t playerid, int32_t x)
     {
         _pickup_peep_old_x = x;
     }
-    int32_t NetworkGetPickupPeepOldX(uint8_t playerid)
+    int32_t GetPickupPeepOldX(uint8_t playerid)
     {
         return _pickup_peep_old_x;
     }
-    void NetworkSendChat(const char* text, const std::vector<uint8_t>& playerIds)
+    void SendChat(const char* text, const std::vector<uint8_t>& playerIds)
     {
     }
-    void NetworkSendPassword(const std::string& password)
+    void SendPassword(const std::string& password)
     {
     }
-    void NetworkReconnect()
+    void Reconnect()
     {
     }
-    void NetworkShutdownClient()
+    void ShutdownClient()
     {
     }
-    void NetworkSetPassword(const char* password)
+    void SetPassword(const char* password)
     {
     }
-    uint8_t NetworkGetCurrentPlayerId()
-    {
-        return 0;
-    }
-    int32_t NetworkGetCurrentPlayerGroupIndex()
+    uint8_t GetCurrentPlayerId()
     {
         return 0;
     }
-    bool NetworkIsServerPlayerInvisible()
+    int32_t GetCurrentPlayerGroupIndex()
+    {
+        return 0;
+    }
+    bool IsServerPlayerInvisible()
     {
         return false;
     }
-    void NetworkAppendChatLog(std::string_view)
+    void AppendChatLog(std::string_view)
     {
     }
-    void NetworkAppendServerLog(const utf8* text)
+    void AppendServerLog(const utf8* text)
     {
     }
-    u8string NetworkGetServerName()
-    {
-        return u8string();
-    }
-    u8string NetworkGetServerDescription()
+    u8string GetServerName()
     {
         return u8string();
     }
-    u8string NetworkGetServerGreeting()
+    u8string GetServerDescription()
     {
         return u8string();
     }
-    u8string NetworkGetServerProviderName()
+    u8string GetServerGreeting()
     {
         return u8string();
     }
-    u8string NetworkGetServerProviderEmail()
+    u8string GetServerProviderName()
     {
         return u8string();
     }
-    u8string NetworkGetServerProviderWebsite()
+    u8string GetServerProviderEmail()
     {
         return u8string();
     }
-    std::string NetworkGetVersion()
+    u8string GetServerProviderWebsite()
+    {
+        return u8string();
+    }
+    std::string GetVersion()
     {
         return "Multiplayer disabled";
     }
-    NetworkStats NetworkGetStats()
+    Stats GetStats()
     {
-        return NetworkStats{};
+        return Stats{};
     }
-    NetworkServerState NetworkGetServerState()
+    ServerState GetServerState()
     {
-        return NetworkServerState{};
+        return ServerState{};
     }
-    json_t NetworkGetServerInfoAsJson()
+    json_t GetServerInfoAsJson()
     {
         return {};
     }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -719,7 +719,7 @@ static constexpr uint32_t kMaxPacketsPerUpdate = 100;
 
         if (fromPlayer != nullptr)
         {
-            auto& network = OpenRCT2::GetContext()->GetNetwork();
+            auto& network = GetContext()->GetNetwork();
             auto it = network.GetGroupByID(fromPlayer->Id);
             std::string groupName = "";
             std::vector<std::string> colours;

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -22,235 +22,239 @@ namespace OpenRCT2
     struct IContext;
 }
 
-class NetworkBase : public OpenRCT2::System
+namespace OpenRCT2::Network
 {
-public:
-    NetworkBase(OpenRCT2::IContext& context);
-
-public: // Uncategorized
-    bool BeginServer(uint16_t port, const std::string& address);
-    bool BeginClient(const std::string& host, uint16_t port);
-
-public: // Common
-    bool Init();
-    void Close();
-    uint32_t GetServerTick() const noexcept;
-    // FIXME: This is currently the wrong function to override in System, will be refactored later.
-    void Update() override final;
-    void Flush();
-    void ProcessPending();
-    void ProcessPlayerList();
-    auto GetPlayerIteratorByID(uint8_t id) const;
-    auto GetGroupIteratorByID(uint8_t id) const;
-    NetworkPlayer* GetPlayerByID(uint8_t id) const;
-    NetworkGroup* GetGroupByID(uint8_t id) const;
-    int32_t GetTotalNumPlayers() const noexcept;
-    int32_t GetNumVisiblePlayers() const noexcept;
-    void SetPassword(u8string_view password);
-    uint8_t GetDefaultGroup() const noexcept;
-    std::string BeginLog(const std::string& directory, const std::string& midName, const std::string& filenameFormat);
-    void AppendLog(std::ostream& fs, std::string_view s);
-    void BeginChatLog();
-    void AppendChatLog(std::string_view s);
-    void CloseChatLog();
-    NetworkStats GetStats() const;
-    json_t GetServerInfoAsJson() const;
-    bool ProcessConnection(NetworkConnection& connection);
-    void CloseConnection();
-    NetworkPlayer* AddPlayer(const std::string& name, const std::string& keyhash);
-    void ProcessPacket(NetworkConnection& connection, NetworkPacket& packet);
-
-public: // Server
-    NetworkConnection* GetPlayerConnection(uint8_t id) const;
-    void KickPlayer(int32_t playerId);
-    NetworkGroup* AddGroup();
-    void LoadGroups();
-    void SetDefaultGroup(uint8_t id);
-    void SaveGroups();
-    void RemoveGroup(uint8_t id);
-    uint8_t GetGroupIDByHash(const std::string& keyhash);
-    void BeginServerLog();
-    void AppendServerLog(const std::string& s);
-    void CloseServerLog();
-    void DecayCooldown(NetworkPlayer* player);
-    void AddClient(std::unique_ptr<ITcpSocket>&& socket);
-    std::string GetMasterServerUrl();
-    std::string GenerateAdvertiseKey();
-    void SetupDefaultGroups();
-    void RemovePlayer(std::unique_ptr<NetworkConnection>& connection);
-    void UpdateServer();
-    void ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection);
-    bool SaveMap(OpenRCT2::IStream* stream, const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
-    std::vector<uint8_t> SaveForNetwork(const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
-    std::string MakePlayerNameUnique(const std::string& name);
-
-    // Packet dispatchers.
-    void ServerSendAuth(NetworkConnection& connection);
-    void ServerSendToken(NetworkConnection& connection);
-    void ServerSendMap(NetworkConnection* connection = nullptr);
-    void ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
-    void ServerSendGameAction(const OpenRCT2::GameActions::GameAction* action);
-    void ServerSendTick();
-    void ServerSendPlayerInfo(int32_t playerId);
-    void ServerSendPlayerList();
-    void ServerSendPing();
-    void ServerSendPingList();
-    void ServerSendSetDisconnectMsg(NetworkConnection& connection, const char* msg);
-    void ServerSendGameInfo(NetworkConnection& connection);
-    void ServerSendShowError(NetworkConnection& connection, StringId title, StringId message);
-    void ServerSendGroupList(NetworkConnection& connection);
-    void ServerSendEventPlayerJoined(const char* playerName);
-    void ServerSendEventPlayerDisconnected(const char* playerName, const char* reason);
-    void ServerSendObjectsList(
-        NetworkConnection& connection, const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
-    void ServerSendScripts(NetworkConnection& connection);
-
-    // Handlers
-    void ServerHandleRequestGamestate(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandleHeartbeat(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandleAuth(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerClientJoined(std::string_view name, const std::string& keyhash, NetworkConnection& connection);
-    void ServerHandleChat(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandleGameAction(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandlePing(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandleGameInfo(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandleToken(NetworkConnection& connection, NetworkPacket& packet);
-    void ServerHandleMapRequest(NetworkConnection& connection, NetworkPacket& packet);
-
-public: // Client
-    void Reconnect();
-    int32_t GetMode() const noexcept;
-    NetworkAuth GetAuthStatus();
-    int32_t GetStatus() const noexcept;
-    uint8_t GetPlayerID() const noexcept;
-    void ProcessPlayerInfo();
-    void ProcessDisconnectedClients();
-    static const char* FormatChat(NetworkPlayer* fromplayer, const char* text);
-    void SendPacketToClients(const NetworkPacket& packet, bool front = false, bool gameCmd = false) const;
-    bool CheckSRAND(uint32_t tick, uint32_t srand0);
-    bool CheckDesynchronizaton();
-    void RequestStateSnapshot();
-    bool IsDesynchronised() const noexcept;
-    NetworkServerState GetServerState() const noexcept;
-    void ServerClientDisconnected();
-    bool LoadMap(OpenRCT2::IStream* stream);
-    void UpdateClient();
-
-    // Packet dispatchers.
-    void Client_Send_RequestGameState(uint32_t tick);
-    void Client_Send_TOKEN();
-    void Client_Send_AUTH(
-        const std::string& name, const std::string& password, const std::string& pubkey, const std::vector<uint8_t>& signature);
-    void Client_Send_CHAT(const char* text);
-    void Client_Send_GAME_ACTION(const OpenRCT2::GameActions::GameAction* action);
-    void Client_Send_PING();
-    void Client_Send_GAMEINFO();
-    void Client_Send_MAPREQUEST(const std::vector<OpenRCT2::ObjectEntryDescriptor>& objects);
-    void Client_Send_HEARTBEAT(NetworkConnection& connection) const;
-
-    // Handlers.
-    void Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_MAP(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_CHAT(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_GAME_ACTION(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_TICK(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_PLAYERINFO(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_PLAYERLIST(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_PING(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_PINGLIST(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_SETDISCONNECTMSG(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_GAMEINFO(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_SHOWERROR(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_GROUPLIST(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_EVENT(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_OBJECTS_LIST(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_SCRIPTS_HEADER(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_SCRIPTS_DATA(NetworkConnection& connection, NetworkPacket& packet);
-    void Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet);
-
-    std::vector<uint8_t> _challenge;
-    std::map<uint32_t, OpenRCT2::GameActions::GameAction::Callback_t> _gameActionCallbacks;
-    NetworkKey _key;
-    NetworkUserManager _userManager;
-
-public: // Public common
-    std::string ServerName;
-    std::string ServerDescription;
-    std::string ServerGreeting;
-    std::string ServerProviderName;
-    std::string ServerProviderEmail;
-    std::string ServerProviderWebsite;
-    std::vector<std::unique_ptr<NetworkPlayer>> player_list;
-    std::vector<std::unique_ptr<NetworkGroup>> group_list;
-    bool IsServerPlayerInvisible = false;
-
-private: // Common Data
-    using CommandHandler = void (NetworkBase::*)(NetworkConnection& connection, NetworkPacket& packet);
-
-    std::vector<uint8_t> chunk_buffer;
-    std::ofstream _chat_log_fs;
-    uint32_t _lastUpdateTime = 0;
-    uint32_t _currentDeltaTime = 0;
-    int32_t mode = NETWORK_MODE_NONE;
-    uint8_t default_group = 0;
-    bool _closeLock = false;
-    bool _requireClose = false;
-
-private: // Server Data
-    std::unordered_map<NetworkCommand, CommandHandler> server_command_handlers;
-    std::unique_ptr<ITcpSocket> _listenSocket;
-    std::unique_ptr<INetworkServerAdvertiser> _advertiser;
-    std::list<std::unique_ptr<NetworkConnection>> client_connection_list;
-    std::string _serverLogPath;
-    std::string _serverLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
-    std::ofstream _server_log_fs;
-    uint16_t listening_port = 0;
-    bool _playerListInvalidated = false;
-
-private: // Client Data
-    struct PlayerListUpdate
+    class NetworkBase : public OpenRCT2::System
     {
-        std::vector<NetworkPlayer> players;
-    };
+    public:
+        NetworkBase(OpenRCT2::IContext& context);
 
-    struct ServerTickData
-    {
-        uint32_t srand0;
-        uint32_t tick;
-        std::string spriteHash;
-    };
+    public: // Uncategorized
+        bool BeginServer(uint16_t port, const std::string& address);
+        bool BeginClient(const std::string& host, uint16_t port);
 
-    struct ServerScriptsData
-    {
-        uint32_t pluginCount{};
-        uint32_t dataSize{};
-        OpenRCT2::MemoryStream data;
-    };
+    public: // Common
+        bool Init();
+        void Close();
+        uint32_t GetServerTick() const noexcept;
+        // FIXME: This is currently the wrong function to override in System, will be refactored later.
+        void Update() override final;
+        void Flush();
+        void ProcessPending();
+        void ProcessPlayerList();
+        auto GetPlayerIteratorByID(uint8_t id) const;
+        auto GetGroupIteratorByID(uint8_t id) const;
+        NetworkPlayer* GetPlayerByID(uint8_t id) const;
+        NetworkGroup* GetGroupByID(uint8_t id) const;
+        int32_t GetTotalNumPlayers() const noexcept;
+        int32_t GetNumVisiblePlayers() const noexcept;
+        void SetPassword(u8string_view password);
+        uint8_t GetDefaultGroup() const noexcept;
+        std::string BeginLog(const std::string& directory, const std::string& midName, const std::string& filenameFormat);
+        void AppendLog(std::ostream& fs, std::string_view s);
+        void BeginChatLog();
+        void AppendChatLog(std::string_view s);
+        void CloseChatLog();
+        NetworkStats GetStats() const;
+        json_t GetServerInfoAsJson() const;
+        bool ProcessConnection(NetworkConnection& connection);
+        void CloseConnection();
+        NetworkPlayer* AddPlayer(const std::string& name, const std::string& keyhash);
+        void ProcessPacket(NetworkConnection& connection, NetworkPacket& packet);
 
-    std::unordered_map<NetworkCommand, CommandHandler> client_command_handlers;
-    std::unique_ptr<NetworkConnection> _serverConnection;
-    std::map<uint32_t, PlayerListUpdate> _pendingPlayerLists;
-    std::multimap<uint32_t, NetworkPlayer> _pendingPlayerInfo;
-    std::map<uint32_t, ServerTickData> _serverTickData;
-    std::vector<OpenRCT2::ObjectEntryDescriptor> _missingObjects;
-    std::string _host;
-    std::string _chatLogPath;
-    std::string _chatLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
-    std::string _password;
-    OpenRCT2::MemoryStream _serverGameState;
-    NetworkServerState _serverState;
-    uint32_t _lastSentHeartbeat = 0;
-    uint32_t last_ping_sent_time = 0;
-    uint32_t server_connect_time = 0;
-    uint32_t _actionId;
-    int32_t status = NETWORK_STATUS_NONE;
-    uint8_t player_id = 0;
-    uint16_t _port = 0;
-    SocketStatus _lastConnectStatus = SocketStatus::Closed;
-    bool _requireReconnect = false;
-    bool _clientMapLoaded = false;
-    ServerScriptsData _serverScriptsData{};
-};
+    public: // Server
+        NetworkConnection* GetPlayerConnection(uint8_t id) const;
+        void KickPlayer(int32_t playerId);
+        NetworkGroup* AddGroup();
+        void LoadGroups();
+        void SetDefaultGroup(uint8_t id);
+        void SaveGroups();
+        void RemoveGroup(uint8_t id);
+        uint8_t GetGroupIDByHash(const std::string& keyhash);
+        void BeginServerLog();
+        void AppendServerLog(const std::string& s);
+        void CloseServerLog();
+        void DecayCooldown(NetworkPlayer* player);
+        void AddClient(std::unique_ptr<ITcpSocket>&& socket);
+        std::string GetMasterServerUrl();
+        std::string GenerateAdvertiseKey();
+        void SetupDefaultGroups();
+        void RemovePlayer(std::unique_ptr<NetworkConnection>& connection);
+        void UpdateServer();
+        void ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection);
+        bool SaveMap(OpenRCT2::IStream* stream, const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
+        std::vector<uint8_t> SaveForNetwork(const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
+        std::string MakePlayerNameUnique(const std::string& name);
+
+        // Packet dispatchers.
+        void ServerSendAuth(NetworkConnection& connection);
+        void ServerSendToken(NetworkConnection& connection);
+        void ServerSendMap(NetworkConnection* connection = nullptr);
+        void ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
+        void ServerSendGameAction(const OpenRCT2::GameActions::GameAction* action);
+        void ServerSendTick();
+        void ServerSendPlayerInfo(int32_t playerId);
+        void ServerSendPlayerList();
+        void ServerSendPing();
+        void ServerSendPingList();
+        void ServerSendSetDisconnectMsg(NetworkConnection& connection, const char* msg);
+        void ServerSendGameInfo(NetworkConnection& connection);
+        void ServerSendShowError(NetworkConnection& connection, StringId title, StringId message);
+        void ServerSendGroupList(NetworkConnection& connection);
+        void ServerSendEventPlayerJoined(const char* playerName);
+        void ServerSendEventPlayerDisconnected(const char* playerName, const char* reason);
+        void ServerSendObjectsList(
+            NetworkConnection& connection, const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
+        void ServerSendScripts(NetworkConnection& connection);
+
+        // Handlers
+        void ServerHandleRequestGamestate(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleHeartbeat(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleAuth(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerClientJoined(std::string_view name, const std::string& keyhash, NetworkConnection& connection);
+        void ServerHandleChat(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleGameAction(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandlePing(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleGameInfo(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleToken(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleMapRequest(NetworkConnection& connection, NetworkPacket& packet);
+
+    public: // Client
+        void Reconnect();
+        int32_t GetMode() const noexcept;
+        NetworkAuth GetAuthStatus();
+        int32_t GetStatus() const noexcept;
+        uint8_t GetPlayerID() const noexcept;
+        void ProcessPlayerInfo();
+        void ProcessDisconnectedClients();
+        static const char* FormatChat(NetworkPlayer* fromplayer, const char* text);
+        void SendPacketToClients(const NetworkPacket& packet, bool front = false, bool gameCmd = false) const;
+        bool CheckSRAND(uint32_t tick, uint32_t srand0);
+        bool CheckDesynchronizaton();
+        void RequestStateSnapshot();
+        bool IsDesynchronised() const noexcept;
+        NetworkServerState GetServerState() const noexcept;
+        void ServerClientDisconnected();
+        bool LoadMap(OpenRCT2::IStream* stream);
+        void UpdateClient();
+
+        // Packet dispatchers.
+        void Client_Send_RequestGameState(uint32_t tick);
+        void Client_Send_TOKEN();
+        void Client_Send_AUTH(
+            const std::string& name, const std::string& password, const std::string& pubkey,
+            const std::vector<uint8_t>& signature);
+        void Client_Send_CHAT(const char* text);
+        void Client_Send_GAME_ACTION(const OpenRCT2::GameActions::GameAction* action);
+        void Client_Send_PING();
+        void Client_Send_GAMEINFO();
+        void Client_Send_MAPREQUEST(const std::vector<OpenRCT2::ObjectEntryDescriptor>& objects);
+        void Client_Send_HEARTBEAT(NetworkConnection& connection) const;
+
+        // Handlers.
+        void Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_MAP(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_CHAT(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_GAME_ACTION(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_TICK(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_PLAYERINFO(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_PLAYERLIST(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_PING(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_PINGLIST(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_SETDISCONNECTMSG(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_GAMEINFO(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_SHOWERROR(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_GROUPLIST(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_EVENT(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_OBJECTS_LIST(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_SCRIPTS_HEADER(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_SCRIPTS_DATA(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet);
+
+        std::vector<uint8_t> _challenge;
+        std::map<uint32_t, OpenRCT2::GameActions::GameAction::Callback_t> _gameActionCallbacks;
+        NetworkKey _key;
+        NetworkUserManager _userManager;
+
+    public: // Public common
+        std::string ServerName;
+        std::string ServerDescription;
+        std::string ServerGreeting;
+        std::string ServerProviderName;
+        std::string ServerProviderEmail;
+        std::string ServerProviderWebsite;
+        std::vector<std::unique_ptr<NetworkPlayer>> player_list;
+        std::vector<std::unique_ptr<NetworkGroup>> group_list;
+        bool IsServerPlayerInvisible = false;
+
+    private: // Common Data
+        using CommandHandler = void (NetworkBase::*)(NetworkConnection& connection, NetworkPacket& packet);
+
+        std::vector<uint8_t> chunk_buffer;
+        std::ofstream _chat_log_fs;
+        uint32_t _lastUpdateTime = 0;
+        uint32_t _currentDeltaTime = 0;
+        int32_t mode = NETWORK_MODE_NONE;
+        uint8_t default_group = 0;
+        bool _closeLock = false;
+        bool _requireClose = false;
+
+    private: // Server Data
+        std::unordered_map<NetworkCommand, CommandHandler> server_command_handlers;
+        std::unique_ptr<ITcpSocket> _listenSocket;
+        std::unique_ptr<INetworkServerAdvertiser> _advertiser;
+        std::list<std::unique_ptr<NetworkConnection>> client_connection_list;
+        std::string _serverLogPath;
+        std::string _serverLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
+        std::ofstream _server_log_fs;
+        uint16_t listening_port = 0;
+        bool _playerListInvalidated = false;
+
+    private: // Client Data
+        struct PlayerListUpdate
+        {
+            std::vector<NetworkPlayer> players;
+        };
+
+        struct ServerTickData
+        {
+            uint32_t srand0;
+            uint32_t tick;
+            std::string spriteHash;
+        };
+
+        struct ServerScriptsData
+        {
+            uint32_t pluginCount{};
+            uint32_t dataSize{};
+            OpenRCT2::MemoryStream data;
+        };
+
+        std::unordered_map<NetworkCommand, CommandHandler> client_command_handlers;
+        std::unique_ptr<NetworkConnection> _serverConnection;
+        std::map<uint32_t, PlayerListUpdate> _pendingPlayerLists;
+        std::multimap<uint32_t, NetworkPlayer> _pendingPlayerInfo;
+        std::map<uint32_t, ServerTickData> _serverTickData;
+        std::vector<OpenRCT2::ObjectEntryDescriptor> _missingObjects;
+        std::string _host;
+        std::string _chatLogPath;
+        std::string _chatLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
+        std::string _password;
+        OpenRCT2::MemoryStream _serverGameState;
+        NetworkServerState _serverState;
+        uint32_t _lastSentHeartbeat = 0;
+        uint32_t last_ping_sent_time = 0;
+        uint32_t server_connect_time = 0;
+        uint32_t _actionId;
+        int32_t status = NETWORK_STATUS_NONE;
+        uint8_t player_id = 0;
+        uint16_t _port = 0;
+        SocketStatus _lastConnectStatus = SocketStatus::Closed;
+        bool _requireReconnect = false;
+        bool _clientMapLoaded = false;
+        ServerScriptsData _serverScriptsData{};
+    };
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -24,10 +24,10 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Network
 {
-    class NetworkBase : public OpenRCT2::System
+    class NetworkBase : public System
     {
     public:
-        NetworkBase(OpenRCT2::IContext& context);
+        NetworkBase(IContext& context);
 
     public: // Uncategorized
         bool BeginServer(uint16_t port, const std::string& address);
@@ -82,8 +82,8 @@ namespace OpenRCT2::Network
         void RemovePlayer(std::unique_ptr<NetworkConnection>& connection);
         void UpdateServer();
         void ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection);
-        bool SaveMap(OpenRCT2::IStream* stream, const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
-        std::vector<uint8_t> SaveForNetwork(const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
+        bool SaveMap(IStream* stream, const std::vector<const ObjectRepositoryItem*>& objects) const;
+        std::vector<uint8_t> SaveForNetwork(const std::vector<const ObjectRepositoryItem*>& objects) const;
         std::string MakePlayerNameUnique(const std::string& name);
 
         // Packet dispatchers.
@@ -91,7 +91,7 @@ namespace OpenRCT2::Network
         void ServerSendToken(NetworkConnection& connection);
         void ServerSendMap(NetworkConnection* connection = nullptr);
         void ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
-        void ServerSendGameAction(const OpenRCT2::GameActions::GameAction* action);
+        void ServerSendGameAction(const GameActions::GameAction* action);
         void ServerSendTick();
         void ServerSendPlayerInfo(int32_t playerId);
         void ServerSendPlayerList();
@@ -104,7 +104,7 @@ namespace OpenRCT2::Network
         void ServerSendEventPlayerJoined(const char* playerName);
         void ServerSendEventPlayerDisconnected(const char* playerName, const char* reason);
         void ServerSendObjectsList(
-            NetworkConnection& connection, const std::vector<const OpenRCT2::ObjectRepositoryItem*>& objects) const;
+            NetworkConnection& connection, const std::vector<const ObjectRepositoryItem*>& objects) const;
         void ServerSendScripts(NetworkConnection& connection);
 
         // Handlers
@@ -135,7 +135,7 @@ namespace OpenRCT2::Network
         bool IsDesynchronised() const noexcept;
         NetworkServerState GetServerState() const noexcept;
         void ServerClientDisconnected();
-        bool LoadMap(OpenRCT2::IStream* stream);
+        bool LoadMap(IStream* stream);
         void UpdateClient();
 
         // Packet dispatchers.
@@ -145,10 +145,10 @@ namespace OpenRCT2::Network
             const std::string& name, const std::string& password, const std::string& pubkey,
             const std::vector<uint8_t>& signature);
         void Client_Send_CHAT(const char* text);
-        void Client_Send_GAME_ACTION(const OpenRCT2::GameActions::GameAction* action);
+        void Client_Send_GAME_ACTION(const GameActions::GameAction* action);
         void Client_Send_PING();
         void Client_Send_GAMEINFO();
-        void Client_Send_MAPREQUEST(const std::vector<OpenRCT2::ObjectEntryDescriptor>& objects);
+        void Client_Send_MAPREQUEST(const std::vector<ObjectEntryDescriptor>& objects);
         void Client_Send_HEARTBEAT(NetworkConnection& connection) const;
 
         // Handlers.
@@ -173,7 +173,7 @@ namespace OpenRCT2::Network
         void Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet);
 
         std::vector<uint8_t> _challenge;
-        std::map<uint32_t, OpenRCT2::GameActions::GameAction::Callback_t> _gameActionCallbacks;
+        std::map<uint32_t, GameActions::GameAction::Callback_t> _gameActionCallbacks;
         NetworkKey _key;
         NetworkUserManager _userManager;
 
@@ -228,7 +228,7 @@ namespace OpenRCT2::Network
         {
             uint32_t pluginCount{};
             uint32_t dataSize{};
-            OpenRCT2::MemoryStream data;
+            MemoryStream data;
         };
 
         std::unordered_map<NetworkCommand, CommandHandler> client_command_handlers;
@@ -236,12 +236,12 @@ namespace OpenRCT2::Network
         std::map<uint32_t, PlayerListUpdate> _pendingPlayerLists;
         std::multimap<uint32_t, NetworkPlayer> _pendingPlayerInfo;
         std::map<uint32_t, ServerTickData> _serverTickData;
-        std::vector<OpenRCT2::ObjectEntryDescriptor> _missingObjects;
+        std::vector<ObjectEntryDescriptor> _missingObjects;
         std::string _host;
         std::string _chatLogPath;
         std::string _chatLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
         std::string _password;
-        OpenRCT2::MemoryStream _serverGameState;
+        MemoryStream _serverGameState;
         NetworkServerState _serverState;
         uint32_t _lastSentHeartbeat = 0;
         uint32_t last_ping_sent_time = 0;

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -44,7 +44,7 @@ namespace OpenRCT2::Network
         void ProcessPlayerList();
         auto GetPlayerIteratorByID(uint8_t id) const;
         auto GetGroupIteratorByID(uint8_t id) const;
-        NetworkPlayer* GetPlayerByID(uint8_t id) const;
+        Player* GetPlayerByID(uint8_t id) const;
         NetworkGroup* GetGroupByID(uint8_t id) const;
         int32_t GetTotalNumPlayers() const noexcept;
         int32_t GetNumVisiblePlayers() const noexcept;
@@ -55,11 +55,11 @@ namespace OpenRCT2::Network
         void BeginChatLog();
         void AppendChatLog(std::string_view s);
         void CloseChatLog();
-        NetworkStats GetStats() const;
+        Stats GetStats() const;
         json_t GetServerInfoAsJson() const;
         bool ProcessConnection(NetworkConnection& connection);
         void CloseConnection();
-        NetworkPlayer* AddPlayer(const std::string& name, const std::string& keyhash);
+        Player* AddPlayer(const std::string& name, const std::string& keyhash);
         void ProcessPacket(NetworkConnection& connection, NetworkPacket& packet);
 
     public: // Server
@@ -74,7 +74,7 @@ namespace OpenRCT2::Network
         void BeginServerLog();
         void AppendServerLog(const std::string& s);
         void CloseServerLog();
-        void DecayCooldown(NetworkPlayer* player);
+        void DecayCooldown(Player* player);
         void AddClient(std::unique_ptr<ITcpSocket>&& socket);
         std::string GetMasterServerUrl();
         std::string GenerateAdvertiseKey();
@@ -121,19 +121,19 @@ namespace OpenRCT2::Network
 
     public: // Client
         void Reconnect();
-        int32_t GetMode() const noexcept;
-        NetworkAuth GetAuthStatus();
-        int32_t GetStatus() const noexcept;
-        uint8_t GetPlayerID() const noexcept;
+        Mode GetMode() const noexcept;
+        Auth GetAuthStatus();
+        Status GetStatus() const noexcept;
+        PlayerId_t GetPlayerID() const noexcept;
         void ProcessPlayerInfo();
         void ProcessDisconnectedClients();
-        static const char* FormatChat(NetworkPlayer* fromplayer, const char* text);
+        static const char* FormatChat(Player* fromplayer, const char* text);
         void SendPacketToClients(const NetworkPacket& packet, bool front = false, bool gameCmd = false) const;
         bool CheckSRAND(uint32_t tick, uint32_t srand0);
         bool CheckDesynchronizaton();
         void RequestStateSnapshot();
         bool IsDesynchronised() const noexcept;
-        NetworkServerState GetServerState() const noexcept;
+        ServerState GetServerState() const noexcept;
         void ServerClientDisconnected();
         bool LoadMap(IStream* stream);
         void UpdateClient();
@@ -184,7 +184,7 @@ namespace OpenRCT2::Network
         std::string ServerProviderName;
         std::string ServerProviderEmail;
         std::string ServerProviderWebsite;
-        std::vector<std::unique_ptr<NetworkPlayer>> player_list;
+        std::vector<std::unique_ptr<Player>> player_list;
         std::vector<std::unique_ptr<NetworkGroup>> group_list;
         bool IsServerPlayerInvisible = false;
 
@@ -195,13 +195,13 @@ namespace OpenRCT2::Network
         std::ofstream _chat_log_fs;
         uint32_t _lastUpdateTime = 0;
         uint32_t _currentDeltaTime = 0;
-        int32_t mode = NETWORK_MODE_NONE;
+        Mode mode = Network::Mode::none;
         uint8_t default_group = 0;
         bool _closeLock = false;
         bool _requireClose = false;
 
     private: // Server Data
-        std::unordered_map<NetworkCommand, CommandHandler> server_command_handlers;
+        std::unordered_map<Command, CommandHandler> server_command_handlers;
         std::unique_ptr<ITcpSocket> _listenSocket;
         std::unique_ptr<INetworkServerAdvertiser> _advertiser;
         std::list<std::unique_ptr<NetworkConnection>> client_connection_list;
@@ -214,7 +214,7 @@ namespace OpenRCT2::Network
     private: // Client Data
         struct PlayerListUpdate
         {
-            std::vector<NetworkPlayer> players;
+            std::vector<Player> players;
         };
 
         struct ServerTickData
@@ -231,10 +231,10 @@ namespace OpenRCT2::Network
             MemoryStream data;
         };
 
-        std::unordered_map<NetworkCommand, CommandHandler> client_command_handlers;
+        std::unordered_map<Command, CommandHandler> client_command_handlers;
         std::unique_ptr<NetworkConnection> _serverConnection;
         std::map<uint32_t, PlayerListUpdate> _pendingPlayerLists;
-        std::multimap<uint32_t, NetworkPlayer> _pendingPlayerInfo;
+        std::multimap<uint32_t, Player> _pendingPlayerInfo;
         std::map<uint32_t, ServerTickData> _serverTickData;
         std::vector<ObjectEntryDescriptor> _missingObjects;
         std::string _host;
@@ -242,15 +242,15 @@ namespace OpenRCT2::Network
         std::string _chatLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
         std::string _password;
         MemoryStream _serverGameState;
-        NetworkServerState _serverState;
+        ServerState _serverState;
         uint32_t _lastSentHeartbeat = 0;
         uint32_t last_ping_sent_time = 0;
         uint32_t server_connect_time = 0;
         uint32_t _actionId;
-        int32_t status = NETWORK_STATUS_NONE;
+        Status status = Network::Status::none;
         uint8_t player_id = 0;
         uint16_t _port = 0;
-        SocketStatus _lastConnectStatus = SocketStatus::Closed;
+        SocketStatus _lastConnectStatus = SocketStatus::closed;
         bool _requireReconnect = false;
         bool _clientMapLoaded = false;
         ServerScriptsData _serverScriptsData{};

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -57,13 +57,13 @@ namespace OpenRCT2::Network
         void CloseChatLog();
         Stats GetStats() const;
         json_t GetServerInfoAsJson() const;
-        bool ProcessConnection(NetworkConnection& connection);
+        bool ProcessConnection(Connection& connection);
         void CloseConnection();
         Player* AddPlayer(const std::string& name, const std::string& keyhash);
-        void ProcessPacket(NetworkConnection& connection, NetworkPacket& packet);
+        void ProcessPacket(Connection& connection, Packet& packet);
 
     public: // Server
-        NetworkConnection* GetPlayerConnection(uint8_t id) const;
+        Connection* GetPlayerConnection(uint8_t id) const;
         void KickPlayer(int32_t playerId);
         NetworkGroup* AddGroup();
         void LoadGroups();
@@ -79,17 +79,17 @@ namespace OpenRCT2::Network
         std::string GetMasterServerUrl();
         std::string GenerateAdvertiseKey();
         void SetupDefaultGroups();
-        void RemovePlayer(std::unique_ptr<NetworkConnection>& connection);
+        void RemovePlayer(std::unique_ptr<Connection>& connection);
         void UpdateServer();
-        void ServerClientDisconnected(std::unique_ptr<NetworkConnection>& connection);
+        void ServerClientDisconnected(std::unique_ptr<Connection>& connection);
         bool SaveMap(IStream* stream, const std::vector<const ObjectRepositoryItem*>& objects) const;
         std::vector<uint8_t> SaveForNetwork(const std::vector<const ObjectRepositoryItem*>& objects) const;
         std::string MakePlayerNameUnique(const std::string& name);
 
         // Packet dispatchers.
-        void ServerSendAuth(NetworkConnection& connection);
-        void ServerSendToken(NetworkConnection& connection);
-        void ServerSendMap(NetworkConnection* connection = nullptr);
+        void ServerSendAuth(Connection& connection);
+        void ServerSendToken(Connection& connection);
+        void ServerSendMap(Connection* connection = nullptr);
         void ServerSendChat(const char* text, const std::vector<uint8_t>& playerIds = {});
         void ServerSendGameAction(const GameActions::GameAction* action);
         void ServerSendTick();
@@ -97,27 +97,26 @@ namespace OpenRCT2::Network
         void ServerSendPlayerList();
         void ServerSendPing();
         void ServerSendPingList();
-        void ServerSendSetDisconnectMsg(NetworkConnection& connection, const char* msg);
-        void ServerSendGameInfo(NetworkConnection& connection);
-        void ServerSendShowError(NetworkConnection& connection, StringId title, StringId message);
-        void ServerSendGroupList(NetworkConnection& connection);
+        void ServerSendSetDisconnectMsg(Connection& connection, const char* msg);
+        void ServerSendGameInfo(Connection& connection);
+        void ServerSendShowError(Connection& connection, StringId title, StringId message);
+        void ServerSendGroupList(Connection& connection);
         void ServerSendEventPlayerJoined(const char* playerName);
         void ServerSendEventPlayerDisconnected(const char* playerName, const char* reason);
-        void ServerSendObjectsList(
-            NetworkConnection& connection, const std::vector<const ObjectRepositoryItem*>& objects) const;
-        void ServerSendScripts(NetworkConnection& connection);
+        void ServerSendObjectsList(Connection& connection, const std::vector<const ObjectRepositoryItem*>& objects) const;
+        void ServerSendScripts(Connection& connection);
 
         // Handlers
-        void ServerHandleRequestGamestate(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandleHeartbeat(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandleAuth(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerClientJoined(std::string_view name, const std::string& keyhash, NetworkConnection& connection);
-        void ServerHandleChat(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandleGameAction(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandlePing(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandleGameInfo(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandleToken(NetworkConnection& connection, NetworkPacket& packet);
-        void ServerHandleMapRequest(NetworkConnection& connection, NetworkPacket& packet);
+        void ServerHandleRequestGamestate(Connection& connection, Packet& packet);
+        void ServerHandleHeartbeat(Connection& connection, Packet& packet);
+        void ServerHandleAuth(Connection& connection, Packet& packet);
+        void ServerClientJoined(std::string_view name, const std::string& keyhash, Connection& connection);
+        void ServerHandleChat(Connection& connection, Packet& packet);
+        void ServerHandleGameAction(Connection& connection, Packet& packet);
+        void ServerHandlePing(Connection& connection, Packet& packet);
+        void ServerHandleGameInfo(Connection& connection, Packet& packet);
+        void ServerHandleToken(Connection& connection, Packet& packet);
+        void ServerHandleMapRequest(Connection& connection, Packet& packet);
 
     public: // Client
         void Reconnect();
@@ -128,7 +127,7 @@ namespace OpenRCT2::Network
         void ProcessPlayerInfo();
         void ProcessDisconnectedClients();
         static const char* FormatChat(Player* fromplayer, const char* text);
-        void SendPacketToClients(const NetworkPacket& packet, bool front = false, bool gameCmd = false) const;
+        void SendPacketToClients(const Packet& packet, bool front = false, bool gameCmd = false) const;
         bool CheckSRAND(uint32_t tick, uint32_t srand0);
         bool CheckDesynchronizaton();
         void RequestStateSnapshot();
@@ -149,33 +148,33 @@ namespace OpenRCT2::Network
         void Client_Send_PING();
         void Client_Send_GAMEINFO();
         void Client_Send_MAPREQUEST(const std::vector<ObjectEntryDescriptor>& objects);
-        void Client_Send_HEARTBEAT(NetworkConnection& connection) const;
+        void Client_Send_HEARTBEAT(Connection& connection) const;
 
         // Handlers.
-        void Client_Handle_AUTH(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_MAP(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_CHAT(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_GAME_ACTION(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_TICK(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_PLAYERINFO(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_PLAYERLIST(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_PING(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_PINGLIST(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_SETDISCONNECTMSG(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_GAMEINFO(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_SHOWERROR(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_GROUPLIST(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_EVENT(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_TOKEN(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_OBJECTS_LIST(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_SCRIPTS_HEADER(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_SCRIPTS_DATA(NetworkConnection& connection, NetworkPacket& packet);
-        void Client_Handle_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet);
+        void Client_Handle_AUTH(Connection& connection, Packet& packet);
+        void Client_Handle_MAP(Connection& connection, Packet& packet);
+        void Client_Handle_CHAT(Connection& connection, Packet& packet);
+        void Client_Handle_GAME_ACTION(Connection& connection, Packet& packet);
+        void Client_Handle_TICK(Connection& connection, Packet& packet);
+        void Client_Handle_PLAYERINFO(Connection& connection, Packet& packet);
+        void Client_Handle_PLAYERLIST(Connection& connection, Packet& packet);
+        void Client_Handle_PING(Connection& connection, Packet& packet);
+        void Client_Handle_PINGLIST(Connection& connection, Packet& packet);
+        void Client_Handle_SETDISCONNECTMSG(Connection& connection, Packet& packet);
+        void Client_Handle_GAMEINFO(Connection& connection, Packet& packet);
+        void Client_Handle_SHOWERROR(Connection& connection, Packet& packet);
+        void Client_Handle_GROUPLIST(Connection& connection, Packet& packet);
+        void Client_Handle_EVENT(Connection& connection, Packet& packet);
+        void Client_Handle_TOKEN(Connection& connection, Packet& packet);
+        void Client_Handle_OBJECTS_LIST(Connection& connection, Packet& packet);
+        void Client_Handle_SCRIPTS_HEADER(Connection& connection, Packet& packet);
+        void Client_Handle_SCRIPTS_DATA(Connection& connection, Packet& packet);
+        void Client_Handle_GAMESTATE(Connection& connection, Packet& packet);
 
         std::vector<uint8_t> _challenge;
         std::map<uint32_t, GameActions::GameAction::Callback_t> _gameActionCallbacks;
-        NetworkKey _key;
-        NetworkUserManager _userManager;
+        Key _key;
+        UserManager _userManager;
 
     public: // Public common
         std::string ServerName;
@@ -189,7 +188,7 @@ namespace OpenRCT2::Network
         bool IsServerPlayerInvisible = false;
 
     private: // Common Data
-        using CommandHandler = void (NetworkBase::*)(NetworkConnection& connection, NetworkPacket& packet);
+        using CommandHandler = void (NetworkBase::*)(Connection& connection, Packet& packet);
 
         std::vector<uint8_t> chunk_buffer;
         std::ofstream _chat_log_fs;
@@ -204,7 +203,7 @@ namespace OpenRCT2::Network
         std::unordered_map<Command, CommandHandler> server_command_handlers;
         std::unique_ptr<ITcpSocket> _listenSocket;
         std::unique_ptr<INetworkServerAdvertiser> _advertiser;
-        std::list<std::unique_ptr<NetworkConnection>> client_connection_list;
+        std::list<std::unique_ptr<Connection>> client_connection_list;
         std::string _serverLogPath;
         std::string _serverLogFilenameFormat = "%Y%m%d-%H%M%S.txt";
         std::ofstream _server_log_fs;
@@ -232,7 +231,7 @@ namespace OpenRCT2::Network
         };
 
         std::unordered_map<Command, CommandHandler> client_command_handlers;
-        std::unique_ptr<NetworkConnection> _serverConnection;
+        std::unique_ptr<Connection> _serverConnection;
         std::map<uint32_t, PlayerListUpdate> _pendingPlayerLists;
         std::multimap<uint32_t, Player> _pendingPlayerInfo;
         std::map<uint32_t, ServerTickData> _serverTickData;

--- a/src/openrct2/network/NetworkClient.h
+++ b/src/openrct2/network/NetworkClient.h
@@ -4,9 +4,12 @@
 
 #ifndef DISABLE_NETWORK
 
-class NetworkClient final : public NetworkBase
+namespace OpenRCT2::Network
 {
-public:
-};
+    class NetworkClient final : public NetworkBase
+    {
+    public:
+    };
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -21,13 +21,13 @@
 
 namespace OpenRCT2::Network
 {
-    static constexpr size_t kNetworkDisconnectReasonBufSize = 256;
-    static constexpr size_t kNetworkBufferSize = (1024 * 64) - 1; // 64 KiB, maximum packet size.
+    static constexpr size_t kDisconnectReasonBufSize = 256;
+    static constexpr size_t kBufferSize = (1024 * 64) - 1; // 64 KiB, maximum packet size.
     #ifndef DEBUG
-    static constexpr size_t kNetworkNoDataTimeout = 20; // Seconds.
+    static constexpr size_t kNoDataTimeout = 20; // Seconds.
     #endif
 
-    static_assert(kNetworkBufferSize <= std::numeric_limits<uint16_t>::max(), "kNetworkBufferSize too big, uint16_t is max.");
+    static_assert(kBufferSize <= std::numeric_limits<uint16_t>::max(), "kBufferSize too big, uint16_t is max.");
 
     NetworkConnection::NetworkConnection() noexcept
     {
@@ -75,11 +75,11 @@ namespace OpenRCT2::Network
             // NOTE: BytesTransfered includes the header length, this will not underflow.
             const size_t missingLength = header.Size - (InboundPacket.BytesTransferred - sizeof(header));
 
-            uint8_t buffer[kNetworkBufferSize];
+            uint8_t buffer[kBufferSize];
 
             if (missingLength > 0)
             {
-                NetworkReadPacket status = Socket->ReceiveData(buffer, std::min(missingLength, kNetworkBufferSize), &bytesRead);
+                NetworkReadPacket status = Socket->ReceiveData(buffer, std::min(missingLength, kBufferSize), &bytesRead);
                 if (status != NetworkReadPacket::success)
                 {
                     return status;
@@ -176,7 +176,7 @@ namespace OpenRCT2::Network
     bool NetworkConnection::ReceivedPacketRecently() const noexcept
     {
     #ifndef DEBUG
-        constexpr auto kTimeoutMs = kNetworkNoDataTimeout * 1000;
+        constexpr auto kTimeoutMs = kNoDataTimeout * 1000;
         if (Platform::GetTicks() > _lastPacketTime + kTimeoutMs)
         {
             return false;
@@ -197,8 +197,8 @@ namespace OpenRCT2::Network
 
     void NetworkConnection::SetLastDisconnectReason(const StringId string_id, void* args)
     {
-        char buffer[kNetworkDisconnectReasonBufSize];
-        FormatStringLegacy(buffer, kNetworkDisconnectReasonBufSize, string_id, args);
+        char buffer[kDisconnectReasonBufSize];
+        FormatStringLegacy(buffer, kDisconnectReasonBufSize, string_id, args);
         SetLastDisconnectReason(buffer);
     }
 

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -198,7 +198,7 @@ namespace OpenRCT2::Network
     void NetworkConnection::SetLastDisconnectReason(const StringId string_id, void* args)
     {
         char buffer[kNetworkDisconnectReasonBufSize];
-        OpenRCT2::FormatStringLegacy(buffer, kNetworkDisconnectReasonBufSize, string_id, args);
+        FormatStringLegacy(buffer, kNetworkDisconnectReasonBufSize, string_id, args);
         SetLastDisconnectReason(buffer);
     }
 

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -19,217 +19,218 @@
 
     #include <sfl/small_vector.hpp>
 
-using namespace OpenRCT2;
-
-static constexpr size_t kNetworkDisconnectReasonBufSize = 256;
-static constexpr size_t kNetworkBufferSize = (1024 * 64) - 1; // 64 KiB, maximum packet size.
+namespace OpenRCT2::Network
+{
+    static constexpr size_t kNetworkDisconnectReasonBufSize = 256;
+    static constexpr size_t kNetworkBufferSize = (1024 * 64) - 1; // 64 KiB, maximum packet size.
     #ifndef DEBUG
-static constexpr size_t kNetworkNoDataTimeout = 20; // Seconds.
+    static constexpr size_t kNetworkNoDataTimeout = 20; // Seconds.
     #endif
 
-static_assert(kNetworkBufferSize <= std::numeric_limits<uint16_t>::max(), "kNetworkBufferSize too big, uint16_t is max.");
+    static_assert(kNetworkBufferSize <= std::numeric_limits<uint16_t>::max(), "kNetworkBufferSize too big, uint16_t is max.");
 
-NetworkConnection::NetworkConnection() noexcept
-{
-    ResetLastPacketTime();
-}
-
-NetworkReadPacket NetworkConnection::ReadPacket()
-{
-    size_t bytesRead = 0;
-
-    // Read packet header.
-    auto& header = InboundPacket.Header;
-    if (InboundPacket.BytesTransferred < sizeof(InboundPacket.Header))
+    NetworkConnection::NetworkConnection() noexcept
     {
-        const size_t missingLength = sizeof(header) - InboundPacket.BytesTransferred;
-
-        uint8_t* buffer = reinterpret_cast<uint8_t*>(&InboundPacket.Header);
-
-        NetworkReadPacket status = Socket->ReceiveData(buffer, missingLength, &bytesRead);
-        if (status != NetworkReadPacket::Success)
-        {
-            return status;
-        }
-
-        InboundPacket.BytesTransferred += bytesRead;
-        if (InboundPacket.BytesTransferred < sizeof(InboundPacket.Header))
-        {
-            // If still not enough data for header, keep waiting.
-            return NetworkReadPacket::MoreData;
-        }
-
-        // Normalise values.
-        header.Size = Convert::NetworkToHost(header.Size);
-        header.Id = ByteSwapBE(header.Id);
-
-        // NOTE: For compatibility reasons for the master server we need to remove sizeof(Header.Id) from the size.
-        // Previously the Id field was not part of the header rather part of the body.
-        header.Size -= std::min<uint16_t>(header.Size, sizeof(header.Id));
-
-        // Fall-through: Read rest of packet.
+        ResetLastPacketTime();
     }
 
-    // Read packet body.
+    NetworkReadPacket NetworkConnection::ReadPacket()
     {
-        // NOTE: BytesTransfered includes the header length, this will not underflow.
-        const size_t missingLength = header.Size - (InboundPacket.BytesTransferred - sizeof(header));
+        size_t bytesRead = 0;
 
-        uint8_t buffer[kNetworkBufferSize];
-
-        if (missingLength > 0)
+        // Read packet header.
+        auto& header = InboundPacket.Header;
+        if (InboundPacket.BytesTransferred < sizeof(InboundPacket.Header))
         {
-            NetworkReadPacket status = Socket->ReceiveData(buffer, std::min(missingLength, kNetworkBufferSize), &bytesRead);
+            const size_t missingLength = sizeof(header) - InboundPacket.BytesTransferred;
+
+            uint8_t* buffer = reinterpret_cast<uint8_t*>(&InboundPacket.Header);
+
+            NetworkReadPacket status = Socket->ReceiveData(buffer, missingLength, &bytesRead);
             if (status != NetworkReadPacket::Success)
             {
                 return status;
             }
 
             InboundPacket.BytesTransferred += bytesRead;
-            InboundPacket.Write(buffer, bytesRead);
+            if (InboundPacket.BytesTransferred < sizeof(InboundPacket.Header))
+            {
+                // If still not enough data for header, keep waiting.
+                return NetworkReadPacket::MoreData;
+            }
+
+            // Normalise values.
+            header.Size = Convert::NetworkToHost(header.Size);
+            header.Id = ByteSwapBE(header.Id);
+
+            // NOTE: For compatibility reasons for the master server we need to remove sizeof(Header.Id) from the size.
+            // Previously the Id field was not part of the header rather part of the body.
+            header.Size -= std::min<uint16_t>(header.Size, sizeof(header.Id));
+
+            // Fall-through: Read rest of packet.
         }
 
-        if (InboundPacket.Data.size() == header.Size)
+        // Read packet body.
         {
-            // Received complete packet.
-            _lastPacketTime = Platform::GetTicks();
+            // NOTE: BytesTransfered includes the header length, this will not underflow.
+            const size_t missingLength = header.Size - (InboundPacket.BytesTransferred - sizeof(header));
 
-            RecordPacketStats(InboundPacket, false);
+            uint8_t buffer[kNetworkBufferSize];
 
-            return NetworkReadPacket::Success;
+            if (missingLength > 0)
+            {
+                NetworkReadPacket status = Socket->ReceiveData(buffer, std::min(missingLength, kNetworkBufferSize), &bytesRead);
+                if (status != NetworkReadPacket::Success)
+                {
+                    return status;
+                }
+
+                InboundPacket.BytesTransferred += bytesRead;
+                InboundPacket.Write(buffer, bytesRead);
+            }
+
+            if (InboundPacket.Data.size() == header.Size)
+            {
+                // Received complete packet.
+                _lastPacketTime = Platform::GetTicks();
+
+                RecordPacketStats(InboundPacket, false);
+
+                return NetworkReadPacket::Success;
+            }
+        }
+
+        return NetworkReadPacket::MoreData;
+    }
+
+    static sfl::small_vector<uint8_t, 512> serializePacket(const NetworkPacket& packet)
+    {
+        // NOTE: For compatibility reasons for the master server we need to add sizeof(Header.Id) to the size.
+        // Previously the Id field was not part of the header rather part of the body.
+        const auto bodyLength = packet.Data.size() + sizeof(packet.Header.Id);
+
+        Guard::Assert(bodyLength <= std::numeric_limits<uint16_t>::max(), "Packet size too large");
+
+        auto header = packet.Header;
+        header.Size = static_cast<uint16_t>(bodyLength);
+        header.Size = Convert::HostToNetwork(header.Size);
+        header.Id = ByteSwapBE(header.Id);
+
+        sfl::small_vector<uint8_t, 512> buffer;
+        buffer.reserve(sizeof(header) + packet.Data.size());
+
+        buffer.insert(buffer.end(), reinterpret_cast<uint8_t*>(&header), reinterpret_cast<uint8_t*>(&header) + sizeof(header));
+        buffer.insert(buffer.end(), packet.Data.begin(), packet.Data.end());
+
+        return buffer;
+    }
+
+    void NetworkConnection::QueuePacket(const NetworkPacket& packet, bool front)
+    {
+        if (AuthStatus == NetworkAuth::Ok || !packet.CommandRequiresAuth())
+        {
+            const auto payload = serializePacket(packet);
+            if (front)
+            {
+                _outboundBuffer.insert(_outboundBuffer.begin(), payload.begin(), payload.end());
+            }
+            else
+            {
+                _outboundBuffer.insert(_outboundBuffer.end(), payload.begin(), payload.end());
+            }
+
+            RecordPacketStats(packet, true);
         }
     }
 
-    return NetworkReadPacket::MoreData;
-}
-
-static sfl::small_vector<uint8_t, 512> serializePacket(const NetworkPacket& packet)
-{
-    // NOTE: For compatibility reasons for the master server we need to add sizeof(Header.Id) to the size.
-    // Previously the Id field was not part of the header rather part of the body.
-    const auto bodyLength = packet.Data.size() + sizeof(packet.Header.Id);
-
-    Guard::Assert(bodyLength <= std::numeric_limits<uint16_t>::max(), "Packet size too large");
-
-    auto header = packet.Header;
-    header.Size = static_cast<uint16_t>(bodyLength);
-    header.Size = Convert::HostToNetwork(header.Size);
-    header.Id = ByteSwapBE(header.Id);
-
-    sfl::small_vector<uint8_t, 512> buffer;
-    buffer.reserve(sizeof(header) + packet.Data.size());
-
-    buffer.insert(buffer.end(), reinterpret_cast<uint8_t*>(&header), reinterpret_cast<uint8_t*>(&header) + sizeof(header));
-    buffer.insert(buffer.end(), packet.Data.begin(), packet.Data.end());
-
-    return buffer;
-}
-
-void NetworkConnection::QueuePacket(const NetworkPacket& packet, bool front)
-{
-    if (AuthStatus == NetworkAuth::Ok || !packet.CommandRequiresAuth())
+    void NetworkConnection::Disconnect() noexcept
     {
-        const auto payload = serializePacket(packet);
-        if (front)
+        ShouldDisconnect = true;
+    }
+
+    bool NetworkConnection::IsValid() const
+    {
+        return !ShouldDisconnect && Socket->GetStatus() == SocketStatus::Connected;
+    }
+
+    void NetworkConnection::SendQueuedData()
+    {
+        if (_outboundBuffer.empty())
         {
-            _outboundBuffer.insert(_outboundBuffer.begin(), payload.begin(), payload.end());
+            return;
+        }
+
+        const auto bytesSent = Socket->SendData(_outboundBuffer.data(), _outboundBuffer.size());
+
+        if (bytesSent > 0)
+        {
+            _outboundBuffer.erase(_outboundBuffer.begin(), _outboundBuffer.begin() + bytesSent);
+        }
+    }
+
+    void NetworkConnection::ResetLastPacketTime() noexcept
+    {
+        _lastPacketTime = Platform::GetTicks();
+    }
+
+    bool NetworkConnection::ReceivedPacketRecently() const noexcept
+    {
+    #ifndef DEBUG
+        constexpr auto kTimeoutMs = kNetworkNoDataTimeout * 1000;
+        if (Platform::GetTicks() > _lastPacketTime + kTimeoutMs)
+        {
+            return false;
+        }
+    #endif
+        return true;
+    }
+
+    const utf8* NetworkConnection::GetLastDisconnectReason() const noexcept
+    {
+        return this->_lastDisconnectReason.c_str();
+    }
+
+    void NetworkConnection::SetLastDisconnectReason(std::string_view src)
+    {
+        _lastDisconnectReason = src;
+    }
+
+    void NetworkConnection::SetLastDisconnectReason(const StringId string_id, void* args)
+    {
+        char buffer[kNetworkDisconnectReasonBufSize];
+        OpenRCT2::FormatStringLegacy(buffer, kNetworkDisconnectReasonBufSize, string_id, args);
+        SetLastDisconnectReason(buffer);
+    }
+
+    void NetworkConnection::RecordPacketStats(const NetworkPacket& packet, bool sending)
+    {
+        uint32_t packetSize = static_cast<uint32_t>(packet.BytesTransferred);
+        NetworkStatisticsGroup trafficGroup;
+
+        switch (packet.GetCommand())
+        {
+            case NetworkCommand::GameAction:
+                trafficGroup = NetworkStatisticsGroup::Commands;
+                break;
+            case NetworkCommand::Map:
+                trafficGroup = NetworkStatisticsGroup::MapData;
+                break;
+            default:
+                trafficGroup = NetworkStatisticsGroup::Base;
+                break;
+        }
+
+        if (sending)
+        {
+            Stats.bytesSent[EnumValue(trafficGroup)] += packetSize;
+            Stats.bytesSent[EnumValue(NetworkStatisticsGroup::Total)] += packetSize;
         }
         else
         {
-            _outboundBuffer.insert(_outboundBuffer.end(), payload.begin(), payload.end());
+            Stats.bytesReceived[EnumValue(trafficGroup)] += packetSize;
+            Stats.bytesReceived[EnumValue(NetworkStatisticsGroup::Total)] += packetSize;
         }
-
-        RecordPacketStats(packet, true);
     }
-}
-
-void NetworkConnection::Disconnect() noexcept
-{
-    ShouldDisconnect = true;
-}
-
-bool NetworkConnection::IsValid() const
-{
-    return !ShouldDisconnect && Socket->GetStatus() == SocketStatus::Connected;
-}
-
-void NetworkConnection::SendQueuedData()
-{
-    if (_outboundBuffer.empty())
-    {
-        return;
-    }
-
-    const auto bytesSent = Socket->SendData(_outboundBuffer.data(), _outboundBuffer.size());
-
-    if (bytesSent > 0)
-    {
-        _outboundBuffer.erase(_outboundBuffer.begin(), _outboundBuffer.begin() + bytesSent);
-    }
-}
-
-void NetworkConnection::ResetLastPacketTime() noexcept
-{
-    _lastPacketTime = Platform::GetTicks();
-}
-
-bool NetworkConnection::ReceivedPacketRecently() const noexcept
-{
-    #ifndef DEBUG
-    constexpr auto kTimeoutMs = kNetworkNoDataTimeout * 1000;
-    if (Platform::GetTicks() > _lastPacketTime + kTimeoutMs)
-    {
-        return false;
-    }
-    #endif
-    return true;
-}
-
-const utf8* NetworkConnection::GetLastDisconnectReason() const noexcept
-{
-    return this->_lastDisconnectReason.c_str();
-}
-
-void NetworkConnection::SetLastDisconnectReason(std::string_view src)
-{
-    _lastDisconnectReason = src;
-}
-
-void NetworkConnection::SetLastDisconnectReason(const StringId string_id, void* args)
-{
-    char buffer[kNetworkDisconnectReasonBufSize];
-    OpenRCT2::FormatStringLegacy(buffer, kNetworkDisconnectReasonBufSize, string_id, args);
-    SetLastDisconnectReason(buffer);
-}
-
-void NetworkConnection::RecordPacketStats(const NetworkPacket& packet, bool sending)
-{
-    uint32_t packetSize = static_cast<uint32_t>(packet.BytesTransferred);
-    NetworkStatisticsGroup trafficGroup;
-
-    switch (packet.GetCommand())
-    {
-        case NetworkCommand::GameAction:
-            trafficGroup = NetworkStatisticsGroup::Commands;
-            break;
-        case NetworkCommand::Map:
-            trafficGroup = NetworkStatisticsGroup::MapData;
-            break;
-        default:
-            trafficGroup = NetworkStatisticsGroup::Base;
-            break;
-    }
-
-    if (sending)
-    {
-        Stats.bytesSent[EnumValue(trafficGroup)] += packetSize;
-        Stats.bytesSent[EnumValue(NetworkStatisticsGroup::Total)] += packetSize;
-    }
-    else
-    {
-        Stats.bytesReceived[EnumValue(trafficGroup)] += packetSize;
-        Stats.bytesReceived[EnumValue(NetworkStatisticsGroup::Total)] += packetSize;
-    }
-}
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -29,24 +29,24 @@ namespace OpenRCT2::Network
 {
     class Player;
 
-    class NetworkConnection final
+    class Connection final
     {
     public:
         std::unique_ptr<ITcpSocket> Socket = nullptr;
-        NetworkPacket InboundPacket;
+        Packet InboundPacket;
         Auth AuthStatus = Auth::none;
         Stats stats = {};
         Player* player = nullptr;
         uint32_t PingTime = 0;
-        NetworkKey Key;
+        Key key;
         std::vector<uint8_t> Challenge;
         std::vector<const ObjectRepositoryItem*> RequestedObjects;
         bool ShouldDisconnect = false;
 
-        NetworkConnection() noexcept;
+        Connection() noexcept;
 
-        NetworkReadPacket ReadPacket();
-        void QueuePacket(const NetworkPacket& packet, bool front = false);
+        ReadPacket readPacket();
+        void QueuePacket(const Packet& packet, bool front = false);
 
         // This will not immediately disconnect the client. The disconnect
         // will happen post-tick.
@@ -66,7 +66,7 @@ namespace OpenRCT2::Network
         uint32_t _lastPacketTime = 0;
         std::string _lastDisconnectReason;
 
-        void RecordPacketStats(const NetworkPacket& packet, bool sending);
+        void RecordPacketStats(const Packet& packet, bool sending);
     };
 } // namespace OpenRCT2::Network
 

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -20,51 +20,54 @@
     #include <string_view>
     #include <vector>
 
-class NetworkPlayer;
-
 namespace OpenRCT2
 {
     struct ObjectRepositoryItem;
 }
 
-class NetworkConnection final
+namespace OpenRCT2::Network
 {
-public:
-    std::unique_ptr<ITcpSocket> Socket = nullptr;
-    NetworkPacket InboundPacket;
-    NetworkAuth AuthStatus = NetworkAuth::None;
-    NetworkStats Stats = {};
-    NetworkPlayer* Player = nullptr;
-    uint32_t PingTime = 0;
-    NetworkKey Key;
-    std::vector<uint8_t> Challenge;
-    std::vector<const OpenRCT2::ObjectRepositoryItem*> RequestedObjects;
-    bool ShouldDisconnect = false;
+    class NetworkPlayer;
 
-    NetworkConnection() noexcept;
+    class NetworkConnection final
+    {
+    public:
+        std::unique_ptr<ITcpSocket> Socket = nullptr;
+        NetworkPacket InboundPacket;
+        NetworkAuth AuthStatus = NetworkAuth::None;
+        NetworkStats Stats = {};
+        NetworkPlayer* Player = nullptr;
+        uint32_t PingTime = 0;
+        NetworkKey Key;
+        std::vector<uint8_t> Challenge;
+        std::vector<const OpenRCT2::ObjectRepositoryItem*> RequestedObjects;
+        bool ShouldDisconnect = false;
 
-    NetworkReadPacket ReadPacket();
-    void QueuePacket(const NetworkPacket& packet, bool front = false);
+        NetworkConnection() noexcept;
 
-    // This will not immediately disconnect the client. The disconnect
-    // will happen post-tick.
-    void Disconnect() noexcept;
+        NetworkReadPacket ReadPacket();
+        void QueuePacket(const NetworkPacket& packet, bool front = false);
 
-    bool IsValid() const;
-    void SendQueuedData();
-    void ResetLastPacketTime() noexcept;
-    bool ReceivedPacketRecently() const noexcept;
+        // This will not immediately disconnect the client. The disconnect
+        // will happen post-tick.
+        void Disconnect() noexcept;
 
-    const utf8* GetLastDisconnectReason() const noexcept;
-    void SetLastDisconnectReason(std::string_view src);
-    void SetLastDisconnectReason(const StringId string_id, void* args = nullptr);
+        bool IsValid() const;
+        void SendQueuedData();
+        void ResetLastPacketTime() noexcept;
+        bool ReceivedPacketRecently() const noexcept;
 
-private:
-    std::vector<uint8_t> _outboundBuffer;
-    uint32_t _lastPacketTime = 0;
-    std::string _lastDisconnectReason;
+        const utf8* GetLastDisconnectReason() const noexcept;
+        void SetLastDisconnectReason(std::string_view src);
+        void SetLastDisconnectReason(const StringId string_id, void* args = nullptr);
 
-    void RecordPacketStats(const NetworkPacket& packet, bool sending);
-};
+    private:
+        std::vector<uint8_t> _outboundBuffer;
+        uint32_t _lastPacketTime = 0;
+        std::string _lastDisconnectReason;
+
+        void RecordPacketStats(const NetworkPacket& packet, bool sending);
+    };
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -27,16 +27,16 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Network
 {
-    class NetworkPlayer;
+    class Player;
 
     class NetworkConnection final
     {
     public:
         std::unique_ptr<ITcpSocket> Socket = nullptr;
         NetworkPacket InboundPacket;
-        NetworkAuth AuthStatus = NetworkAuth::None;
-        NetworkStats Stats = {};
-        NetworkPlayer* Player = nullptr;
+        Auth AuthStatus = Auth::none;
+        Stats stats = {};
+        Player* player = nullptr;
         uint32_t PingTime = 0;
         NetworkKey Key;
         std::vector<uint8_t> Challenge;

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -40,7 +40,7 @@ namespace OpenRCT2::Network
         uint32_t PingTime = 0;
         NetworkKey Key;
         std::vector<uint8_t> Challenge;
-        std::vector<const OpenRCT2::ObjectRepositoryItem*> RequestedObjects;
+        std::vector<const ObjectRepositoryItem*> RequestedObjects;
         bool ShouldDisconnect = false;
 
         NetworkConnection() noexcept;

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -76,7 +76,7 @@ namespace OpenRCT2::Network
         _name = name;
     }
 
-    void NetworkGroup::Read(NetworkPacket& packet)
+    void NetworkGroup::Read(Packet& packet)
     {
         packet >> Id;
         SetName(packet.ReadString());
@@ -86,7 +86,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    void NetworkGroup::Write(NetworkPacket& packet) const
+    void NetworkGroup::Write(Packet& packet) const
     {
         packet << Id;
         packet.WriteString(GetName().c_str());

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -39,8 +39,8 @@ namespace OpenRCT2::Network
         {
             const std::string permission = Json::GetString(jsonValue);
 
-            NetworkPermission action_id = NetworkActions::FindCommandByPermissionName(permission);
-            if (action_id != NetworkPermission::Count)
+            Permission action_id = NetworkActions::FindCommandByPermissionName(permission);
+            if (action_id != Permission::Count)
             {
                 group.ToggleActionPermission(action_id);
             }
@@ -57,7 +57,7 @@ namespace OpenRCT2::Network
         json_t actionsArray = json_t::array();
         for (size_t i = 0; i < NetworkActions::Actions.size(); i++)
         {
-            if (CanPerformAction(static_cast<NetworkPermission>(i)))
+            if (CanPerformAction(static_cast<Permission>(i)))
             {
                 actionsArray.emplace_back(NetworkActions::Actions[i].PermissionName);
             }
@@ -96,7 +96,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    void NetworkGroup::ToggleActionPermission(NetworkPermission index)
+    void NetworkGroup::ToggleActionPermission(Permission index)
     {
         size_t index_st = static_cast<size_t>(index);
         size_t byte = index_st / 8;
@@ -108,7 +108,7 @@ namespace OpenRCT2::Network
         ActionsAllowed[byte] ^= (1 << bit);
     }
 
-    bool NetworkGroup::CanPerformAction(NetworkPermission index) const noexcept
+    bool NetworkGroup::CanPerformAction(Permission index) const noexcept
     {
         size_t index_st = static_cast<size_t>(index);
         size_t byte = index_st / 8;
@@ -122,8 +122,8 @@ namespace OpenRCT2::Network
 
     bool NetworkGroup::CanPerformCommand(GameCommand command) const
     {
-        NetworkPermission action = NetworkActions::FindCommand(command);
-        if (action != NetworkPermission::Count)
+        Permission action = NetworkActions::FindCommand(command);
+        if (action != Permission::Count)
         {
             return CanPerformAction(action);
         }

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -15,119 +15,120 @@
     #include "NetworkAction.h"
     #include "NetworkTypes.h"
 
-using namespace OpenRCT2;
-
-NetworkGroup NetworkGroup::FromJson(const json_t& jsonData)
+namespace OpenRCT2::Network
 {
-    Guard::Assert(jsonData.is_object(), "NetworkGroup::FromJson expects parameter jsonData to be object");
-
-    NetworkGroup group;
-    json_t jsonId = jsonData["id"];
-    json_t jsonName = jsonData["name"];
-    json_t jsonPermissions = jsonData["permissions"];
-
-    if (jsonId.is_null() || jsonName.is_null() || jsonPermissions.is_null())
+    NetworkGroup NetworkGroup::FromJson(const json_t& jsonData)
     {
-        throw std::runtime_error("Missing group data");
+        Guard::Assert(jsonData.is_object(), "NetworkGroup::FromJson expects parameter jsonData to be object");
+
+        NetworkGroup group;
+        json_t jsonId = jsonData["id"];
+        json_t jsonName = jsonData["name"];
+        json_t jsonPermissions = jsonData["permissions"];
+
+        if (jsonId.is_null() || jsonName.is_null() || jsonPermissions.is_null())
+        {
+            throw std::runtime_error("Missing group data");
+        }
+
+        group.Id = Json::GetNumber<uint8_t>(jsonId);
+        group._name = Json::GetString(jsonName);
+        std::fill(group.ActionsAllowed.begin(), group.ActionsAllowed.end(), 0);
+
+        for (const auto& jsonValue : jsonPermissions)
+        {
+            const std::string permission = Json::GetString(jsonValue);
+
+            NetworkPermission action_id = NetworkActions::FindCommandByPermissionName(permission);
+            if (action_id != NetworkPermission::Count)
+            {
+                group.ToggleActionPermission(action_id);
+            }
+        }
+        return group;
     }
 
-    group.Id = Json::GetNumber<uint8_t>(jsonId);
-    group._name = Json::GetString(jsonName);
-    std::fill(group.ActionsAllowed.begin(), group.ActionsAllowed.end(), 0);
-
-    for (const auto& jsonValue : jsonPermissions)
+    json_t NetworkGroup::ToJson() const
     {
-        const std::string permission = Json::GetString(jsonValue);
-
-        NetworkPermission action_id = NetworkActions::FindCommandByPermissionName(permission);
-        if (action_id != NetworkPermission::Count)
+        json_t jsonGroup = {
+            { "id", Id },
+            { "name", GetName() },
+        };
+        json_t actionsArray = json_t::array();
+        for (size_t i = 0; i < NetworkActions::Actions.size(); i++)
         {
-            group.ToggleActionPermission(action_id);
+            if (CanPerformAction(static_cast<NetworkPermission>(i)))
+            {
+                actionsArray.emplace_back(NetworkActions::Actions[i].PermissionName);
+            }
+        }
+        jsonGroup["permissions"] = actionsArray;
+        return jsonGroup;
+    }
+
+    const std::string& NetworkGroup::GetName() const noexcept
+    {
+        return _name;
+    }
+
+    void NetworkGroup::SetName(std::string_view name)
+    {
+        _name = name;
+    }
+
+    void NetworkGroup::Read(NetworkPacket& packet)
+    {
+        packet >> Id;
+        SetName(packet.ReadString());
+        for (auto& action : ActionsAllowed)
+        {
+            packet >> action;
         }
     }
-    return group;
-}
 
-json_t NetworkGroup::ToJson() const
-{
-    json_t jsonGroup = {
-        { "id", Id },
-        { "name", GetName() },
-    };
-    json_t actionsArray = json_t::array();
-    for (size_t i = 0; i < NetworkActions::Actions.size(); i++)
+    void NetworkGroup::Write(NetworkPacket& packet) const
     {
-        if (CanPerformAction(static_cast<NetworkPermission>(i)))
+        packet << Id;
+        packet.WriteString(GetName().c_str());
+        for (const auto& action : ActionsAllowed)
         {
-            actionsArray.emplace_back(NetworkActions::Actions[i].PermissionName);
+            packet << action;
         }
     }
-    jsonGroup["permissions"] = actionsArray;
-    return jsonGroup;
-}
 
-const std::string& NetworkGroup::GetName() const noexcept
-{
-    return _name;
-}
-
-void NetworkGroup::SetName(std::string_view name)
-{
-    _name = name;
-}
-
-void NetworkGroup::Read(NetworkPacket& packet)
-{
-    packet >> Id;
-    SetName(packet.ReadString());
-    for (auto& action : ActionsAllowed)
+    void NetworkGroup::ToggleActionPermission(NetworkPermission index)
     {
-        packet >> action;
+        size_t index_st = static_cast<size_t>(index);
+        size_t byte = index_st / 8;
+        size_t bit = index_st % 8;
+        if (byte >= ActionsAllowed.size())
+        {
+            return;
+        }
+        ActionsAllowed[byte] ^= (1 << bit);
     }
-}
 
-void NetworkGroup::Write(NetworkPacket& packet) const
-{
-    packet << Id;
-    packet.WriteString(GetName().c_str());
-    for (const auto& action : ActionsAllowed)
+    bool NetworkGroup::CanPerformAction(NetworkPermission index) const noexcept
     {
-        packet << action;
+        size_t index_st = static_cast<size_t>(index);
+        size_t byte = index_st / 8;
+        size_t bit = index_st % 8;
+        if (byte >= ActionsAllowed.size())
+        {
+            return false;
+        }
+        return (ActionsAllowed[byte] & (1 << bit)) != 0;
     }
-}
 
-void NetworkGroup::ToggleActionPermission(NetworkPermission index)
-{
-    size_t index_st = static_cast<size_t>(index);
-    size_t byte = index_st / 8;
-    size_t bit = index_st % 8;
-    if (byte >= ActionsAllowed.size())
+    bool NetworkGroup::CanPerformCommand(GameCommand command) const
     {
-        return;
-    }
-    ActionsAllowed[byte] ^= (1 << bit);
-}
-
-bool NetworkGroup::CanPerformAction(NetworkPermission index) const noexcept
-{
-    size_t index_st = static_cast<size_t>(index);
-    size_t byte = index_st / 8;
-    size_t bit = index_st % 8;
-    if (byte >= ActionsAllowed.size())
-    {
+        NetworkPermission action = NetworkActions::FindCommand(command);
+        if (action != NetworkPermission::Count)
+        {
+            return CanPerformAction(action);
+        }
         return false;
     }
-    return (ActionsAllowed[byte] & (1 << bit)) != 0;
-}
-
-bool NetworkGroup::CanPerformCommand(GameCommand command) const
-{
-    NetworkPermission action = NetworkActions::FindCommand(command);
-    if (action != NetworkPermission::Count)
-    {
-        return CanPerformAction(action);
-    }
-    return false;
-}
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/NetworkGroup.h
+++ b/src/openrct2/network/NetworkGroup.h
@@ -18,7 +18,7 @@
 
 namespace OpenRCT2::Network
 {
-    enum class NetworkPermission : uint32_t;
+    enum class Permission : uint32_t;
 
     class NetworkGroup final
     {
@@ -40,8 +40,8 @@ namespace OpenRCT2::Network
 
         void Read(NetworkPacket& packet);
         void Write(NetworkPacket& packet) const;
-        void ToggleActionPermission(NetworkPermission index);
-        bool CanPerformAction(NetworkPermission index) const noexcept;
+        void ToggleActionPermission(Permission index);
+        bool CanPerformAction(Permission index) const noexcept;
         bool CanPerformCommand(GameCommand command) const;
 
         /**

--- a/src/openrct2/network/NetworkGroup.h
+++ b/src/openrct2/network/NetworkGroup.h
@@ -38,8 +38,8 @@ namespace OpenRCT2::Network
         const std::string& GetName() const noexcept;
         void SetName(std::string_view name);
 
-        void Read(NetworkPacket& packet);
-        void Write(NetworkPacket& packet) const;
+        void Read(Packet& packet);
+        void Write(Packet& packet) const;
         void ToggleActionPermission(Permission index);
         bool CanPerformAction(Permission index) const noexcept;
         bool CanPerformCommand(GameCommand command) const;

--- a/src/openrct2/network/NetworkGroup.h
+++ b/src/openrct2/network/NetworkGroup.h
@@ -16,39 +16,42 @@
 #include <string>
 #include <string_view>
 
-enum class NetworkPermission : uint32_t;
-
-class NetworkGroup final
+namespace OpenRCT2::Network
 {
-public:
-    std::array<uint8_t, 8> ActionsAllowed{};
-    uint8_t Id = 0;
+    enum class NetworkPermission : uint32_t;
 
-    /**
-     * Creates a NetworkGroup object from a JSON object
-     *
-     * @param json JSON data source
-     * @return A NetworkGroup object
-     * @note json is deliberately left non-const: json_t behaviour changes when const
-     */
-    static NetworkGroup FromJson(const json_t& json);
+    class NetworkGroup final
+    {
+    public:
+        std::array<uint8_t, 8> ActionsAllowed{};
+        uint8_t Id = 0;
 
-    const std::string& GetName() const noexcept;
-    void SetName(std::string_view name);
+        /**
+         * Creates a NetworkGroup object from a JSON object
+         *
+         * @param json JSON data source
+         * @return A NetworkGroup object
+         * @note json is deliberately left non-const: json_t behaviour changes when const
+         */
+        static NetworkGroup FromJson(const json_t& json);
 
-    void Read(NetworkPacket& packet);
-    void Write(NetworkPacket& packet) const;
-    void ToggleActionPermission(NetworkPermission index);
-    bool CanPerformAction(NetworkPermission index) const noexcept;
-    bool CanPerformCommand(GameCommand command) const;
+        const std::string& GetName() const noexcept;
+        void SetName(std::string_view name);
 
-    /**
-     * Serialise a NetworkGroup object into a JSON object
-     *
-     * @return JSON representation of the NetworkGroup object
-     */
-    json_t ToJson() const;
+        void Read(NetworkPacket& packet);
+        void Write(NetworkPacket& packet) const;
+        void ToggleActionPermission(NetworkPermission index);
+        bool CanPerformAction(NetworkPermission index) const noexcept;
+        bool CanPerformCommand(GameCommand command) const;
 
-private:
-    std::string _name;
-};
+        /**
+         * Serialise a NetworkGroup object into a JSON object
+         *
+         * @return JSON representation of the NetworkGroup object
+         */
+        json_t ToJson() const;
+
+    private:
+        std::string _name;
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -21,15 +21,15 @@
 
 namespace OpenRCT2::Network
 {
-    NetworkKey::NetworkKey() = default;
-    NetworkKey::~NetworkKey() = default;
+    Key::Key() = default;
+    Key::~Key() = default;
 
-    void NetworkKey::Unload()
+    void Key::Unload()
     {
         _key = nullptr;
     }
 
-    bool NetworkKey::Generate()
+    bool Key::Generate()
     {
         try
         {
@@ -39,12 +39,12 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::Generate failed: %s", e.what());
+            LOG_ERROR("Network::Key::Generate failed: %s", e.what());
             return false;
         }
     }
 
-    bool NetworkKey::LoadPrivate(IStream* stream)
+    bool Key::LoadPrivate(IStream* stream)
     {
         Guard::ArgumentNotNull(stream);
 
@@ -71,12 +71,12 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::LoadPrivate failed: %s", e.what());
+            LOG_ERROR("Network::Key::LoadPrivate failed: %s", e.what());
             return false;
         }
     }
 
-    bool NetworkKey::LoadPublic(IStream* stream)
+    bool Key::LoadPublic(IStream* stream)
     {
         Guard::ArgumentNotNull(stream);
 
@@ -103,12 +103,12 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::LoadPublic failed: %s", e.what());
+            LOG_ERROR("Network::Key::LoadPublic failed: %s", e.what());
             return false;
         }
     }
 
-    bool NetworkKey::SavePrivate(IStream* stream)
+    bool Key::SavePrivate(IStream* stream)
     {
         try
         {
@@ -122,12 +122,12 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::SavePrivate failed: %s", e.what());
+            LOG_ERROR("Network::Key::SavePrivate failed: %s", e.what());
             return false;
         }
     }
 
-    bool NetworkKey::SavePublic(IStream* stream)
+    bool Key::SavePublic(IStream* stream)
     {
         try
         {
@@ -141,12 +141,12 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::SavePublic failed: %s", e.what());
+            LOG_ERROR("Network::Key::SavePublic failed: %s", e.what());
             return false;
         }
     }
 
-    std::string NetworkKey::PublicKeyString()
+    std::string Key::PublicKeyString()
     {
         if (_key == nullptr)
         {
@@ -156,7 +156,7 @@ namespace OpenRCT2::Network
     }
 
     /**
-     * @brief NetworkKey::PublicKeyHash
+     * @brief Key::PublicKeyHash
      * Computes a short, human-readable (e.g. asciif-ied hex) hash for a given
      * public key. Serves a purpose of easy identification keys in multiplayer
      * overview, multiplayer settings.
@@ -166,7 +166,7 @@ namespace OpenRCT2::Network
      *
      * @return returns a string containing key hash.
      */
-    std::string NetworkKey::PublicKeyHash()
+    std::string Key::PublicKeyHash()
     {
         try
         {
@@ -185,7 +185,7 @@ namespace OpenRCT2::Network
         return nullptr;
     }
 
-    bool NetworkKey::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const
+    bool Key::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const
     {
         try
         {
@@ -195,12 +195,12 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::Sign failed: %s", e.what());
+            LOG_ERROR("Network::Key::Sign failed: %s", e.what());
             return false;
         }
     }
 
-    bool NetworkKey::Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const
+    bool Key::Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const
     {
         try
         {
@@ -209,7 +209,7 @@ namespace OpenRCT2::Network
         }
         catch (const std::exception& e)
         {
-            LOG_ERROR("NetworkKey::Verify failed: %s", e.what());
+            LOG_ERROR("Network::Key::Verify failed: %s", e.what());
             return false;
         }
     }

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    bool NetworkKey::IStream* stream)
+    bool NetworkKey::LoadPrivate(IStream* stream)
     {
         Guard::ArgumentNotNull(stream);
 

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    bool NetworkKey::LoadPrivate(OpenRCT2::IStream* stream)
+    bool NetworkKey::IStream* stream)
     {
         Guard::ArgumentNotNull(stream);
 
@@ -76,7 +76,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    bool NetworkKey::LoadPublic(OpenRCT2::IStream* stream)
+    bool NetworkKey::LoadPublic(IStream* stream)
     {
         Guard::ArgumentNotNull(stream);
 
@@ -108,7 +108,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    bool NetworkKey::SavePrivate(OpenRCT2::IStream* stream)
+    bool NetworkKey::SavePrivate(IStream* stream)
     {
         try
         {
@@ -127,7 +127,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    bool NetworkKey::SavePublic(OpenRCT2::IStream* stream)
+    bool NetworkKey::SavePublic(IStream* stream)
     {
         try
         {

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -19,199 +19,200 @@
 
     #include <vector>
 
-using namespace OpenRCT2;
-
-NetworkKey::NetworkKey() = default;
-NetworkKey::~NetworkKey() = default;
-
-void NetworkKey::Unload()
+namespace OpenRCT2::Network
 {
-    _key = nullptr;
-}
+    NetworkKey::NetworkKey() = default;
+    NetworkKey::~NetworkKey() = default;
 
-bool NetworkKey::Generate()
-{
-    try
+    void NetworkKey::Unload()
     {
-        _key = Crypt::CreateRSAKey();
-        _key->Generate();
-        return true;
-    }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::Generate failed: %s", e.what());
-        return false;
-    }
-}
-
-bool NetworkKey::LoadPrivate(OpenRCT2::IStream* stream)
-{
-    Guard::ArgumentNotNull(stream);
-
-    size_t size = static_cast<size_t>(stream->GetLength());
-    if (size == static_cast<size_t>(-1))
-    {
-        LOG_ERROR("unknown size, refusing to load key");
-        return false;
-    }
-    if (size > 4 * 1024 * 1024)
-    {
-        LOG_ERROR("Key file suspiciously large, refusing to load it");
-        return false;
+        _key = nullptr;
     }
 
-    std::string pem(size, '\0');
-    stream->Read(pem.data(), pem.size());
-
-    try
+    bool NetworkKey::Generate()
     {
-        _key = Crypt::CreateRSAKey();
-        _key->SetPrivate(pem);
-        return true;
-    }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::LoadPrivate failed: %s", e.what());
-        return false;
-    }
-}
-
-bool NetworkKey::LoadPublic(OpenRCT2::IStream* stream)
-{
-    Guard::ArgumentNotNull(stream);
-
-    size_t size = static_cast<size_t>(stream->GetLength());
-    if (size == static_cast<size_t>(-1))
-    {
-        LOG_ERROR("unknown size, refusing to load key");
-        return false;
-    }
-    if (size > 4 * 1024 * 1024)
-    {
-        LOG_ERROR("Key file suspiciously large, refusing to load it");
-        return false;
+        try
+        {
+            _key = Crypt::CreateRSAKey();
+            _key->Generate();
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::Generate failed: %s", e.what());
+            return false;
+        }
     }
 
-    std::string pem(size, '\0');
-    stream->Read(pem.data(), pem.size());
-
-    try
+    bool NetworkKey::LoadPrivate(OpenRCT2::IStream* stream)
     {
-        _key = Crypt::CreateRSAKey();
-        _key->SetPublic(pem);
-        return true;
-    }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::LoadPublic failed: %s", e.what());
-        return false;
-    }
-}
+        Guard::ArgumentNotNull(stream);
 
-bool NetworkKey::SavePrivate(OpenRCT2::IStream* stream)
-{
-    try
+        size_t size = static_cast<size_t>(stream->GetLength());
+        if (size == static_cast<size_t>(-1))
+        {
+            LOG_ERROR("unknown size, refusing to load key");
+            return false;
+        }
+        if (size > 4 * 1024 * 1024)
+        {
+            LOG_ERROR("Key file suspiciously large, refusing to load it");
+            return false;
+        }
+
+        std::string pem(size, '\0');
+        stream->Read(pem.data(), pem.size());
+
+        try
+        {
+            _key = Crypt::CreateRSAKey();
+            _key->SetPrivate(pem);
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::LoadPrivate failed: %s", e.what());
+            return false;
+        }
+    }
+
+    bool NetworkKey::LoadPublic(OpenRCT2::IStream* stream)
+    {
+        Guard::ArgumentNotNull(stream);
+
+        size_t size = static_cast<size_t>(stream->GetLength());
+        if (size == static_cast<size_t>(-1))
+        {
+            LOG_ERROR("unknown size, refusing to load key");
+            return false;
+        }
+        if (size > 4 * 1024 * 1024)
+        {
+            LOG_ERROR("Key file suspiciously large, refusing to load it");
+            return false;
+        }
+
+        std::string pem(size, '\0');
+        stream->Read(pem.data(), pem.size());
+
+        try
+        {
+            _key = Crypt::CreateRSAKey();
+            _key->SetPublic(pem);
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::LoadPublic failed: %s", e.what());
+            return false;
+        }
+    }
+
+    bool NetworkKey::SavePrivate(OpenRCT2::IStream* stream)
+    {
+        try
+        {
+            if (_key == nullptr)
+            {
+                throw std::runtime_error("No key loaded");
+            }
+            auto pem = _key->GetPrivate();
+            stream->Write(pem.data(), pem.size());
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::SavePrivate failed: %s", e.what());
+            return false;
+        }
+    }
+
+    bool NetworkKey::SavePublic(OpenRCT2::IStream* stream)
+    {
+        try
+        {
+            if (_key == nullptr)
+            {
+                throw std::runtime_error("No key loaded");
+            }
+            auto pem = _key->GetPublic();
+            stream->Write(pem.data(), pem.size());
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::SavePublic failed: %s", e.what());
+            return false;
+        }
+    }
+
+    std::string NetworkKey::PublicKeyString()
     {
         if (_key == nullptr)
         {
             throw std::runtime_error("No key loaded");
         }
-        auto pem = _key->GetPrivate();
-        stream->Write(pem.data(), pem.size());
-        return true;
+        return _key->GetPublic();
     }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::SavePrivate failed: %s", e.what());
-        return false;
-    }
-}
 
-bool NetworkKey::SavePublic(OpenRCT2::IStream* stream)
-{
-    try
+    /**
+     * @brief NetworkKey::PublicKeyHash
+     * Computes a short, human-readable (e.g. asciif-ied hex) hash for a given
+     * public key. Serves a purpose of easy identification keys in multiplayer
+     * overview, multiplayer settings.
+     *
+     * In particular, any of digest functions applied to a standardised key
+     * representation, like PEM, will be sufficient.
+     *
+     * @return returns a string containing key hash.
+     */
+    std::string NetworkKey::PublicKeyHash()
     {
-        if (_key == nullptr)
+        try
         {
-            throw std::runtime_error("No key loaded");
+            std::string key = PublicKeyString();
+            if (key.empty())
+            {
+                throw std::runtime_error("No key found");
+            }
+            auto hash = Crypt::SHA1(key.c_str(), key.size());
+            return String::StringFromHex(hash);
         }
-        auto pem = _key->GetPublic();
-        stream->Write(pem.data(), pem.size());
-        return true;
-    }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::SavePublic failed: %s", e.what());
-        return false;
-    }
-}
-
-std::string NetworkKey::PublicKeyString()
-{
-    if (_key == nullptr)
-    {
-        throw std::runtime_error("No key loaded");
-    }
-    return _key->GetPublic();
-}
-
-/**
- * @brief NetworkKey::PublicKeyHash
- * Computes a short, human-readable (e.g. asciif-ied hex) hash for a given
- * public key. Serves a purpose of easy identification keys in multiplayer
- * overview, multiplayer settings.
- *
- * In particular, any of digest functions applied to a standardised key
- * representation, like PEM, will be sufficient.
- *
- * @return returns a string containing key hash.
- */
-std::string NetworkKey::PublicKeyHash()
-{
-    try
-    {
-        std::string key = PublicKeyString();
-        if (key.empty())
+        catch (const std::exception& e)
         {
-            throw std::runtime_error("No key found");
+            LOG_ERROR("Failed to create hash of public key: %s", e.what());
         }
-        auto hash = Crypt::SHA1(key.c_str(), key.size());
-        return String::StringFromHex(hash);
+        return nullptr;
     }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("Failed to create hash of public key: %s", e.what());
-    }
-    return nullptr;
-}
 
-bool NetworkKey::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const
-{
-    try
+    bool NetworkKey::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const
     {
-        auto rsa = Crypt::CreateRSA();
-        signature = rsa->SignData(*_key, md, len);
-        return true;
+        try
+        {
+            auto rsa = Crypt::CreateRSA();
+            signature = rsa->SignData(*_key, md, len);
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::Sign failed: %s", e.what());
+            return false;
+        }
     }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::Sign failed: %s", e.what());
-        return false;
-    }
-}
 
-bool NetworkKey::Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const
-{
-    try
+    bool NetworkKey::Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const
     {
-        auto rsa = Crypt::CreateRSA();
-        return rsa->VerifyData(*_key, md, len, signature.data(), signature.size());
+        try
+        {
+            auto rsa = Crypt::CreateRSA();
+            return rsa->VerifyData(*_key, md, len, signature.data(), signature.size());
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("NetworkKey::Verify failed: %s", e.what());
+            return false;
+        }
     }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("NetworkKey::Verify failed: %s", e.what());
-        return false;
-    }
-}
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -33,10 +33,10 @@ namespace OpenRCT2::Network
         NetworkKey();
         ~NetworkKey();
         bool Generate();
-        bool LoadPrivate(OpenRCT2::IStream* stream);
-        bool LoadPublic(OpenRCT2::IStream* stream);
-        bool SavePrivate(OpenRCT2::IStream* stream);
-        bool SavePublic(OpenRCT2::IStream* stream);
+        bool LoadPrivate(IStream* stream);
+        bool LoadPublic(IStream* stream);
+        bool SavePrivate(IStream* stream);
+        bool SavePublic(IStream* stream);
         std::string PublicKeyString();
         std::string PublicKeyHash();
         void Unload();
@@ -45,7 +45,7 @@ namespace OpenRCT2::Network
 
     private:
         NetworkKey(const NetworkKey&) = delete;
-        std::unique_ptr<OpenRCT2::Crypt::RsaKey> _key;
+        std::unique_ptr<Crypt::RsaKey> _key;
     };
 } // namespace OpenRCT2::Network
 

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -27,11 +27,11 @@ namespace OpenRCT2::Crypt
 
 namespace OpenRCT2::Network
 {
-    class NetworkKey final
+    class Key final
     {
     public:
-        NetworkKey();
-        ~NetworkKey();
+        Key();
+        ~Key();
         bool Generate();
         bool LoadPrivate(IStream* stream);
         bool LoadPublic(IStream* stream);
@@ -44,7 +44,7 @@ namespace OpenRCT2::Network
         bool Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const;
 
     private:
-        NetworkKey(const NetworkKey&) = delete;
+        Key(const Key&) = delete;
         std::unique_ptr<Crypt::RsaKey> _key;
     };
 } // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -25,25 +25,28 @@ namespace OpenRCT2::Crypt
     class RsaKey;
 }
 
-class NetworkKey final
+namespace OpenRCT2::Network
 {
-public:
-    NetworkKey();
-    ~NetworkKey();
-    bool Generate();
-    bool LoadPrivate(OpenRCT2::IStream* stream);
-    bool LoadPublic(OpenRCT2::IStream* stream);
-    bool SavePrivate(OpenRCT2::IStream* stream);
-    bool SavePublic(OpenRCT2::IStream* stream);
-    std::string PublicKeyString();
-    std::string PublicKeyHash();
-    void Unload();
-    bool Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const;
-    bool Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const;
+    class NetworkKey final
+    {
+    public:
+        NetworkKey();
+        ~NetworkKey();
+        bool Generate();
+        bool LoadPrivate(OpenRCT2::IStream* stream);
+        bool LoadPublic(OpenRCT2::IStream* stream);
+        bool SavePrivate(OpenRCT2::IStream* stream);
+        bool SavePublic(OpenRCT2::IStream* stream);
+        std::string PublicKeyString();
+        std::string PublicKeyHash();
+        void Unload();
+        bool Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const;
+        bool Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const;
 
-private:
-    NetworkKey(const NetworkKey&) = delete;
-    std::unique_ptr<OpenRCT2::Crypt::RsaKey> _key;
-};
+    private:
+        NetworkKey(const NetworkKey&) = delete;
+        std::unique_ptr<OpenRCT2::Crypt::RsaKey> _key;
+    };
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -15,97 +15,100 @@
 
     #include <memory>
 
-NetworkPacket::NetworkPacket(NetworkCommand id) noexcept
-    : Header{ 0, id }
+namespace OpenRCT2::Network
 {
-}
-
-uint8_t* NetworkPacket::GetData() noexcept
-{
-    return Data.data();
-}
-
-const uint8_t* NetworkPacket::GetData() const noexcept
-{
-    return Data.data();
-}
-
-NetworkCommand NetworkPacket::GetCommand() const noexcept
-{
-    return Header.Id;
-}
-
-void NetworkPacket::Clear() noexcept
-{
-    BytesTransferred = 0;
-    BytesRead = 0;
-    Data.clear();
-}
-
-bool NetworkPacket::CommandRequiresAuth() const noexcept
-{
-    switch (GetCommand())
+    NetworkPacket::NetworkPacket(NetworkCommand id) noexcept
+        : Header{ 0, id }
     {
-        case NetworkCommand::Ping:
-        case NetworkCommand::Auth:
-        case NetworkCommand::Token:
-        case NetworkCommand::GameInfo:
-        case NetworkCommand::ObjectsList:
-        case NetworkCommand::ScriptsHeader:
-        case NetworkCommand::ScriptsData:
-        case NetworkCommand::MapRequest:
-        case NetworkCommand::Heartbeat:
-            return false;
-        default:
-            return true;
-    }
-}
-
-void NetworkPacket::Write(const void* bytes, size_t size)
-{
-    const uint8_t* src = reinterpret_cast<const uint8_t*>(bytes);
-    Data.insert(Data.end(), src, src + size);
-}
-
-void NetworkPacket::WriteString(std::string_view s)
-{
-    Write(s.data(), s.size());
-    Data.push_back(0);
-}
-
-const uint8_t* NetworkPacket::Read(size_t size)
-{
-    if (BytesRead + size > Data.size())
-    {
-        return nullptr;
     }
 
-    const uint8_t* data = Data.data() + BytesRead;
-    BytesRead += size;
-    return data;
-}
-
-std::string_view NetworkPacket::ReadString()
-{
-    if (BytesRead >= Data.size())
-        return {};
-
-    const char* str = reinterpret_cast<const char*>(Data.data() + BytesRead);
-
-    size_t stringLen = 0;
-    while (BytesRead < Data.size() && str[stringLen] != '\0')
+    uint8_t* NetworkPacket::GetData() noexcept
     {
+        return Data.data();
+    }
+
+    const uint8_t* NetworkPacket::GetData() const noexcept
+    {
+        return Data.data();
+    }
+
+    NetworkCommand NetworkPacket::GetCommand() const noexcept
+    {
+        return Header.Id;
+    }
+
+    void NetworkPacket::Clear() noexcept
+    {
+        BytesTransferred = 0;
+        BytesRead = 0;
+        Data.clear();
+    }
+
+    bool NetworkPacket::CommandRequiresAuth() const noexcept
+    {
+        switch (GetCommand())
+        {
+            case NetworkCommand::Ping:
+            case NetworkCommand::Auth:
+            case NetworkCommand::Token:
+            case NetworkCommand::GameInfo:
+            case NetworkCommand::ObjectsList:
+            case NetworkCommand::ScriptsHeader:
+            case NetworkCommand::ScriptsData:
+            case NetworkCommand::MapRequest:
+            case NetworkCommand::Heartbeat:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    void NetworkPacket::Write(const void* bytes, size_t size)
+    {
+        const uint8_t* src = reinterpret_cast<const uint8_t*>(bytes);
+        Data.insert(Data.end(), src, src + size);
+    }
+
+    void NetworkPacket::WriteString(std::string_view s)
+    {
+        Write(s.data(), s.size());
+        Data.push_back(0);
+    }
+
+    const uint8_t* NetworkPacket::Read(size_t size)
+    {
+        if (BytesRead + size > Data.size())
+        {
+            return nullptr;
+        }
+
+        const uint8_t* data = Data.data() + BytesRead;
+        BytesRead += size;
+        return data;
+    }
+
+    std::string_view NetworkPacket::ReadString()
+    {
+        if (BytesRead >= Data.size())
+            return {};
+
+        const char* str = reinterpret_cast<const char*>(Data.data() + BytesRead);
+
+        size_t stringLen = 0;
+        while (BytesRead < Data.size() && str[stringLen] != '\0')
+        {
+            BytesRead++;
+            stringLen++;
+        }
+
+        if (str[stringLen] != '\0')
+            return {};
+
+        // Skip null terminator.
         BytesRead++;
-        stringLen++;
+
+        return std::string_view(str, stringLen);
     }
-
-    if (str[stringLen] != '\0')
-        return {};
-
-    // Skip null terminator.
-    BytesRead++;
-
-    return std::string_view(str, stringLen);
-}
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -17,34 +17,34 @@
 
 namespace OpenRCT2::Network
 {
-    NetworkPacket::NetworkPacket(Command id) noexcept
+    Packet::Packet(Command id) noexcept
         : Header{ 0, id }
     {
     }
 
-    uint8_t* NetworkPacket::GetData() noexcept
+    uint8_t* Packet::GetData() noexcept
     {
         return Data.data();
     }
 
-    const uint8_t* NetworkPacket::GetData() const noexcept
+    const uint8_t* Packet::GetData() const noexcept
     {
         return Data.data();
     }
 
-    Command NetworkPacket::GetCommand() const noexcept
+    Command Packet::GetCommand() const noexcept
     {
         return Header.Id;
     }
 
-    void NetworkPacket::Clear() noexcept
+    void Packet::Clear() noexcept
     {
         BytesTransferred = 0;
         BytesRead = 0;
         Data.clear();
     }
 
-    bool NetworkPacket::CommandRequiresAuth() const noexcept
+    bool Packet::CommandRequiresAuth() const noexcept
     {
         switch (GetCommand())
         {
@@ -63,19 +63,19 @@ namespace OpenRCT2::Network
         }
     }
 
-    void NetworkPacket::Write(const void* bytes, size_t size)
+    void Packet::Write(const void* bytes, size_t size)
     {
         const uint8_t* src = reinterpret_cast<const uint8_t*>(bytes);
         Data.insert(Data.end(), src, src + size);
     }
 
-    void NetworkPacket::WriteString(std::string_view s)
+    void Packet::WriteString(std::string_view s)
     {
         Write(s.data(), s.size());
         Data.push_back(0);
     }
 
-    const uint8_t* NetworkPacket::Read(size_t size)
+    const uint8_t* Packet::Read(size_t size)
     {
         if (BytesRead + size > Data.size())
         {
@@ -87,7 +87,7 @@ namespace OpenRCT2::Network
         return data;
     }
 
-    std::string_view NetworkPacket::ReadString()
+    std::string_view Packet::ReadString()
     {
         if (BytesRead >= Data.size())
             return {};

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -17,7 +17,7 @@
 
 namespace OpenRCT2::Network
 {
-    NetworkPacket::NetworkPacket(NetworkCommand id) noexcept
+    NetworkPacket::NetworkPacket(Command id) noexcept
         : Header{ 0, id }
     {
     }
@@ -32,7 +32,7 @@ namespace OpenRCT2::Network
         return Data.data();
     }
 
-    NetworkCommand NetworkPacket::GetCommand() const noexcept
+    Command NetworkPacket::GetCommand() const noexcept
     {
         return Header.Id;
     }
@@ -48,15 +48,15 @@ namespace OpenRCT2::Network
     {
         switch (GetCommand())
         {
-            case NetworkCommand::Ping:
-            case NetworkCommand::Auth:
-            case NetworkCommand::Token:
-            case NetworkCommand::GameInfo:
-            case NetworkCommand::ObjectsList:
-            case NetworkCommand::ScriptsHeader:
-            case NetworkCommand::ScriptsData:
-            case NetworkCommand::MapRequest:
-            case NetworkCommand::Heartbeat:
+            case Command::ping:
+            case Command::auth:
+            case Command::token:
+            case Command::gameInfo:
+            case Command::objectsList:
+            case Command::scriptsHeader:
+            case Command::scriptsData:
+            case Command::mapRequest:
+            case Command::heartbeat:
                 return false;
             default:
                 return true;

--- a/src/openrct2/network/NetworkPacket.h
+++ b/src/openrct2/network/NetworkPacket.h
@@ -27,10 +27,10 @@ namespace OpenRCT2::Network
     static_assert(sizeof(PacketHeader) == 6);
 #pragma pack(pop)
 
-    struct NetworkPacket final
+    struct Packet final
     {
-        NetworkPacket() noexcept = default;
-        NetworkPacket(Command id) noexcept;
+        Packet() noexcept = default;
+        Packet(Command id) noexcept;
 
         uint8_t* GetData() noexcept;
         const uint8_t* GetData() const noexcept;
@@ -47,7 +47,7 @@ namespace OpenRCT2::Network
         void WriteString(std::string_view s);
 
         template<typename T>
-        NetworkPacket& operator>>(T& value)
+        Packet& operator>>(T& value)
         {
             if (BytesRead + sizeof(value) > Header.Size)
             {
@@ -64,14 +64,14 @@ namespace OpenRCT2::Network
         }
 
         template<typename T>
-        NetworkPacket& operator<<(T value)
+        Packet& operator<<(T value)
         {
             T swapped = ByteSwapBE(value);
             Write(&swapped, sizeof(T));
             return *this;
         }
 
-        NetworkPacket& operator<<(DataSerialiser& data)
+        Packet& operator<<(DataSerialiser& data)
         {
             Write(static_cast<const uint8_t*>(data.GetStream().GetData()), data.GetStream().GetLength());
             return *this;

--- a/src/openrct2/network/NetworkPacket.h
+++ b/src/openrct2/network/NetworkPacket.h
@@ -16,68 +16,71 @@
 #include <sfl/small_vector.hpp>
 #include <vector>
 
-#pragma pack(push, 1)
-struct PacketHeader
+namespace OpenRCT2::Network
 {
-    uint16_t Size = 0;
-    NetworkCommand Id = NetworkCommand::Invalid;
-};
-static_assert(sizeof(PacketHeader) == 6);
+#pragma pack(push, 1)
+    struct PacketHeader
+    {
+        uint16_t Size = 0;
+        NetworkCommand Id = NetworkCommand::Invalid;
+    };
+    static_assert(sizeof(PacketHeader) == 6);
 #pragma pack(pop)
 
-struct NetworkPacket final
-{
-    NetworkPacket() noexcept = default;
-    NetworkPacket(NetworkCommand id) noexcept;
-
-    uint8_t* GetData() noexcept;
-    const uint8_t* GetData() const noexcept;
-
-    NetworkCommand GetCommand() const noexcept;
-
-    void Clear() noexcept;
-    bool CommandRequiresAuth() const noexcept;
-
-    const uint8_t* Read(size_t size);
-    std::string_view ReadString();
-
-    void Write(const void* bytes, size_t size);
-    void WriteString(std::string_view s);
-
-    template<typename T>
-    NetworkPacket& operator>>(T& value)
+    struct NetworkPacket final
     {
-        if (BytesRead + sizeof(value) > Header.Size)
+        NetworkPacket() noexcept = default;
+        NetworkPacket(NetworkCommand id) noexcept;
+
+        uint8_t* GetData() noexcept;
+        const uint8_t* GetData() const noexcept;
+
+        NetworkCommand GetCommand() const noexcept;
+
+        void Clear() noexcept;
+        bool CommandRequiresAuth() const noexcept;
+
+        const uint8_t* Read(size_t size);
+        std::string_view ReadString();
+
+        void Write(const void* bytes, size_t size);
+        void WriteString(std::string_view s);
+
+        template<typename T>
+        NetworkPacket& operator>>(T& value)
         {
-            value = T{};
+            if (BytesRead + sizeof(value) > Header.Size)
+            {
+                value = T{};
+            }
+            else
+            {
+                T local;
+                std::memcpy(&local, &GetData()[BytesRead], sizeof(local));
+                value = ByteSwapBE(local);
+                BytesRead += sizeof(value);
+            }
+            return *this;
         }
-        else
+
+        template<typename T>
+        NetworkPacket& operator<<(T value)
         {
-            T local;
-            std::memcpy(&local, &GetData()[BytesRead], sizeof(local));
-            value = ByteSwapBE(local);
-            BytesRead += sizeof(value);
+            T swapped = ByteSwapBE(value);
+            Write(&swapped, sizeof(T));
+            return *this;
         }
-        return *this;
-    }
 
-    template<typename T>
-    NetworkPacket& operator<<(T value)
-    {
-        T swapped = ByteSwapBE(value);
-        Write(&swapped, sizeof(T));
-        return *this;
-    }
+        NetworkPacket& operator<<(DataSerialiser& data)
+        {
+            Write(static_cast<const uint8_t*>(data.GetStream().GetData()), data.GetStream().GetLength());
+            return *this;
+        }
 
-    NetworkPacket& operator<<(DataSerialiser& data)
-    {
-        Write(static_cast<const uint8_t*>(data.GetStream().GetData()), data.GetStream().GetLength());
-        return *this;
-    }
-
-public:
-    PacketHeader Header{};
-    sfl::small_vector<uint8_t, 512> Data;
-    size_t BytesTransferred = 0;
-    size_t BytesRead = 0;
-};
+    public:
+        PacketHeader Header{};
+        sfl::small_vector<uint8_t, 512> Data;
+        size_t BytesTransferred = 0;
+        size_t BytesRead = 0;
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkPacket.h
+++ b/src/openrct2/network/NetworkPacket.h
@@ -22,7 +22,7 @@ namespace OpenRCT2::Network
     struct PacketHeader
     {
         uint16_t Size = 0;
-        NetworkCommand Id = NetworkCommand::Invalid;
+        Command Id = Command::invalid;
     };
     static_assert(sizeof(PacketHeader) == 6);
 #pragma pack(pop)
@@ -30,12 +30,12 @@ namespace OpenRCT2::Network
     struct NetworkPacket final
     {
         NetworkPacket() noexcept = default;
-        NetworkPacket(NetworkCommand id) noexcept;
+        NetworkPacket(Command id) noexcept;
 
         uint8_t* GetData() noexcept;
         const uint8_t* GetData() const noexcept;
 
-        NetworkCommand GetCommand() const noexcept;
+        Command GetCommand() const noexcept;
 
         void Clear() noexcept;
         bool CommandRequiresAuth() const noexcept;

--- a/src/openrct2/network/NetworkPlayer.cpp
+++ b/src/openrct2/network/NetworkPlayer.cpp
@@ -15,39 +15,42 @@
     #include "../ui/WindowManager.h"
     #include "NetworkPacket.h"
 
-void NetworkPlayer::SetName(std::string_view name)
+namespace OpenRCT2::Network
 {
-    // 36 == 31 + strlen(" #255");
-    Name = name.substr(0, 36);
-}
+    void NetworkPlayer::SetName(std::string_view name)
+    {
+        // 36 == 31 + strlen(" #255");
+        Name = name.substr(0, 36);
+    }
 
-void NetworkPlayer::Read(NetworkPacket& packet)
-{
-    auto name = packet.ReadString();
-    SetName(name);
-    packet >> Id >> Flags >> Group >> LastAction >> LastActionCoord.x >> LastActionCoord.y >> LastActionCoord.z >> MoneySpent
-        >> CommandsRan;
-}
+    void NetworkPlayer::Read(NetworkPacket& packet)
+    {
+        auto name = packet.ReadString();
+        SetName(name);
+        packet >> Id >> Flags >> Group >> LastAction >> LastActionCoord.x >> LastActionCoord.y >> LastActionCoord.z
+            >> MoneySpent >> CommandsRan;
+    }
 
-void NetworkPlayer::Write(NetworkPacket& packet)
-{
-    packet.WriteString(Name);
-    packet << Id << Flags << Group << LastAction << LastActionCoord.x << LastActionCoord.y << LastActionCoord.z << MoneySpent
-           << CommandsRan;
-}
+    void NetworkPlayer::Write(NetworkPacket& packet)
+    {
+        packet.WriteString(Name);
+        packet << Id << Flags << Group << LastAction << LastActionCoord.x << LastActionCoord.y << LastActionCoord.z
+               << MoneySpent << CommandsRan;
+    }
 
-void NetworkPlayer::IncrementNumCommands()
-{
-    CommandsRan++;
-    auto* windowMgr = OpenRCT2::Ui::GetWindowManager();
-    windowMgr->InvalidateByNumber(WindowClass::Player, Id);
-}
+    void NetworkPlayer::IncrementNumCommands()
+    {
+        CommandsRan++;
+        auto* windowMgr = OpenRCT2::Ui::GetWindowManager();
+        windowMgr->InvalidateByNumber(WindowClass::Player, Id);
+    }
 
-void NetworkPlayer::AddMoneySpent(money64 cost)
-{
-    MoneySpent += cost;
-    auto* windowMgr = OpenRCT2::Ui::GetWindowManager();
-    windowMgr->InvalidateByNumber(WindowClass::Player, Id);
-}
+    void NetworkPlayer::AddMoneySpent(money64 cost)
+    {
+        MoneySpent += cost;
+        auto* windowMgr = OpenRCT2::Ui::GetWindowManager();
+        windowMgr->InvalidateByNumber(WindowClass::Player, Id);
+    }
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/NetworkPlayer.cpp
+++ b/src/openrct2/network/NetworkPlayer.cpp
@@ -23,7 +23,7 @@ namespace OpenRCT2::Network
         Name = name.substr(0, 36);
     }
 
-    void Player::Read(NetworkPacket& packet)
+    void Player::Read(Packet& packet)
     {
         auto name = packet.ReadString();
         SetName(name);
@@ -31,7 +31,7 @@ namespace OpenRCT2::Network
             >> MoneySpent >> CommandsRan;
     }
 
-    void Player::Write(NetworkPacket& packet)
+    void Player::Write(Packet& packet)
     {
         packet.WriteString(Name);
         packet << Id << Flags << Group << LastAction << LastActionCoord.x << LastActionCoord.y << LastActionCoord.z

--- a/src/openrct2/network/NetworkPlayer.cpp
+++ b/src/openrct2/network/NetworkPlayer.cpp
@@ -41,14 +41,14 @@ namespace OpenRCT2::Network
     void NetworkPlayer::IncrementNumCommands()
     {
         CommandsRan++;
-        auto* windowMgr = OpenRCT2::Ui::GetWindowManager();
+        auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByNumber(WindowClass::Player, Id);
     }
 
     void NetworkPlayer::AddMoneySpent(money64 cost)
     {
         MoneySpent += cost;
-        auto* windowMgr = OpenRCT2::Ui::GetWindowManager();
+        auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByNumber(WindowClass::Player, Id);
     }
 } // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkPlayer.cpp
+++ b/src/openrct2/network/NetworkPlayer.cpp
@@ -17,13 +17,13 @@
 
 namespace OpenRCT2::Network
 {
-    void NetworkPlayer::SetName(std::string_view name)
+    void Player::SetName(std::string_view name)
     {
         // 36 == 31 + strlen(" #255");
         Name = name.substr(0, 36);
     }
 
-    void NetworkPlayer::Read(NetworkPacket& packet)
+    void Player::Read(NetworkPacket& packet)
     {
         auto name = packet.ReadString();
         SetName(name);
@@ -31,21 +31,21 @@ namespace OpenRCT2::Network
             >> MoneySpent >> CommandsRan;
     }
 
-    void NetworkPlayer::Write(NetworkPacket& packet)
+    void Player::Write(NetworkPacket& packet)
     {
         packet.WriteString(Name);
         packet << Id << Flags << Group << LastAction << LastActionCoord.x << LastActionCoord.y << LastActionCoord.z
                << MoneySpent << CommandsRan;
     }
 
-    void NetworkPlayer::IncrementNumCommands()
+    void Player::IncrementNumCommands()
     {
         CommandsRan++;
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByNumber(WindowClass::Player, Id);
     }
 
-    void NetworkPlayer::AddMoneySpent(money64 cost)
+    void Player::AddMoneySpent(money64 cost)
     {
         MoneySpent += cost;
         auto* windowMgr = Ui::GetWindowManager();

--- a/src/openrct2/network/NetworkPlayer.h
+++ b/src/openrct2/network/NetworkPlayer.h
@@ -17,34 +17,38 @@
 #include <string_view>
 #include <unordered_map>
 
-struct NetworkPacket;
 struct Peep;
 
-class NetworkPlayer final
+namespace OpenRCT2::Network
 {
-public:
-    uint8_t Id = 0;
-    std::string Name;
-    uint16_t Ping = 0;
-    uint8_t Flags = 0;
-    uint8_t Group = 0;
-    money64 MoneySpent = 0.00_GBP;
-    uint32_t CommandsRan = 0;
-    int32_t LastAction = -999;
-    uint32_t LastActionTime = 0;
-    CoordsXYZ LastActionCoord = {};
-    Peep* PickupPeep = nullptr;
-    int32_t PickupPeepOldX = kLocationNull;
-    std::string KeyHash;
-    uint32_t LastDemolishRideTime = 0;
-    uint32_t LastPlaceSceneryTime = 0;
-    std::unordered_map<GameCommand, int32_t> CooldownTime;
-    NetworkPlayer() noexcept = default;
+    struct NetworkPacket;
 
-    void SetName(std::string_view name);
+    class NetworkPlayer final
+    {
+    public:
+        uint8_t Id = 0;
+        std::string Name;
+        uint16_t Ping = 0;
+        uint8_t Flags = 0;
+        uint8_t Group = 0;
+        money64 MoneySpent = 0.00_GBP;
+        uint32_t CommandsRan = 0;
+        int32_t LastAction = -999;
+        uint32_t LastActionTime = 0;
+        CoordsXYZ LastActionCoord = {};
+        Peep* PickupPeep = nullptr;
+        int32_t PickupPeepOldX = kLocationNull;
+        std::string KeyHash;
+        uint32_t LastDemolishRideTime = 0;
+        uint32_t LastPlaceSceneryTime = 0;
+        std::unordered_map<GameCommand, int32_t> CooldownTime;
+        NetworkPlayer() noexcept = default;
 
-    void Read(NetworkPacket& packet);
-    void Write(NetworkPacket& packet);
-    void IncrementNumCommands();
-    void AddMoneySpent(money64 cost);
-};
+        void SetName(std::string_view name);
+
+        void Read(NetworkPacket& packet);
+        void Write(NetworkPacket& packet);
+        void IncrementNumCommands();
+        void AddMoneySpent(money64 cost);
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkPlayer.h
+++ b/src/openrct2/network/NetworkPlayer.h
@@ -21,7 +21,7 @@ struct Peep;
 
 namespace OpenRCT2::Network
 {
-    struct NetworkPacket;
+    struct Packet;
 
     class Player final
     {
@@ -46,8 +46,8 @@ namespace OpenRCT2::Network
 
         void SetName(std::string_view name);
 
-        void Read(NetworkPacket& packet);
-        void Write(NetworkPacket& packet);
+        void Read(Packet& packet);
+        void Write(Packet& packet);
         void IncrementNumCommands();
         void AddMoneySpent(money64 cost);
     };

--- a/src/openrct2/network/NetworkPlayer.h
+++ b/src/openrct2/network/NetworkPlayer.h
@@ -23,7 +23,7 @@ namespace OpenRCT2::Network
 {
     struct NetworkPacket;
 
-    class NetworkPlayer final
+    class Player final
     {
     public:
         uint8_t Id = 0;
@@ -42,7 +42,7 @@ namespace OpenRCT2::Network
         uint32_t LastDemolishRideTime = 0;
         uint32_t LastPlaceSceneryTime = 0;
         std::unordered_map<GameCommand, int32_t> CooldownTime;
-        NetworkPlayer() noexcept = default;
+        Player() noexcept = default;
 
         void SetName(std::string_view name);
 

--- a/src/openrct2/network/NetworkServer.h
+++ b/src/openrct2/network/NetworkServer.h
@@ -4,9 +4,12 @@
 
 #ifndef DISABLE_NETWORK
 
-class NetworkServer final : public NetworkBase
+namespace OpenRCT2::Network
 {
-public:
-};
+    class NetworkServer final : public NetworkBase
+    {
+    public:
+    };
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -34,330 +34,331 @@
     #include <random>
     #include <string>
 
-using namespace OpenRCT2;
-
-enum class MasterServerStatus
+namespace OpenRCT2::Network
 {
-    Ok = 200,
-    InvalidToken = 401,
-    ServerNotFound = 404,
-    InternalError = 500
-};
+    enum class MasterServerStatus
+    {
+        Ok = 200,
+        InvalidToken = 401,
+        ServerNotFound = 404,
+        InternalError = 500
+    };
 
     #ifndef DISABLE_HTTP
-using namespace std::chrono_literals;
-constexpr int32_t kMasterServerRegisterTime = std::chrono::milliseconds(2min).count();
-constexpr int32_t kMasterServerHeartbeatTime = std::chrono::milliseconds(1min).count();
+    using namespace std::chrono_literals;
+    constexpr int32_t kMasterServerRegisterTime = std::chrono::milliseconds(2min).count();
+    constexpr int32_t kMasterServerHeartbeatTime = std::chrono::milliseconds(1min).count();
     #endif
 
-class NetworkServerAdvertiser final : public INetworkServerAdvertiser
-{
-private:
-    uint16_t _port;
+    class NetworkServerAdvertiser final : public INetworkServerAdvertiser
+    {
+    private:
+        uint16_t _port;
 
-    std::unique_ptr<IUdpSocket> _lanListener;
-    uint32_t _lastListenTime{};
+        std::unique_ptr<IUdpSocket> _lanListener;
+        uint32_t _lastListenTime{};
 
-    AdvertiseStatus _status = AdvertiseStatus::unregistered;
+        AdvertiseStatus _status = AdvertiseStatus::unregistered;
 
     #ifndef DISABLE_HTTP
-    uint32_t _lastAdvertiseTime = 0;
-    uint32_t _lastHeartbeatTime = 0;
+        uint32_t _lastAdvertiseTime = 0;
+        uint32_t _lastHeartbeatTime = 0;
 
-    // Our unique token for this server
-    std::string _token;
+        // Our unique token for this server
+        std::string _token;
 
-    // Key received from the master server
-    std::string _key;
+        // Key received from the master server
+        std::string _key;
 
-    // See https://github.com/OpenRCT2/OpenRCT2/issues/6277 and 4953
-    bool _forceIPv4 = false;
+        // See https://github.com/OpenRCT2/OpenRCT2/issues/6277 and 4953
+        bool _forceIPv4 = false;
     #endif
 
-public:
-    explicit NetworkServerAdvertiser(uint16_t port)
-    {
-        _port = port;
-        _lanListener = CreateUdpSocket();
-    #ifndef DISABLE_HTTP
-        _key = GenerateAdvertiseKey();
-    #endif
-    }
-
-    AdvertiseStatus GetStatus() const override
-    {
-        return _status;
-    }
-
-    void Update() override
-    {
-        UpdateLAN();
-    #ifndef DISABLE_HTTP
-        if (Config::Get().network.Advertise)
+    public:
+        explicit NetworkServerAdvertiser(uint16_t port)
         {
-            UpdateWAN();
+            _port = port;
+            _lanListener = CreateUdpSocket();
+    #ifndef DISABLE_HTTP
+            _key = GenerateAdvertiseKey();
+    #endif
         }
-    #endif
-    }
 
-private:
-    void UpdateLAN()
-    {
-        auto ticks = Platform::GetTicks();
-        if (ticks > _lastListenTime + 500)
+        AdvertiseStatus GetStatus() const override
         {
-            if (_lanListener->GetStatus() != SocketStatus::Listening)
+            return _status;
+        }
+
+        void Update() override
+        {
+            UpdateLAN();
+    #ifndef DISABLE_HTTP
+            if (Config::Get().network.Advertise)
             {
-                _lanListener->Listen(kNetworkLanBroadcastPort);
+                UpdateWAN();
+            }
+    #endif
+        }
+
+    private:
+        void UpdateLAN()
+        {
+            auto ticks = Platform::GetTicks();
+            if (ticks > _lastListenTime + 500)
+            {
+                if (_lanListener->GetStatus() != SocketStatus::Listening)
+                {
+                    _lanListener->Listen(kNetworkLanBroadcastPort);
+                }
+                else
+                {
+                    char buffer[256]{};
+                    size_t recievedBytes{};
+                    std::unique_ptr<INetworkEndpoint> endpoint;
+                    auto p = _lanListener->ReceiveData(buffer, sizeof(buffer) - 1, &recievedBytes, &endpoint);
+                    if (p == NetworkReadPacket::Success)
+                    {
+                        std::string sender = endpoint->GetHostname();
+                        LOG_VERBOSE("Received %zu bytes from %s on LAN broadcast port", recievedBytes, sender.c_str());
+                        if (String::equals(buffer, kNetworkLanBroadcastMsg))
+                        {
+                            auto body = GetBroadcastJson();
+                            auto bodyDump = body.dump();
+                            size_t sendLen = bodyDump.size() + 1;
+                            LOG_VERBOSE("Sending %zu bytes back to %s", sendLen, sender.c_str());
+                            _lanListener->SendData(*endpoint, bodyDump.c_str(), sendLen);
+                        }
+                    }
+                }
+                _lastListenTime = ticks;
+            }
+        }
+
+        json_t GetBroadcastJson()
+        {
+            json_t root = NetworkGetServerInfoAsJson();
+            root["port"] = _port;
+            return root;
+        }
+
+    #ifndef DISABLE_HTTP
+        void UpdateWAN()
+        {
+            switch (_status)
+            {
+                case AdvertiseStatus::unregistered:
+                    if (_lastAdvertiseTime == 0 || Platform::GetTicks() > _lastAdvertiseTime + kMasterServerRegisterTime)
+                    {
+                        if (_lastAdvertiseTime == 0)
+                        {
+                            Console::WriteLine("Registering server on master server");
+                        }
+                        SendRegistration(_forceIPv4);
+                    }
+                    break;
+                case AdvertiseStatus::registered:
+                    if (Platform::GetTicks() > _lastHeartbeatTime + kMasterServerHeartbeatTime)
+                    {
+                        SendHeartbeat();
+                    }
+                    break;
+                // exhaust enum values to satisfy clang
+                case AdvertiseStatus::disabled:
+                    break;
+            }
+        }
+
+        void SendRegistration(bool forceIPv4)
+        {
+            _lastAdvertiseTime = Platform::GetTicks();
+
+            // Send the registration request
+            Http::Request request;
+            request.url = GetMasterServerUrl();
+            request.method = Http::Method::POST;
+            request.forceIPv4 = forceIPv4;
+
+            json_t body = {
+                { "key", _key },
+                { "port", _port },
+            };
+
+            if (!Config::Get().network.AdvertiseAddress.empty())
+            {
+                body["address"] = Config::Get().network.AdvertiseAddress;
+            }
+
+            request.body = body.dump();
+            request.header["Content-Type"] = "application/json";
+
+            Http::DoAsync(request, [&](Http::Response response) -> void {
+                if (response.status != Http::Status::Ok)
+                {
+                    Console::Error::WriteLine("Unable to connect to master server");
+                    return;
+                }
+
+                json_t root = Json::FromString(response.body);
+                root = Json::AsObject(root);
+                this->OnRegistrationResponse(root);
+            });
+        }
+
+        void SendHeartbeat()
+        {
+            Http::Request request;
+            request.url = GetMasterServerUrl();
+            request.method = Http::Method::PUT;
+
+            json_t body = GetHeartbeatJson();
+            request.body = body.dump();
+            request.header["Content-Type"] = "application/json";
+
+            _lastHeartbeatTime = Platform::GetTicks();
+            Http::DoAsync(request, [&](Http::Response response) -> void {
+                if (response.status != Http::Status::Ok)
+                {
+                    Console::Error::WriteLine("Unable to connect to master server");
+                    return;
+                }
+
+                json_t root = Json::FromString(response.body);
+                root = Json::AsObject(root);
+                this->OnHeartbeatResponse(root);
+            });
+        }
+
+        /**
+         * @param jsonRoot must be of JSON type object or null
+         * @note jsonRoot is deliberately left non-const: json_t behaviour changes when const
+         */
+        void OnRegistrationResponse(json_t& jsonRoot)
+        {
+            Guard::Assert(jsonRoot.is_object(), "OnRegistrationResponse expects parameter jsonRoot to be object");
+
+            auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::InternalError);
+
+            if (status == MasterServerStatus::Ok)
+            {
+                Console::WriteLine("Server successfully registered on master server");
+                json_t jsonToken = jsonRoot["token"];
+                if (jsonToken.is_string())
+                {
+                    _token = Json::GetString(jsonToken);
+                    _status = AdvertiseStatus::registered;
+                }
             }
             else
             {
-                char buffer[256]{};
-                size_t recievedBytes{};
-                std::unique_ptr<INetworkEndpoint> endpoint;
-                auto p = _lanListener->ReceiveData(buffer, sizeof(buffer) - 1, &recievedBytes, &endpoint);
-                if (p == NetworkReadPacket::Success)
+                std::string message = Json::GetString(jsonRoot["message"]);
+                if (message.empty())
                 {
-                    std::string sender = endpoint->GetHostname();
-                    LOG_VERBOSE("Received %zu bytes from %s on LAN broadcast port", recievedBytes, sender.c_str());
-                    if (String::equals(buffer, kNetworkLanBroadcastMsg))
-                    {
-                        auto body = GetBroadcastJson();
-                        auto bodyDump = body.dump();
-                        size_t sendLen = bodyDump.size() + 1;
-                        LOG_VERBOSE("Sending %zu bytes back to %s", sendLen, sender.c_str());
-                        _lanListener->SendData(*endpoint, bodyDump.c_str(), sendLen);
-                    }
+                    message = "Invalid response from server";
+                }
+                Console::Error::WriteLine(
+                    "Unable to advertise (%d): %s\n  * Check that you have port forwarded %u\n  * Try setting "
+                    "advertise_address in config.ini",
+                    status, message.c_str(), _port);
+
+                // Hack for https://github.com/OpenRCT2/OpenRCT2/issues/6277
+                // Master server may not reply correctly if using IPv6, retry forcing IPv4,
+                // don't wait the full timeout.
+                if (!_forceIPv4 && status == MasterServerStatus::InternalError)
+                {
+                    _forceIPv4 = true;
+                    _lastAdvertiseTime = 0;
+                    LOG_INFO("Forcing HTTP(S) over IPv4");
                 }
             }
-            _lastListenTime = ticks;
-        }
-    }
-
-    json_t GetBroadcastJson()
-    {
-        json_t root = NetworkGetServerInfoAsJson();
-        root["port"] = _port;
-        return root;
-    }
-
-    #ifndef DISABLE_HTTP
-    void UpdateWAN()
-    {
-        switch (_status)
-        {
-            case AdvertiseStatus::unregistered:
-                if (_lastAdvertiseTime == 0 || Platform::GetTicks() > _lastAdvertiseTime + kMasterServerRegisterTime)
-                {
-                    if (_lastAdvertiseTime == 0)
-                    {
-                        Console::WriteLine("Registering server on master server");
-                    }
-                    SendRegistration(_forceIPv4);
-                }
-                break;
-            case AdvertiseStatus::registered:
-                if (Platform::GetTicks() > _lastHeartbeatTime + kMasterServerHeartbeatTime)
-                {
-                    SendHeartbeat();
-                }
-                break;
-            // exhaust enum values to satisfy clang
-            case AdvertiseStatus::disabled:
-                break;
-        }
-    }
-
-    void SendRegistration(bool forceIPv4)
-    {
-        _lastAdvertiseTime = Platform::GetTicks();
-
-        // Send the registration request
-        Http::Request request;
-        request.url = GetMasterServerUrl();
-        request.method = Http::Method::POST;
-        request.forceIPv4 = forceIPv4;
-
-        json_t body = {
-            { "key", _key },
-            { "port", _port },
-        };
-
-        if (!Config::Get().network.AdvertiseAddress.empty())
-        {
-            body["address"] = Config::Get().network.AdvertiseAddress;
         }
 
-        request.body = body.dump();
-        request.header["Content-Type"] = "application/json";
-
-        Http::DoAsync(request, [&](Http::Response response) -> void {
-            if (response.status != Http::Status::Ok)
-            {
-                Console::Error::WriteLine("Unable to connect to master server");
-                return;
-            }
-
-            json_t root = Json::FromString(response.body);
-            root = Json::AsObject(root);
-            this->OnRegistrationResponse(root);
-        });
-    }
-
-    void SendHeartbeat()
-    {
-        Http::Request request;
-        request.url = GetMasterServerUrl();
-        request.method = Http::Method::PUT;
-
-        json_t body = GetHeartbeatJson();
-        request.body = body.dump();
-        request.header["Content-Type"] = "application/json";
-
-        _lastHeartbeatTime = Platform::GetTicks();
-        Http::DoAsync(request, [&](Http::Response response) -> void {
-            if (response.status != Http::Status::Ok)
-            {
-                Console::Error::WriteLine("Unable to connect to master server");
-                return;
-            }
-
-            json_t root = Json::FromString(response.body);
-            root = Json::AsObject(root);
-            this->OnHeartbeatResponse(root);
-        });
-    }
-
-    /**
-     * @param jsonRoot must be of JSON type object or null
-     * @note jsonRoot is deliberately left non-const: json_t behaviour changes when const
-     */
-    void OnRegistrationResponse(json_t& jsonRoot)
-    {
-        Guard::Assert(jsonRoot.is_object(), "OnRegistrationResponse expects parameter jsonRoot to be object");
-
-        auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::InternalError);
-
-        if (status == MasterServerStatus::Ok)
+        /**
+         * @param jsonRoot must be of JSON type object or null
+         * @note jsonRoot is deliberately left non-const: json_t behaviour changes when const
+         */
+        void OnHeartbeatResponse(json_t& jsonRoot)
         {
-            Console::WriteLine("Server successfully registered on master server");
-            json_t jsonToken = jsonRoot["token"];
-            if (jsonToken.is_string())
-            {
-                _token = Json::GetString(jsonToken);
-                _status = AdvertiseStatus::registered;
-            }
-        }
-        else
-        {
-            std::string message = Json::GetString(jsonRoot["message"]);
-            if (message.empty())
-            {
-                message = "Invalid response from server";
-            }
-            Console::Error::WriteLine(
-                "Unable to advertise (%d): %s\n  * Check that you have port forwarded %u\n  * Try setting "
-                "advertise_address in config.ini",
-                status, message.c_str(), _port);
+            Guard::Assert(jsonRoot.is_object(), "OnHeartbeatResponse expects parameter jsonRoot to be object");
 
-            // Hack for https://github.com/OpenRCT2/OpenRCT2/issues/6277
-            // Master server may not reply correctly if using IPv6, retry forcing IPv4,
-            // don't wait the full timeout.
-            if (!_forceIPv4 && status == MasterServerStatus::InternalError)
+            auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::InternalError);
+            if (status == MasterServerStatus::Ok)
             {
-                _forceIPv4 = true;
+                // Master server has successfully updated our server status
+            }
+            else if (status == MasterServerStatus::InvalidToken)
+            {
+                _status = AdvertiseStatus::unregistered;
                 _lastAdvertiseTime = 0;
-                LOG_INFO("Forcing HTTP(S) over IPv4");
+                Console::Error::WriteLine("Master server heartbeat failed: Invalid Token");
             }
         }
-    }
 
-    /**
-     * @param jsonRoot must be of JSON type object or null
-     * @note jsonRoot is deliberately left non-const: json_t behaviour changes when const
-     */
-    void OnHeartbeatResponse(json_t& jsonRoot)
-    {
-        Guard::Assert(jsonRoot.is_object(), "OnHeartbeatResponse expects parameter jsonRoot to be object");
-
-        auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::InternalError);
-        if (status == MasterServerStatus::Ok)
+        json_t GetHeartbeatJson()
         {
-            // Master server has successfully updated our server status
-        }
-        else if (status == MasterServerStatus::InvalidToken)
-        {
-            _status = AdvertiseStatus::unregistered;
-            _lastAdvertiseTime = 0;
-            Console::Error::WriteLine("Master server heartbeat failed: Invalid Token");
-        }
-    }
+            uint32_t numPlayers = NetworkGetNumVisiblePlayers();
 
-    json_t GetHeartbeatJson()
-    {
-        uint32_t numPlayers = NetworkGetNumVisiblePlayers();
+            json_t root = {
+                { "token", _token },
+                { "players", numPlayers },
+            };
 
-        json_t root = {
-            { "token", _token },
-            { "players", numPlayers },
-        };
+            const auto& gameState = getGameState();
+            const auto& date = GetDate();
+            json_t mapSize = { { "x", gameState.mapSize.x - 2 }, { "y", gameState.mapSize.y - 2 } };
+            json_t gameInfo = {
+                { "mapSize", mapSize },
+                { "day", date.GetMonthTicks() },
+                { "month", date.GetMonthsElapsed() },
+                { "guests", gameState.park.numGuestsInPark },
+                { "parkValue", gameState.park.value },
+            };
 
-        const auto& gameState = getGameState();
-        const auto& date = GetDate();
-        json_t mapSize = { { "x", gameState.mapSize.x - 2 }, { "y", gameState.mapSize.y - 2 } };
-        json_t gameInfo = {
-            { "mapSize", mapSize },
-            { "day", date.GetMonthTicks() },
-            { "month", date.GetMonthsElapsed() },
-            { "guests", gameState.park.numGuestsInPark },
-            { "parkValue", gameState.park.value },
-        };
+            if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+            {
+                gameInfo["cash"] = gameState.park.cash;
+            }
 
-        if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
-        {
-            gameInfo["cash"] = gameState.park.cash;
+            root["gameInfo"] = gameInfo;
+
+            return root;
         }
 
-        root["gameInfo"] = gameInfo;
-
-        return root;
-    }
-
-    static std::string GenerateAdvertiseKey()
-    {
-        // Generate a string of 16 random hex characters (64-integer key as a hex formatted string)
-        static constexpr char hexChars[] = {
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
-        };
-
-        std::random_device rd;
-        std::uniform_int_distribution<int32_t> dist(0, static_cast<int32_t>(std::size(hexChars) - 1));
-
-        char key[17];
-        for (int32_t i = 0; i < 16; i++)
+        static std::string GenerateAdvertiseKey()
         {
-            int32_t hexCharIndex = dist(rd);
-            key[i] = hexChars[hexCharIndex];
-        }
-        key[std::size(key) - 1] = 0;
-        return key;
-    }
+            // Generate a string of 16 random hex characters (64-integer key as a hex formatted string)
+            static constexpr char hexChars[] = {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+            };
 
-    static std::string GetMasterServerUrl()
-    {
-        std::string result = kMasterServerURL;
-        if (!Config::Get().network.MasterServerUrl.empty())
-        {
-            result = Config::Get().network.MasterServerUrl;
+            std::random_device rd;
+            std::uniform_int_distribution<int32_t> dist(0, static_cast<int32_t>(std::size(hexChars) - 1));
+
+            char key[17];
+            for (int32_t i = 0; i < 16; i++)
+            {
+                int32_t hexCharIndex = dist(rd);
+                key[i] = hexChars[hexCharIndex];
+            }
+            key[std::size(key) - 1] = 0;
+            return key;
         }
-        return result;
-    }
+
+        static std::string GetMasterServerUrl()
+        {
+            std::string result = kMasterServerURL;
+            if (!Config::Get().network.MasterServerUrl.empty())
+            {
+                result = Config::Get().network.MasterServerUrl;
+            }
+            return result;
+        }
     #endif
-};
+    };
 
-std::unique_ptr<INetworkServerAdvertiser> CreateServerAdvertiser(uint16_t port)
-{
-    return std::make_unique<NetworkServerAdvertiser>(port);
-}
+    std::unique_ptr<INetworkServerAdvertiser> CreateServerAdvertiser(uint16_t port)
+    {
+        return std::make_unique<NetworkServerAdvertiser>(port);
+    }
+} // namespace OpenRCT2::Network
 
 #endif // DISABLE_NETWORK

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -38,10 +38,10 @@ namespace OpenRCT2::Network
 {
     enum class MasterServerStatus
     {
-        Ok = 200,
-        InvalidToken = 401,
-        ServerNotFound = 404,
-        InternalError = 500
+        ok = 200,
+        invalidToken = 401,
+        serverNotFound = 404,
+        internalError = 500
     };
 
     #ifndef DISABLE_HTTP
@@ -106,7 +106,7 @@ namespace OpenRCT2::Network
             auto ticks = Platform::GetTicks();
             if (ticks > _lastListenTime + 500)
             {
-                if (_lanListener->GetStatus() != SocketStatus::Listening)
+                if (_lanListener->GetStatus() != SocketStatus::listening)
                 {
                     _lanListener->Listen(kNetworkLanBroadcastPort);
                 }
@@ -116,7 +116,7 @@ namespace OpenRCT2::Network
                     size_t recievedBytes{};
                     std::unique_ptr<INetworkEndpoint> endpoint;
                     auto p = _lanListener->ReceiveData(buffer, sizeof(buffer) - 1, &recievedBytes, &endpoint);
-                    if (p == NetworkReadPacket::Success)
+                    if (p == NetworkReadPacket::success)
                     {
                         std::string sender = endpoint->GetHostname();
                         LOG_VERBOSE("Received %zu bytes from %s on LAN broadcast port", recievedBytes, sender.c_str());
@@ -136,7 +136,7 @@ namespace OpenRCT2::Network
 
         json_t GetBroadcastJson()
         {
-            json_t root = NetworkGetServerInfoAsJson();
+            json_t root = Network::GetServerInfoAsJson();
             root["port"] = _port;
             return root;
         }
@@ -236,9 +236,9 @@ namespace OpenRCT2::Network
         {
             Guard::Assert(jsonRoot.is_object(), "OnRegistrationResponse expects parameter jsonRoot to be object");
 
-            auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::InternalError);
+            auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::internalError);
 
-            if (status == MasterServerStatus::Ok)
+            if (status == MasterServerStatus::ok)
             {
                 Console::WriteLine("Server successfully registered on master server");
                 json_t jsonToken = jsonRoot["token"];
@@ -263,7 +263,7 @@ namespace OpenRCT2::Network
                 // Hack for https://github.com/OpenRCT2/OpenRCT2/issues/6277
                 // Master server may not reply correctly if using IPv6, retry forcing IPv4,
                 // don't wait the full timeout.
-                if (!_forceIPv4 && status == MasterServerStatus::InternalError)
+                if (!_forceIPv4 && status == MasterServerStatus::internalError)
                 {
                     _forceIPv4 = true;
                     _lastAdvertiseTime = 0;
@@ -280,12 +280,12 @@ namespace OpenRCT2::Network
         {
             Guard::Assert(jsonRoot.is_object(), "OnHeartbeatResponse expects parameter jsonRoot to be object");
 
-            auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::InternalError);
-            if (status == MasterServerStatus::Ok)
+            auto status = Json::GetEnum<MasterServerStatus>(jsonRoot["status"], MasterServerStatus::internalError);
+            if (status == MasterServerStatus::ok)
             {
                 // Master server has successfully updated our server status
             }
-            else if (status == MasterServerStatus::InvalidToken)
+            else if (status == MasterServerStatus::invalidToken)
             {
                 _status = AdvertiseStatus::unregistered;
                 _lastAdvertiseTime = 0;
@@ -295,7 +295,7 @@ namespace OpenRCT2::Network
 
         json_t GetHeartbeatJson()
         {
-            uint32_t numPlayers = NetworkGetNumVisiblePlayers();
+            uint32_t numPlayers = Network::GetNumVisiblePlayers();
 
             json_t root = {
                 { "token", _token },

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -108,7 +108,7 @@ namespace OpenRCT2::Network
             {
                 if (_lanListener->GetStatus() != SocketStatus::listening)
                 {
-                    _lanListener->Listen(kNetworkLanBroadcastPort);
+                    _lanListener->Listen(kLanBroadcastPort);
                 }
                 else
                 {
@@ -120,7 +120,7 @@ namespace OpenRCT2::Network
                     {
                         std::string sender = endpoint->GetHostname();
                         LOG_VERBOSE("Received %zu bytes from %s on LAN broadcast port", recievedBytes, sender.c_str());
-                        if (String::equals(buffer, kNetworkLanBroadcastMsg))
+                        if (String::equals(buffer, kLanBroadcastMsg))
                         {
                             auto body = GetBroadcastJson();
                             auto bodyDump = body.dump();

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -116,7 +116,7 @@ namespace OpenRCT2::Network
                     size_t recievedBytes{};
                     std::unique_ptr<INetworkEndpoint> endpoint;
                     auto p = _lanListener->ReceiveData(buffer, sizeof(buffer) - 1, &recievedBytes, &endpoint);
-                    if (p == NetworkReadPacket::success)
+                    if (p == ReadPacket::success)
                     {
                         std::string sender = endpoint->GetHostname();
                         LOG_VERBOSE("Received %zu bytes from %s on LAN broadcast port", recievedBytes, sender.c_str());

--- a/src/openrct2/network/NetworkServerAdvertiser.h
+++ b/src/openrct2/network/NetworkServerAdvertiser.h
@@ -11,21 +11,24 @@
 
 #include <memory>
 
-enum class AdvertiseStatus
+namespace OpenRCT2::Network
 {
-    disabled,
-    unregistered,
-    registered,
-};
-
-struct INetworkServerAdvertiser
-{
-    virtual ~INetworkServerAdvertiser()
+    enum class AdvertiseStatus
     {
-    }
+        disabled,
+        unregistered,
+        registered,
+    };
 
-    virtual AdvertiseStatus GetStatus() const = 0;
-    virtual void Update() = 0;
-};
+    struct INetworkServerAdvertiser
+    {
+        virtual ~INetworkServerAdvertiser()
+        {
+        }
 
-[[nodiscard]] std::unique_ptr<INetworkServerAdvertiser> CreateServerAdvertiser(uint16_t port);
+        virtual AdvertiseStatus GetStatus() const = 0;
+        virtual void Update() = 0;
+    };
+
+    [[nodiscard]] std::unique_ptr<INetworkServerAdvertiser> CreateServerAdvertiser(uint16_t port);
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -15,15 +15,15 @@
 
 namespace OpenRCT2::Network
 {
-    enum
+    enum class ServerEvent : uint16_t
     {
-        SERVER_EVENT_PLAYER_JOINED,
-        SERVER_EVENT_PLAYER_DISCONNECTED,
+        playerJoined,
+        playerDisconnected,
     };
 
-    enum
+    namespace TickFlags
     {
-        NETWORK_TICK_FLAG_CHECKSUMS = 1 << 0,
+        constexpr uint16_t kChecksums = 1 << 0;
     };
 
     enum class Mode : int32_t
@@ -33,9 +33,9 @@ namespace OpenRCT2::Network
         server
     };
 
-    enum
+    namespace PlayerFlags
     {
-        NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
+        constexpr uint16_t kIsServer = 1 << 0;
     };
 
     enum class Status : int32_t

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -13,136 +13,139 @@
 #include "../core/EnumUtils.hpp"
 #include "../ride/RideTypes.h"
 
-enum
+namespace OpenRCT2::Network
 {
-    SERVER_EVENT_PLAYER_JOINED,
-    SERVER_EVENT_PLAYER_DISCONNECTED,
-};
+    enum
+    {
+        SERVER_EVENT_PLAYER_JOINED,
+        SERVER_EVENT_PLAYER_DISCONNECTED,
+    };
 
-enum
-{
-    NETWORK_TICK_FLAG_CHECKSUMS = 1 << 0,
-};
+    enum
+    {
+        NETWORK_TICK_FLAG_CHECKSUMS = 1 << 0,
+    };
 
-enum
-{
-    NETWORK_MODE_NONE,
-    NETWORK_MODE_CLIENT,
-    NETWORK_MODE_SERVER
-};
+    enum
+    {
+        NETWORK_MODE_NONE,
+        NETWORK_MODE_CLIENT,
+        NETWORK_MODE_SERVER
+    };
 
-enum
-{
-    NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
-};
+    enum
+    {
+        NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
+    };
 
-enum
-{
-    NETWORK_STATUS_NONE,
-    NETWORK_STATUS_READY,
-    NETWORK_STATUS_CONNECTING,
-    NETWORK_STATUS_CONNECTED
-};
+    enum
+    {
+        NETWORK_STATUS_NONE,
+        NETWORK_STATUS_READY,
+        NETWORK_STATUS_CONNECTING,
+        NETWORK_STATUS_CONNECTED
+    };
 
-enum class NetworkAuth : int32_t
-{
-    None,
-    Requested,
-    Ok,
-    BadVersion,
-    BadName,
-    BadPassword,
-    VerificationFailure,
-    Full,
-    RequirePassword,
-    Verified,
-    UnknownKeyDisallowed
-};
+    enum class NetworkAuth : int32_t
+    {
+        None,
+        Requested,
+        Ok,
+        BadVersion,
+        BadName,
+        BadPassword,
+        VerificationFailure,
+        Full,
+        RequirePassword,
+        Verified,
+        UnknownKeyDisallowed
+    };
 
-enum class NetworkCommand : uint32_t
-{
-    Auth,
-    Map,
-    Chat,
-    Tick = 4,
-    PlayerList,
-    Ping,
-    PingList,
-    DisconnectMessage,
-    GameInfo,
-    ShowError,
-    GroupList,
-    Event,
-    Token,
-    ObjectsList,
-    MapRequest,
-    GameAction,
-    PlayerInfo,
-    RequestGameState,
-    GameState,
-    ScriptsHeader,
-    ScriptsData,
-    Heartbeat,
-    Max,
-    Invalid = static_cast<uint32_t>(-1),
-};
+    enum class NetworkCommand : uint32_t
+    {
+        Auth,
+        Map,
+        Chat,
+        Tick = 4,
+        PlayerList,
+        Ping,
+        PingList,
+        DisconnectMessage,
+        GameInfo,
+        ShowError,
+        GroupList,
+        Event,
+        Token,
+        ObjectsList,
+        MapRequest,
+        GameAction,
+        PlayerInfo,
+        RequestGameState,
+        GameState,
+        ScriptsHeader,
+        ScriptsData,
+        Heartbeat,
+        Max,
+        Invalid = static_cast<uint32_t>(-1),
+    };
 
-static_assert(NetworkCommand::GameInfo == static_cast<NetworkCommand>(9), "Master server expects this to be 9");
+    static_assert(NetworkCommand::GameInfo == static_cast<NetworkCommand>(9), "Master server expects this to be 9");
 
-enum class NetworkServerStatus
-{
-    Ok,
-    Desynced
-};
+    enum class NetworkServerStatus
+    {
+        Ok,
+        Desynced
+    };
 
-struct NetworkServerState
-{
-    NetworkServerStatus state = NetworkServerStatus::Ok;
-    uint32_t desyncTick = 0;
-    uint32_t tick = 0;
-    uint32_t srand0 = 0;
-    bool gamestateSnapshotsEnabled = false;
-};
+    struct NetworkServerState
+    {
+        NetworkServerStatus state = NetworkServerStatus::Ok;
+        uint32_t desyncTick = 0;
+        uint32_t tick = 0;
+        uint32_t srand0 = 0;
+        bool gamestateSnapshotsEnabled = false;
+    };
 
 // Structure is used for networking specific fields with meaning,
 // this structure can be used in combination with DataSerialiser
 // to provide extra details with template specialization.
 #pragma pack(push, 1)
-template<typename T, size_t _TypeID>
-struct NetworkObjectId
-{
-    NetworkObjectId(T v)
-        : id(v)
+    template<typename T, size_t _TypeID>
+    struct NetworkObjectId
     {
-    }
-    NetworkObjectId()
-        : id(T(-1))
-    {
-    }
-    operator T() const
-    {
-        return id;
-    }
-    T id;
-};
+        NetworkObjectId(T v)
+            : id(v)
+        {
+        }
+        NetworkObjectId()
+            : id(T(-1))
+        {
+        }
+        operator T() const
+        {
+            return id;
+        }
+        T id;
+    };
 #pragma pack(pop)
 
-// NOTE: When adding new types make sure to have no duplicate _TypeID's otherwise
-// there is no way to specialize templates if they have the exact symbol.
-using NetworkPlayerId_t = NetworkObjectId<int32_t, 0>;
-using NetworkCheatType_t = NetworkObjectId<int32_t, 2>;
+    // NOTE: When adding new types make sure to have no duplicate _TypeID's otherwise
+    // there is no way to specialize templates if they have the exact symbol.
+    using NetworkPlayerId_t = NetworkObjectId<int32_t, 0>;
+    using NetworkCheatType_t = NetworkObjectId<int32_t, 2>;
 
-enum class NetworkStatisticsGroup : uint32_t
-{
-    Total = 0, // Entire network traffic.
-    Base,      // Messages such as Tick, Ping
-    Commands,  // Command / Game actions
-    MapData,
-    Max,
-};
+    enum class NetworkStatisticsGroup : uint32_t
+    {
+        Total = 0, // Entire network traffic.
+        Base,      // Messages such as Tick, Ping
+        Commands,  // Command / Game actions
+        MapData,
+        Max,
+    };
 
-struct NetworkStats
-{
-    uint64_t bytesReceived[EnumValue(NetworkStatisticsGroup::Max)];
-    uint64_t bytesSent[EnumValue(NetworkStatisticsGroup::Max)];
-};
+    struct NetworkStats
+    {
+        uint64_t bytesReceived[EnumValue(NetworkStatisticsGroup::Max)];
+        uint64_t bytesSent[EnumValue(NetworkStatisticsGroup::Max)];
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -26,11 +26,11 @@ namespace OpenRCT2::Network
         NETWORK_TICK_FLAG_CHECKSUMS = 1 << 0,
     };
 
-    enum
+    enum class Mode : int32_t
     {
-        NETWORK_MODE_NONE,
-        NETWORK_MODE_CLIENT,
-        NETWORK_MODE_SERVER
+        none,
+        client,
+        server
     };
 
     enum
@@ -38,68 +38,68 @@ namespace OpenRCT2::Network
         NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
     };
 
-    enum
+    enum class Status : int32_t
     {
-        NETWORK_STATUS_NONE,
-        NETWORK_STATUS_READY,
-        NETWORK_STATUS_CONNECTING,
-        NETWORK_STATUS_CONNECTED
+        none,
+        ready,
+        connecting,
+        connected
     };
 
-    enum class NetworkAuth : int32_t
+    enum class Auth : int32_t
     {
-        None,
-        Requested,
-        Ok,
-        BadVersion,
-        BadName,
-        BadPassword,
-        VerificationFailure,
-        Full,
-        RequirePassword,
-        Verified,
-        UnknownKeyDisallowed
+        none,
+        requested,
+        ok,
+        badVersion,
+        badName,
+        badPassword,
+        verificationFailure,
+        full,
+        requirePassword,
+        verified,
+        unknownKeyDisallowed
     };
 
-    enum class NetworkCommand : uint32_t
+    enum class Command : uint32_t
     {
-        Auth,
-        Map,
-        Chat,
-        Tick = 4,
-        PlayerList,
-        Ping,
-        PingList,
-        DisconnectMessage,
-        GameInfo,
-        ShowError,
-        GroupList,
-        Event,
-        Token,
-        ObjectsList,
-        MapRequest,
-        GameAction,
-        PlayerInfo,
-        RequestGameState,
-        GameState,
-        ScriptsHeader,
-        ScriptsData,
-        Heartbeat,
-        Max,
-        Invalid = static_cast<uint32_t>(-1),
+        auth,
+        map,
+        chat,
+        tick = 4,
+        playerList,
+        ping,
+        pingList,
+        disconnectMessage,
+        gameInfo,
+        showError,
+        groupList,
+        event,
+        token,
+        objectsList,
+        mapRequest,
+        gameAction,
+        playerInfo,
+        requestGameState,
+        gameState,
+        scriptsHeader,
+        scriptsData,
+        heartbeat,
+        max,
+        invalid = static_cast<uint32_t>(-1),
     };
 
-    static_assert(NetworkCommand::GameInfo == static_cast<NetworkCommand>(9), "Master server expects this to be 9");
+    static_assert(Command::gameInfo == static_cast<Command>(9), "Master server expects this to be 9");
 
-    enum class NetworkServerStatus
+    enum class ServerStatus
     {
-        Ok,
-        Desynced
+        ok,
+        desynced
     };
 
-    struct NetworkServerState
+    struct ServerState
     {
-        NetworkServerStatus state = NetworkServerStatus::Ok;
+        ServerStatus state = ServerStatus::ok;
         uint32_t desyncTick = 0;
         uint32_t tick = 0;
         uint32_t srand0 = 0;
@@ -131,10 +131,10 @@ namespace OpenRCT2::Network
 
     // NOTE: When adding new types make sure to have no duplicate _TypeID's otherwise
     // there is no way to specialize templates if they have the exact symbol.
-    using NetworkPlayerId_t = NetworkObjectId<int32_t, 0>;
-    using NetworkCheatType_t = NetworkObjectId<int32_t, 2>;
+    using PlayerId_t = NetworkObjectId<int32_t, 0>;
+    using CheatType_t = NetworkObjectId<int32_t, 2>;
 
-    enum class NetworkStatisticsGroup : uint32_t
+    enum class StatisticsGroup : uint32_t
     {
         Total = 0, // Entire network traffic.
         Base,      // Messages such as Tick, Ping
@@ -143,9 +143,9 @@ namespace OpenRCT2::Network
         Max,
     };
 
-    struct NetworkStats
+    struct Stats
     {
-        uint64_t bytesReceived[EnumValue(NetworkStatisticsGroup::Max)];
-        uint64_t bytesSent[EnumValue(NetworkStatisticsGroup::Max)];
+        uint64_t bytesReceived[EnumValue(StatisticsGroup::Max)];
+        uint64_t bytesSent[EnumValue(StatisticsGroup::Max)];
     };
 } // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -22,198 +22,199 @@
 
     #include <unordered_set>
 
-using namespace OpenRCT2;
-
-constexpr const utf8* kUserStoreFilename = "users.json";
-
-std::unique_ptr<NetworkUser> NetworkUser::FromJson(const json_t& jsonData)
+namespace OpenRCT2::Network
 {
-    Guard::Assert(jsonData.is_object(), "NetworkUser::FromJson expects parameter jsonData to be object");
+    constexpr const utf8* kUserStoreFilename = "users.json";
 
-    const std::string hash = Json::GetString(jsonData["hash"]);
-    const std::string name = Json::GetString(jsonData["name"]);
-    json_t jsonGroupId = jsonData["groupId"];
-
-    std::unique_ptr<NetworkUser> user = nullptr;
-    if (!hash.empty() && !name.empty())
+    std::unique_ptr<NetworkUser> NetworkUser::FromJson(const json_t& jsonData)
     {
-        user = std::make_unique<NetworkUser>();
-        user->Hash = hash;
-        user->Name = name;
-        if (jsonGroupId.is_number_integer())
+        Guard::Assert(jsonData.is_object(), "NetworkUser::FromJson expects parameter jsonData to be object");
+
+        const std::string hash = Json::GetString(jsonData["hash"]);
+        const std::string name = Json::GetString(jsonData["name"]);
+        json_t jsonGroupId = jsonData["groupId"];
+
+        std::unique_ptr<NetworkUser> user = nullptr;
+        if (!hash.empty() && !name.empty())
         {
-            user->GroupId = Json::GetNumber<uint8_t>(jsonGroupId);
-        }
-        user->Remove = false;
-    }
-    return user;
-}
-
-json_t NetworkUser::ToJson() const
-{
-    json_t jsonData;
-    jsonData["hash"] = Hash;
-    jsonData["name"] = Name;
-
-    json_t jsonGroupId;
-    if (GroupId.has_value())
-    {
-        jsonGroupId = *GroupId;
-    }
-    jsonData["groupId"] = jsonGroupId;
-
-    return jsonData;
-}
-
-void NetworkUserManager::Load()
-{
-    const auto path = GetStorePath();
-
-    if (File::Exists(path))
-    {
-        _usersByHash.clear();
-
-        try
-        {
-            json_t jsonUsers = Json::ReadFromFile(path);
-            for (const auto& jsonUser : jsonUsers)
+            user = std::make_unique<NetworkUser>();
+            user->Hash = hash;
+            user->Name = name;
+            if (jsonGroupId.is_number_integer())
             {
-                if (jsonUser.is_object())
+                user->GroupId = Json::GetNumber<uint8_t>(jsonGroupId);
+            }
+            user->Remove = false;
+        }
+        return user;
+    }
+
+    json_t NetworkUser::ToJson() const
+    {
+        json_t jsonData;
+        jsonData["hash"] = Hash;
+        jsonData["name"] = Name;
+
+        json_t jsonGroupId;
+        if (GroupId.has_value())
+        {
+            jsonGroupId = *GroupId;
+        }
+        jsonData["groupId"] = jsonGroupId;
+
+        return jsonData;
+    }
+
+    void NetworkUserManager::Load()
+    {
+        const auto path = GetStorePath();
+
+        if (File::Exists(path))
+        {
+            _usersByHash.clear();
+
+            try
+            {
+                json_t jsonUsers = Json::ReadFromFile(path);
+                for (const auto& jsonUser : jsonUsers)
                 {
-                    auto networkUser = NetworkUser::FromJson(jsonUser);
-                    if (networkUser != nullptr)
+                    if (jsonUser.is_object())
                     {
-                        _usersByHash[networkUser->Hash] = std::move(networkUser);
+                        auto networkUser = NetworkUser::FromJson(jsonUser);
+                        if (networkUser != nullptr)
+                        {
+                            _usersByHash[networkUser->Hash] = std::move(networkUser);
+                        }
                     }
                 }
             }
-        }
-        catch (const std::exception& ex)
-        {
-            Console::Error::WriteLine("Failed to read %s as JSON. %s", path.c_str(), ex.what());
-        }
-    }
-}
-
-void NetworkUserManager::Save()
-{
-    const auto path = GetStorePath();
-
-    json_t jsonUsers;
-    try
-    {
-        if (File::Exists(path))
-        {
-            jsonUsers = Json::ReadFromFile(path);
-        }
-    }
-    catch (const std::exception&)
-    {
-    }
-
-    // Update existing users
-    std::unordered_set<std::string> savedHashes;
-    for (auto it = jsonUsers.begin(); it != jsonUsers.end();)
-    {
-        json_t jsonUser = *it;
-        if (!jsonUser.is_object())
-        {
-            continue;
-        }
-        std::string hashString = Json::GetString(jsonUser["hash"]);
-
-        const auto networkUser = GetUserByHash(hashString);
-        if (networkUser != nullptr)
-        {
-            if (networkUser->Remove)
+            catch (const std::exception& ex)
             {
-                it = jsonUsers.erase(it);
-                // erase advances the iterator so make sure we don't do it again
+                Console::Error::WriteLine("Failed to read %s as JSON. %s", path.c_str(), ex.what());
+            }
+        }
+    }
+
+    void NetworkUserManager::Save()
+    {
+        const auto path = GetStorePath();
+
+        json_t jsonUsers;
+        try
+        {
+            if (File::Exists(path))
+            {
+                jsonUsers = Json::ReadFromFile(path);
+            }
+        }
+        catch (const std::exception&)
+        {
+        }
+
+        // Update existing users
+        std::unordered_set<std::string> savedHashes;
+        for (auto it = jsonUsers.begin(); it != jsonUsers.end();)
+        {
+            json_t jsonUser = *it;
+            if (!jsonUser.is_object())
+            {
                 continue;
             }
+            std::string hashString = Json::GetString(jsonUser["hash"]);
 
-            // replace the existing element in jsonUsers
-            *it = networkUser->ToJson();
-            savedHashes.insert(hashString);
+            const auto networkUser = GetUserByHash(hashString);
+            if (networkUser != nullptr)
+            {
+                if (networkUser->Remove)
+                {
+                    it = jsonUsers.erase(it);
+                    // erase advances the iterator so make sure we don't do it again
+                    continue;
+                }
+
+                // replace the existing element in jsonUsers
+                *it = networkUser->ToJson();
+                savedHashes.insert(hashString);
+            }
+
+            it++;
         }
 
-        it++;
-    }
-
-    // Add new users
-    for (const auto& kvp : _usersByHash)
-    {
-        const auto& networkUser = kvp.second;
-        if (!networkUser->Remove && savedHashes.find(networkUser->Hash) == savedHashes.end())
+        // Add new users
+        for (const auto& kvp : _usersByHash)
         {
-            jsonUsers.push_back(networkUser->ToJson());
+            const auto& networkUser = kvp.second;
+            if (!networkUser->Remove && savedHashes.find(networkUser->Hash) == savedHashes.end())
+            {
+                jsonUsers.push_back(networkUser->ToJson());
+            }
         }
+
+        Json::WriteToFile(path, jsonUsers);
     }
 
-    Json::WriteToFile(path, jsonUsers);
-}
-
-void NetworkUserManager::UnsetUsersOfGroup(uint8_t groupId)
-{
-    for (const auto& kvp : _usersByHash)
+    void NetworkUserManager::UnsetUsersOfGroup(uint8_t groupId)
     {
-        auto& networkUser = kvp.second;
-        if (networkUser->GroupId.has_value() && *networkUser->GroupId == groupId)
+        for (const auto& kvp : _usersByHash)
         {
-            networkUser->GroupId = std::nullopt;
+            auto& networkUser = kvp.second;
+            if (networkUser->GroupId.has_value() && *networkUser->GroupId == groupId)
+            {
+                networkUser->GroupId = std::nullopt;
+            }
         }
     }
-}
 
-void NetworkUserManager::RemoveUser(const std::string& hash)
-{
-    NetworkUser* networkUser = const_cast<NetworkUser*>(GetUserByHash(hash));
-    if (networkUser != nullptr)
+    void NetworkUserManager::RemoveUser(const std::string& hash)
     {
-        networkUser->Remove = true;
-    }
-}
-
-const NetworkUser* NetworkUserManager::GetUserByHash(const std::string& hash) const
-{
-    auto it = _usersByHash.find(hash);
-    if (it != _usersByHash.end())
-    {
-        return it->second.get();
-    }
-    return nullptr;
-}
-
-const NetworkUser* NetworkUserManager::GetUserByName(const std::string& name) const
-{
-    for (const auto& kvp : _usersByHash)
-    {
-        const auto& networkUser = kvp.second;
-        if (String::iequals(name, networkUser->Name))
+        NetworkUser* networkUser = const_cast<NetworkUser*>(GetUserByHash(hash));
+        if (networkUser != nullptr)
         {
-            return networkUser.get();
+            networkUser->Remove = true;
         }
     }
-    return nullptr;
-}
 
-NetworkUser* NetworkUserManager::GetOrAddUser(const std::string& hash)
-{
-    NetworkUser* networkUser = const_cast<NetworkUser*>(GetUserByHash(hash));
-    if (networkUser == nullptr)
+    const NetworkUser* NetworkUserManager::GetUserByHash(const std::string& hash) const
     {
-        auto newNetworkUser = std::make_unique<NetworkUser>();
-        newNetworkUser->Hash = hash;
-        networkUser = newNetworkUser.get();
-        _usersByHash[hash] = std::move(newNetworkUser);
+        auto it = _usersByHash.find(hash);
+        if (it != _usersByHash.end())
+        {
+            return it->second.get();
+        }
+        return nullptr;
     }
-    return networkUser;
-}
 
-u8string NetworkUserManager::GetStorePath()
-{
-    auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-    return Path::Combine(env.GetDirectoryPath(OpenRCT2::DirBase::user), kUserStoreFilename);
-}
+    const NetworkUser* NetworkUserManager::GetUserByName(const std::string& name) const
+    {
+        for (const auto& kvp : _usersByHash)
+        {
+            const auto& networkUser = kvp.second;
+            if (String::iequals(name, networkUser->Name))
+            {
+                return networkUser.get();
+            }
+        }
+        return nullptr;
+    }
+
+    NetworkUser* NetworkUserManager::GetOrAddUser(const std::string& hash)
+    {
+        NetworkUser* networkUser = const_cast<NetworkUser*>(GetUserByHash(hash));
+        if (networkUser == nullptr)
+        {
+            auto newNetworkUser = std::make_unique<NetworkUser>();
+            newNetworkUser->Hash = hash;
+            networkUser = newNetworkUser.get();
+            _usersByHash[hash] = std::move(newNetworkUser);
+        }
+        return networkUser;
+    }
+
+    u8string NetworkUserManager::GetStorePath()
+    {
+        auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+        return Path::Combine(env.GetDirectoryPath(OpenRCT2::DirBase::user), kUserStoreFilename);
+    }
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -212,8 +212,8 @@ namespace OpenRCT2::Network
 
     u8string NetworkUserManager::GetStorePath()
     {
-        auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-        return Path::Combine(env.GetDirectoryPath(OpenRCT2::DirBase::user), kUserStoreFilename);
+        auto& env = GetContext()->GetPlatformEnvironment();
+        return Path::Combine(env.GetDirectoryPath(DirBase::user), kUserStoreFilename);
     }
 } // namespace OpenRCT2::Network
 

--- a/src/openrct2/network/NetworkUser.h
+++ b/src/openrct2/network/NetworkUser.h
@@ -16,52 +16,55 @@
 #include <optional>
 #include <unordered_map>
 
-class NetworkUser final
+namespace OpenRCT2::Network
 {
-public:
-    std::string Hash;
-    std::string Name;
-    std::optional<uint8_t> GroupId;
-    bool Remove;
+    class NetworkUser final
+    {
+    public:
+        std::string Hash;
+        std::string Name;
+        std::optional<uint8_t> GroupId;
+        bool Remove;
 
-    /**
-     * Creates a NetworkUser object from a JSON object
-     * @param jsonData Must be a JSON node of type object
-     * @return Pointer to a new NetworkUser object
-     * @note jsonData is deliberately left non-const: json_t behaviour changes when const
-     */
-    static std::unique_ptr<NetworkUser> FromJson(const json_t& jsonData);
+        /**
+         * Creates a NetworkUser object from a JSON object
+         * @param jsonData Must be a JSON node of type object
+         * @return Pointer to a new NetworkUser object
+         * @note jsonData is deliberately left non-const: json_t behaviour changes when const
+         */
+        static std::unique_ptr<NetworkUser> FromJson(const json_t& jsonData);
 
-    /**
-     * Serialise a NetworkUser object into a JSON object
-     *
-     * @return JSON representation of the NetworkUser object
-     */
-    json_t ToJson() const;
-};
+        /**
+         * Serialise a NetworkUser object into a JSON object
+         *
+         * @return JSON representation of the NetworkUser object
+         */
+        json_t ToJson() const;
+    };
 
-class NetworkUserManager final
-{
-public:
-    void Load();
+    class NetworkUserManager final
+    {
+    public:
+        void Load();
 
-    /**
-     * @brief NetworkUserManager::Save
-     * Reads mappings from JSON, updates them in-place and saves JSON.
-     *
-     * Useful for retaining custom entries in JSON file.
-     */
-    void Save();
+        /**
+         * @brief NetworkUserManager::Save
+         * Reads mappings from JSON, updates them in-place and saves JSON.
+         *
+         * Useful for retaining custom entries in JSON file.
+         */
+        void Save();
 
-    void UnsetUsersOfGroup(uint8_t groupId);
-    void RemoveUser(const std::string& hash);
+        void UnsetUsersOfGroup(uint8_t groupId);
+        void RemoveUser(const std::string& hash);
 
-    const NetworkUser* GetUserByHash(const std::string& hash) const;
-    const NetworkUser* GetUserByName(const std::string& name) const;
-    NetworkUser* GetOrAddUser(const std::string& hash);
+        const NetworkUser* GetUserByHash(const std::string& hash) const;
+        const NetworkUser* GetUserByName(const std::string& name) const;
+        NetworkUser* GetOrAddUser(const std::string& hash);
 
-private:
-    std::unordered_map<std::string, std::unique_ptr<NetworkUser>> _usersByHash;
+    private:
+        std::unordered_map<std::string, std::unique_ptr<NetworkUser>> _usersByHash;
 
-    static u8string GetStorePath();
-};
+        static u8string GetStorePath();
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/NetworkUser.h
+++ b/src/openrct2/network/NetworkUser.h
@@ -18,7 +18,7 @@
 
 namespace OpenRCT2::Network
 {
-    class NetworkUser final
+    class User final
     {
     public:
         std::string Hash;
@@ -27,28 +27,28 @@ namespace OpenRCT2::Network
         bool Remove;
 
         /**
-         * Creates a NetworkUser object from a JSON object
+         * Creates a User object from a JSON object
          * @param jsonData Must be a JSON node of type object
-         * @return Pointer to a new NetworkUser object
+         * @return Pointer to a new User object
          * @note jsonData is deliberately left non-const: json_t behaviour changes when const
          */
-        static std::unique_ptr<NetworkUser> FromJson(const json_t& jsonData);
+        static std::unique_ptr<User> FromJson(const json_t& jsonData);
 
         /**
-         * Serialise a NetworkUser object into a JSON object
+         * Serialise a User object into a JSON object
          *
-         * @return JSON representation of the NetworkUser object
+         * @return JSON representation of the User object
          */
         json_t ToJson() const;
     };
 
-    class NetworkUserManager final
+    class UserManager final
     {
     public:
         void Load();
 
         /**
-         * @brief NetworkUserManager::Save
+         * @brief UserManager::Save
          * Reads mappings from JSON, updates them in-place and saves JSON.
          *
          * Useful for retaining custom entries in JSON file.
@@ -58,12 +58,12 @@ namespace OpenRCT2::Network
         void UnsetUsersOfGroup(uint8_t groupId);
         void RemoveUser(const std::string& hash);
 
-        const NetworkUser* GetUserByHash(const std::string& hash) const;
-        const NetworkUser* GetUserByName(const std::string& name) const;
-        NetworkUser* GetOrAddUser(const std::string& hash);
+        const User* GetUserByHash(const std::string& hash) const;
+        const User* GetUserByName(const std::string& name) const;
+        User* GetOrAddUser(const std::string& hash);
 
     private:
-        std::unordered_map<std::string, std::unique_ptr<NetworkUser>> _usersByHash;
+        std::unordered_map<std::string, std::unique_ptr<User>> _usersByHash;
 
         static u8string GetStorePath();
     };

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -293,7 +293,7 @@ namespace OpenRCT2::Network
                     size_t recievedLen{};
                     std::unique_ptr<INetworkEndpoint> endpoint;
                     auto p = udpSocket->ReceiveData(buffer, sizeof(buffer) - 1, &recievedLen, &endpoint);
-                    if (p == NetworkReadPacket::success)
+                    if (p == ReadPacket::success)
                     {
                         auto sender = endpoint->GetHostname();
                         LOG_VERBOSE("Received %zu bytes back from %s", recievedLen, sender.c_str());

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -31,412 +31,415 @@
     #include <numeric>
     #include <optional>
 
-using namespace OpenRCT2;
-
-int32_t ServerListEntry::CompareTo(const ServerListEntry& other) const
+namespace OpenRCT2::Network
 {
-    const auto& a = *this;
-    const auto& b = other;
-
-    if (a.Favourite != b.Favourite)
+    int32_t ServerListEntry::CompareTo(const ServerListEntry& other) const
     {
-        return a.Favourite ? -1 : 1;
-    }
+        const auto& a = *this;
+        const auto& b = other;
 
-    if (a.Local != b.Local)
-    {
-        return a.Local ? -1 : 1;
-    }
-
-    bool serverACompatible = a.Version == NetworkGetVersion();
-    bool serverBCompatible = b.Version == NetworkGetVersion();
-    if (serverACompatible != serverBCompatible)
-    {
-        return serverACompatible ? -1 : 1;
-    }
-
-    if (a.RequiresPassword != b.RequiresPassword)
-    {
-        return a.RequiresPassword ? 1 : -1;
-    }
-
-    if (a.Players != b.Players)
-    {
-        return a.Players > b.Players ? -1 : 1;
-    }
-
-    return String::compare(a.Name, b.Name, true);
-}
-
-bool ServerListEntry::IsVersionValid() const noexcept
-{
-    return Version.empty() || Version == NetworkGetVersion();
-}
-
-std::optional<ServerListEntry> ServerListEntry::FromJson(json_t& server)
-{
-    Guard::Assert(server.is_object(), "ServerListEntry::FromJson expects parameter server to be object");
-
-    const auto port = Json::GetNumber<int32_t>(server["port"]);
-    const auto name = Json::GetString(server["name"]);
-    const auto description = Json::GetString(server["description"]);
-    const auto requiresPassword = Json::GetBoolean(server["requiresPassword"]);
-    const auto version = Json::GetString(server["version"]);
-    const auto players = Json::GetNumber<uint8_t>(server["players"]);
-    const auto maxPlayers = Json::GetNumber<uint8_t>(server["maxPlayers"]);
-    std::string ip;
-    // if server["ip"] or server["ip"]["v4"] are values, this will throw an exception, so check first
-    if (server["ip"].is_object() && server["ip"]["v4"].is_array())
-    {
-        ip = Json::GetString(server["ip"]["v4"][0]);
-    }
-
-    if (name.empty() || version.empty())
-    {
-        LOG_VERBOSE("Cowardly refusing to add server without name or version specified.");
-
-        return std::nullopt;
-    }
-
-    ServerListEntry entry;
-
-    entry.Address = ip + ":" + std::to_string(port);
-    entry.Name = name;
-    entry.Description = description;
-    entry.Version = version;
-    entry.RequiresPassword = requiresPassword;
-    entry.Players = players;
-    entry.MaxPlayers = maxPlayers;
-
-    return entry;
-}
-
-void ServerList::Sort()
-{
-    _serverEntries.erase(
-        std::unique(
-            _serverEntries.begin(), _serverEntries.end(),
-            [](const ServerListEntry& a, const ServerListEntry& b) {
-                if (a.Favourite == b.Favourite)
-                {
-                    return String::iequals(a.Address, b.Address);
-                }
-                return false;
-            }),
-        _serverEntries.end());
-    std::sort(_serverEntries.begin(), _serverEntries.end(), [](const ServerListEntry& a, const ServerListEntry& b) {
-        return a.CompareTo(b) < 0;
-    });
-}
-
-ServerListEntry& ServerList::GetServer(size_t index)
-{
-    return _serverEntries[index];
-}
-
-size_t ServerList::GetCount() const
-{
-    return _serverEntries.size();
-}
-
-void ServerList::Add(const ServerListEntry& entry)
-{
-    _serverEntries.push_back(entry);
-    Sort();
-}
-
-void ServerList::AddRange(const std::vector<ServerListEntry>& entries)
-{
-    _serverEntries.insert(_serverEntries.end(), entries.begin(), entries.end());
-    Sort();
-}
-
-void ServerList::AddOrUpdateRange(const std::vector<ServerListEntry>& entries)
-{
-    for (auto& existsEntry : _serverEntries)
-    {
-        auto match = std::find_if(
-            entries.begin(), entries.end(), [&](const ServerListEntry& entry) { return existsEntry.Address == entry.Address; });
-        if (match != entries.end())
+        if (a.Favourite != b.Favourite)
         {
-            // Keep favourites
-            auto fav = existsEntry.Favourite;
-
-            existsEntry = *match;
-            existsEntry.Favourite = fav;
+            return a.Favourite ? -1 : 1;
         }
+
+        if (a.Local != b.Local)
+        {
+            return a.Local ? -1 : 1;
+        }
+
+        bool serverACompatible = a.Version == NetworkGetVersion();
+        bool serverBCompatible = b.Version == NetworkGetVersion();
+        if (serverACompatible != serverBCompatible)
+        {
+            return serverACompatible ? -1 : 1;
+        }
+
+        if (a.RequiresPassword != b.RequiresPassword)
+        {
+            return a.RequiresPassword ? 1 : -1;
+        }
+
+        if (a.Players != b.Players)
+        {
+            return a.Players > b.Players ? -1 : 1;
+        }
+
+        return String::compare(a.Name, b.Name, true);
     }
 
-    std::vector<ServerListEntry> newServers;
-    std::copy_if(entries.begin(), entries.end(), std::back_inserter(newServers), [this](const ServerListEntry& entry) {
-        return std::find_if(
-                   _serverEntries.begin(), _serverEntries.end(),
-                   [&](const ServerListEntry& existsEntry) { return existsEntry.Address == entry.Address; })
-            == _serverEntries.end();
-    });
-
-    AddRange(newServers);
-}
-
-void ServerList::Clear() noexcept
-{
-    _serverEntries.clear();
-}
-
-std::vector<ServerListEntry> ServerList::ReadFavourites() const
-{
-    LOG_VERBOSE("server_list_read(...)");
-    std::vector<ServerListEntry> entries;
-    try
+    bool ServerListEntry::IsVersionValid() const noexcept
     {
-        auto& env = GetContext()->GetPlatformEnvironment();
-        auto path = env.GetFilePath(PathId::networkServers);
-        if (File::Exists(path))
+        return Version.empty() || Version == NetworkGetVersion();
+    }
+
+    std::optional<ServerListEntry> ServerListEntry::FromJson(json_t& server)
+    {
+        Guard::Assert(server.is_object(), "ServerListEntry::FromJson expects parameter server to be object");
+
+        const auto port = Json::GetNumber<int32_t>(server["port"]);
+        const auto name = Json::GetString(server["name"]);
+        const auto description = Json::GetString(server["description"]);
+        const auto requiresPassword = Json::GetBoolean(server["requiresPassword"]);
+        const auto version = Json::GetString(server["version"]);
+        const auto players = Json::GetNumber<uint8_t>(server["players"]);
+        const auto maxPlayers = Json::GetNumber<uint8_t>(server["maxPlayers"]);
+        std::string ip;
+        // if server["ip"] or server["ip"]["v4"] are values, this will throw an exception, so check first
+        if (server["ip"].is_object() && server["ip"]["v4"].is_array())
         {
-            auto fs = FileStream(path, FileMode::open);
-            auto numEntries = fs.ReadValue<uint32_t>();
-            for (size_t i = 0; i < numEntries; i++)
+            ip = Json::GetString(server["ip"]["v4"][0]);
+        }
+
+        if (name.empty() || version.empty())
+        {
+            LOG_VERBOSE("Cowardly refusing to add server without name or version specified.");
+
+            return std::nullopt;
+        }
+
+        ServerListEntry entry;
+
+        entry.Address = ip + ":" + std::to_string(port);
+        entry.Name = name;
+        entry.Description = description;
+        entry.Version = version;
+        entry.RequiresPassword = requiresPassword;
+        entry.Players = players;
+        entry.MaxPlayers = maxPlayers;
+
+        return entry;
+    }
+
+    void ServerList::Sort()
+    {
+        _serverEntries.erase(
+            std::unique(
+                _serverEntries.begin(), _serverEntries.end(),
+                [](const ServerListEntry& a, const ServerListEntry& b) {
+                    if (a.Favourite == b.Favourite)
+                    {
+                        return String::iequals(a.Address, b.Address);
+                    }
+                    return false;
+                }),
+            _serverEntries.end());
+        std::sort(_serverEntries.begin(), _serverEntries.end(), [](const ServerListEntry& a, const ServerListEntry& b) {
+            return a.CompareTo(b) < 0;
+        });
+    }
+
+    ServerListEntry& ServerList::GetServer(size_t index)
+    {
+        return _serverEntries[index];
+    }
+
+    size_t ServerList::GetCount() const
+    {
+        return _serverEntries.size();
+    }
+
+    void ServerList::Add(const ServerListEntry& entry)
+    {
+        _serverEntries.push_back(entry);
+        Sort();
+    }
+
+    void ServerList::AddRange(const std::vector<ServerListEntry>& entries)
+    {
+        _serverEntries.insert(_serverEntries.end(), entries.begin(), entries.end());
+        Sort();
+    }
+
+    void ServerList::AddOrUpdateRange(const std::vector<ServerListEntry>& entries)
+    {
+        for (auto& existsEntry : _serverEntries)
+        {
+            auto match = std::find_if(entries.begin(), entries.end(), [&](const ServerListEntry& entry) {
+                return existsEntry.Address == entry.Address;
+            });
+            if (match != entries.end())
             {
-                ServerListEntry serverInfo;
-                serverInfo.Address = fs.ReadString();
-                serverInfo.Name = fs.ReadString();
-                serverInfo.RequiresPassword = false;
-                serverInfo.Description = fs.ReadString();
-                serverInfo.Version.clear();
-                serverInfo.Favourite = true;
-                serverInfo.Players = 0;
-                serverInfo.MaxPlayers = 0;
-                entries.push_back(std::move(serverInfo));
+                // Keep favourites
+                auto fav = existsEntry.Favourite;
+
+                existsEntry = *match;
+                existsEntry.Favourite = fav;
             }
         }
+
+        std::vector<ServerListEntry> newServers;
+        std::copy_if(entries.begin(), entries.end(), std::back_inserter(newServers), [this](const ServerListEntry& entry) {
+            return std::find_if(
+                       _serverEntries.begin(), _serverEntries.end(),
+                       [&](const ServerListEntry& existsEntry) { return existsEntry.Address == entry.Address; })
+                == _serverEntries.end();
+        });
+
+        AddRange(newServers);
     }
-    catch (const std::exception& e)
+
+    void ServerList::Clear() noexcept
     {
-        LOG_ERROR("Unable to read server list: %s", e.what());
-        entries = std::vector<ServerListEntry>();
+        _serverEntries.clear();
     }
-    return entries;
-}
 
-void ServerList::ReadAndAddFavourites()
-{
-    _serverEntries.erase(
-        std::remove_if(
-            _serverEntries.begin(), _serverEntries.end(), [](const ServerListEntry& entry) { return entry.Favourite; }),
-        _serverEntries.end());
-    auto entries = ReadFavourites();
-    AddRange(entries);
-}
-
-void ServerList::WriteFavourites() const
-{
-    // Save just favourite servers
-    std::vector<ServerListEntry> favouriteServers;
-    std::copy_if(
-        _serverEntries.begin(), _serverEntries.end(), std::back_inserter(favouriteServers),
-        [](const ServerListEntry& entry) { return entry.Favourite; });
-    WriteFavourites(favouriteServers);
-}
-
-bool ServerList::WriteFavourites(const std::vector<ServerListEntry>& entries) const
-{
-    LOG_VERBOSE("server_list_write(%d, 0x%p)", entries.size(), entries.data());
-
-    auto& env = GetContext()->GetPlatformEnvironment();
-    auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"servers.cfg");
-
-    try
+    std::vector<ServerListEntry> ServerList::ReadFavourites() const
     {
-        auto fs = FileStream(path, FileMode::write);
-        fs.WriteValue<uint32_t>(static_cast<uint32_t>(entries.size()));
-        for (const auto& entry : entries)
-        {
-            fs.WriteString(entry.Address);
-            fs.WriteString(entry.Name);
-            fs.WriteString(entry.Description);
-        }
-        return true;
-    }
-    catch (const std::exception& e)
-    {
-        LOG_ERROR("Unable to write server list: %s", e.what());
-        return false;
-    }
-}
-
-std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync(const INetworkEndpoint& broadcastEndpoint) const
-{
-    auto broadcastAddress = broadcastEndpoint.GetHostname();
-    return std::async(std::launch::async, [broadcastAddress] {
-        constexpr auto kReceiveDelayInMs = 10;
-        constexpr auto kReceiveWaitInMs = 2000;
-
-        std::string_view msg = kNetworkLanBroadcastMsg;
-        auto udpSocket = CreateUdpSocket();
-
-        LOG_VERBOSE("Broadcasting %zu bytes to the LAN (%s)", msg.size(), broadcastAddress.c_str());
-        auto len = udpSocket->SendData(broadcastAddress, kNetworkLanBroadcastPort, msg.data(), msg.size());
-        if (len != msg.size())
-        {
-            throw std::runtime_error("Unable to broadcast server query.");
-        }
-
+        LOG_VERBOSE("server_list_read(...)");
         std::vector<ServerListEntry> entries;
-        for (int i = 0; i < (kReceiveWaitInMs / kReceiveDelayInMs); i++)
+        try
         {
-            try
+            auto& env = GetContext()->GetPlatformEnvironment();
+            auto path = env.GetFilePath(PathId::networkServers);
+            if (File::Exists(path))
             {
-                // Start with initialised buffer in case we receive a non-terminated string
-                char buffer[1024]{};
-                size_t recievedLen{};
-                std::unique_ptr<INetworkEndpoint> endpoint;
-                auto p = udpSocket->ReceiveData(buffer, sizeof(buffer) - 1, &recievedLen, &endpoint);
-                if (p == NetworkReadPacket::Success)
+                auto fs = FileStream(path, FileMode::open);
+                auto numEntries = fs.ReadValue<uint32_t>();
+                for (size_t i = 0; i < numEntries; i++)
                 {
-                    auto sender = endpoint->GetHostname();
-                    LOG_VERBOSE("Received %zu bytes back from %s", recievedLen, sender.c_str());
-                    auto jinfo = Json::FromString(std::string_view(buffer));
+                    ServerListEntry serverInfo;
+                    serverInfo.Address = fs.ReadString();
+                    serverInfo.Name = fs.ReadString();
+                    serverInfo.RequiresPassword = false;
+                    serverInfo.Description = fs.ReadString();
+                    serverInfo.Version.clear();
+                    serverInfo.Favourite = true;
+                    serverInfo.Players = 0;
+                    serverInfo.MaxPlayers = 0;
+                    entries.push_back(std::move(serverInfo));
+                }
+            }
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("Unable to read server list: %s", e.what());
+            entries = std::vector<ServerListEntry>();
+        }
+        return entries;
+    }
 
-                    if (jinfo.is_object())
+    void ServerList::ReadAndAddFavourites()
+    {
+        _serverEntries.erase(
+            std::remove_if(
+                _serverEntries.begin(), _serverEntries.end(), [](const ServerListEntry& entry) { return entry.Favourite; }),
+            _serverEntries.end());
+        auto entries = ReadFavourites();
+        AddRange(entries);
+    }
+
+    void ServerList::WriteFavourites() const
+    {
+        // Save just favourite servers
+        std::vector<ServerListEntry> favouriteServers;
+        std::copy_if(
+            _serverEntries.begin(), _serverEntries.end(), std::back_inserter(favouriteServers),
+            [](const ServerListEntry& entry) { return entry.Favourite; });
+        WriteFavourites(favouriteServers);
+    }
+
+    bool ServerList::WriteFavourites(const std::vector<ServerListEntry>& entries) const
+    {
+        LOG_VERBOSE("server_list_write(%d, 0x%p)", entries.size(), entries.data());
+
+        auto& env = GetContext()->GetPlatformEnvironment();
+        auto path = Path::Combine(env.GetDirectoryPath(DirBase::user), u8"servers.cfg");
+
+        try
+        {
+            auto fs = FileStream(path, FileMode::write);
+            fs.WriteValue<uint32_t>(static_cast<uint32_t>(entries.size()));
+            for (const auto& entry : entries)
+            {
+                fs.WriteString(entry.Address);
+                fs.WriteString(entry.Name);
+                fs.WriteString(entry.Description);
+            }
+            return true;
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("Unable to write server list: %s", e.what());
+            return false;
+        }
+    }
+
+    std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync(
+        const INetworkEndpoint& broadcastEndpoint) const
+    {
+        auto broadcastAddress = broadcastEndpoint.GetHostname();
+        return std::async(std::launch::async, [broadcastAddress] {
+            constexpr auto kReceiveDelayInMs = 10;
+            constexpr auto kReceiveWaitInMs = 2000;
+
+            std::string_view msg = kNetworkLanBroadcastMsg;
+            auto udpSocket = CreateUdpSocket();
+
+            LOG_VERBOSE("Broadcasting %zu bytes to the LAN (%s)", msg.size(), broadcastAddress.c_str());
+            auto len = udpSocket->SendData(broadcastAddress, kNetworkLanBroadcastPort, msg.data(), msg.size());
+            if (len != msg.size())
+            {
+                throw std::runtime_error("Unable to broadcast server query.");
+            }
+
+            std::vector<ServerListEntry> entries;
+            for (int i = 0; i < (kReceiveWaitInMs / kReceiveDelayInMs); i++)
+            {
+                try
+                {
+                    // Start with initialised buffer in case we receive a non-terminated string
+                    char buffer[1024]{};
+                    size_t recievedLen{};
+                    std::unique_ptr<INetworkEndpoint> endpoint;
+                    auto p = udpSocket->ReceiveData(buffer, sizeof(buffer) - 1, &recievedLen, &endpoint);
+                    if (p == NetworkReadPacket::Success)
                     {
-                        jinfo["ip"] = { { "v4", { sender } } };
+                        auto sender = endpoint->GetHostname();
+                        LOG_VERBOSE("Received %zu bytes back from %s", recievedLen, sender.c_str());
+                        auto jinfo = Json::FromString(std::string_view(buffer));
 
-                        auto entry = ServerListEntry::FromJson(jinfo);
-                        if (entry.has_value())
+                        if (jinfo.is_object())
                         {
-                            (*entry).Local = true;
-                            entries.push_back(std::move(*entry));
+                            jinfo["ip"] = { { "v4", { sender } } };
+
+                            auto entry = ServerListEntry::FromJson(jinfo);
+                            if (entry.has_value())
+                            {
+                                (*entry).Local = true;
+                                entries.push_back(std::move(*entry));
+                            }
                         }
                     }
                 }
+                catch (const std::exception& e)
+                {
+                    LOG_WARNING("Error receiving data: %s", e.what());
+                }
+                Platform::Sleep(kReceiveDelayInMs);
             }
-            catch (const std::exception& e)
+            return entries;
+        });
+    }
+
+    std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync() const
+    {
+        return std::async(std::launch::async, [&] {
+            // Get all possible LAN broadcast addresses
+            auto broadcastEndpoints = GetBroadcastAddresses();
+
+            // Spin off a fetch for each broadcast address
+            std::vector<std::future<std::vector<ServerListEntry>>> futures;
+            for (const auto& broadcastEndpoint : broadcastEndpoints)
             {
-                LOG_WARNING("Error receiving data: %s", e.what());
+                auto f = FetchLocalServerListAsync(*broadcastEndpoint);
+                futures.push_back(std::move(f));
             }
-            Platform::Sleep(kReceiveDelayInMs);
-        }
-        return entries;
-    });
-}
 
-std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync() const
-{
-    return std::async(std::launch::async, [&] {
-        // Get all possible LAN broadcast addresses
-        auto broadcastEndpoints = GetBroadcastAddresses();
+            // Wait and merge all results
+            std::vector<ServerListEntry> mergedEntries;
+            for (auto& f : futures)
+            {
+                try
+                {
+                    auto entries = f.get();
+                    mergedEntries.insert(mergedEntries.begin(), entries.begin(), entries.end());
+                }
+                catch (...)
+                {
+                    // Ignore any exceptions from a particular broadcast fetch
+                }
+            }
+            return mergedEntries;
+        });
+    }
 
-        // Spin off a fetch for each broadcast address
-        std::vector<std::future<std::vector<ServerListEntry>>> futures;
-        for (const auto& broadcastEndpoint : broadcastEndpoints)
+    std::future<std::vector<ServerListEntry>> ServerList::FetchOnlineServerListAsync() const
+    {
+    #ifdef DISABLE_HTTP
+        return {};
+    #else
+
+        auto p = std::make_shared<std::promise<std::vector<ServerListEntry>>>();
+        auto f = p->get_future();
+
+        std::string masterServerUrl = kMasterServerURL;
+        if (!Config::Get().network.MasterServerUrl.empty())
         {
-            auto f = FetchLocalServerListAsync(*broadcastEndpoint);
-            futures.push_back(std::move(f));
+            masterServerUrl = Config::Get().network.MasterServerUrl;
         }
 
-        // Wait and merge all results
-        std::vector<ServerListEntry> mergedEntries;
-        for (auto& f : futures)
-        {
+        Http::Request request;
+        request.url = std::move(masterServerUrl);
+        request.method = Http::Method::GET;
+        request.header["Accept"] = "application/json";
+        Http::DoAsync(request, [p](Http::Response& response) -> void {
+            json_t root;
             try
             {
-                auto entries = f.get();
-                mergedEntries.insert(mergedEntries.begin(), entries.begin(), entries.end());
+                if (response.status != Http::Status::Ok)
+                {
+                    throw MasterServerException(STR_SERVER_LIST_NO_CONNECTION);
+                }
+
+                root = Json::FromString(response.body);
+                if (root.is_object())
+                {
+                    auto jsonStatus = root["status"];
+                    if (!jsonStatus.is_number_integer())
+                    {
+                        throw MasterServerException(STR_SERVER_LIST_INVALID_RESPONSE_JSON_NUMBER);
+                    }
+
+                    auto status = Json::GetNumber<int32_t>(jsonStatus);
+                    if (status != 200)
+                    {
+                        throw MasterServerException(STR_SERVER_LIST_MASTER_SERVER_FAILED);
+                    }
+
+                    auto jServers = root["servers"];
+                    if (!jServers.is_array())
+                    {
+                        throw MasterServerException(STR_SERVER_LIST_INVALID_RESPONSE_JSON_ARRAY);
+                    }
+
+                    std::vector<ServerListEntry> entries;
+                    for (auto& jServer : jServers)
+                    {
+                        if (jServer.is_object())
+                        {
+                            auto entry = ServerListEntry::FromJson(jServer);
+                            if (entry.has_value())
+                            {
+                                entries.push_back(std::move(*entry));
+                            }
+                        }
+                    }
+
+                    p->set_value(entries);
+                }
             }
             catch (...)
             {
-                // Ignore any exceptions from a particular broadcast fetch
+                p->set_exception(std::current_exception());
             }
-        }
-        return mergedEntries;
-    });
-}
-
-std::future<std::vector<ServerListEntry>> ServerList::FetchOnlineServerListAsync() const
-{
-    #ifdef DISABLE_HTTP
-    return {};
-    #else
-
-    auto p = std::make_shared<std::promise<std::vector<ServerListEntry>>>();
-    auto f = p->get_future();
-
-    std::string masterServerUrl = kMasterServerURL;
-    if (!Config::Get().network.MasterServerUrl.empty())
-    {
-        masterServerUrl = Config::Get().network.MasterServerUrl;
+        });
+        return f;
+    #endif
     }
 
-    Http::Request request;
-    request.url = std::move(masterServerUrl);
-    request.method = Http::Method::GET;
-    request.header["Accept"] = "application/json";
-    Http::DoAsync(request, [p](Http::Response& response) -> void {
-        json_t root;
-        try
-        {
-            if (response.status != Http::Status::Ok)
-            {
-                throw MasterServerException(STR_SERVER_LIST_NO_CONNECTION);
-            }
+    uint32_t ServerList::GetTotalPlayerCount() const
+    {
+        return std::accumulate(_serverEntries.begin(), _serverEntries.end(), 0, [](uint32_t acc, const ServerListEntry& entry) {
+            return acc + entry.Players;
+        });
+    }
 
-            root = Json::FromString(response.body);
-            if (root.is_object())
-            {
-                auto jsonStatus = root["status"];
-                if (!jsonStatus.is_number_integer())
-                {
-                    throw MasterServerException(STR_SERVER_LIST_INVALID_RESPONSE_JSON_NUMBER);
-                }
-
-                auto status = Json::GetNumber<int32_t>(jsonStatus);
-                if (status != 200)
-                {
-                    throw MasterServerException(STR_SERVER_LIST_MASTER_SERVER_FAILED);
-                }
-
-                auto jServers = root["servers"];
-                if (!jServers.is_array())
-                {
-                    throw MasterServerException(STR_SERVER_LIST_INVALID_RESPONSE_JSON_ARRAY);
-                }
-
-                std::vector<ServerListEntry> entries;
-                for (auto& jServer : jServers)
-                {
-                    if (jServer.is_object())
-                    {
-                        auto entry = ServerListEntry::FromJson(jServer);
-                        if (entry.has_value())
-                        {
-                            entries.push_back(std::move(*entry));
-                        }
-                    }
-                }
-
-                p->set_value(entries);
-            }
-        }
-        catch (...)
-        {
-            p->set_exception(std::current_exception());
-        }
-    });
-    return f;
-    #endif
-}
-
-uint32_t ServerList::GetTotalPlayerCount() const
-{
-    return std::accumulate(_serverEntries.begin(), _serverEntries.end(), 0, [](uint32_t acc, const ServerListEntry& entry) {
-        return acc + entry.Players;
-    });
-}
-
-const char* MasterServerException::what() const noexcept
-{
-    static std::string localisedStatusText = LanguageGetString(StatusText);
-    return localisedStatusText.c_str();
-}
+    const char* MasterServerException::what() const noexcept
+    {
+        static std::string localisedStatusText = LanguageGetString(StatusText);
+        return localisedStatusText.c_str();
+    }
+} // namespace OpenRCT2::Network
 
 #endif

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -48,8 +48,8 @@ namespace OpenRCT2::Network
             return a.Local ? -1 : 1;
         }
 
-        bool serverACompatible = a.Version == NetworkGetVersion();
-        bool serverBCompatible = b.Version == NetworkGetVersion();
+        bool serverACompatible = a.Version == Network::GetVersion();
+        bool serverBCompatible = b.Version == Network::GetVersion();
         if (serverACompatible != serverBCompatible)
         {
             return serverACompatible ? -1 : 1;
@@ -70,7 +70,7 @@ namespace OpenRCT2::Network
 
     bool ServerListEntry::IsVersionValid() const noexcept
     {
-        return Version.empty() || Version == NetworkGetVersion();
+        return Version.empty() || Version == Network::GetVersion();
     }
 
     std::optional<ServerListEntry> ServerListEntry::FromJson(json_t& server)
@@ -293,7 +293,7 @@ namespace OpenRCT2::Network
                     size_t recievedLen{};
                     std::unique_ptr<INetworkEndpoint> endpoint;
                     auto p = udpSocket->ReceiveData(buffer, sizeof(buffer) - 1, &recievedLen, &endpoint);
-                    if (p == NetworkReadPacket::Success)
+                    if (p == NetworkReadPacket::success)
                     {
                         auto sender = endpoint->GetHostname();
                         LOG_VERBOSE("Received %zu bytes back from %s", recievedLen, sender.c_str());

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -273,11 +273,11 @@ namespace OpenRCT2::Network
             constexpr auto kReceiveDelayInMs = 10;
             constexpr auto kReceiveWaitInMs = 2000;
 
-            std::string_view msg = kNetworkLanBroadcastMsg;
+            std::string_view msg = kLanBroadcastMsg;
             auto udpSocket = CreateUdpSocket();
 
             LOG_VERBOSE("Broadcasting %zu bytes to the LAN (%s)", msg.size(), broadcastAddress.c_str());
-            auto len = udpSocket->SendData(broadcastAddress, kNetworkLanBroadcastPort, msg.data(), msg.size());
+            auto len = udpSocket->SendData(broadcastAddress, kLanBroadcastPort, msg.data(), msg.size());
             if (len != msg.size())
             {
                 throw std::runtime_error("Unable to broadcast server query.");

--- a/src/openrct2/network/ServerList.h
+++ b/src/openrct2/network/ServerList.h
@@ -18,68 +18,71 @@
 #include <string>
 #include <vector>
 
-struct INetworkEndpoint;
-
-struct ServerListEntry
+namespace OpenRCT2::Network
 {
-    std::string Address;
-    std::string Name;
-    std::string Description;
-    std::string Version;
-    bool RequiresPassword{};
-    bool Favourite{};
-    uint8_t Players{};
-    uint8_t MaxPlayers{};
-    bool Local{};
+    struct INetworkEndpoint;
 
-    int32_t CompareTo(const ServerListEntry& other) const;
-    bool IsVersionValid() const noexcept;
-
-    /**
-     * Creates a ServerListEntry object from a JSON object
-     *
-     * @param json JSON data source - must be object type
-     * @return A NetworkGroup object
-     * @note json is deliberately left non-const: json_t behaviour changes when const
-     */
-    static std::optional<ServerListEntry> FromJson(json_t& server);
-};
-
-class ServerList
-{
-private:
-    std::vector<ServerListEntry> _serverEntries;
-
-    void Sort();
-    std::vector<ServerListEntry> ReadFavourites() const;
-    bool WriteFavourites(const std::vector<ServerListEntry>& entries) const;
-    std::future<std::vector<ServerListEntry>> FetchLocalServerListAsync(const INetworkEndpoint& broadcastEndpoint) const;
-
-public:
-    ServerListEntry& GetServer(size_t index);
-    size_t GetCount() const;
-    void Add(const ServerListEntry& entry);
-    void AddRange(const std::vector<ServerListEntry>& entries);
-    void AddOrUpdateRange(const std::vector<ServerListEntry>& entries);
-    void Clear() noexcept;
-
-    void ReadAndAddFavourites();
-    void WriteFavourites() const;
-
-    std::future<std::vector<ServerListEntry>> FetchLocalServerListAsync() const;
-    std::future<std::vector<ServerListEntry>> FetchOnlineServerListAsync() const;
-    uint32_t GetTotalPlayerCount() const;
-};
-
-class MasterServerException : public std::exception
-{
-public:
-    StringId StatusText;
-
-    MasterServerException(StringId statusText)
-        : StatusText(statusText)
+    struct ServerListEntry
     {
-    }
+        std::string Address;
+        std::string Name;
+        std::string Description;
+        std::string Version;
+        bool RequiresPassword{};
+        bool Favourite{};
+        uint8_t Players{};
+        uint8_t MaxPlayers{};
+        bool Local{};
 
-    const char* what() const noexcept override;
-};
+        int32_t CompareTo(const ServerListEntry& other) const;
+        bool IsVersionValid() const noexcept;
+
+        /**
+         * Creates a ServerListEntry object from a JSON object
+         *
+         * @param json JSON data source - must be object type
+         * @return A NetworkGroup object
+         * @note json is deliberately left non-const: json_t behaviour changes when const
+         */
+        static std::optional<ServerListEntry> FromJson(json_t& server);
+    };
+
+    class ServerList
+    {
+    private:
+        std::vector<ServerListEntry> _serverEntries;
+
+        void Sort();
+        std::vector<ServerListEntry> ReadFavourites() const;
+        bool WriteFavourites(const std::vector<ServerListEntry>& entries) const;
+        std::future<std::vector<ServerListEntry>> FetchLocalServerListAsync(const INetworkEndpoint& broadcastEndpoint) const;
+
+    public:
+        ServerListEntry& GetServer(size_t index);
+        size_t GetCount() const;
+        void Add(const ServerListEntry& entry);
+        void AddRange(const std::vector<ServerListEntry>& entries);
+        void AddOrUpdateRange(const std::vector<ServerListEntry>& entries);
+        void Clear() noexcept;
+
+        void ReadAndAddFavourites();
+        void WriteFavourites() const;
+
+        std::future<std::vector<ServerListEntry>> FetchLocalServerListAsync() const;
+        std::future<std::vector<ServerListEntry>> FetchOnlineServerListAsync() const;
+        uint32_t GetTotalPlayerCount() const;
+    };
+
+    class MasterServerException : public std::exception
+    {
+    public:
+        StringId StatusText;
+
+        MasterServerException(StringId statusText)
+            : StatusText(statusText)
+        {
+        }
+
+        const char* what() const noexcept override;
+    };
+} // namespace OpenRCT2::Network

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -73,354 +73,243 @@
 
     #include "Socket.h"
 
-constexpr auto kConnectTimeout = std::chrono::milliseconds(3000);
+namespace OpenRCT2::Network
+{
+    constexpr auto kConnectTimeout = std::chrono::milliseconds(3000);
 
     // RAII WSA initialisation needed for Windows
     #ifdef _WIN32
-class WSA
-{
-private:
-    bool _isInitialised{};
-
-public:
-    bool IsInitialised() const noexcept
+    class WSA
     {
-        return _isInitialised;
-    }
+    private:
+        bool _isInitialised{};
 
-    bool Initialise()
-    {
-        if (!_isInitialised)
+    public:
+        bool IsInitialised() const noexcept
         {
-            LOG_VERBOSE("WSAStartup()");
-            WSADATA wsa_data;
-            if (WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0)
+            return _isInitialised;
+        }
+
+        bool Initialise()
+        {
+            if (!_isInitialised)
             {
-                LOG_ERROR("Unable to initialise winsock.");
+                LOG_VERBOSE("WSAStartup()");
+                WSADATA wsa_data;
+                if (WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0)
+                {
+                    LOG_ERROR("Unable to initialise winsock.");
+                    return false;
+                }
+                _isInitialised = true;
+            }
+            return true;
+        }
+
+        ~WSA() noexcept
+        {
+            if (_isInitialised)
+            {
+                LOG_VERBOSE("WSACleanup()");
+                WSACleanup();
+                _isInitialised = false;
+            }
+        }
+    };
+
+    static bool InitialiseWSA()
+    {
+        static WSA wsa;
+        return wsa.Initialise();
+    }
+    #else
+    static bool InitialiseWSA()
+    {
+        return true;
+    }
+    #endif
+
+    class SocketException : public std::runtime_error
+    {
+    public:
+        explicit SocketException(const std::string& message)
+            : std::runtime_error(message)
+        {
+        }
+    };
+
+    class NetworkEndpoint final : public INetworkEndpoint
+    {
+    private:
+        sockaddr _address{};
+        socklen_t _addressLen{};
+
+    public:
+        NetworkEndpoint() noexcept = default;
+
+        NetworkEndpoint(const sockaddr* address, socklen_t addressLen)
+        {
+            std::memcpy(&_address, address, addressLen);
+            _addressLen = addressLen;
+        }
+
+        constexpr const sockaddr& GetAddress() const noexcept
+        {
+            return _address;
+        }
+
+        constexpr socklen_t GetAddressLen() const noexcept
+        {
+            return _addressLen;
+        }
+
+        int32_t GetPort() const
+        {
+            if (_address.sa_family == AF_INET)
+            {
+                return reinterpret_cast<const sockaddr_in*>(&_address)->sin_port;
+            }
+
+            return reinterpret_cast<const sockaddr_in6*>(&_address)->sin6_port;
+        }
+
+        std::string GetHostname() const override
+        {
+            char hostname[256]{};
+            int res = getnameinfo(&_address, _addressLen, hostname, sizeof(hostname), nullptr, 0, NI_NUMERICHOST);
+            if (res == 0)
+            {
+                return hostname;
+            }
+            return {};
+        }
+    };
+
+    class Socket
+    {
+    protected:
+        static bool ResolveAddress(const std::string& address, uint16_t port, sockaddr_storage* ss, socklen_t* ss_len)
+        {
+            return ResolveAddress(AF_UNSPEC, address, port, ss, ss_len);
+        }
+
+        static bool ResolveAddressIPv4(const std::string& address, uint16_t port, sockaddr_storage* ss, socklen_t* ss_len)
+        {
+            return ResolveAddress(AF_INET, address, port, ss, ss_len);
+        }
+
+        static bool SetNonBlocking(SOCKET socket, bool on)
+        {
+    #ifdef _WIN32
+            u_long nonBlocking = on;
+            return ioctlsocket(socket, FIONBIO, &nonBlocking) == 0;
+    #else
+            int32_t flags = fcntl(socket, F_GETFL, 0);
+            return fcntl(socket, F_SETFL, on ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK)) == 0;
+    #endif
+        }
+
+        static bool SetOption(SOCKET socket, int32_t a, int32_t b, bool value)
+        {
+            int32_t ivalue = value ? 1 : 0;
+            return setsockopt(socket, a, b, reinterpret_cast<const char*>(&ivalue), sizeof(ivalue)) == 0;
+        }
+
+    private:
+        static bool ResolveAddress(
+            int32_t family, const std::string& address, uint16_t port, sockaddr_storage* ss, socklen_t* ss_len)
+        {
+            std::string serviceName = std::to_string(port);
+
+            addrinfo hints = {};
+            hints.ai_family = family;
+            if (address.empty())
+            {
+                hints.ai_flags = AI_PASSIVE;
+            }
+
+            addrinfo* result = nullptr;
+            int errorcode = getaddrinfo(address.empty() ? nullptr : address.c_str(), serviceName.c_str(), &hints, &result);
+            if (errorcode != 0)
+            {
+                LOG_ERROR("Resolving address failed: Code %d.", errorcode);
+                LOG_ERROR("Resolution error message: %s.", gai_strerror(errorcode));
                 return false;
             }
-            _isInitialised = true;
-        }
-        return true;
-    }
 
-    ~WSA() noexcept
-    {
-        if (_isInitialised)
-        {
-            LOG_VERBOSE("WSACleanup()");
-            WSACleanup();
-            _isInitialised = false;
-        }
-    }
-};
-
-static bool InitialiseWSA()
-{
-    static WSA wsa;
-    return wsa.Initialise();
-}
-    #else
-static bool InitialiseWSA()
-{
-    return true;
-}
-    #endif
-
-class SocketException : public std::runtime_error
-{
-public:
-    explicit SocketException(const std::string& message)
-        : std::runtime_error(message)
-    {
-    }
-};
-
-class NetworkEndpoint final : public INetworkEndpoint
-{
-private:
-    sockaddr _address{};
-    socklen_t _addressLen{};
-
-public:
-    NetworkEndpoint() noexcept = default;
-
-    NetworkEndpoint(const sockaddr* address, socklen_t addressLen)
-    {
-        std::memcpy(&_address, address, addressLen);
-        _addressLen = addressLen;
-    }
-
-    constexpr const sockaddr& GetAddress() const noexcept
-    {
-        return _address;
-    }
-
-    constexpr socklen_t GetAddressLen() const noexcept
-    {
-        return _addressLen;
-    }
-
-    int32_t GetPort() const
-    {
-        if (_address.sa_family == AF_INET)
-        {
-            return reinterpret_cast<const sockaddr_in*>(&_address)->sin_port;
-        }
-
-        return reinterpret_cast<const sockaddr_in6*>(&_address)->sin6_port;
-    }
-
-    std::string GetHostname() const override
-    {
-        char hostname[256]{};
-        int res = getnameinfo(&_address, _addressLen, hostname, sizeof(hostname), nullptr, 0, NI_NUMERICHOST);
-        if (res == 0)
-        {
-            return hostname;
-        }
-        return {};
-    }
-};
-
-class Socket
-{
-protected:
-    static bool ResolveAddress(const std::string& address, uint16_t port, sockaddr_storage* ss, socklen_t* ss_len)
-    {
-        return ResolveAddress(AF_UNSPEC, address, port, ss, ss_len);
-    }
-
-    static bool ResolveAddressIPv4(const std::string& address, uint16_t port, sockaddr_storage* ss, socklen_t* ss_len)
-    {
-        return ResolveAddress(AF_INET, address, port, ss, ss_len);
-    }
-
-    static bool SetNonBlocking(SOCKET socket, bool on)
-    {
-    #ifdef _WIN32
-        u_long nonBlocking = on;
-        return ioctlsocket(socket, FIONBIO, &nonBlocking) == 0;
-    #else
-        int32_t flags = fcntl(socket, F_GETFL, 0);
-        return fcntl(socket, F_SETFL, on ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK)) == 0;
-    #endif
-    }
-
-    static bool SetOption(SOCKET socket, int32_t a, int32_t b, bool value)
-    {
-        int32_t ivalue = value ? 1 : 0;
-        return setsockopt(socket, a, b, reinterpret_cast<const char*>(&ivalue), sizeof(ivalue)) == 0;
-    }
-
-private:
-    static bool ResolveAddress(
-        int32_t family, const std::string& address, uint16_t port, sockaddr_storage* ss, socklen_t* ss_len)
-    {
-        std::string serviceName = std::to_string(port);
-
-        addrinfo hints = {};
-        hints.ai_family = family;
-        if (address.empty())
-        {
-            hints.ai_flags = AI_PASSIVE;
-        }
-
-        addrinfo* result = nullptr;
-        int errorcode = getaddrinfo(address.empty() ? nullptr : address.c_str(), serviceName.c_str(), &hints, &result);
-        if (errorcode != 0)
-        {
-            LOG_ERROR("Resolving address failed: Code %d.", errorcode);
-            LOG_ERROR("Resolution error message: %s.", gai_strerror(errorcode));
-            return false;
-        }
-
-        if (result == nullptr)
-        {
-            return false;
-        }
-
-        std::memcpy(ss, result->ai_addr, result->ai_addrlen);
-        *ss_len = static_cast<socklen_t>(result->ai_addrlen);
-        freeaddrinfo(result);
-        return true;
-    }
-};
-
-class TcpSocket final : public ITcpSocket, protected Socket
-{
-private:
-    std::atomic<SocketStatus> _status{ SocketStatus::Closed };
-    uint16_t _listeningPort = 0;
-    SOCKET _socket = INVALID_SOCKET;
-
-    std::string _ipAddress;
-    std::string _hostName;
-    std::future<void> _connectFuture;
-    std::string _error;
-
-public:
-    TcpSocket() noexcept = default;
-
-    explicit TcpSocket(SOCKET socket, std::string hostName, std::string ipAddress) noexcept
-        : _status(SocketStatus::Connected)
-        , _socket(socket)
-        , _ipAddress(std::move(ipAddress))
-        , _hostName(std::move(hostName))
-    {
-    }
-
-    ~TcpSocket() override
-    {
-        if (_connectFuture.valid())
-        {
-            _connectFuture.wait();
-        }
-        CloseSocket();
-    }
-
-    SocketStatus GetStatus() const override
-    {
-        return _status;
-    }
-
-    const char* GetError() const override
-    {
-        return _error.empty() ? nullptr : _error.c_str();
-    }
-
-    void SetNoDelay(bool noDelay) override
-    {
-        if (_socket != INVALID_SOCKET)
-        {
-            SetOption(_socket, IPPROTO_TCP, TCP_NODELAY, noDelay);
-        }
-    }
-
-    void Listen(uint16_t port) override
-    {
-        Listen("", port);
-    }
-
-    void Listen(const std::string& address, uint16_t port) override
-    {
-        if (_status != SocketStatus::Closed)
-        {
-            throw std::runtime_error("Socket not closed.");
-        }
-
-        sockaddr_storage ss{};
-        socklen_t ss_len;
-        if (!ResolveAddress(address, port, &ss, &ss_len))
-        {
-            throw SocketException("Unable to resolve address.");
-        }
-
-        // Create the listening socket
-        _socket = socket(ss.ss_family, SOCK_STREAM, IPPROTO_TCP);
-        if (_socket == INVALID_SOCKET)
-        {
-            throw SocketException("Unable to create socket.");
-        }
-
-        // Turn off IPV6_V6ONLY so we can accept both v4 and v6 connections
-        if (!SetOption(_socket, IPPROTO_IPV6, IPV6_V6ONLY, false))
-        {
-            LOG_VERBOSE("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
-        }
-
-        if (!SetOption(_socket, SOL_SOCKET, SO_REUSEADDR, true))
-        {
-            LOG_VERBOSE("setsockopt(socket, SO_REUSEADDR) failed: %d", LAST_SOCKET_ERROR());
-        }
-
-        try
-        {
-            // Bind to address:port and listen
-            if (bind(_socket, reinterpret_cast<sockaddr*>(&ss), ss_len) != 0)
+            if (result == nullptr)
             {
-                std::string addressOrStar = address.empty() ? "*" : address.c_str();
-                throw SocketException("Unable to bind to address " + addressOrStar + ":" + std::to_string(port));
-            }
-            if (listen(_socket, SOMAXCONN) != 0)
-            {
-                throw SocketException("Unable to listen on socket.");
+                return false;
             }
 
-            if (!SetNonBlocking(_socket, true))
-            {
-                throw SocketException("Failed to set non-blocking mode.");
-            }
+            std::memcpy(ss, result->ai_addr, result->ai_addrlen);
+            *ss_len = static_cast<socklen_t>(result->ai_addrlen);
+            freeaddrinfo(result);
+            return true;
         }
-        catch (const std::exception&)
+    };
+
+    class TcpSocket final : public ITcpSocket, protected Socket
+    {
+    private:
+        std::atomic<SocketStatus> _status{ SocketStatus::Closed };
+        uint16_t _listeningPort = 0;
+        SOCKET _socket = INVALID_SOCKET;
+
+        std::string _ipAddress;
+        std::string _hostName;
+        std::future<void> _connectFuture;
+        std::string _error;
+
+    public:
+        TcpSocket() noexcept = default;
+
+        explicit TcpSocket(SOCKET socket, std::string hostName, std::string ipAddress) noexcept
+            : _status(SocketStatus::Connected)
+            , _socket(socket)
+            , _ipAddress(std::move(ipAddress))
+            , _hostName(std::move(hostName))
         {
+        }
+
+        ~TcpSocket() override
+        {
+            if (_connectFuture.valid())
+            {
+                _connectFuture.wait();
+            }
             CloseSocket();
-            throw;
         }
 
-        _listeningPort = port;
-        _status = SocketStatus::Listening;
-    }
-
-    std::unique_ptr<ITcpSocket> Accept() override
-    {
-        if (_status != SocketStatus::Listening)
+        SocketStatus GetStatus() const override
         {
-            throw std::runtime_error("Socket not listening.");
+            return _status;
         }
-        struct sockaddr_storage client_addr{};
-        socklen_t client_len = sizeof(struct sockaddr_storage);
 
-        std::unique_ptr<ITcpSocket> tcpSocket;
-        SOCKET socket = accept(_socket, reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
-        if (socket == INVALID_SOCKET)
+        const char* GetError() const override
         {
-            if (LAST_SOCKET_ERROR() != EWOULDBLOCK)
+            return _error.empty() ? nullptr : _error.c_str();
+        }
+
+        void SetNoDelay(bool noDelay) override
+        {
+            if (_socket != INVALID_SOCKET)
             {
-                LOG_ERROR("Failed to accept client.");
+                SetOption(_socket, IPPROTO_TCP, TCP_NODELAY, noDelay);
             }
         }
-        else
+
+        void Listen(uint16_t port) override
         {
-            if (!SetNonBlocking(socket, true))
-            {
-                closesocket(socket);
-                LOG_ERROR("Failed to set non-blocking mode.");
-            }
-            else
-            {
-                auto ipAddress = GetIpAddressFromSocket(reinterpret_cast<sockaddr_in*>(&client_addr));
-
-                char hostName[NI_MAXHOST];
-                int32_t rc = getnameinfo(
-                    reinterpret_cast<struct sockaddr*>(&client_addr), client_len, hostName, sizeof(hostName), nullptr, 0,
-                    NI_NUMERICHOST | NI_NUMERICSERV);
-                SetNoDelay(true);
-
-                if (rc == 0)
-                {
-                    tcpSocket = std::make_unique<TcpSocket>(socket, hostName, ipAddress);
-                }
-                else
-                {
-                    tcpSocket = std::make_unique<TcpSocket>(socket, "", ipAddress);
-                }
-            }
-        }
-        return tcpSocket;
-    }
-
-    void Connect(const std::string& address, uint16_t port) override
-    {
-        if (_status != SocketStatus::Closed && _status != SocketStatus::Waiting)
-        {
-            throw std::runtime_error("Socket not closed.");
+            Listen("", port);
         }
 
-        try
+        void Listen(const std::string& address, uint16_t port) override
         {
-            // Resolve address
-            _status = SocketStatus::Resolving;
+            if (_status != SocketStatus::Closed)
+            {
+                throw std::runtime_error("Socket not closed.");
+            }
 
             sockaddr_storage ss{};
             socklen_t ss_len;
@@ -429,550 +318,666 @@ public:
                 throw SocketException("Unable to resolve address.");
             }
 
-            _status = SocketStatus::Connecting;
+            // Create the listening socket
             _socket = socket(ss.ss_family, SOCK_STREAM, IPPROTO_TCP);
             if (_socket == INVALID_SOCKET)
             {
                 throw SocketException("Unable to create socket.");
             }
 
-            SetNoDelay(true);
-            if (!SetNonBlocking(_socket, true))
+            // Turn off IPV6_V6ONLY so we can accept both v4 and v6 connections
+            if (!SetOption(_socket, IPPROTO_IPV6, IPV6_V6ONLY, false))
+            {
+                LOG_VERBOSE("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
+            }
+
+            if (!SetOption(_socket, SOL_SOCKET, SO_REUSEADDR, true))
+            {
+                LOG_VERBOSE("setsockopt(socket, SO_REUSEADDR) failed: %d", LAST_SOCKET_ERROR());
+            }
+
+            try
+            {
+                // Bind to address:port and listen
+                if (bind(_socket, reinterpret_cast<sockaddr*>(&ss), ss_len) != 0)
+                {
+                    std::string addressOrStar = address.empty() ? "*" : address.c_str();
+                    throw SocketException("Unable to bind to address " + addressOrStar + ":" + std::to_string(port));
+                }
+                if (listen(_socket, SOMAXCONN) != 0)
+                {
+                    throw SocketException("Unable to listen on socket.");
+                }
+
+                if (!SetNonBlocking(_socket, true))
+                {
+                    throw SocketException("Failed to set non-blocking mode.");
+                }
+            }
+            catch (const std::exception&)
+            {
+                CloseSocket();
+                throw;
+            }
+
+            _listeningPort = port;
+            _status = SocketStatus::Listening;
+        }
+
+        std::unique_ptr<ITcpSocket> Accept() override
+        {
+            if (_status != SocketStatus::Listening)
+            {
+                throw std::runtime_error("Socket not listening.");
+            }
+            struct sockaddr_storage client_addr{};
+            socklen_t client_len = sizeof(struct sockaddr_storage);
+
+            std::unique_ptr<ITcpSocket> tcpSocket;
+            SOCKET socket = accept(_socket, reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
+            if (socket == INVALID_SOCKET)
+            {
+                if (LAST_SOCKET_ERROR() != EWOULDBLOCK)
+                {
+                    LOG_ERROR("Failed to accept client.");
+                }
+            }
+            else
+            {
+                if (!SetNonBlocking(socket, true))
+                {
+                    closesocket(socket);
+                    LOG_ERROR("Failed to set non-blocking mode.");
+                }
+                else
+                {
+                    auto ipAddress = GetIpAddressFromSocket(reinterpret_cast<sockaddr_in*>(&client_addr));
+
+                    char hostName[NI_MAXHOST];
+                    int32_t rc = getnameinfo(
+                        reinterpret_cast<struct sockaddr*>(&client_addr), client_len, hostName, sizeof(hostName), nullptr, 0,
+                        NI_NUMERICHOST | NI_NUMERICSERV);
+                    SetNoDelay(true);
+
+                    if (rc == 0)
+                    {
+                        tcpSocket = std::make_unique<TcpSocket>(socket, hostName, ipAddress);
+                    }
+                    else
+                    {
+                        tcpSocket = std::make_unique<TcpSocket>(socket, "", ipAddress);
+                    }
+                }
+            }
+            return tcpSocket;
+        }
+
+        void Connect(const std::string& address, uint16_t port) override
+        {
+            if (_status != SocketStatus::Closed && _status != SocketStatus::Waiting)
+            {
+                throw std::runtime_error("Socket not closed.");
+            }
+
+            try
+            {
+                // Resolve address
+                _status = SocketStatus::Resolving;
+
+                sockaddr_storage ss{};
+                socklen_t ss_len;
+                if (!ResolveAddress(address, port, &ss, &ss_len))
+                {
+                    throw SocketException("Unable to resolve address.");
+                }
+
+                _status = SocketStatus::Connecting;
+                _socket = socket(ss.ss_family, SOCK_STREAM, IPPROTO_TCP);
+                if (_socket == INVALID_SOCKET)
+                {
+                    throw SocketException("Unable to create socket.");
+                }
+
+                SetNoDelay(true);
+                if (!SetNonBlocking(_socket, true))
+                {
+                    throw SocketException("Failed to set non-blocking mode.");
+                }
+
+                // Connect
+                int32_t connectResult = connect(_socket, reinterpret_cast<sockaddr*>(&ss), ss_len);
+                if (connectResult != SOCKET_ERROR || (LAST_SOCKET_ERROR() != EINPROGRESS && LAST_SOCKET_ERROR() != EWOULDBLOCK))
+                {
+                    throw SocketException("Failed to connect.");
+                }
+
+                auto connectStartTime = std::chrono::system_clock::now();
+
+                int32_t error = 0;
+                socklen_t len = sizeof(error);
+                if (getsockopt(_socket, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) != 0)
+                {
+                    throw SocketException("getsockopt failed with error: " + std::to_string(LAST_SOCKET_ERROR()));
+                }
+                if (error != 0)
+                {
+                    throw SocketException("Connection failed: " + std::to_string(error));
+                }
+
+                do
+                {
+                    // Sleep for a bit
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+                    fd_set writeFD;
+                    FD_ZERO(&writeFD);
+    #pragma warning(push)
+    #pragma warning(disable : 4548) // expression before comma has no effect; expected expression with side-effect
+                    FD_SET(_socket, &writeFD);
+    #pragma warning(pop)
+                    timeval timeout{};
+                    timeout.tv_sec = 0;
+                    timeout.tv_usec = 0;
+                    if (select(static_cast<int32_t>(_socket + 1), nullptr, &writeFD, nullptr, &timeout) > 0)
+                    {
+                        error = 0;
+                        len = sizeof(error);
+                        if (getsockopt(_socket, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) != 0)
+                        {
+                            throw SocketException("getsockopt failed with error: " + std::to_string(LAST_SOCKET_ERROR()));
+                        }
+                        if (error == 0)
+                        {
+                            _status = SocketStatus::Connected;
+                            return;
+                        }
+                    }
+                } while ((std::chrono::system_clock::now() - connectStartTime) < kConnectTimeout);
+
+                // Connection request timed out
+                throw SocketException("Connection timed out.");
+            }
+            catch (const std::exception&)
+            {
+                CloseSocket();
+                throw;
+            }
+        }
+
+        void ConnectAsync(const std::string& address, uint16_t port) override
+        {
+            if (_status != SocketStatus::Closed)
+            {
+                throw std::runtime_error("Socket not closed.");
+            }
+
+            // When connect is called, the status is set to resolving, but we want to make sure
+            // the status is changed before this async method exits. Otherwise, the consumer
+            // might think the status has closed before it started to connect.
+            _status = SocketStatus::Waiting;
+
+            auto saddress = std::string(address);
+            std::promise<void> barrier;
+            _connectFuture = barrier.get_future();
+            auto thread = std::thread(
+                [this, saddress, port](std::promise<void> barrier2) -> void {
+                    try
+                    {
+                        Connect(saddress.c_str(), port);
+                    }
+                    catch (const std::exception& ex)
+                    {
+                        _error = std::string(ex.what());
+                    }
+                    barrier2.set_value();
+                },
+                std::move(barrier));
+            thread.detach();
+        }
+
+        void Finish() override
+        {
+            if (_status == SocketStatus::Connected)
+            {
+                shutdown(_socket, SHUT_WR);
+            }
+        }
+
+        void Disconnect() override
+        {
+            if (_status == SocketStatus::Connected)
+            {
+                shutdown(_socket, SHUT_RDWR);
+            }
+            _status = SocketStatus::Closed;
+        }
+
+        size_t SendData(const void* buffer, size_t size) override
+        {
+            if (_status != SocketStatus::Connected)
+            {
+                throw std::runtime_error("Socket not connected.");
+            }
+
+            size_t totalSent = 0;
+            do
+            {
+                const char* bufferStart = static_cast<const char*>(buffer) + totalSent;
+                size_t remainingSize = size - totalSent;
+                int32_t sentBytes = send(_socket, bufferStart, static_cast<int32_t>(remainingSize), FLAG_NO_PIPE);
+                if (sentBytes == SOCKET_ERROR)
+                {
+                    return totalSent;
+                }
+                totalSent += sentBytes;
+            } while (totalSent < size);
+            return totalSent;
+        }
+
+        NetworkReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) override
+        {
+            if (_status != SocketStatus::Connected)
+            {
+                throw std::runtime_error("Socket not connected.");
+            }
+
+            int32_t readBytes = recv(_socket, static_cast<char*>(buffer), static_cast<int32_t>(size), 0);
+            if (readBytes == 0)
+            {
+                *sizeReceived = 0;
+                return NetworkReadPacket::Disconnected;
+            }
+
+            if (readBytes == SOCKET_ERROR)
+            {
+                *sizeReceived = 0;
+    #ifndef _WIN32
+                // Removing the check for EAGAIN and instead relying on the values being the same allows turning on of
+                // -Wlogical-op warning.
+                // This is not true on Windows, see:
+                // * https://msdn.microsoft.com/en-us/library/windows/desktop/ms737828(v=vs.85).aspx
+                // * https://msdn.microsoft.com/en-us/library/windows/desktop/ms741580(v=vs.85).aspx
+                // * https://msdn.microsoft.com/en-us/library/windows/desktop/ms740668(v=vs.85).aspx
+                static_assert(
+                    EWOULDBLOCK == EAGAIN,
+                    "Portability note: your system has different values for EWOULDBLOCK "
+                    "and EAGAIN, please extend the condition below");
+    #endif // _WIN32
+                if (LAST_SOCKET_ERROR() != EWOULDBLOCK)
+                {
+                    return NetworkReadPacket::Disconnected;
+                }
+
+                return NetworkReadPacket::NoData;
+            }
+
+            *sizeReceived = readBytes;
+            return NetworkReadPacket::Success;
+        }
+
+        void Close() override
+        {
+            if (_connectFuture.valid())
+            {
+                _connectFuture.wait();
+            }
+            CloseSocket();
+        }
+
+        const char* GetHostName() const override
+        {
+            return _hostName.empty() ? nullptr : _hostName.c_str();
+        }
+
+        std::string GetIpAddress() const override
+        {
+            return _ipAddress;
+        }
+
+    private:
+        void CloseSocket()
+        {
+            if (_socket != INVALID_SOCKET)
+            {
+                closesocket(_socket);
+                _socket = INVALID_SOCKET;
+            }
+            _status = SocketStatus::Closed;
+        }
+
+        std::string GetIpAddressFromSocket(const sockaddr_in* addr) const
+        {
+            std::string result;
+            if (addr->sin_family == AF_INET)
+            {
+                char str[INET_ADDRSTRLEN]{};
+                inet_ntop(AF_INET, &addr->sin_addr, str, sizeof(str));
+                result = str;
+            }
+            else if (addr->sin_family == AF_INET6)
+            {
+                auto addrv6 = reinterpret_cast<const sockaddr_in6*>(&addr);
+                char str[INET6_ADDRSTRLEN]{};
+                inet_ntop(AF_INET6, &addrv6->sin6_addr, str, sizeof(str));
+                result = str;
+            }
+            return result;
+        }
+    };
+
+    class UdpSocket final : public IUdpSocket, protected Socket
+    {
+    private:
+        SocketStatus _status = SocketStatus::Closed;
+        uint16_t _listeningPort = 0;
+        SOCKET _socket = INVALID_SOCKET;
+        NetworkEndpoint _endpoint;
+
+        std::string _hostName;
+        std::string _error;
+
+    public:
+        UdpSocket() noexcept = default;
+
+        ~UdpSocket() override
+        {
+            CloseSocket();
+        }
+
+        SocketStatus GetStatus() const override
+        {
+            return _status;
+        }
+
+        const char* GetError() const override
+        {
+            return _error.empty() ? nullptr : _error.c_str();
+        }
+
+        void Listen(uint16_t port) override
+        {
+            Listen("", port);
+        }
+
+        void Listen(const std::string& address, uint16_t port) override
+        {
+            if (_status != SocketStatus::Closed)
+            {
+                throw std::runtime_error("Socket not closed.");
+            }
+
+            sockaddr_storage ss{};
+            socklen_t ss_len;
+            if (!ResolveAddressIPv4(address, port, &ss, &ss_len))
+            {
+                throw SocketException("Unable to resolve address.");
+            }
+
+            // Create the listening socket
+            _socket = CreateSocket();
+            try
+            {
+                // Bind to address:port and listen
+                if (bind(_socket, reinterpret_cast<sockaddr*>(&ss), ss_len) != 0)
+                {
+                    throw SocketException("Unable to bind to socket.");
+                }
+            }
+            catch (const std::exception&)
+            {
+                CloseSocket();
+                throw;
+            }
+
+            _listeningPort = port;
+            _status = SocketStatus::Listening;
+        }
+
+        size_t SendData(const std::string& address, uint16_t port, const void* buffer, size_t size) override
+        {
+            sockaddr_storage ss{};
+            socklen_t ss_len;
+            if (!ResolveAddressIPv4(address, port, &ss, &ss_len))
+            {
+                throw SocketException("Unable to resolve address.");
+            }
+            NetworkEndpoint endpoint(reinterpret_cast<const sockaddr*>(&ss), ss_len);
+            return SendData(endpoint, buffer, size);
+        }
+
+        size_t SendData(const INetworkEndpoint& destination, const void* buffer, size_t size) override
+        {
+            if (_socket == INVALID_SOCKET)
+            {
+                _socket = CreateSocket();
+            }
+
+            const auto& dest = dynamic_cast<const NetworkEndpoint*>(&destination);
+            if (dest == nullptr)
+            {
+                throw std::invalid_argument("destination is not compatible.");
+            }
+            auto ss = &dest->GetAddress();
+            auto ss_len = dest->GetAddressLen();
+
+            if (_status != SocketStatus::Listening)
+            {
+                _endpoint = *dest;
+            }
+
+            size_t totalSent = 0;
+            do
+            {
+                const char* bufferStart = static_cast<const char*>(buffer) + totalSent;
+                size_t remainingSize = size - totalSent;
+                int32_t sentBytes = sendto(
+                    _socket, bufferStart, static_cast<int32_t>(remainingSize), FLAG_NO_PIPE, static_cast<const sockaddr*>(ss),
+                    ss_len);
+                if (sentBytes == SOCKET_ERROR)
+                {
+                    return totalSent;
+                }
+                totalSent += sentBytes;
+            } while (totalSent < size);
+            return totalSent;
+        }
+
+        NetworkReadPacket ReceiveData(
+            void* buffer, size_t size, size_t* sizeReceived, std::unique_ptr<INetworkEndpoint>* sender) override
+        {
+            sockaddr_in senderAddr{};
+            socklen_t senderAddrLen = sizeof(sockaddr_in);
+            if (_status != SocketStatus::Listening)
+            {
+                senderAddrLen = _endpoint.GetAddressLen();
+                std::memcpy(&senderAddr, &_endpoint.GetAddress(), senderAddrLen);
+            }
+            auto readBytes = recvfrom(
+                _socket, static_cast<char*>(buffer), static_cast<int32_t>(size), 0, reinterpret_cast<sockaddr*>(&senderAddr),
+                &senderAddrLen);
+            if (readBytes <= 0)
+            {
+                *sizeReceived = 0;
+                return NetworkReadPacket::NoData;
+            }
+
+            *sizeReceived = readBytes;
+            if (sender != nullptr)
+            {
+                *sender = std::make_unique<NetworkEndpoint>(reinterpret_cast<sockaddr*>(&senderAddr), senderAddrLen);
+            }
+            return NetworkReadPacket::Success;
+        }
+
+        void Close() override
+        {
+            CloseSocket();
+        }
+
+        const char* GetHostName() const override
+        {
+            return _hostName.empty() ? nullptr : _hostName.c_str();
+        }
+
+    private:
+        SOCKET CreateSocket() const
+        {
+            auto sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+            if (sock == INVALID_SOCKET)
+            {
+                throw SocketException("Unable to create socket.");
+            }
+
+            // Enable send and receiving of broadcast messages
+            if (!SetOption(sock, SOL_SOCKET, SO_BROADCAST, true))
+            {
+                LOG_VERBOSE("setsockopt(socket, SO_BROADCAST) failed: %d", LAST_SOCKET_ERROR());
+            }
+
+            // Turn off IPV6_V6ONLY so we can accept both v4 and v6 connections
+            if (!SetOption(sock, IPPROTO_IPV6, IPV6_V6ONLY, false))
+            {
+                LOG_VERBOSE("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
+            }
+
+            if (!SetOption(sock, SOL_SOCKET, SO_REUSEADDR, true))
+            {
+                LOG_VERBOSE("setsockopt(socket, SO_REUSEADDR) failed: %d", LAST_SOCKET_ERROR());
+            }
+
+            if (!SetNonBlocking(sock, true))
             {
                 throw SocketException("Failed to set non-blocking mode.");
             }
 
-            // Connect
-            int32_t connectResult = connect(_socket, reinterpret_cast<sockaddr*>(&ss), ss_len);
-            if (connectResult != SOCKET_ERROR || (LAST_SOCKET_ERROR() != EINPROGRESS && LAST_SOCKET_ERROR() != EWOULDBLOCK))
+            return sock;
+        }
+
+        void CloseSocket()
+        {
+            if (_socket != INVALID_SOCKET)
             {
-                throw SocketException("Failed to connect.");
+                closesocket(_socket);
+                _socket = INVALID_SOCKET;
             }
-
-            auto connectStartTime = std::chrono::system_clock::now();
-
-            int32_t error = 0;
-            socklen_t len = sizeof(error);
-            if (getsockopt(_socket, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) != 0)
-            {
-                throw SocketException("getsockopt failed with error: " + std::to_string(LAST_SOCKET_ERROR()));
-            }
-            if (error != 0)
-            {
-                throw SocketException("Connection failed: " + std::to_string(error));
-            }
-
-            do
-            {
-                // Sleep for a bit
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-                fd_set writeFD;
-                FD_ZERO(&writeFD);
-    #pragma warning(push)
-    #pragma warning(disable : 4548) // expression before comma has no effect; expected expression with side-effect
-                FD_SET(_socket, &writeFD);
-    #pragma warning(pop)
-                timeval timeout{};
-                timeout.tv_sec = 0;
-                timeout.tv_usec = 0;
-                if (select(static_cast<int32_t>(_socket + 1), nullptr, &writeFD, nullptr, &timeout) > 0)
-                {
-                    error = 0;
-                    len = sizeof(error);
-                    if (getsockopt(_socket, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&error), &len) != 0)
-                    {
-                        throw SocketException("getsockopt failed with error: " + std::to_string(LAST_SOCKET_ERROR()));
-                    }
-                    if (error == 0)
-                    {
-                        _status = SocketStatus::Connected;
-                        return;
-                    }
-                }
-            } while ((std::chrono::system_clock::now() - connectStartTime) < kConnectTimeout);
-
-            // Connection request timed out
-            throw SocketException("Connection timed out.");
+            _status = SocketStatus::Closed;
         }
-        catch (const std::exception&)
-        {
-            CloseSocket();
-            throw;
-        }
-    }
+    };
 
-    void ConnectAsync(const std::string& address, uint16_t port) override
+    std::unique_ptr<ITcpSocket> CreateTcpSocket()
     {
-        if (_status != SocketStatus::Closed)
-        {
-            throw std::runtime_error("Socket not closed.");
-        }
-
-        // When connect is called, the status is set to resolving, but we want to make sure
-        // the status is changed before this async method exits. Otherwise, the consumer
-        // might think the status has closed before it started to connect.
-        _status = SocketStatus::Waiting;
-
-        auto saddress = std::string(address);
-        std::promise<void> barrier;
-        _connectFuture = barrier.get_future();
-        auto thread = std::thread(
-            [this, saddress, port](std::promise<void> barrier2) -> void {
-                try
-                {
-                    Connect(saddress.c_str(), port);
-                }
-                catch (const std::exception& ex)
-                {
-                    _error = std::string(ex.what());
-                }
-                barrier2.set_value();
-            },
-            std::move(barrier));
-        thread.detach();
+        InitialiseWSA();
+        return std::make_unique<TcpSocket>();
     }
 
-    void Finish() override
+    std::unique_ptr<IUdpSocket> CreateUdpSocket()
     {
-        if (_status == SocketStatus::Connected)
-        {
-            shutdown(_socket, SHUT_WR);
-        }
+        InitialiseWSA();
+        return std::make_unique<UdpSocket>();
     }
-
-    void Disconnect() override
-    {
-        if (_status == SocketStatus::Connected)
-        {
-            shutdown(_socket, SHUT_RDWR);
-        }
-        _status = SocketStatus::Closed;
-    }
-
-    size_t SendData(const void* buffer, size_t size) override
-    {
-        if (_status != SocketStatus::Connected)
-        {
-            throw std::runtime_error("Socket not connected.");
-        }
-
-        size_t totalSent = 0;
-        do
-        {
-            const char* bufferStart = static_cast<const char*>(buffer) + totalSent;
-            size_t remainingSize = size - totalSent;
-            int32_t sentBytes = send(_socket, bufferStart, static_cast<int32_t>(remainingSize), FLAG_NO_PIPE);
-            if (sentBytes == SOCKET_ERROR)
-            {
-                return totalSent;
-            }
-            totalSent += sentBytes;
-        } while (totalSent < size);
-        return totalSent;
-    }
-
-    NetworkReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) override
-    {
-        if (_status != SocketStatus::Connected)
-        {
-            throw std::runtime_error("Socket not connected.");
-        }
-
-        int32_t readBytes = recv(_socket, static_cast<char*>(buffer), static_cast<int32_t>(size), 0);
-        if (readBytes == 0)
-        {
-            *sizeReceived = 0;
-            return NetworkReadPacket::Disconnected;
-        }
-
-        if (readBytes == SOCKET_ERROR)
-        {
-            *sizeReceived = 0;
-    #ifndef _WIN32
-            // Removing the check for EAGAIN and instead relying on the values being the same allows turning on of
-            // -Wlogical-op warning.
-            // This is not true on Windows, see:
-            // * https://msdn.microsoft.com/en-us/library/windows/desktop/ms737828(v=vs.85).aspx
-            // * https://msdn.microsoft.com/en-us/library/windows/desktop/ms741580(v=vs.85).aspx
-            // * https://msdn.microsoft.com/en-us/library/windows/desktop/ms740668(v=vs.85).aspx
-            static_assert(
-                EWOULDBLOCK == EAGAIN,
-                "Portability note: your system has different values for EWOULDBLOCK "
-                "and EAGAIN, please extend the condition below");
-    #endif // _WIN32
-            if (LAST_SOCKET_ERROR() != EWOULDBLOCK)
-            {
-                return NetworkReadPacket::Disconnected;
-            }
-
-            return NetworkReadPacket::NoData;
-        }
-
-        *sizeReceived = readBytes;
-        return NetworkReadPacket::Success;
-    }
-
-    void Close() override
-    {
-        if (_connectFuture.valid())
-        {
-            _connectFuture.wait();
-        }
-        CloseSocket();
-    }
-
-    const char* GetHostName() const override
-    {
-        return _hostName.empty() ? nullptr : _hostName.c_str();
-    }
-
-    std::string GetIpAddress() const override
-    {
-        return _ipAddress;
-    }
-
-private:
-    void CloseSocket()
-    {
-        if (_socket != INVALID_SOCKET)
-        {
-            closesocket(_socket);
-            _socket = INVALID_SOCKET;
-        }
-        _status = SocketStatus::Closed;
-    }
-
-    std::string GetIpAddressFromSocket(const sockaddr_in* addr) const
-    {
-        std::string result;
-        if (addr->sin_family == AF_INET)
-        {
-            char str[INET_ADDRSTRLEN]{};
-            inet_ntop(AF_INET, &addr->sin_addr, str, sizeof(str));
-            result = str;
-        }
-        else if (addr->sin_family == AF_INET6)
-        {
-            auto addrv6 = reinterpret_cast<const sockaddr_in6*>(&addr);
-            char str[INET6_ADDRSTRLEN]{};
-            inet_ntop(AF_INET6, &addrv6->sin6_addr, str, sizeof(str));
-            result = str;
-        }
-        return result;
-    }
-};
-
-class UdpSocket final : public IUdpSocket, protected Socket
-{
-private:
-    SocketStatus _status = SocketStatus::Closed;
-    uint16_t _listeningPort = 0;
-    SOCKET _socket = INVALID_SOCKET;
-    NetworkEndpoint _endpoint;
-
-    std::string _hostName;
-    std::string _error;
-
-public:
-    UdpSocket() noexcept = default;
-
-    ~UdpSocket() override
-    {
-        CloseSocket();
-    }
-
-    SocketStatus GetStatus() const override
-    {
-        return _status;
-    }
-
-    const char* GetError() const override
-    {
-        return _error.empty() ? nullptr : _error.c_str();
-    }
-
-    void Listen(uint16_t port) override
-    {
-        Listen("", port);
-    }
-
-    void Listen(const std::string& address, uint16_t port) override
-    {
-        if (_status != SocketStatus::Closed)
-        {
-            throw std::runtime_error("Socket not closed.");
-        }
-
-        sockaddr_storage ss{};
-        socklen_t ss_len;
-        if (!ResolveAddressIPv4(address, port, &ss, &ss_len))
-        {
-            throw SocketException("Unable to resolve address.");
-        }
-
-        // Create the listening socket
-        _socket = CreateSocket();
-        try
-        {
-            // Bind to address:port and listen
-            if (bind(_socket, reinterpret_cast<sockaddr*>(&ss), ss_len) != 0)
-            {
-                throw SocketException("Unable to bind to socket.");
-            }
-        }
-        catch (const std::exception&)
-        {
-            CloseSocket();
-            throw;
-        }
-
-        _listeningPort = port;
-        _status = SocketStatus::Listening;
-    }
-
-    size_t SendData(const std::string& address, uint16_t port, const void* buffer, size_t size) override
-    {
-        sockaddr_storage ss{};
-        socklen_t ss_len;
-        if (!ResolveAddressIPv4(address, port, &ss, &ss_len))
-        {
-            throw SocketException("Unable to resolve address.");
-        }
-        NetworkEndpoint endpoint(reinterpret_cast<const sockaddr*>(&ss), ss_len);
-        return SendData(endpoint, buffer, size);
-    }
-
-    size_t SendData(const INetworkEndpoint& destination, const void* buffer, size_t size) override
-    {
-        if (_socket == INVALID_SOCKET)
-        {
-            _socket = CreateSocket();
-        }
-
-        const auto& dest = dynamic_cast<const NetworkEndpoint*>(&destination);
-        if (dest == nullptr)
-        {
-            throw std::invalid_argument("destination is not compatible.");
-        }
-        auto ss = &dest->GetAddress();
-        auto ss_len = dest->GetAddressLen();
-
-        if (_status != SocketStatus::Listening)
-        {
-            _endpoint = *dest;
-        }
-
-        size_t totalSent = 0;
-        do
-        {
-            const char* bufferStart = static_cast<const char*>(buffer) + totalSent;
-            size_t remainingSize = size - totalSent;
-            int32_t sentBytes = sendto(
-                _socket, bufferStart, static_cast<int32_t>(remainingSize), FLAG_NO_PIPE, static_cast<const sockaddr*>(ss),
-                ss_len);
-            if (sentBytes == SOCKET_ERROR)
-            {
-                return totalSent;
-            }
-            totalSent += sentBytes;
-        } while (totalSent < size);
-        return totalSent;
-    }
-
-    NetworkReadPacket ReceiveData(
-        void* buffer, size_t size, size_t* sizeReceived, std::unique_ptr<INetworkEndpoint>* sender) override
-    {
-        sockaddr_in senderAddr{};
-        socklen_t senderAddrLen = sizeof(sockaddr_in);
-        if (_status != SocketStatus::Listening)
-        {
-            senderAddrLen = _endpoint.GetAddressLen();
-            std::memcpy(&senderAddr, &_endpoint.GetAddress(), senderAddrLen);
-        }
-        auto readBytes = recvfrom(
-            _socket, static_cast<char*>(buffer), static_cast<int32_t>(size), 0, reinterpret_cast<sockaddr*>(&senderAddr),
-            &senderAddrLen);
-        if (readBytes <= 0)
-        {
-            *sizeReceived = 0;
-            return NetworkReadPacket::NoData;
-        }
-
-        *sizeReceived = readBytes;
-        if (sender != nullptr)
-        {
-            *sender = std::make_unique<NetworkEndpoint>(reinterpret_cast<sockaddr*>(&senderAddr), senderAddrLen);
-        }
-        return NetworkReadPacket::Success;
-    }
-
-    void Close() override
-    {
-        CloseSocket();
-    }
-
-    const char* GetHostName() const override
-    {
-        return _hostName.empty() ? nullptr : _hostName.c_str();
-    }
-
-private:
-    SOCKET CreateSocket() const
-    {
-        auto sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-        if (sock == INVALID_SOCKET)
-        {
-            throw SocketException("Unable to create socket.");
-        }
-
-        // Enable send and receiving of broadcast messages
-        if (!SetOption(sock, SOL_SOCKET, SO_BROADCAST, true))
-        {
-            LOG_VERBOSE("setsockopt(socket, SO_BROADCAST) failed: %d", LAST_SOCKET_ERROR());
-        }
-
-        // Turn off IPV6_V6ONLY so we can accept both v4 and v6 connections
-        if (!SetOption(sock, IPPROTO_IPV6, IPV6_V6ONLY, false))
-        {
-            LOG_VERBOSE("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
-        }
-
-        if (!SetOption(sock, SOL_SOCKET, SO_REUSEADDR, true))
-        {
-            LOG_VERBOSE("setsockopt(socket, SO_REUSEADDR) failed: %d", LAST_SOCKET_ERROR());
-        }
-
-        if (!SetNonBlocking(sock, true))
-        {
-            throw SocketException("Failed to set non-blocking mode.");
-        }
-
-        return sock;
-    }
-
-    void CloseSocket()
-    {
-        if (_socket != INVALID_SOCKET)
-        {
-            closesocket(_socket);
-            _socket = INVALID_SOCKET;
-        }
-        _status = SocketStatus::Closed;
-    }
-};
-
-std::unique_ptr<ITcpSocket> CreateTcpSocket()
-{
-    InitialiseWSA();
-    return std::make_unique<TcpSocket>();
-}
-
-std::unique_ptr<IUdpSocket> CreateUdpSocket()
-{
-    InitialiseWSA();
-    return std::make_unique<UdpSocket>();
-}
 
     #ifdef _WIN32
-static std::vector<INTERFACE_INFO> GetNetworkInterfaces()
-{
-    InitialiseWSA();
-
-    int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock == -1)
+    static std::vector<INTERFACE_INFO> GetNetworkInterfaces()
     {
-        return {};
-    }
+        InitialiseWSA();
 
-    // Get all the network interfaces, requires a trial and error approach
-    // until we find the capacity required to store all of them.
-    DWORD len = 0;
-    size_t capacity = 16;
-    std::vector<INTERFACE_INFO> interfaces;
-    for (;;)
-    {
-        interfaces.resize(capacity);
-        if (WSAIoctl(
-                sock, SIO_GET_INTERFACE_LIST, nullptr, 0, interfaces.data(),
-                static_cast<DWORD>(capacity * sizeof(INTERFACE_INFO)), &len, nullptr, nullptr)
-            == 0)
+        int sock = socket(AF_INET, SOCK_DGRAM, 0);
+        if (sock == -1)
         {
-            break;
-        }
-        if (WSAGetLastError() != WSAEFAULT)
-        {
-            closesocket(sock);
             return {};
         }
-        capacity *= 2;
-    }
-    interfaces.resize(len / sizeof(INTERFACE_INFO));
-    interfaces.shrink_to_fit();
-    return interfaces;
-}
-    #endif
 
-std::vector<std::unique_ptr<INetworkEndpoint>> GetBroadcastAddresses()
-{
-    std::vector<std::unique_ptr<INetworkEndpoint>> baddresses;
-    #ifdef _WIN32
-    auto interfaces = GetNetworkInterfaces();
-    for (const auto& ifo : interfaces)
-    {
-        if (ifo.iiFlags & IFF_LOOPBACK)
-            continue;
-        if (!(ifo.iiFlags & IFF_BROADCAST))
-            continue;
-
-        // iiBroadcast is unusable, because it always seems to be set to 255.255.255.255.
-        sockaddr_storage address{};
-        memcpy(&address, &ifo.iiAddress.Address, sizeof(sockaddr));
-        (reinterpret_cast<sockaddr_in*>(&address))->sin_addr.s_addr = ifo.iiAddress.AddressIn.sin_addr.s_addr
-            | ~ifo.iiNetmask.AddressIn.sin_addr.s_addr;
-        baddresses.push_back(
-            std::make_unique<NetworkEndpoint>(
-                reinterpret_cast<const sockaddr*>(&address), static_cast<socklen_t>(sizeof(sockaddr))));
-    }
-    #else
-    int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock == -1)
-    {
-        return baddresses;
-    }
-
-    char buf[4 * 1024]{};
-    ifconf ifconfx{};
-    ifconfx.ifc_len = sizeof(buf);
-    ifconfx.ifc_buf = buf;
-    if (ioctl(sock, SIOCGIFCONF, &ifconfx) == -1)
-    {
-        close(sock);
-        return baddresses;
-    }
-
-    const char* buf_end = buf + ifconfx.ifc_len;
-    for (const char* p = buf; p < buf_end;)
-    {
-        auto req = reinterpret_cast<const ifreq*>(p);
-        if (req->ifr_addr.sa_family == AF_INET)
+        // Get all the network interfaces, requires a trial and error approach
+        // until we find the capacity required to store all of them.
+        DWORD len = 0;
+        size_t capacity = 16;
+        std::vector<INTERFACE_INFO> interfaces;
+        for (;;)
         {
-            ifreq r;
-            strcpy(r.ifr_name, req->ifr_name);
-            if (ioctl(sock, SIOCGIFFLAGS, &r) != -1 && (r.ifr_flags & IFF_BROADCAST) && ioctl(sock, SIOCGIFBRDADDR, &r) != -1)
+            interfaces.resize(capacity);
+            if (WSAIoctl(
+                    sock, SIO_GET_INTERFACE_LIST, nullptr, 0, interfaces.data(),
+                    static_cast<DWORD>(capacity * sizeof(INTERFACE_INFO)), &len, nullptr, nullptr)
+                == 0)
             {
-                baddresses.push_back(std::make_unique<NetworkEndpoint>(&r.ifr_broadaddr, sizeof(sockaddr)));
+                break;
             }
+            if (WSAGetLastError() != WSAEFAULT)
+            {
+                closesocket(sock);
+                return {};
+            }
+            capacity *= 2;
         }
-        p += sizeof(ifreq);
-        #if defined(AF_LINK) && !defined(SUNOS)
-        p += req->ifr_addr.sa_len - sizeof(struct sockaddr);
-        #endif
+        interfaces.resize(len / sizeof(INTERFACE_INFO));
+        interfaces.shrink_to_fit();
+        return interfaces;
     }
-    close(sock);
     #endif
-    return baddresses;
-}
+
+    std::vector<std::unique_ptr<INetworkEndpoint>> GetBroadcastAddresses()
+    {
+        std::vector<std::unique_ptr<INetworkEndpoint>> baddresses;
+    #ifdef _WIN32
+        auto interfaces = GetNetworkInterfaces();
+        for (const auto& ifo : interfaces)
+        {
+            if (ifo.iiFlags & IFF_LOOPBACK)
+                continue;
+            if (!(ifo.iiFlags & IFF_BROADCAST))
+                continue;
+
+            // iiBroadcast is unusable, because it always seems to be set to 255.255.255.255.
+            sockaddr_storage address{};
+            memcpy(&address, &ifo.iiAddress.Address, sizeof(sockaddr));
+            (reinterpret_cast<sockaddr_in*>(&address))->sin_addr.s_addr = ifo.iiAddress.AddressIn.sin_addr.s_addr
+                | ~ifo.iiNetmask.AddressIn.sin_addr.s_addr;
+            baddresses.push_back(
+                std::make_unique<NetworkEndpoint>(
+                    reinterpret_cast<const sockaddr*>(&address), static_cast<socklen_t>(sizeof(sockaddr))));
+        }
+    #else
+        int sock = socket(AF_INET, SOCK_DGRAM, 0);
+        if (sock == -1)
+        {
+            return baddresses;
+        }
+
+        char buf[4 * 1024]{};
+        ifconf ifconfx{};
+        ifconfx.ifc_len = sizeof(buf);
+        ifconfx.ifc_buf = buf;
+        if (ioctl(sock, SIOCGIFCONF, &ifconfx) == -1)
+        {
+            close(sock);
+            return baddresses;
+        }
+
+        const char* buf_end = buf + ifconfx.ifc_len;
+        for (const char* p = buf; p < buf_end;)
+        {
+            auto req = reinterpret_cast<const ifreq*>(p);
+            if (req->ifr_addr.sa_family == AF_INET)
+            {
+                ifreq r;
+                strcpy(r.ifr_name, req->ifr_name);
+                if (ioctl(sock, SIOCGIFFLAGS, &r) != -1 && (r.ifr_flags & IFF_BROADCAST)
+                    && ioctl(sock, SIOCGIFBRDADDR, &r) != -1)
+                {
+                    baddresses.push_back(std::make_unique<NetworkEndpoint>(&r.ifr_broadaddr, sizeof(sockaddr)));
+                }
+            }
+            p += sizeof(ifreq);
+        #if defined(AF_LINK) && !defined(SUNOS)
+            p += req->ifr_addr.sa_len - sizeof(struct sockaddr);
+        #endif
+        }
+        close(sock);
+    #endif
+        return baddresses;
+    }
+
+} // namespace OpenRCT2::Network
 
 namespace OpenRCT2::Convert
 {

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -574,7 +574,7 @@ namespace OpenRCT2::Network
             return totalSent;
         }
 
-        NetworkReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) override
+        ReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) override
         {
             if (_status != SocketStatus::connected)
             {
@@ -585,7 +585,7 @@ namespace OpenRCT2::Network
             if (readBytes == 0)
             {
                 *sizeReceived = 0;
-                return NetworkReadPacket::disconnected;
+                return ReadPacket::disconnected;
             }
 
             if (readBytes == SOCKET_ERROR)
@@ -605,14 +605,14 @@ namespace OpenRCT2::Network
     #endif // _WIN32
                 if (LAST_SOCKET_ERROR() != EWOULDBLOCK)
                 {
-                    return NetworkReadPacket::disconnected;
+                    return ReadPacket::disconnected;
                 }
 
-                return NetworkReadPacket::noData;
+                return ReadPacket::noData;
             }
 
             *sizeReceived = readBytes;
-            return NetworkReadPacket::success;
+            return ReadPacket::success;
         }
 
         void Close() override
@@ -782,7 +782,7 @@ namespace OpenRCT2::Network
             return totalSent;
         }
 
-        NetworkReadPacket ReceiveData(
+        ReadPacket ReceiveData(
             void* buffer, size_t size, size_t* sizeReceived, std::unique_ptr<INetworkEndpoint>* sender) override
         {
             sockaddr_in senderAddr{};
@@ -798,7 +798,7 @@ namespace OpenRCT2::Network
             if (readBytes <= 0)
             {
                 *sizeReceived = 0;
-                return NetworkReadPacket::noData;
+                return ReadPacket::noData;
             }
 
             *sizeReceived = readBytes;
@@ -806,7 +806,7 @@ namespace OpenRCT2::Network
             {
                 *sender = std::make_unique<NetworkEndpoint>(reinterpret_cast<sockaddr*>(&senderAddr), senderAddrLen);
             }
-            return NetworkReadPacket::success;
+            return ReadPacket::success;
         }
 
         void Close() override

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -17,20 +17,20 @@ namespace OpenRCT2::Network
 {
     enum class SocketStatus
     {
-        Closed,
-        Waiting,
-        Resolving,
-        Connecting,
-        Connected,
-        Listening,
+        closed,
+        waiting,
+        resolving,
+        connecting,
+        connected,
+        listening,
     };
 
     enum class NetworkReadPacket : int32_t
     {
-        Success,
-        NoData,
-        MoreData,
-        Disconnected
+        success,
+        noData,
+        moreData,
+        disconnected
     };
 
     /**

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -25,7 +25,7 @@ namespace OpenRCT2::Network
         listening,
     };
 
-    enum class NetworkReadPacket : int32_t
+    enum class ReadPacket : int32_t
     {
         success,
         noData,
@@ -66,7 +66,7 @@ namespace OpenRCT2::Network
         virtual void ConnectAsync(const std::string& address, uint16_t port) = 0;
 
         virtual size_t SendData(const void* buffer, size_t size) = 0;
-        virtual NetworkReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) = 0;
+        virtual ReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) = 0;
 
         virtual void SetNoDelay(bool noDelay) = 0;
 
@@ -92,7 +92,7 @@ namespace OpenRCT2::Network
 
         virtual size_t SendData(const std::string& address, uint16_t port, const void* buffer, size_t size) = 0;
         virtual size_t SendData(const INetworkEndpoint& destination, const void* buffer, size_t size) = 0;
-        virtual NetworkReadPacket ReceiveData(
+        virtual ReadPacket ReceiveData(
             void* buffer, size_t size, size_t* sizeReceived, std::unique_ptr<INetworkEndpoint>* sender)
             = 0;
 

--- a/src/openrct2/network/Socket.h
+++ b/src/openrct2/network/Socket.h
@@ -13,93 +13,96 @@
 #include <string>
 #include <vector>
 
-enum class SocketStatus
+namespace OpenRCT2::Network
 {
-    Closed,
-    Waiting,
-    Resolving,
-    Connecting,
-    Connected,
-    Listening,
-};
-
-enum class NetworkReadPacket : int32_t
-{
-    Success,
-    NoData,
-    MoreData,
-    Disconnected
-};
-
-/**
- * Represents an address and port.
- */
-struct INetworkEndpoint
-{
-    virtual ~INetworkEndpoint()
+    enum class SocketStatus
     {
-    }
+        Closed,
+        Waiting,
+        Resolving,
+        Connecting,
+        Connected,
+        Listening,
+    };
 
-    virtual std::string GetHostname() const = 0;
-};
+    enum class NetworkReadPacket : int32_t
+    {
+        Success,
+        NoData,
+        MoreData,
+        Disconnected
+    };
 
-/**
- * Represents a TCP socket / connection or listener.
- */
-struct ITcpSocket
-{
-public:
-    virtual ~ITcpSocket() = default;
+    /**
+     * Represents an address and port.
+     */
+    struct INetworkEndpoint
+    {
+        virtual ~INetworkEndpoint()
+        {
+        }
 
-    virtual SocketStatus GetStatus() const = 0;
-    virtual const char* GetError() const = 0;
-    virtual const char* GetHostName() const = 0;
-    virtual std::string GetIpAddress() const = 0;
+        virtual std::string GetHostname() const = 0;
+    };
 
-    virtual void Listen(uint16_t port) = 0;
-    virtual void Listen(const std::string& address, uint16_t port) = 0;
-    [[nodiscard]] virtual std::unique_ptr<ITcpSocket> Accept() = 0;
+    /**
+     * Represents a TCP socket / connection or listener.
+     */
+    struct ITcpSocket
+    {
+    public:
+        virtual ~ITcpSocket() = default;
 
-    virtual void Connect(const std::string& address, uint16_t port) = 0;
-    virtual void ConnectAsync(const std::string& address, uint16_t port) = 0;
+        virtual SocketStatus GetStatus() const = 0;
+        virtual const char* GetError() const = 0;
+        virtual const char* GetHostName() const = 0;
+        virtual std::string GetIpAddress() const = 0;
 
-    virtual size_t SendData(const void* buffer, size_t size) = 0;
-    virtual NetworkReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) = 0;
+        virtual void Listen(uint16_t port) = 0;
+        virtual void Listen(const std::string& address, uint16_t port) = 0;
+        [[nodiscard]] virtual std::unique_ptr<ITcpSocket> Accept() = 0;
 
-    virtual void SetNoDelay(bool noDelay) = 0;
+        virtual void Connect(const std::string& address, uint16_t port) = 0;
+        virtual void ConnectAsync(const std::string& address, uint16_t port) = 0;
 
-    virtual void Finish() = 0;
-    virtual void Disconnect() = 0;
-    virtual void Close() = 0;
-};
+        virtual size_t SendData(const void* buffer, size_t size) = 0;
+        virtual NetworkReadPacket ReceiveData(void* buffer, size_t size, size_t* sizeReceived) = 0;
 
-/**
- * Represents a UDP socket / listener.
- */
-struct IUdpSocket
-{
-public:
-    virtual ~IUdpSocket() = default;
+        virtual void SetNoDelay(bool noDelay) = 0;
 
-    virtual SocketStatus GetStatus() const = 0;
-    virtual const char* GetError() const = 0;
-    virtual const char* GetHostName() const = 0;
+        virtual void Finish() = 0;
+        virtual void Disconnect() = 0;
+        virtual void Close() = 0;
+    };
 
-    virtual void Listen(uint16_t port) = 0;
-    virtual void Listen(const std::string& address, uint16_t port) = 0;
+    /**
+     * Represents a UDP socket / listener.
+     */
+    struct IUdpSocket
+    {
+    public:
+        virtual ~IUdpSocket() = default;
 
-    virtual size_t SendData(const std::string& address, uint16_t port, const void* buffer, size_t size) = 0;
-    virtual size_t SendData(const INetworkEndpoint& destination, const void* buffer, size_t size) = 0;
-    virtual NetworkReadPacket ReceiveData(
-        void* buffer, size_t size, size_t* sizeReceived, std::unique_ptr<INetworkEndpoint>* sender)
-        = 0;
+        virtual SocketStatus GetStatus() const = 0;
+        virtual const char* GetError() const = 0;
+        virtual const char* GetHostName() const = 0;
 
-    virtual void Close() = 0;
-};
+        virtual void Listen(uint16_t port) = 0;
+        virtual void Listen(const std::string& address, uint16_t port) = 0;
 
-[[nodiscard]] std::unique_ptr<ITcpSocket> CreateTcpSocket();
-[[nodiscard]] std::unique_ptr<IUdpSocket> CreateUdpSocket();
-[[nodiscard]] std::vector<std::unique_ptr<INetworkEndpoint>> GetBroadcastAddresses();
+        virtual size_t SendData(const std::string& address, uint16_t port, const void* buffer, size_t size) = 0;
+        virtual size_t SendData(const INetworkEndpoint& destination, const void* buffer, size_t size) = 0;
+        virtual NetworkReadPacket ReceiveData(
+            void* buffer, size_t size, size_t* sizeReceived, std::unique_ptr<INetworkEndpoint>* sender)
+            = 0;
+
+        virtual void Close() = 0;
+    };
+
+    [[nodiscard]] std::unique_ptr<ITcpSocket> CreateTcpSocket();
+    [[nodiscard]] std::unique_ptr<IUdpSocket> CreateUdpSocket();
+    [[nodiscard]] std::vector<std::unique_ptr<INetworkEndpoint>> GetBroadcastAddresses();
+} // namespace OpenRCT2::Network
 
 namespace OpenRCT2::Convert
 {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -511,7 +511,7 @@ namespace OpenRCT2
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     auto earlyCompletion = cs.read<bool>();
-                    if (NetworkGetMode() == NETWORK_MODE_CLIENT)
+                    if (Network::GetMode() == Network::Mode::client)
                     {
                         gAllowEarlyCompletionInNetworkPlay = earlyCompletion;
                     }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -227,7 +227,7 @@ void RideClearForConstruction(Ride& ride)
     // Open circuit rides will go directly into building mode (creating ghosts) where it would normally clear the stats,
     // however this causes desyncs since it's directly run from the window and other clients would not get it.
     // To prevent these problems, unconditionally invalidate the test results on all clients in multiplayer games.
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         InvalidateTestResults(ride);
     }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -607,12 +607,12 @@ ResultWithMessage ScenarioPrepareForSave(GameState_t& gameState)
  */
 bool AllowEarlyCompletion()
 {
-    switch (NetworkGetMode())
+    switch (Network::GetMode())
     {
-        case NETWORK_MODE_CLIENT:
+        case Network::Mode::client:
             return gAllowEarlyCompletionInNetworkPlay;
-        case NETWORK_MODE_NONE:
-        case NETWORK_MODE_SERVER:
+        case Network::Mode::none:
+        case Network::Mode::server:
         default:
             return Config::Get().general.AllowEarlyCompletion;
     }

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -588,7 +588,7 @@ void ScriptEngine::RefreshPlugins()
     }
 
     // Turn on hot reload if not already enabled
-    if (!_hotReloadingInitialised && Config::Get().plugin.EnableHotReloading && NetworkGetMode() == NETWORK_MODE_NONE)
+    if (!_hotReloadingInitialised && Config::Get().plugin.EnableHotReloading && Network::GetMode() == Network::Mode::none)
     {
         SetupHotReloading();
     }
@@ -908,8 +908,8 @@ void ScriptEngine::StartTransientPlugins()
 
 bool ScriptEngine::ShouldStartPlugin(const std::shared_ptr<Plugin>& plugin)
 {
-    auto networkMode = NetworkGetMode();
-    if (networkMode == NETWORK_MODE_CLIENT)
+    auto networkMode = Network::GetMode();
+    if (networkMode == Network::Mode::client)
     {
         // Only client plugins and plugins downloaded from server should be started
         const auto& metadata = plugin->GetMetadata();
@@ -1561,9 +1561,9 @@ std::unique_ptr<GameActions::GameAction> ScriptEngine::CreateGameAction(
     duk_pop(ctx);
     auto customAction = std::make_unique<GameActions::CustomAction>(actionid, json, pluginName);
 
-    if (customAction->GetPlayer() == -1 && NetworkGetMode() != NETWORK_MODE_NONE)
+    if (customAction->GetPlayer() == -1 && Network::GetMode() != Network::Mode::none)
     {
-        customAction->SetPlayer(NetworkGetCurrentPlayerId());
+        customAction->SetPlayer(Network::GetCurrentPlayerId());
     }
     return customAction;
 }
@@ -1817,7 +1817,7 @@ std::string OpenRCT2::Scripting::ProcessString(const DukValue& value)
 bool OpenRCT2::Scripting::IsGameStateMutable()
 {
     // Allow single player to alter game state anywhere
-    if (NetworkGetMode() == NETWORK_MODE_NONE)
+    if (Network::GetMode() == Network::Mode::none)
     {
         return true;
     }
@@ -1830,7 +1830,7 @@ bool OpenRCT2::Scripting::IsGameStateMutable()
 void OpenRCT2::Scripting::ThrowIfGameStateNotMutable()
 {
     // Allow single player to alter game state anywhere
-    if (NetworkGetMode() != NETWORK_MODE_NONE)
+    if (Network::GetMode() != Network::Mode::none)
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto& execInfo = scriptEngine.GetExecInfo();

--- a/src/openrct2/scripting/bindings/network/ScNetwork.cpp
+++ b/src/openrct2/scripting/bindings/network/ScNetwork.cpp
@@ -27,12 +27,14 @@ namespace OpenRCT2::Scripting
     std::string ScNetwork::mode_get() const
     {
     #ifndef DISABLE_NETWORK
-        switch (NetworkGetMode())
+        switch (Network::GetMode())
         {
-            case NETWORK_MODE_SERVER:
+            case Network::Mode::server:
                 return "server";
-            case NETWORK_MODE_CLIENT:
+            case Network::Mode::client:
                 return "client";
+            default:
+                break;
         }
     #endif
         return "none";
@@ -41,7 +43,7 @@ namespace OpenRCT2::Scripting
     int32_t ScNetwork::numPlayers_get() const
     {
     #ifndef DISABLE_NETWORK
-        return NetworkGetNumPlayers();
+        return Network::GetNumPlayers();
     #else
         return 0;
     #endif
@@ -50,7 +52,7 @@ namespace OpenRCT2::Scripting
     int32_t ScNetwork::numGroups_get() const
     {
     #ifndef DISABLE_NETWORK
-        return NetworkGetNumGroups();
+        return Network::GetNumGroups();
     #else
         return 0;
     #endif
@@ -59,7 +61,7 @@ namespace OpenRCT2::Scripting
     int32_t ScNetwork::defaultGroup_get() const
     {
     #ifndef DISABLE_NETWORK
-        return NetworkGetDefaultGroup();
+        return Network::GetDefaultGroup();
     #else
         return 0;
     #endif
@@ -77,10 +79,10 @@ namespace OpenRCT2::Scripting
     {
         std::vector<std::shared_ptr<ScPlayerGroup>> groups;
     #ifndef DISABLE_NETWORK
-        auto numGroups = NetworkGetNumGroups();
+        auto numGroups = Network::GetNumGroups();
         for (int32_t i = 0; i < numGroups; i++)
         {
-            auto groupId = NetworkGetGroupID(i);
+            auto groupId = Network::GetGroupID(i);
             groups.push_back(std::make_shared<ScPlayerGroup>(groupId));
         }
     #endif
@@ -91,10 +93,10 @@ namespace OpenRCT2::Scripting
     {
         std::vector<std::shared_ptr<ScPlayer>> players;
     #ifndef DISABLE_NETWORK
-        auto numPlayers = NetworkGetNumPlayers();
+        auto numPlayers = Network::GetNumPlayers();
         for (int32_t i = 0; i < numPlayers; i++)
         {
-            auto playerId = NetworkGetPlayerID(i);
+            auto playerId = Network::GetPlayerID(i);
             players.push_back(std::make_shared<ScPlayer>(playerId));
         }
     #endif
@@ -105,7 +107,7 @@ namespace OpenRCT2::Scripting
     {
         std::shared_ptr<ScPlayer> player;
     #ifndef DISABLE_NETWORK
-        auto playerId = NetworkGetCurrentPlayerId();
+        auto playerId = Network::GetCurrentPlayerId();
         player = std::make_shared<ScPlayer>(playerId);
     #endif
         return player;
@@ -117,16 +119,16 @@ namespace OpenRCT2::Scripting
         if (GetTargetAPIVersion() < kApiVersionNetworkIDs)
         {
             auto index = id;
-            auto numPlayers = NetworkGetNumPlayers();
+            auto numPlayers = Network::GetNumPlayers();
             if (index < numPlayers)
             {
-                auto playerId = NetworkGetPlayerID(index);
+                auto playerId = Network::GetPlayerID(index);
                 return std::make_shared<ScPlayer>(playerId);
             }
         }
         else
         {
-            auto index = NetworkGetPlayerIndex(id);
+            auto index = Network::GetPlayerIndex(id);
             if (index != -1)
             {
                 return std::make_shared<ScPlayer>(id);
@@ -141,7 +143,7 @@ namespace OpenRCT2::Scripting
     {
     #ifndef DISABLE_NETWORK
         auto obj = OpenRCT2::Scripting::DukObject(_context);
-        auto networkStats = NetworkGetStats();
+        auto networkStats = Network::GetStats();
         {
             duk_push_array(_context);
             duk_uarridx_t index = 0;
@@ -176,16 +178,16 @@ namespace OpenRCT2::Scripting
         if (GetTargetAPIVersion() < kApiVersionNetworkIDs)
         {
             auto index = id;
-            auto numGroups = NetworkGetNumGroups();
+            auto numGroups = Network::GetNumGroups();
             if (index < numGroups)
             {
-                auto groupId = NetworkGetGroupID(index);
+                auto groupId = Network::GetGroupID(index);
                 return std::make_shared<ScPlayerGroup>(groupId);
             }
         }
         else
         {
-            auto index = NetworkGetGroupIndex(id);
+            auto index = Network::GetGroupIndex(id);
             if (index != -1)
             {
                 return std::make_shared<ScPlayerGroup>(id);
@@ -209,17 +211,17 @@ namespace OpenRCT2::Scripting
         if (GetTargetAPIVersion() < kApiVersionNetworkIDs)
         {
             auto index = id;
-            auto numGroups = NetworkGetNumGroups();
+            auto numGroups = Network::GetNumGroups();
             if (index < numGroups)
             {
-                auto groupId = NetworkGetGroupID(index);
+                auto groupId = Network::GetGroupID(index);
                 auto networkAction = GameActions::NetworkModifyGroupAction(GameActions::ModifyGroupType::RemoveGroup, groupId);
                 GameActions::Execute(&networkAction);
             }
         }
         else
         {
-            auto index = NetworkGetGroupIndex(id);
+            auto index = Network::GetGroupIndex(id);
             if (index != -1)
             {
                 auto networkAction = GameActions::NetworkModifyGroupAction(GameActions::ModifyGroupType::RemoveGroup, id);
@@ -235,17 +237,17 @@ namespace OpenRCT2::Scripting
         if (GetTargetAPIVersion() < kApiVersionNetworkIDs)
         {
             auto index = id;
-            auto numPlayers = NetworkGetNumPlayers();
+            auto numPlayers = Network::GetNumPlayers();
             if (index < numPlayers)
             {
-                auto playerId = NetworkGetPlayerID(index);
+                auto playerId = Network::GetPlayerID(index);
                 auto kickPlayerAction = GameActions::PlayerKickAction(playerId);
                 GameActions::Execute(&kickPlayerAction);
             }
         }
         else
         {
-            auto index = NetworkGetPlayerIndex(id);
+            auto index = Network::GetPlayerIndex(id);
             if (index != -1)
             {
                 auto kickPlayerAction = GameActions::PlayerKickAction(id);
@@ -260,7 +262,7 @@ namespace OpenRCT2::Scripting
     #ifndef DISABLE_NETWORK
         if (players.is_array())
         {
-            if (NetworkGetMode() == NETWORK_MODE_SERVER)
+            if (Network::GetMode() == Network::Mode::server)
             {
                 std::vector<uint8_t> playerIds;
                 auto playerArray = players.as_array();
@@ -273,7 +275,7 @@ namespace OpenRCT2::Scripting
                 }
                 if (!playerArray.empty())
                 {
-                    NetworkSendChat(message.c_str(), playerIds);
+                    Network::SendChat(message.c_str(), playerIds);
                 }
             }
             else
@@ -283,7 +285,7 @@ namespace OpenRCT2::Scripting
         }
         else
         {
-            NetworkSendChat(message.c_str());
+            Network::SendChat(message.c_str());
         }
     #endif
     }

--- a/src/openrct2/scripting/bindings/network/ScPlayer.cpp
+++ b/src/openrct2/scripting/bindings/network/ScPlayer.cpp
@@ -31,10 +31,10 @@ namespace OpenRCT2::Scripting
     std::string ScPlayer::name_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetPlayerIndex(_id);
+        auto index = Network::GetPlayerIndex(_id);
         if (index == -1)
             return {};
-        return NetworkGetPlayerName(index);
+        return Network::GetPlayerName(index);
     #else
         return {};
     #endif
@@ -43,10 +43,10 @@ namespace OpenRCT2::Scripting
     int32_t ScPlayer::group_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetPlayerIndex(_id);
+        auto index = Network::GetPlayerIndex(_id);
         if (index == -1)
             return {};
-        return NetworkGetPlayerGroup(index);
+        return Network::GetPlayerGroup(index);
     #else
         return 0;
     #endif
@@ -62,10 +62,10 @@ namespace OpenRCT2::Scripting
     int32_t ScPlayer::ping_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetPlayerIndex(_id);
+        auto index = Network::GetPlayerIndex(_id);
         if (index == -1)
             return {};
-        return NetworkGetPlayerPing(index);
+        return Network::GetPlayerPing(index);
     #else
         return 0;
     #endif
@@ -74,10 +74,10 @@ namespace OpenRCT2::Scripting
     int32_t ScPlayer::commandsRan_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetPlayerIndex(_id);
+        auto index = Network::GetPlayerIndex(_id);
         if (index == -1)
             return {};
-        return NetworkGetPlayerCommandsRan(index);
+        return Network::GetPlayerCommandsRan(index);
     #else
         return 0;
     #endif
@@ -86,10 +86,10 @@ namespace OpenRCT2::Scripting
     int32_t ScPlayer::moneySpent_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetPlayerIndex(_id);
+        auto index = Network::GetPlayerIndex(_id);
         if (index == -1)
             return {};
-        return NetworkGetPlayerMoneySpent(index);
+        return Network::GetPlayerMoneySpent(index);
     #else
         return 0;
     #endif
@@ -97,12 +97,12 @@ namespace OpenRCT2::Scripting
 
     std::string ScPlayer::ipAddress_get() const
     {
-        return NetworkGetPlayerIPAddress(_id);
+        return Network::GetPlayerIPAddress(_id);
     }
 
     std::string ScPlayer::publicKeyHash_get() const
     {
-        return NetworkGetPlayerPublicKeyHash(_id);
+        return Network::GetPlayerPublicKeyHash(_id);
     }
 
     void ScPlayer::Register(duk_context* ctx)

--- a/src/openrct2/scripting/bindings/network/ScPlayerGroup.cpp
+++ b/src/openrct2/scripting/bindings/network/ScPlayerGroup.cpp
@@ -34,10 +34,10 @@ namespace OpenRCT2::Scripting
     std::string ScPlayerGroup::name_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetGroupIndex(_id);
+        auto index = Network::GetGroupIndex(_id);
         if (index == -1)
             return {};
-        return NetworkGetGroupName(index);
+        return Network::GetGroupName(index);
     #else
         return {};
     #endif
@@ -71,16 +71,16 @@ namespace OpenRCT2::Scripting
     std::vector<std::string> ScPlayerGroup::permissions_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto index = NetworkGetGroupIndex(_id);
+        auto index = Network::GetGroupIndex(_id);
         if (index == -1)
             return {};
 
         // Create array of permissions
         std::vector<std::string> result;
         auto permissionIndex = 0;
-        for (const auto& action : NetworkActions::Actions)
+        for (const auto& action : Network::NetworkActions::Actions)
         {
-            if (NetworkCanPerformAction(index, static_cast<NetworkPermission>(permissionIndex)))
+            if (Network::CanPerformAction(index, static_cast<Network::Permission>(permissionIndex)))
             {
                 result.push_back(TransformPermissionKeyToJS(action.PermissionName));
             }
@@ -95,7 +95,7 @@ namespace OpenRCT2::Scripting
     void ScPlayerGroup::permissions_set(std::vector<std::string> value)
     {
     #ifndef DISABLE_NETWORK
-        auto groupIndex = NetworkGetGroupIndex(_id);
+        auto groupIndex = Network::GetGroupIndex(_id);
         if (groupIndex == -1)
             return;
 
@@ -105,13 +105,13 @@ namespace OpenRCT2::Scripting
         GameActions::Execute(&networkAction);
 
         std::vector<bool> enabledPermissions;
-        enabledPermissions.resize(NetworkActions::Actions.size());
+        enabledPermissions.resize(Network::NetworkActions::Actions.size());
         for (const auto& p : value)
         {
             auto permissionName = TransformPermissionKeyToInternal(p);
 
             auto permissionIndex = 0;
-            for (const auto& action : NetworkActions::Actions)
+            for (const auto& action : Network::NetworkActions::Actions)
             {
                 if (action.PermissionName == permissionName)
                 {
@@ -124,7 +124,7 @@ namespace OpenRCT2::Scripting
         for (size_t i = 0; i < enabledPermissions.size(); i++)
         {
             auto toggle
-                = (enabledPermissions[i] != (NetworkCanPerformAction(groupIndex, static_cast<NetworkPermission>(i)) != 0));
+                = (enabledPermissions[i] != (Network::CanPerformAction(groupIndex, static_cast<Network::Permission>(i)) != 0));
             if (toggle)
             {
                 auto networkAction2 = GameActions::NetworkModifyGroupAction(

--- a/src/openrct2/scripting/bindings/network/ScSocket.hpp
+++ b/src/openrct2/scripting/bindings/network/ScSocket.hpp
@@ -349,14 +349,14 @@ namespace OpenRCT2::Scripting
                     auto result = _socket->ReceiveData(buffer, sizeof(buffer), &bytesRead);
                     switch (result)
                     {
-                        case Network::NetworkReadPacket::success:
+                        case Network::ReadPacket::success:
                             RaiseOnData(std::string(buffer, bytesRead));
                             break;
-                        case Network::NetworkReadPacket::noData:
+                        case Network::ReadPacket::noData:
                             break;
-                        case Network::NetworkReadPacket::moreData:
+                        case Network::ReadPacket::moreData:
                             break;
-                        case Network::NetworkReadPacket::disconnected:
+                        case Network::ReadPacket::disconnected:
                             CloseSocket();
                             break;
                     }

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -134,7 +134,7 @@ void SceneryUpdateTile(const CoordsXY& sceneryPos)
     {
         // Ghosts are purely this-client-side and should not cause any interaction,
         // as that may lead to a desync.
-        if (NetworkGetMode() != NETWORK_MODE_NONE)
+        if (Network::GetMode() != Network::Mode::none)
         {
             if (tileElement->IsGhost())
                 continue;


### PR DESCRIPTION
Continues moving classes and functions into the `OpenRCT2` namespace, this time into a sub-namespace `OpenRCT2::Network`. Functions that used to be prefixed `Network` now lose their prefix, as the namespace takes care of disambiguation already.