### PR TITLE
Vehicle Pitch and Vehicle Roll as strong types

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -425,6 +425,7 @@
     <ClInclude Include="rct2\RCT2.h" />
     <ClInclude Include="rct2\T6Exporter.h" />
     <ClInclude Include="ReplayManager.h" />
+    <ClInclude Include="ride\Angles.h" />
     <ClInclude Include="ride\CableLift.h" />
     <ClInclude Include="ride\CarEntry.h" />
     <ClInclude Include="ride\MazeCost.h" />

--- a/src/openrct2/math/Trigonometry.hpp
+++ b/src/openrct2/math/Trigonometry.hpp
@@ -101,8 +101,9 @@ namespace OpenRCT2::Math::Trigonometry
         { 195, -165 },  // inverting transition slopes down
         { 134, -217 },  // inverting transition slopes down
         { 252, 44 },    // spiral lift hill up
+        { 252, -44 },   // spiral lift hill down
     };
-    static_assert(std::size(PitchToDirectionVectorFromGeometry) == NumVehiclePitches);
+    static_assert(std::size(PitchToDirectionVectorFromGeometry) == EnumValue(VehiclePitch::pitchCount));
 
     constexpr int32_t ComputeHorizontalMagnitude(int32_t length, uint8_t pitch)
     {

--- a/src/openrct2/paint/vehicle/Vehicle.RiverRapids.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.RiverRapids.cpp
@@ -39,15 +39,15 @@ namespace OpenRCT2
         uint32_t rotation = session.CurrentRotation;
         int32_t ecx = ((vehicle->spin_sprite / 8) + (rotation * 8)) & 31;
         int32_t j = 0;
-        if (vehicle->pitch == 0)
+        if (vehicle->pitch == VehiclePitch::flat)
         {
             baseImage_id = ecx & 7;
         }
         else
         {
-            if (vehicle->pitch == 1 || vehicle->pitch == 5)
+            if (vehicle->pitch == VehiclePitch::up12 || vehicle->pitch == VehiclePitch::down12)
             {
-                if (vehicle->pitch == 5)
+                if (vehicle->pitch == VehiclePitch::down12)
                 {
                     baseImage_id = imageDirection ^ 16;
                 }
@@ -56,9 +56,9 @@ namespace OpenRCT2
                 baseImage_id += (ecx & 7);
                 baseImage_id += 8;
             }
-            else if (vehicle->pitch == 2 || vehicle->pitch == 6)
+            else if (vehicle->pitch == VehiclePitch::up25 || vehicle->pitch == VehiclePitch::down25)
             {
-                if (vehicle->pitch == 6)
+                if (vehicle->pitch == VehiclePitch::down25)
                 {
                     baseImage_id = imageDirection ^ 16;
                 }

--- a/src/openrct2/paint/vehicle/Vehicle.VirginaReel.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.VirginaReel.cpp
@@ -38,13 +38,13 @@ namespace OpenRCT2
         int32_t baseImage_id = [&] {
             switch (vehicle->pitch)
             {
-                case 1:
+                case VehiclePitch::up12:
                     return (imageDirection & 24) + 8;
-                case 2:
+                case VehiclePitch::up25:
                     return (imageDirection & 24) + 40;
-                case 5:
+                case VehiclePitch::down12:
                     return ((imageDirection ^ 16) & 24) + 8;
-                case 6:
+                case VehiclePitch::down25:
                     return ((imageDirection ^ 16) & 24) + 40;
                 default:
                     return 0;

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -940,19 +940,109 @@ const VehicleBoundBox VehicleBoundboxes[16][224] = {
 };
 
 // Opposite Pitch values for reversed cars
-const uint8_t PitchInvertTable[] = {
-    0,                                                                              // Flat Track
-    5,  6,  7,  8,  1,  2,  3,  4,                                                  // Slopes 1
-    17, 18, 19, 20, 21, 22, 23, 16, 9,  10, 11, 12, 13, 14, 15,                     // Vertical Loop
-    29, 30, 31, 32, 33, 24, 25, 26, 27, 28, 39, 40, 41, 42, 43, 34, 35, 36, 37, 38, // Corkscrews
-    0,  0,  0,  0,  0,  0,                                                          // Helices
-    53, 54, 55, 50, 51, 52,                                                         // Slopes 2
-    56, 57, 58,                                                                     // Zero-G Rolls
-    60, 59                                                                          // Spiral Lift Hills
-};
+const VehiclePitch PitchInvertTable[] = {
+    VehiclePitch::flat,
 
-// Opposite Bank values for reversed cars
-const uint8_t BankInvertTable[] = { 0, 3, 4, 1, 2, 10, 11, 12, 13, 14, 5, 6, 7, 8, 9, 15, 18, 19, 16, 17 };
+    VehiclePitch::down12,
+    VehiclePitch::down25,
+    VehiclePitch::down42,
+    VehiclePitch::down60,
+
+    VehiclePitch::up12,
+    VehiclePitch::up25,
+    VehiclePitch::up42,
+    VehiclePitch::up60,
+
+    VehiclePitch::down75,
+    VehiclePitch::down90,
+    VehiclePitch::down105,
+    VehiclePitch::down120,
+    VehiclePitch::down135,
+    VehiclePitch::down150,
+    VehiclePitch::down165,
+
+    VehiclePitch::inverted,
+
+    VehiclePitch::up75,
+    VehiclePitch::up90,
+    VehiclePitch::up105,
+    VehiclePitch::up120,
+    VehiclePitch::up135,
+    VehiclePitch::up150,
+    VehiclePitch::up165,
+
+    VehiclePitch::corkscrewDownLeft0,
+    VehiclePitch::corkscrewDownLeft1,
+    VehiclePitch::corkscrewDownLeft2,
+    VehiclePitch::corkscrewDownLeft3,
+    VehiclePitch::corkscrewDownLeft4,
+
+    VehiclePitch::corkscrewUpRight0,
+    VehiclePitch::corkscrewUpRight1,
+    VehiclePitch::corkscrewUpRight2,
+    VehiclePitch::corkscrewUpRight3,
+    VehiclePitch::corkscrewUpRight4,
+
+    VehiclePitch::corkscrewDownRight0,
+    VehiclePitch::corkscrewDownRight1,
+    VehiclePitch::corkscrewDownRight2,
+    VehiclePitch::corkscrewDownRight3,
+    VehiclePitch::corkscrewDownRight4,
+
+    VehiclePitch::corkscrewUpLeft0,
+    VehiclePitch::corkscrewUpLeft1,
+    VehiclePitch::corkscrewUpLeft2,
+    VehiclePitch::corkscrewUpLeft3,
+    VehiclePitch::corkscrewUpLeft4,
+
+    VehiclePitch::flat, // helixes
+    VehiclePitch::flat,
+    VehiclePitch::flat,
+    VehiclePitch::flat,
+    VehiclePitch::flat,
+    VehiclePitch::flat,
+
+    VehiclePitch::down8,
+    VehiclePitch::down16,
+    VehiclePitch::down50,
+
+    VehiclePitch::up8,
+    VehiclePitch::up16,
+    VehiclePitch::up50,
+
+    VehiclePitch::up25,
+    VehiclePitch::up42,
+    VehiclePitch::up60,
+
+    VehiclePitch::curvedLiftHillDown,
+    VehiclePitch::curvedLiftHillUp,
+};
+static_assert(std::size(PitchInvertTable) == EnumValue(VehiclePitch::pitchCount));
+
+// Opposite Roll values for reversed cars
+const VehicleRoll RollInvertTable[] = {
+    VehicleRoll::unbanked,
+    VehicleRoll::right22,
+    VehicleRoll::right45,
+    VehicleRoll::left22,
+    VehicleRoll::left45,
+    VehicleRoll::right67,
+    VehicleRoll::right90,
+    VehicleRoll::right112,
+    VehicleRoll::right135,
+    VehicleRoll::right157,
+    VehicleRoll::left67,
+    VehicleRoll::left90,
+    VehicleRoll::left112,
+    VehicleRoll::left135,
+    VehicleRoll::left157,
+    VehicleRoll::uninvertingUnbanked,
+    VehicleRoll::uninvertingRight22,
+    VehicleRoll::uninvertingRight45,
+    VehicleRoll::uninvertingLeft22,
+    VehicleRoll::uninvertingLeft45,
+};
+static_assert(std::size(RollInvertTable) == EnumValue(VehicleRoll::rollCount));
 
 constexpr uint32_t kBoundBoxIndexUndefined = std::numeric_limits<uint32_t>::max();
 constexpr uint32_t kBoundBoxIndexFlat = 0;
@@ -1069,9 +1159,9 @@ static void VehicleSpritePaintRestraints(
 }
 
 // Returns the opposite of the bank angle for reversed cars, normal bank angle otherwise
-static uint8_t GetPaintBankRotation(const Vehicle* vehicle)
+static VehicleRoll GetPaintBankRotation(const Vehicle* vehicle)
 {
-    return (vehicle->HasFlag(VehicleFlags::CarIsReversed)) ? BankInvertTable[vehicle->roll] : vehicle->roll;
+    return (vehicle->HasFlag(VehicleFlags::CarIsReversed)) ? RollInvertTable[EnumValue(vehicle->roll)] : vehicle->roll;
 }
 
 #pragma endregion
@@ -1432,67 +1522,65 @@ static void VehiclePitchFlat(
     // 0x009A3DE4:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchFlatUnbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchFlatBankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchFlatBankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchFlatBankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchFlatBankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchFlatBankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchFlatBankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 7:
+        case VehicleRoll::left112:
             VehiclePitchFlatBankedLeft112(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 8:
+        case VehicleRoll::left135:
             VehiclePitchFlatBankedLeft135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 9:
+        case VehicleRoll::left157:
             VehiclePitchFlatBankedLeft157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchFlatBankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchFlatBankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 12:
+        case VehicleRoll::right112:
             VehiclePitchFlatBankedRight112(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 13:
+        case VehicleRoll::right135:
             VehiclePitchFlatBankedRight135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 14:
+        case VehicleRoll::right157:
             VehiclePitchFlatBankedRight157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 15:
-            // what is roll 15?
-            VehiclePitchFlatUnbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
-            break;
-        case 16:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchUninvertedFlatBankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 17:
+        case VehicleRoll::uninvertingLeft45:
             VehiclePitchUninvertedFlatBankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 18:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchUninvertedFlatBankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 19:
+        case VehicleRoll::uninvertingRight45:
             VehiclePitchUninvertedFlatBankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
+        default:
+            VehiclePitchFlatUnbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
     }
 }
 
@@ -1600,31 +1688,31 @@ static void VehiclePitchUp12(
     // 0x009A3C04:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchUp12BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchUp12BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchUp12BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchUp12BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 16:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchUp12BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 17:
+        case VehicleRoll::uninvertingLeft45:
             VehiclePitchUp12BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 18:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchUp12BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 19:
+        case VehicleRoll::uninvertingRight45:
             VehiclePitchUp12BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -1916,66 +2004,65 @@ static void VehiclePitchUp25(
     // 0x009A3CA4:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchUp25BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchUp25BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchUp25BankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchUp25BankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 7:
+        case VehicleRoll::left112:
             VehiclePitchUp25BankedLeft112(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 8:
+        case VehicleRoll::left135:
             VehiclePitchUp25BankedLeft135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 9:
+        case VehicleRoll::left157:
             VehiclePitchUp25BankedLeft157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchUp25BankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchUp25BankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 12:
+        case VehicleRoll::right112:
             VehiclePitchUp25BankedRight112(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 13:
+        case VehicleRoll::right135:
             VehiclePitchUp25BankedRight135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 14:
+        case VehicleRoll::right157:
             VehiclePitchUp25BankedRight157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 15:
-            VehiclePitchUp25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
-            break;
-        case 16:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchUp25BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 17:
+        case VehicleRoll::uninvertingLeft45:
             VehiclePitchUp25BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 18:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchUp25BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 19:
+        case VehicleRoll::uninvertingRight45:
             VehiclePitchUp25BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
+        default:
+            VehiclePitchUp25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
     }
 }
 
@@ -2185,37 +2272,37 @@ static void VehiclePitchUp42(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp42Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchUp42BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchUp42BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchUp42BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchUp42BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchUp42BankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchUp42BankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 8:
+        case VehicleRoll::left135:
             VehiclePitchUp42BankedLeft135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchUp42BankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchUp42BankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 13:
+        case VehicleRoll::right135:
             VehiclePitchUp42BankedRight135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -2281,13 +2368,13 @@ static void VehiclePitchUp60(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp60Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchUp60BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchUp60BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -2399,66 +2486,65 @@ static void VehiclePitchDown12(
     // 0x009A3C54:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchDown12BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchDown12BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchDown12BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchDown12BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 7:
+        case VehicleRoll::left112:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 8:
+        case VehicleRoll::left135:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 9:
+        case VehicleRoll::left157:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 12:
+        case VehicleRoll::right112:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 13:
+        case VehicleRoll::right135:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 14:
+        case VehicleRoll::right157:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 15:
-            VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
-            break;
-        case 16:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchDown12BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 17:
+        case VehicleRoll::uninvertingLeft45:
             VehiclePitchDown12BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 18:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchDown12BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 19:
+        case VehicleRoll::uninvertingRight45:
             VehiclePitchDown12BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
+        default:
+            VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
     }
 }
 #pragma endregion
@@ -2749,66 +2835,65 @@ static void VehiclePitchDown25(
     // 0x009A3CF4:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchDown25BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchDown25BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchDown25BankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchDown25BankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 7:
+        case VehicleRoll::left112:
             VehiclePitchDown25BankedLeft112(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 8:
+        case VehicleRoll::left135:
             VehiclePitchDown25BankedLeft135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 9:
+        case VehicleRoll::left157:
             VehiclePitchDown25BankedLeft157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchDown25BankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchDown25BankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 12:
+        case VehicleRoll::right112:
             VehiclePitchDown25BankedRight112(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 13:
+        case VehicleRoll::right135:
             VehiclePitchDown25BankedRight135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 14:
+        case VehicleRoll::right157:
             VehiclePitchDown25BankedRight157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 15:
-            VehiclePitchDown25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
-            break;
-        case 16:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchDown25BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 17:
+        case VehicleRoll::uninvertingLeft45:
             VehiclePitchDown25BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 18:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchDown25BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 19:
+        case VehicleRoll::uninvertingRight45:
             VehiclePitchDown25BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
+        default:
+            VehiclePitchDown25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
     }
 }
 
@@ -3017,37 +3102,37 @@ static void VehiclePitchDown42(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown42Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchDown42BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchDown42BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchDown42BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchDown42BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchDown42BankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchDown42BankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 8:
+        case VehicleRoll::left135:
             VehiclePitchDown42BankedLeft135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchDown42BankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchDown42BankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 13:
+        case VehicleRoll::right135:
             VehiclePitchDown42BankedRight135(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -3113,13 +3198,13 @@ static void VehiclePitchDown60(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown60Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchDown60BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchDown60BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -3583,21 +3668,21 @@ static void VehiclePitchUp8(
     // 0x009A3D44:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp8Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
-        case 16:
+        case VehicleRoll::left22:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchUp8BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
-        case 18:
+        case VehicleRoll::right22:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchUp8BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchUp8BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchUp8BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -3702,19 +3787,19 @@ static void VehiclePitchUp16(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp16Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchUp16BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchUp16BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchUp16BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchUp16BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -3853,25 +3938,25 @@ static void VehiclePitchUp50(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchUp50Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchUp50BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchUp50BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchUp50BankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchUp50BankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchUp50BankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchUp50BankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -3983,21 +4068,21 @@ static void VehiclePitchDown8(
     // 0x009A3D94:
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown8Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
-        case 16:
+        case VehicleRoll::left22:
+        case VehicleRoll::uninvertingLeft22:
             VehiclePitchDown8BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
-        case 18:
+        case VehicleRoll::right22:
+        case VehicleRoll::uninvertingRight22:
             VehiclePitchDown8BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchDown8BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchDown8BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -4102,19 +4187,19 @@ static void VehiclePitchDown16(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown16Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 1:
+        case VehicleRoll::left22:
             VehiclePitchDown16BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 3:
+        case VehicleRoll::right22:
             VehiclePitchDown16BankedRight22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchDown16BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchDown16BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -4253,25 +4338,25 @@ static void VehiclePitchDown50(
 {
     switch (GetPaintBankRotation(vehicle))
     {
-        case 0:
+        case VehicleRoll::unbanked:
             VehiclePitchDown50Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 2:
+        case VehicleRoll::left45:
             VehiclePitchDown50BankedLeft45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 4:
+        case VehicleRoll::right45:
             VehiclePitchDown50BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 5:
+        case VehicleRoll::left67:
             VehiclePitchDown50BankedLeft67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 6:
+        case VehicleRoll::left90:
             VehiclePitchDown50BankedLeft90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 10:
+        case VehicleRoll::right67:
             VehiclePitchDown50BankedRight67(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
-        case 11:
+        case VehicleRoll::right90:
             VehiclePitchDown50BankedRight90(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         default:
@@ -4424,6 +4509,8 @@ static constexpr vehicle_sprite_func PaintFunctionsByPitch[] = {
 };
 // clang-format on
 
+static_assert(std::size(PaintFunctionsByPitch) == EnumValue(VehiclePitch::pitchCount));
+
 #pragma region SplashEffects
 
 /**
@@ -4463,7 +4550,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, const int32_t z
     {
         return;
     }
-    if (vehicle->pitch != 0)
+    if (vehicle->pitch != VehiclePitch::flat)
     {
         return;
     }
@@ -4486,7 +4573,7 @@ static void vehicle_visual_splash3_effect(PaintSession& session, const int32_t z
     {
         return;
     }
-    if (vehicle->pitch != 0)
+    if (vehicle->pitch != VehiclePitch::flat)
     {
         return;
     }
@@ -4518,7 +4605,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, const int32_t z
     {
         return;
     }
-    if (vehicle->pitch != 0)
+    if (vehicle->pitch != VehiclePitch::flat)
     {
         return;
     }
@@ -4546,7 +4633,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, const int32_t z
     {
         return;
     }
-    if (vehicle->pitch != 0)
+    if (vehicle->pitch != VehiclePitch::flat)
     {
         return;
     }
@@ -4590,18 +4677,19 @@ void VehicleVisualSplashEffect(PaintSession& session, const int32_t z, const Veh
 void VehicleVisualDefault(
     PaintSession& session, int32_t imageDirection, const int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
 {
-    if (vehicle->pitch < std::size(PaintFunctionsByPitch))
+    if (vehicle->pitch < VehiclePitch::pitchCount)
     {
         if (vehicle->HasFlag(VehicleFlags::CarIsReversed))
         {
-            auto imagePitch = PitchInvertTable[vehicle->pitch];
+            auto imagePitch = PitchInvertTable[EnumValue(vehicle->pitch)];
             auto imageYaw = (imageDirection + (OpenRCT2::Entity::Yaw::kBaseRotation / 2))
                 & (OpenRCT2::Entity::Yaw::kBaseRotation - 1);
-            PaintFunctionsByPitch[imagePitch](session, vehicle, imageYaw, z, carEntry, kBoundBoxIndexUndefined);
+            PaintFunctionsByPitch[EnumValue(imagePitch)](session, vehicle, imageYaw, z, carEntry, kBoundBoxIndexUndefined);
         }
         else
         {
-            PaintFunctionsByPitch[vehicle->pitch](session, vehicle, imageDirection, z, carEntry, kBoundBoxIndexUndefined);
+            PaintFunctionsByPitch[EnumValue(vehicle->pitch)](
+                session, vehicle, imageDirection, z, carEntry, kBoundBoxIndexUndefined);
         }
     }
 }

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -1567,6 +1567,9 @@ static void VehiclePitchFlat(
         case VehicleRoll::right157:
             VehiclePitchFlatBankedRight157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
+        case VehicleRoll::uninvertingUnbanked:
+            VehiclePitchFlatUnbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
+            break;
         case VehicleRoll::uninvertingLeft22:
             VehiclePitchUninvertedFlatBankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
@@ -1702,6 +1705,9 @@ static void VehiclePitchUp12(
             break;
         case VehicleRoll::right45:
             VehiclePitchUp12BankedRight45(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
+            break;
+        case VehicleRoll::uninvertingUnbanked:
+            VehiclePitchUp12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         case VehicleRoll::uninvertingLeft22:
             VehiclePitchUp12BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
@@ -2048,6 +2054,9 @@ static void VehiclePitchUp25(
             break;
         case VehicleRoll::right157:
             VehiclePitchUp25BankedRight157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
+            break;
+        case VehicleRoll::uninvertingUnbanked:
+            VehiclePitchUp25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         case VehicleRoll::uninvertingLeft22:
             VehiclePitchUp25BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
@@ -2531,6 +2540,9 @@ static void VehiclePitchDown12(
         case VehicleRoll::right157:
             VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
+        case VehicleRoll::uninvertingUnbanked:
+            VehiclePitchDown12Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
+            break;
         case VehicleRoll::uninvertingLeft22:
             VehiclePitchDown12BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
@@ -2879,6 +2891,9 @@ static void VehiclePitchDown25(
             break;
         case VehicleRoll::right157:
             VehiclePitchDown25BankedRight157(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
+            break;
+        case VehicleRoll::uninvertingUnbanked:
+            VehiclePitchDown25Unbanked(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);
             break;
         case VehicleRoll::uninvertingLeft22:
             VehiclePitchDown25BankedLeft22(session, vehicle, imageDirection, z, carEntry, boundingBoxIndex);

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -12,6 +12,7 @@
 #include "../Diagnostic.h"
 #include "../core/FixedPoint.hpp"
 #include "../rct12/RCT12.h"
+#include "../ride/Angles.h"
 #include "../ride/RideRatings.h"
 #include "../world/ParkData.h"
 #include "Limits.h"
@@ -409,8 +410,8 @@ namespace OpenRCT2::RCT1
 
     struct Vehicle : RCT12EntityBase
     {
-        uint8_t Pitch;        // 0x1F
-        uint8_t BankRotation; // 0x20
+        VehiclePitch pitch; // 0x1F
+        VehicleRoll roll;   // 0x20
         uint8_t Pad21[3];
         int32_t RemainingDistance;  // 0x24
         int32_t Velocity;           // 0x28

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2834,8 +2834,8 @@ namespace OpenRCT2::RCT1
         dst->NumLaps = src->NumLaps;
         dst->var_D3 = src->VarD3;
         dst->scream_sound_id = OpenRCT2::Audio::SoundId::Null;
-        dst->pitch = src->Pitch;
-        dst->roll = src->BankRotation;
+        dst->pitch = src->pitch;
+        dst->roll = src->roll;
 
         // Seat rotation was not in RCT1
         dst->target_seat_rotation = DEFAULT_SEAT_ROTATION;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -12,6 +12,7 @@
 #include "../core/FileSystem.hpp"
 #include "../core/FixedPoint.hpp"
 #include "../rct12/RCT12.h"
+#include "../ride/Angles.h"
 #include "../ride/RideRatings.h"
 #include "../world/ParkData.h"
 #include "Limits.h"
@@ -422,8 +423,8 @@ namespace OpenRCT2::RCT2
 
     struct Vehicle : RCT12EntityBase
     {
-        uint8_t Pitch;        // 0x1F
-        uint8_t BankRotation; // 0x20
+        VehiclePitch pitch; // 0x1F
+        VehicleRoll roll;   // 0x20
         uint8_t Pad21[3];
         int32_t RemainingDistance;  // 0x24
         int32_t Velocity;           // 0x28

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1952,8 +1952,8 @@ namespace OpenRCT2::RCT2
 
         ImportEntityCommonProperties(dst, src);
         dst->SubType = ::Vehicle::Type(src->Type);
-        dst->pitch = src->Pitch;
-        dst->roll = src->BankRotation;
+        dst->pitch = src->pitch;
+        dst->roll = src->roll;
         dst->remaining_distance = src->RemainingDistance;
         dst->velocity = src->Velocity;
         dst->acceleration = src->Acceleration;

--- a/src/openrct2/ride/Angles.h
+++ b/src/openrct2/ride/Angles.h
@@ -1,0 +1,110 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2025 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+/*
+ * VehiclePitch and VehicleRoll are both added to the local scope in VehicleSubpositionData.cpp thanks to 'using enum'
+ * introduced in C++20. As such, enum items must be named to avoid name collisions between the two enums.
+ */
+
+enum class VehiclePitch : uint8_t
+{
+    flat = 0,
+    up12,
+    up25,
+    up42,
+    up60,
+    down12,
+    down25,
+    down42,
+    down60,
+    up75,
+    up90,
+    up105,
+    up120,
+    up135,
+    up150,
+    up165,
+    inverted,
+    down75,
+    down90,
+    down105,
+    down120,
+    down135,
+    down150,
+    down165,
+    corkscrewUpRight0,
+    corkscrewUpRight1,
+    corkscrewUpRight2,
+    corkscrewUpRight3,
+    corkscrewUpRight4,
+    corkscrewDownLeft0,
+    corkscrewDownLeft1,
+    corkscrewDownLeft2,
+    corkscrewDownLeft3,
+    corkscrewDownLeft4,
+    corkscrewUpLeft0,
+    corkscrewUpLeft1,
+    corkscrewUpLeft2,
+    corkscrewUpLeft3,
+    corkscrewUpLeft4,
+    corkscrewDownRight0,
+    corkscrewDownRight1,
+    corkscrewDownRight2,
+    corkscrewDownRight3,
+    corkscrewDownRight4,
+    upHalfHelixLarge,
+    upHalfHelixSmall,
+    downHalfHelixLarge,
+    downHalfHelixSmall,
+    upQuarterHelix,
+    downQuarterHelix,
+    up8,
+    up16,
+    up50,
+    down8,
+    down16,
+    down50,
+    uninvertingDown25, // uninverting pitches are used on inverted-to-upright flyer loops to draw inverted vehicles as upright
+    uninvertingDown42,
+    uninvertingDown60,
+    curvedLiftHillUp,
+    curvedLiftHillDown,
+    pitchCount,
+    nullPitch = 255,
+};
+
+enum class VehicleRoll : uint8_t
+{
+    unbanked = 0,
+    left22,
+    left45,
+    right22,
+    right45,
+    left67,
+    left90,
+    left112,
+    left135,
+    left157,
+    right67,
+    right90,
+    right112,
+    right135,
+    right157,
+    uninvertingUnbanked, // uninverting roll values are used on inverted-to-upright flyer twists to draw inverted vehicles
+    uninvertingLeft22,   // as upright
+    uninvertingLeft45,
+    uninvertingRight22,
+    uninvertingRight45,
+    rollCount,
+    nullRoll = 255,
+};

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -59,8 +59,8 @@ Vehicle* CableLiftSegmentCreate(
     current->animation_frame = 0;
     current->animationState = 0;
     current->scream_sound_id = OpenRCT2::Audio::SoundId::Null;
-    current->pitch = 0;
-    current->roll = 0;
+    current->pitch = VehiclePitch::flat;
+    current->roll = VehicleRoll::unbanked;
     for (auto& peep : current->peep)
     {
         peep = EntityId::GetNull();
@@ -294,7 +294,7 @@ bool Vehicle::CableLiftUpdateTrackMotionForwards()
 
         if (remaining_distance >= 13962)
         {
-            acceleration += AccelerationFromPitch[pitch];
+            acceleration += AccelerationFromPitch[EnumValue(pitch)];
         }
     }
     return true;
@@ -363,7 +363,7 @@ bool Vehicle::CableLiftUpdateTrackMotionBackwards()
 
         if (remaining_distance < 0)
         {
-            acceleration += AccelerationFromPitch[pitch];
+            acceleration += AccelerationFromPitch[EnumValue(pitch)];
         }
     }
     return true;
@@ -394,7 +394,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
 
     for (Vehicle* vehicle = frontVehicle; vehicle != nullptr;)
     {
-        vehicle->acceleration = AccelerationFromPitch[vehicle->pitch];
+        vehicle->acceleration = AccelerationFromPitch[EnumValue(vehicle->pitch)];
         _vehicleUnkF64E10 = 1;
         vehicle->remaining_distance += _vehicleVelocityF64E0C;
 
@@ -415,7 +415,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
                     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                     _vehicleVelocityF64E0C -= vehicle->remaining_distance - 13962;
                     vehicle->remaining_distance = 13962;
-                    vehicle->acceleration += AccelerationFromPitch[vehicle->pitch];
+                    vehicle->acceleration += AccelerationFromPitch[EnumValue(vehicle->pitch)];
                     _vehicleUnkF64E10++;
                     continue;
                 }
@@ -428,7 +428,7 @@ int32_t Vehicle::CableLiftUpdateTrackMotion()
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                 _vehicleVelocityF64E0C -= vehicle->remaining_distance + 1;
                 vehicle->remaining_distance = -1;
-                vehicle->acceleration += AccelerationFromPitch[vehicle->pitch];
+                vehicle->acceleration += AccelerationFromPitch[EnumValue(vehicle->pitch)];
                 _vehicleUnkF64E10++;
             }
             vehicle->MoveTo(_vehicleCurPosition);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3266,8 +3266,8 @@ static Vehicle* VehicleCreateCar(
     vehicle->animation_frame = 0;
     vehicle->animationState = 0;
     vehicle->scream_sound_id = OpenRCT2::Audio::SoundId::Null;
-    vehicle->pitch = 0;
-    vehicle->roll = 0;
+    vehicle->pitch = VehiclePitch::flat;
+    vehicle->roll = VehicleRoll::unbanked;
     vehicle->target_seat_rotation = 4;
     vehicle->seat_rotation = 4;
     for (size_t i = 0; i < std::size(vehicle->peep); i++)

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -416,7 +416,7 @@ static constexpr int32_t kUnk9A37E4[] = {
     -1073741824, -1859775393, 1859775393,  1073741824,  0,           -1073741824, -1859775393, 1859775393,  1073741824,
     0,           -1073741824, -1859775393, 1859775393,  1073741824,  0,           -1073741824, -1859775393, 2144540595,
     2139311823,  2144540595,  2139311823,  2135719507,  2135719507,  2125953864,  2061796213,  1411702590,  2125953864,
-    2061796213,  1411702590,  1985590284,  1636362342,  1127484953,  2115506168,
+    2061796213,  1411702590,  1985590284,  1636362342,  1127484953,  2115506168,  2115506168,
 };
 
 /** rct2: 0x009A38D4 */
@@ -427,7 +427,7 @@ static constexpr int32_t kUnk9A38D4[] = {
     1859775393,  1073741824,  -1073741824, -1859775393, -2147483647, -1859775393, -1073741824, 1073741824,  1859775393,
     2147483647,  1859775393,  1073741824,  -1073741824, -1859775393, -2147483647, -1859775393, -1073741824, 112390610,
     187165532,   -112390610,  -187165532,  224473165,   -224473165,  303325208,   600568389,   1618265062,  -303325208,
-    -600568389,  -1618265062, -817995863,  -1390684831, -1827693544, 369214930,
+    -600568389,  -1618265062, -817995863,  -1390684831, -1827693544, 369214930,   -369214930,
 };
 
 /** rct2: 0x009A39C4 */
@@ -1176,12 +1176,12 @@ void Vehicle::UpdateMeasurements()
 
         curRide->increaseNumShelteredSections();
 
-        if (pitch != 0)
+        if (pitch != VehiclePitch::flat)
         {
             curRide->numShelteredSections |= ShelteredSectionsBits::kRotatingWhileSheltered;
         }
 
-        if (roll != 0)
+        if (roll != VehicleRoll::unbanked)
         {
             curRide->numShelteredSections |= ShelteredSectionsBits::kBankingWhileSheltered;
         }
@@ -1274,7 +1274,7 @@ void Vehicle::Update()
         auto carEntry = &rideEntry->Cars[vehicle_type];
         if ((carEntry->flags & CAR_ENTRY_FLAG_POWERED) && curRide->breakdownReasonPending == BREAKDOWN_SAFETY_CUT_OUT)
         {
-            if (!(carEntry->flags & CAR_ENTRY_FLAG_WATER_RIDE) || (pitch == 2 && velocity <= 2.0_mph))
+            if (!(carEntry->flags & CAR_ENTRY_FLAG_WATER_RIDE) || (pitch == VehiclePitch::up25 && velocity <= 2.0_mph))
             {
                 SetFlag(VehicleFlags::StoppedOnLift);
             }
@@ -2966,9 +2966,9 @@ void Vehicle::UpdateCrashSetup()
         trainVehicle->sub_state = 0;
         int32_t trainX = stru_9A3AC4[trainVehicle->Orientation / 2].x;
         int32_t trainY = stru_9A3AC4[trainVehicle->Orientation / 2].y;
-        auto trainZ = kUnk9A38D4[trainVehicle->pitch] >> 23;
+        auto trainZ = kUnk9A38D4[EnumValue(trainVehicle->pitch)] >> 23;
 
-        int32_t ecx = kUnk9A37E4[trainVehicle->pitch] >> 15;
+        int32_t ecx = kUnk9A37E4[EnumValue(trainVehicle->pitch)] >> 15;
         trainX *= ecx;
         trainY *= ecx;
         trainX >>= 16;
@@ -4987,17 +4987,17 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
         for (Vehicle* vehicle2 = getGameState().entities.GetEntity<Vehicle>(Id); vehicle2 != nullptr;
              vehicle2 = getGameState().entities.GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
         {
-            if (vehicle2->pitch < 1)
+            if (vehicle2->pitch < VehiclePitch::up12)
                 continue;
-            if (vehicle2->pitch <= 4)
+            if (vehicle2->pitch <= VehiclePitch::up60)
                 return ProduceScreamSound(totalNumPeeps);
-            if (vehicle2->pitch < 9)
+            if (vehicle2->pitch < VehiclePitch::up75)
                 continue;
-            if (vehicle2->pitch <= 15)
+            if (vehicle2->pitch <= VehiclePitch::up165)
                 return ProduceScreamSound(totalNumPeeps);
-            // Pitch 52 occurs on steep diagonal backward drops.
-            // (50 and 51 occur on gentle ones.)
-            if (vehicle2->pitch == 52)
+            // up50 occurs on diagonal steep hills
+            // up8 and up16 occur on diagonal gentle hills
+            if (vehicle2->pitch == VehiclePitch::up50)
                 return ProduceScreamSound(totalNumPeeps);
         }
         return OpenRCT2::Audio::SoundId::Null;
@@ -5009,17 +5009,17 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
     for (Vehicle* vehicle2 = getGameState().entities.GetEntity<Vehicle>(Id); vehicle2 != nullptr;
          vehicle2 = getGameState().entities.GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
     {
-        if (vehicle2->pitch < 5)
+        if (vehicle2->pitch < VehiclePitch::down12)
             continue;
-        if (vehicle2->pitch <= 8)
+        if (vehicle2->pitch <= VehiclePitch::down60)
             return ProduceScreamSound(totalNumPeeps);
-        if (vehicle2->pitch < 17)
+        if (vehicle2->pitch <= VehiclePitch::inverted)
             continue;
-        if (vehicle2->pitch <= 23)
+        if (vehicle2->pitch <= VehiclePitch::down165)
             return ProduceScreamSound(totalNumPeeps);
-        // Pitch 55 occurs on steep diagonal drops.
-        // (53 and 54 occur on gentle ones.)
-        if (vehicle2->pitch == 55)
+        // down50 occurs on diagonal steep drops
+        // down8 and down16 occur on diagonal gentle drops
+        if (vehicle2->pitch == VehiclePitch::down50)
             return ProduceScreamSound(totalNumPeeps);
     }
     return OpenRCT2::Audio::SoundId::Null;
@@ -5069,8 +5069,8 @@ OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps
  */
 GForces Vehicle::GetGForces() const
 {
-    int32_t gForceVert = ((static_cast<int64_t>(0x280000)) * kUnk9A37E4[pitch]) >> 32;
-    gForceVert = ((static_cast<int64_t>(gForceVert)) * kUnk9A39C4[roll]) >> 32;
+    int32_t gForceVert = ((static_cast<int64_t>(0x280000)) * kUnk9A37E4[EnumValue(pitch)]) >> 32;
+    gForceVert = ((static_cast<int64_t>(gForceVert)) * kUnk9A39C4[EnumValue(roll)]) >> 32;
 
     const auto& ted = GetTrackElementDescriptor(GetTrackType());
     const int32_t vertFactor = ted.verticalFactor(track_progress);
@@ -5419,7 +5419,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
             gForces.LateralG = std::abs(gForces.LateralG);
             if (gForces.LateralG <= 150)
             {
-                if (AccelerationFromPitch[pitch] < 0)
+                if (AccelerationFromPitch[EnumValue(pitch)] < 0)
                 {
                     if (gForces.VerticalG > -40)
                     {
@@ -5432,7 +5432,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
                 }
             }
 
-            if (pitch != 8)
+            if (pitch != VehiclePitch::down60)
             {
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_DERAILED;
             }
@@ -5445,7 +5445,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
         {
             auto gForces = GetGForces();
 
-            if (AccelerationFromPitch[pitch] < 0)
+            if (AccelerationFromPitch[EnumValue(pitch)] < 0)
             {
                 if (gForces.VerticalG > -45)
                 {
@@ -5460,7 +5460,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
                 }
             }
 
-            if (pitch != 8 && pitch != 55)
+            if (pitch != VehiclePitch::down60 && pitch != VehiclePitch::down50)
             {
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_DERAILED;
             }
@@ -6085,10 +6085,10 @@ static uint8_t GetTargetFrame(const CarEntry& carEntry, uint32_t animationState)
 /**
  * Compute the position that steam should be spawned
  */
-static constexpr CoordsXYZ ComputeSteamOffset(int32_t height, int32_t length, uint8_t pitch, uint8_t yaw)
+static constexpr CoordsXYZ ComputeSteamOffset(int32_t height, int32_t length, VehiclePitch pitch, uint8_t yaw)
 {
     uint8_t trueYaw = OpenRCT2::Entity::Yaw::YawTo64(yaw);
-    auto offsets = PitchToDirectionVectorFromGeometry[pitch];
+    auto offsets = PitchToDirectionVectorFromGeometry[EnumValue(pitch)];
     int32_t projectedRun = (offsets.x * length - offsets.y * height) / 256;
     int32_t projectedHeight = (offsets.x * height + offsets.y * length) / 256;
     return { ComputeXYVector(projectedRun, trueYaw), projectedHeight };
@@ -7319,9 +7319,9 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
             roll = moveInfo->roll;
             pitch = moveInfo->pitch;
 
-            moveInfovehicleAnimationGroup = moveInfo->pitch;
+            moveInfovehicleAnimationGroup = EnumValue(moveInfo->pitch);
 
-            if ((carEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && moveInfo->pitch != 0)
+            if ((carEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && moveInfo->pitch != VehiclePitch::flat)
             {
                 SwingSprite = 0;
                 SwingPosition = 0;
@@ -7606,7 +7606,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
 
         // Loc6DBD42
         track_progress = newTrackProgress;
-        uint8_t moveInfoVehicleAnimationGroup;
+        VehiclePitch moveInfoVehicleAnimationGroup;
         {
             const VehicleInfo* moveInfo = GetMoveInfo();
             auto nextVehiclePosition = TrackLocation
@@ -7634,7 +7634,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             pitch = moveInfo->pitch;
             moveInfoVehicleAnimationGroup = moveInfo->pitch;
 
-            if ((carEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && pitch != 0)
+            if ((carEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && pitch != VehiclePitch::flat)
             {
                 SwingSprite = 0;
                 SwingPosition = 0;
@@ -7693,7 +7693,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         {
             return true;
         }
-        acceleration += AccelerationFromPitch[moveInfoVehicleAnimationGroup];
+        acceleration += AccelerationFromPitch[EnumValue(moveInfoVehicleAnimationGroup)];
         _vehicleUnkF64E10++;
     }
 }
@@ -7714,7 +7714,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             Loc6DCDE4(curRide);
             return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
         }
-        acceleration = AccelerationFromPitch[pitch];
+        acceleration = AccelerationFromPitch[EnumValue(pitch)];
         _vehicleUnkF64E10++;
         return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
     }
@@ -7736,7 +7736,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 Loc6DCDE4(curRide);
                 return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
             }
-            acceleration = AccelerationFromPitch[pitch];
+            acceleration = AccelerationFromPitch[EnumValue(pitch)];
             _vehicleUnkF64E10++;
             return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
         }
@@ -7764,7 +7764,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 Loc6DCDE4(curRide);
                 return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
             }
-            acceleration = AccelerationFromPitch[pitch];
+            acceleration = AccelerationFromPitch[EnumValue(pitch)];
             _vehicleUnkF64E10++;
             return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
         }
@@ -7781,7 +7781,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 Loc6DCDE4(curRide);
                 return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
             }
-            acceleration = AccelerationFromPitch[pitch];
+            acceleration = AccelerationFromPitch[EnumValue(pitch)];
             _vehicleUnkF64E10++;
             return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
         }
@@ -7810,7 +7810,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 Loc6DCDE4(curRide);
                 return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
             }
-            acceleration = AccelerationFromPitch[pitch];
+            acceleration = AccelerationFromPitch[EnumValue(pitch)];
             _vehicleUnkF64E10++;
             return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
         }
@@ -7827,7 +7827,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 Loc6DCDE4(curRide);
                 return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
             }
-            acceleration = AccelerationFromPitch[pitch];
+            acceleration = AccelerationFromPitch[EnumValue(pitch)];
             _vehicleUnkF64E10++;
             return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
         }
@@ -7863,7 +7863,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 Loc6DCDE4(curRide);
                 return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
             }
-            acceleration = AccelerationFromPitch[pitch];
+            acceleration = AccelerationFromPitch[EnumValue(pitch)];
             _vehicleUnkF64E10++;
             return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
         }
@@ -7902,7 +7902,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                 _vehicleVelocityF64E0C -= remaining_distance + 1;
                 remaining_distance = -1;
-                acceleration += AccelerationFromPitch[pitch];
+                acceleration += AccelerationFromPitch[EnumValue(pitch)];
                 _vehicleUnkF64E10++;
                 return UpdateMiniGolfSubroutineStatus::carryOn;
             }
@@ -7919,7 +7919,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 {
                     Loc6DCDE4(curRide);
                 }
-                acceleration += AccelerationFromPitch[pitch];
+                acceleration += AccelerationFromPitch[EnumValue(pitch)];
                 _vehicleUnkF64E10++;
                 return UpdateMiniGolfSubroutineStatus::carryOn;
             }
@@ -8077,7 +8077,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             Loc6DCDE4(curRide);
             return UpdateMiniGolfSubroutineStatus::stop;
         }
-        acceleration = AccelerationFromPitch[pitch];
+        acceleration = AccelerationFromPitch[EnumValue(pitch)];
         _vehicleUnkF64E10++;
     }
 }
@@ -8095,7 +8095,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                 _vehicleVelocityF64E0C -= remaining_distance + 1;
                 remaining_distance = -1;
-                acceleration += AccelerationFromPitch[pitch];
+                acceleration += AccelerationFromPitch[EnumValue(pitch)];
                 _vehicleUnkF64E10++;
                 continue;
             }
@@ -8108,7 +8108,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_5;
                 _vehicleVelocityF64E0C -= remaining_distance - 0x368A;
                 remaining_distance = 0x368A;
-                acceleration = AccelerationFromPitch[pitch];
+                acceleration = AccelerationFromPitch[EnumValue(pitch)];
                 _vehicleUnkF64E10++;
                 return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
             }
@@ -8178,7 +8178,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                         vEBP->velocity = vEDI->velocity >> 1;
                     }
                     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_2;
-                    acceleration = AccelerationFromPitch[pitch];
+                    acceleration = AccelerationFromPitch[EnumValue(pitch)];
                     _vehicleUnkF64E10++;
                     return UpdateMiniGolfSubroutineStatus::restart;
                 }
@@ -8190,7 +8190,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             Loc6DCDE4(curRide);
             return UpdateMiniGolfSubroutineStatus::stop;
         }
-        acceleration += AccelerationFromPitch[pitch];
+        acceleration += AccelerationFromPitch[EnumValue(pitch)];
         _vehicleUnkF64E10++;
     }
 }
@@ -8204,7 +8204,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
 void Vehicle::UpdateTrackMotionMiniGolfVehicle(const Ride& curRide, const RideObjectEntry& rideEntry, const CarEntry* carEntry)
 {
     _vehicleUnkF64E10 = 1;
-    acceleration = AccelerationFromPitch[pitch];
+    acceleration = AccelerationFromPitch[EnumValue(pitch)];
     if (!HasFlag(VehicleFlags::MoveSingleCar))
     {
         remaining_distance = _vehicleVelocityF64E0C + remaining_distance;
@@ -8485,7 +8485,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
             spin_speed = std::clamp(spin_speed, kVehicleMinSpinSpeedWaterRide, kVehicleMaxSpinSpeedWaterRide);
         }
 
-        if (pitch != 0)
+        if (pitch != VehiclePitch::flat)
         {
             if (poweredAcceleration < 0)
             {
@@ -8495,7 +8495,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
             if (carEntry->flags & CAR_ENTRY_FLAG_SPINNING)
             {
                 // If the vehicle is on the up slope kill the spin speedModifier
-                if (pitch == 2)
+                if (pitch == VehiclePitch::up25)
                 {
                     spin_speed = 0;
                 }
@@ -8530,7 +8530,7 @@ void Vehicle::UpdateTrackMotionPreUpdate(
     {
         car.UpdateAdditionalAnimation();
     }
-    car.acceleration = AccelerationFromPitch[car.pitch];
+    car.acceleration = AccelerationFromPitch[EnumValue(car.pitch)];
     _vehicleUnkF64E10 = 1;
 
     if (!car.HasFlag(VehicleFlags::MoveSingleCar))
@@ -8558,7 +8558,7 @@ void Vehicle::UpdateTrackMotionPreUpdate(
             {
                 break;
             }
-            car.acceleration += AccelerationFromPitch[car.pitch];
+            car.acceleration += AccelerationFromPitch[EnumValue(car.pitch)];
             _vehicleUnkF64E10++;
             continue;
         }
@@ -8576,7 +8576,7 @@ void Vehicle::UpdateTrackMotionPreUpdate(
         {
             break;
         }
-        car.acceleration = AccelerationFromPitch[car.pitch];
+        car.acceleration = AccelerationFromPitch[EnumValue(car.pitch)];
         _vehicleUnkF64E10++;
         continue;
     }

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -14,6 +14,7 @@
 #include "../entity/EntityBase.h"
 #include "../ride/RideTypes.h"
 #include "../world/Location.hpp"
+#include "Angles.h"
 #include "CarEntry.h"
 #include "Station.h"
 #include "VehicleColour.h"
@@ -35,22 +36,19 @@ struct GForces
     int32_t LateralG{};
 };
 
-// How many valid pitch values are currently in the game. Eventually pitch will be enumerated.
-constexpr uint8_t NumVehiclePitches = 60;
-
 // Size: 0x09
 struct VehicleInfo
 {
-    int16_t x;         // 0x00
-    int16_t y;         // 0x02
-    int16_t z;         // 0x04
-    uint8_t direction; // 0x06
-    uint8_t pitch;     // 0x07
-    uint8_t roll;      // 0x08
+    int16_t x;          // 0x00
+    int16_t y;          // 0x02
+    int16_t z;          // 0x04
+    uint8_t direction;  // 0x06
+    VehiclePitch pitch; // 0x07
+    VehicleRoll roll;   // 0x08
 
     bool IsInvalid() const
     {
-        return x == 0 && y == 0 && z == 0 && direction == 0 && pitch == 0 && roll == 0;
+        return x == 0 && y == 0 && z == 0 && direction == 0 && pitch == VehiclePitch::flat && roll == VehicleRoll::unbanked;
     }
 };
 
@@ -109,12 +107,12 @@ struct Vehicle : EntityBase
     Type SubType;
     union
     {
-        uint8_t pitch;
+        VehiclePitch pitch;
         uint8_t flatRideAnimationFrame;
     };
     union
     {
-        uint8_t roll;
+        VehicleRoll roll;
         uint8_t flatRideSecondaryAnimationFrame;
     };
     int32_t remaining_distance;

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -140,7 +140,7 @@ namespace OpenRCT2::Scripting
     uint8_t ScVehicle::spriteType_get() const
     {
         auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->pitch : 0;
+        return vehicle != nullptr ? EnumValue(vehicle->pitch) : 0;
     }
     void ScVehicle::spriteType_set(uint8_t value)
     {
@@ -148,7 +148,7 @@ namespace OpenRCT2::Scripting
         auto vehicle = GetVehicle();
         if (vehicle != nullptr)
         {
-            vehicle->pitch = value;
+            vehicle->pitch = static_cast<VehiclePitch>(value);
             vehicle->Invalidate();
         }
     }
@@ -337,7 +337,7 @@ namespace OpenRCT2::Scripting
     uint8_t ScVehicle::bankRotation_get() const
     {
         auto vehicle = GetVehicle();
-        return vehicle != nullptr ? vehicle->roll : 0;
+        return vehicle != nullptr ? EnumValue(vehicle->roll) : 0;
     }
     void ScVehicle::bankRotation_set(uint8_t value)
     {
@@ -345,7 +345,7 @@ namespace OpenRCT2::Scripting
         auto vehicle = GetVehicle();
         if (vehicle != nullptr)
         {
-            vehicle->roll = value;
+            vehicle->roll = static_cast<VehicleRoll>(value);
             vehicle->Invalidate();
         }
     }

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -26,8 +26,8 @@ namespace OpenRCT2::Scripting
         dukSubposition.Set("y", value.y);
         dukSubposition.Set("z", value.z);
         dukSubposition.Set("yaw", value.direction);
-        dukSubposition.Set("pitch", value.pitch);
-        dukSubposition.Set("roll", value.roll);
+        dukSubposition.Set("pitch", EnumValue(value.pitch));
+        dukSubposition.Set("roll", EnumValue(value.roll));
         return dukSubposition.Take();
     }
 


### PR DESCRIPTION
I was working on refactoring all of those annoying vehicle paint functions into a data table, and when it came to some extra stuff covering some of the special cases, I found it would be really useful to have the pitch and bank stored as strong types so that there's no confusing one for another, and I can use human-readable names for them.

This PR does not change any simulation or rendering behavior. The only behavior changes are adding the appropriate casts.

Because Chris Sawyer loves unions, I have been forced to make the pitch and roll parameters unions. I've given them appropriate names for their alternate purposes.

I wrote a python script to read, parse, and (optionally) perform manipulations on each subposition data. It is capable of parsing its own output, and automatically beautifies the output. You can find it here: https://github.com/spacek531/RCT1Vehicles/blob/master/manipulate-subposition-data.py