### PR TITLE
Fix help for subcommands not working

### DIFF
--- a/src/openrct2/command_line/CommandLine.cpp
+++ b/src/openrct2/command_line/CommandLine.cpp
@@ -99,7 +99,7 @@ namespace OpenRCT2::CommandLine
     constexpr const char* kHelpText = "openrct2 -ha shows help for all commands. "
                                       "openrct2 <command> -h will show help and details for a given command.";
 
-    static void PrintHelpFor(const CommandLineCommand* commands);
+    static void PrintHelpFor(const CommandLineCommand* commands, const char* parentCommandName);
     static void PrintOptions(const CommandLineOptionDefinition* options);
     static void PrintExamples(const CommandLineExample* examples);
     static utf8* GetOptionCaption(utf8* buffer, size_t bufferSize, const CommandLineOptionDefinition* option);
@@ -117,7 +117,7 @@ namespace OpenRCT2::CommandLine
 
     void PrintHelp(bool allCommands)
     {
-        PrintHelpFor(kRootCommands);
+        PrintHelpFor(kRootCommands, nullptr);
         PrintExamples(kRootExamples);
 
         if (allCommands)
@@ -138,7 +138,7 @@ namespace OpenRCT2::CommandLine
                         Console::Write("-");
                     }
                     Console::WriteLine();
-                    PrintHelpFor(command->SubCommands);
+                    PrintHelpFor(command->SubCommands, command->Name);
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace OpenRCT2::CommandLine
         }
     }
 
-    static void PrintHelpFor(const CommandLineCommand* commands)
+    static void PrintHelpFor(const CommandLineCommand* commands, const char* parentCommandName)
     {
         // Print usage
         const char* usageString = "usage: openrct2 ";
@@ -170,6 +170,11 @@ namespace OpenRCT2::CommandLine
             if (command != commands)
             {
                 Console::WriteSpace(usageStringLength);
+            }
+            if (parentCommandName != nullptr)
+            {
+                Console::Write(parentCommandName);
+                Console::Write(" ");
             }
 
             Console::Write(command->Name);
@@ -552,7 +557,8 @@ namespace OpenRCT2
                 // Early exit if user is looking for subcommand help
                 if (String::equals(argument, "-h") || String::equals(argument, "--help"))
                 {
-                    OpenRCT2::CommandLine::PrintHelpFor(command);
+                    // TODO: pass parent command name for proper help
+                    OpenRCT2::CommandLine::PrintHelpFor(command, nullptr);
                     return EXITCODE_OK;
                 }
             }


### PR DESCRIPTION
When I was amending our [latest blog post](https://openrct2.io/blog/2025/08/behind-scenes-0-4-26), @janisozaur noticed that our help was completely broken:

1. `openrct2 subcommand -h` was suggested if you wanted the help for a specific subcommand, but didn't work (**Fixed on first commit**)
2. `openrct2 -ha` would print help without the subcommand name (**Fixed on second commit**)
3. `openrct2 subcommand -h` would print help without the subcommand name (**Still pending, see TODO of possible alternative in code**)

This PR fixes items 1 and 2, I don't think I'll have time to work on this before the release, so opening up for grabs and to bring attention.