### PR TITLE
Make peeps not stop on level crossings

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.28 (in development)
 ------------------------------------------------------------------------
+- Change: [#25089] Peep actions and animations that cause them to stop moving no longer trigger when they are on a level crossing.
 - Fix: [#25299] The Mine Train Coaster left large helix draws incorrect sprites at certain angles (original bug).
 
 0.4.27 (2025-10-04)
@@ -7,7 +8,6 @@
 - Feature: [#25218] `sprite exportobject` command, which allows extracting images from an object.
 - Feature: [#25274] New title sequence (see https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.26 for credits).
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
-- Change: [#25089] Peep actions and animations that cause them to stop moving no longer trigger when they are on a level crossing.
 - Change: [#25111] Frozen guests no longer finish consuming any food or drink they are carrying.
 - Change: [#25161] Revert to the ‘fair ride price’ calculation of vanilla RCT2.
 - Change: [#25201] Ride List: put unknown popularity and satisfaction last when sorting.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#25218] `sprite exportobject` command, which allows extracting images from an object.
 - Feature: [#25274] New title sequence (see https://github.com/OpenRCT2/title-sequences/releases/tag/v0.4.26 for credits).
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
+- Change: [#25089] Peep actions and animations that cause them to stop moving no longer trigger when they are on a level crossing.
 - Change: [#25111] Frozen guests no longer finish consuming any food or drink they are carrying.
 - Change: [#25161] Revert to the ‘fair ride price’ calculation of vanilla RCT2.
 - Change: [#25201] Ride List: put unknown popularity and satisfaction last when sorting.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5473,31 +5473,24 @@ void Guest::UpdateWalking()
 
     const auto currentTicks = getGameState().currentTicks;
 
-    if (PeepFlags & PEEP_FLAGS_WAVING && IsActionInterruptableSafely() && (0xFFFF & ScenarioRand()) < 936)
+    if (IsActionInterruptableSafely())
     {
-        Action = PeepActionType::Wave2;
-        AnimationFrameNum = 0;
-        AnimationImageIdOffset = 0;
+        PeepActionType NewAction = Action;
 
-        UpdateCurrentAnimationType();
-    }
+        if (PeepFlags & PEEP_FLAGS_WAVING && (0xFFFF & ScenarioRand()) < 936)
+            NewAction = PeepActionType::Wave2;
+        else if (PeepFlags & PEEP_FLAGS_PHOTO && (0xFFFF & ScenarioRand()) < 936)
+            NewAction = PeepActionType::TakePhoto;
+        else if (PeepFlags & PEEP_FLAGS_PAINTING && (0xFFFF & ScenarioRand()) < 936)
+            NewAction = PeepActionType::DrawPicture;
 
-    if (PeepFlags & PEEP_FLAGS_PHOTO && IsActionInterruptableSafely() && (0xFFFF & ScenarioRand()) < 936)
-    {
-        Action = PeepActionType::TakePhoto;
-        AnimationFrameNum = 0;
-        AnimationImageIdOffset = 0;
-
-        UpdateCurrentAnimationType();
-    }
-
-    if (PeepFlags & PEEP_FLAGS_PAINTING && IsActionInterruptableSafely() && (0xFFFF & ScenarioRand()) < 936)
-    {
-        Action = PeepActionType::DrawPicture;
-        AnimationFrameNum = 0;
-        AnimationImageIdOffset = 0;
-
-        UpdateCurrentAnimationType();
+        if (NewAction != Action)
+        {
+            Action = NewAction;
+            AnimationFrameNum = 0;
+            AnimationImageIdOffset = 0;
+            UpdateCurrentAnimationType();
+        }
     }
 
     if (PeepFlags & PEEP_FLAGS_LITTER)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -532,7 +532,7 @@ void Guest::GivePassingGuestPizza(Guest& passingPeep)
     int32_t otherPeepOppositeDirection = passingPeep.Orientation >> 3;
     if (peepDirection == otherPeepOppositeDirection)
     {
-        if (passingPeep.IsActionInterruptable())
+        if (passingPeep.IsActionInterruptableSafely())
         {
             passingPeep.Action = PeepActionType::Wave2;
             passingPeep.AnimationFrameNum = 0;
@@ -547,7 +547,7 @@ void Guest::MakePassingGuestSick(Guest& passingPeep)
     if (passingPeep.State != PeepState::Walking)
         return;
 
-    if (passingPeep.IsActionInterruptable())
+    if (passingPeep.IsActionInterruptableSafely())
     {
         passingPeep.Action = PeepActionType::ThrowUp;
         passingPeep.AnimationFrameNum = 0;
@@ -595,7 +595,7 @@ void Guest::UpdateEasterEggInteractions()
     {
         if ((ScenarioRand() & 0xFFFF) <= 1456)
         {
-            if (IsActionInterruptable())
+            if (IsActionInterruptableSafely())
             {
                 Action = PeepActionType::Joy;
                 AnimationFrameNum = 0;
@@ -800,7 +800,7 @@ void Guest::UpdateMotivesIdle()
     {
         if ((ScenarioRand() & 0xFF) <= static_cast<uint8_t>((Nausea - 128) / 2))
         {
-            if (IsActionInterruptable())
+            if (IsActionInterruptableSafely())
             {
                 Action = PeepActionType::ThrowUp;
                 AnimationFrameNum = 0;
@@ -2426,7 +2426,7 @@ void Guest::ChoseNotToGoOnRide(const Ride& ride, bool peepAtRide, bool updateLas
 
 void Guest::ReadMap()
 {
-    if (IsActionInterruptable() && !IsOnLevelCrossing())
+    if (IsActionInterruptableSafely())
     {
         Action = PeepActionType::ReadMap;
         AnimationFrameNum = 0;
@@ -5473,34 +5473,31 @@ void Guest::UpdateWalking()
 
     const auto currentTicks = getGameState().currentTicks;
 
-    if (!IsOnLevelCrossing())
+    if (PeepFlags & PEEP_FLAGS_WAVING && IsActionInterruptableSafely() && (0xFFFF & ScenarioRand()) < 936)
     {
-        if (PeepFlags & PEEP_FLAGS_WAVING && IsActionInterruptable() && (0xFFFF & ScenarioRand()) < 936)
-        {
-            Action = PeepActionType::Wave2;
-            AnimationFrameNum = 0;
-            AnimationImageIdOffset = 0;
+        Action = PeepActionType::Wave2;
+        AnimationFrameNum = 0;
+        AnimationImageIdOffset = 0;
 
-            UpdateCurrentAnimationType();
-        }
+        UpdateCurrentAnimationType();
+    }
 
-        if (PeepFlags & PEEP_FLAGS_PHOTO && IsActionInterruptable() && (0xFFFF & ScenarioRand()) < 936)
-        {
-            Action = PeepActionType::TakePhoto;
-            AnimationFrameNum = 0;
-            AnimationImageIdOffset = 0;
+    if (PeepFlags & PEEP_FLAGS_PHOTO && IsActionInterruptableSafely() && (0xFFFF & ScenarioRand()) < 936)
+    {
+        Action = PeepActionType::TakePhoto;
+        AnimationFrameNum = 0;
+        AnimationImageIdOffset = 0;
 
-            UpdateCurrentAnimationType();
-        }
+        UpdateCurrentAnimationType();
+    }
 
-        if (PeepFlags & PEEP_FLAGS_PAINTING && IsActionInterruptable() && (0xFFFF & ScenarioRand()) < 936)
-        {
-            Action = PeepActionType::DrawPicture;
-            AnimationFrameNum = 0;
-            AnimationImageIdOffset = 0;
+    if (PeepFlags & PEEP_FLAGS_PAINTING && IsActionInterruptableSafely() && (0xFFFF & ScenarioRand()) < 936)
+    {
+        Action = PeepActionType::DrawPicture;
+        AnimationFrameNum = 0;
+        AnimationImageIdOffset = 0;
 
-            UpdateCurrentAnimationType();
-        }
+        UpdateCurrentAnimationType();
     }
 
     if (PeepFlags & PEEP_FLAGS_LITTER)
@@ -7129,7 +7126,7 @@ void Guest::InsertNewThought(PeepThoughtType thought_type, RideId rideId)
 void Guest::InsertNewThought(PeepThoughtType thoughtType, uint16_t thoughtArguments)
 {
     PeepActionType newAction = PeepThoughtToActionMap[EnumValue(thoughtType)].action;
-    if (newAction != PeepActionType::Walking && IsActionInterruptable())
+    if (newAction != PeepActionType::Walking && IsActionInterruptableSafely())
     {
         Action = newAction;
         AnimationFrameNum = 0;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1534,7 +1534,8 @@ bool Peep::IsActionInterruptable() const
 }
 
 /**
- * Used to avoid peep action and animation triggers that might put them at risk of getting run over at level crossings.
+ * Used to avoid peep action and animation triggers that cause them to stop moving and might put them at risk
+ * of getting run over at level crossings, such as guests reading the map and entertainers performing.
  */
 bool Peep::IsActionInterruptableSafely() const
 {

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1229,7 +1229,7 @@ void PeepApplause()
         GuestReleaseBalloon(peep, peep->z + 9);
 
         // Clap
-        if ((peep->State == PeepState::Walking || peep->State == PeepState::Queuing) && peep->IsActionInterruptable())
+        if ((peep->State == PeepState::Walking || peep->State == PeepState::Queuing) && peep->IsActionInterruptableSafely())
         {
             peep->Action = PeepActionType::Clap;
             peep->AnimationFrameNum = 0;
@@ -1531,6 +1531,11 @@ bool Peep::IsActionIdle() const
 bool Peep::IsActionInterruptable() const
 {
     return IsActionIdle() || IsActionWalking();
+}
+
+bool Peep::IsActionInterruptableSafely() const
+{
+    return IsActionInterruptable() && !IsOnLevelCrossing();
 }
 
 void PeepSetMapTooltip(Peep* peep)

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1533,6 +1533,9 @@ bool Peep::IsActionInterruptable() const
     return IsActionIdle() || IsActionWalking();
 }
 
+/**
+ * Used to avoid peep action and animation triggers that might put them at risk of getting run over at level crossings.
+ */
 bool Peep::IsActionInterruptableSafely() const
 {
     return IsActionInterruptable() && !IsOnLevelCrossing();

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -388,6 +388,7 @@ public: // Peep
     bool IsActionWalking() const;
     bool IsActionIdle() const;
     bool IsActionInterruptable() const;
+    bool IsActionInterruptableSafely() const;
 
     // Reset the peep's stored goal, which means they will forget any stored pathfinding history
     // on the next GuestPathfinding::ChooseDirection call.

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -924,7 +924,7 @@ void Staff::EntertainerUpdateNearbyPeeps() const
  */
 bool Staff::DoEntertainerPathFinding()
 {
-    if (((ScenarioRand() & 0xFFFF) <= 0x4000) && IsActionInterruptable())
+    if (((ScenarioRand() & 0xFFFF) <= 0x4000) && IsActionInterruptableSafely())
     {
         Action = (ScenarioRand() & 1) ? PeepActionType::Wave2 : PeepActionType::Joy;
         AnimationFrameNum = 0;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 0;
+constexpr uint8_t kStreamVersion = 1;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -176,7 +176,7 @@ static std::optional<UpdateType> UpdateSmallSceneryAnimation(
                 auto quad = EntityTileList<Peep>(CoordsXY{ loc.x, loc.y } - CoordsDirectionDelta[direction]);
                 for (auto peep : quad)
                 {
-                    if (peep->State != PeepState::Walking || peep->z != baseZ || peep->Action < PeepActionType::Idle)
+                    if (peep->State != PeepState::Walking || peep->z != baseZ || !peep->IsActionInterruptableSafely())
                         continue;
                     peep->Action = PeepActionType::CheckTime;
                     peep->AnimationFrameNum = 0;


### PR DESCRIPTION
Currently these peep actions cannot be triggered if they are on a level crossing, as put in place in https://github.com/OpenRCT2/OpenRCT2/pull/18162:

- Read map
- Chris Sawyer, Simon Foster and Katie Braidshaw (waves periodically) Easter eggs
- Watching rides

This extends this check to the following actions as well:

- [x] Entertainers performing
- [x] Guests throwing up (also affects the Felicity Anderson Easter egg name)
- [x] Guests clapping
- [x] Guests checking their watches triggered by the garden clock scenery item
- [x] Katie Smith Easter egg name (jumps in joy frequently)
- [x] Joanne Barton Easter egg name (gives other guests pizza and also causes them to wave depending on their relative orientation, this affects them waving)
- [x] Guests using special animations triggered by thoughts, encompasses:
    -  `CheckTime` (_"I've been queueing for ages"_)
    - `ShakeHead` (_"I can't afford X"_ and _"I'm running out of money"_)
    - `Wave` (actually it's them scratching their head but this is incorrectly named, _"I'm lost," "I can't find X"_ and _"wow, a new ride being built"_)
    - `Joy` (_"X was great"_)
    - `Disgust` (_"this path is disgusting"_)
    - `EmptyPockets` (_"I have no money left"_)
    - `Wow` (_"X is too intense for me"_)
    - `BeingWatched`

With this the only two actions (that I can think of) that might still cause peeps to stop on level crossings is the janitor sweeping trash and watering flowers, but changing that seems pedantic.

I also refactored the Easter egg logic in Peep::UpdateWalking since I noticed it could be simplified a little.