### PR TITLE
Fix for Attempt to decrement guests in park and guests heading for park below zero. #21172

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -251,6 +251,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * (QuestionableDeer)
 * David Sungaila (sungaila)
 * Garrett Leach (GarrettLeach)
+* Ruohao (Jater) Xu (jaterx)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -326,6 +326,9 @@ namespace OpenRCT2::Title
                     // TODO: Have a separate GameState and exchange once loaded.
                     auto& gameState = getGameState();
                     parkImporter->Import(gameState);
+
+                    GameFixSaveVars(true);
+
                     ReportProgress(100);
 
                     MapAnimations::MarkAllTiles();

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -327,7 +327,7 @@ namespace OpenRCT2::Title
                     auto& gameState = getGameState();
                     parkImporter->Import(gameState);
 
-                    GameFixSaveVars(true);
+                    GameFixSaveVars();
 
                     ReportProgress(100);
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -182,7 +182,7 @@ void RCT2StringToUTF8Self(char* buffer, size_t length)
     }
 }
 
-static void FixGuestsHeadingToParkCount()
+static void FixGuestsHeadingToParkCount(const bool bIgnoreWarning)
 {
     uint32_t guestsHeadingToPark = 0;
 
@@ -195,7 +195,7 @@ static void FixGuestsHeadingToParkCount()
     }
 
     auto& park = getGameState().park;
-    if (park.numGuestsHeadingForPark != guestsHeadingToPark)
+    if (!bIgnoreWarning && park.numGuestsHeadingForPark != guestsHeadingToPark)
     {
         LOG_WARNING(
             "Corrected bad amount of guests heading to park: %u -> %u", park.numGuestsHeadingForPark, guestsHeadingToPark);
@@ -204,7 +204,7 @@ static void FixGuestsHeadingToParkCount()
     park.numGuestsHeadingForPark = guestsHeadingToPark;
 }
 
-static void FixGuestCount()
+static void FixGuestCount(const bool bIgnoreWarning)
 {
     // Recalculates peep count after loading a save to fix corrupted files
     uint32_t guestCount = 0;
@@ -218,7 +218,7 @@ static void FixGuestCount()
     }
 
     auto& park = getGameState().park;
-    if (park.numGuestsInPark != guestCount)
+    if (!bIgnoreWarning && park.numGuestsInPark != guestCount)
     {
         LOG_WARNING("Corrected bad amount of guests in park: %u -> %u", park.numGuestsInPark, guestCount);
     }
@@ -317,11 +317,11 @@ static void FixInvalidSurfaces()
 
 // OpenRCT2 workaround to recalculate some values which are saved redundantly in the save to fix corrupted files.
 // For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
-void GameFixSaveVars()
+void GameFixSaveVars(const bool bShouldIgnoreWarning)
 {
-    FixGuestsHeadingToParkCount();
+    FixGuestsHeadingToParkCount(bShouldIgnoreWarning);
 
-    FixGuestCount();
+    FixGuestCount(bShouldIgnoreWarning);
 
     FixPeepsWithInvalidRideReference();
 

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -182,7 +182,7 @@ void RCT2StringToUTF8Self(char* buffer, size_t length)
     }
 }
 
-static void FixGuestsHeadingToParkCount(const bool bIgnoreWarning)
+static void FixGuestsHeadingToParkCount()
 {
     uint32_t guestsHeadingToPark = 0;
 
@@ -195,16 +195,16 @@ static void FixGuestsHeadingToParkCount(const bool bIgnoreWarning)
     }
 
     auto& park = getGameState().park;
-    if (!bIgnoreWarning && park.numGuestsHeadingForPark != guestsHeadingToPark)
+    if (park.numGuestsHeadingForPark != guestsHeadingToPark)
     {
-        LOG_WARNING(
+        LOG_VERBOSE(
             "Corrected bad amount of guests heading to park: %u -> %u", park.numGuestsHeadingForPark, guestsHeadingToPark);
     }
 
     park.numGuestsHeadingForPark = guestsHeadingToPark;
 }
 
-static void FixGuestCount(const bool bIgnoreWarning)
+static void FixGuestCount()
 {
     // Recalculates peep count after loading a save to fix corrupted files
     uint32_t guestCount = 0;
@@ -218,9 +218,9 @@ static void FixGuestCount(const bool bIgnoreWarning)
     }
 
     auto& park = getGameState().park;
-    if (!bIgnoreWarning && park.numGuestsInPark != guestCount)
+    if (park.numGuestsInPark != guestCount)
     {
-        LOG_WARNING("Corrected bad amount of guests in park: %u -> %u", park.numGuestsInPark, guestCount);
+        LOG_VERBOSE("Corrected bad amount of guests in park: %u -> %u", park.numGuestsInPark, guestCount);
     }
 
     park.numGuestsInPark = guestCount;
@@ -317,11 +317,11 @@ static void FixInvalidSurfaces()
 
 // OpenRCT2 workaround to recalculate some values which are saved redundantly in the save to fix corrupted files.
 // For example recalculate guest count by looking at all the guests instead of trusting the value in the file.
-void GameFixSaveVars(const bool bShouldIgnoreWarning)
+void GameFixSaveVars()
 {
-    FixGuestsHeadingToParkCount(bShouldIgnoreWarning);
+    FixGuestsHeadingToParkCount();
 
-    FixGuestCount(bShouldIgnoreWarning);
+    FixGuestCount();
 
     FixPeepsWithInvalidRideReference();
 

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -174,7 +174,7 @@ void SaveGameCmd(u8string_view name = {});
 void SaveGameWithName(u8string_view name);
 void GameAutosave();
 void RCT2StringToUTF8Self(char* buffer, size_t length);
-void GameFixSaveVars(const bool bShouldIgnoreWarning = false);
+void GameFixSaveVars();
 void StartSilentRecord();
 bool StopSilentRecord();
 void PrepareMapForSave();

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -174,7 +174,7 @@ void SaveGameCmd(u8string_view name = {});
 void SaveGameWithName(u8string_view name);
 void GameAutosave();
 void RCT2StringToUTF8Self(char* buffer, size_t length);
-void GameFixSaveVars();
+void GameFixSaveVars(const bool bShouldIgnoreWarning = false);
 void StartSilentRecord();
 bool StopSilentRecord();
 void PrepareMapForSave();


### PR DESCRIPTION
Fix:
- Calling recompute peep functions when in title sequence
- Provided a way to ignore the warning for title sequence