### PR TITLE
Separate flat ride and tracked ride users of pitch and roll fields

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2512,7 +2512,7 @@ static void PeepChooseSeatFromCar(Guest* guest, const Ride& ride, Vehicle* vehic
 
     if (ride.mode == RideMode::forwardRotation || ride.mode == RideMode::backwardRotation)
     {
-        chosen_seat = (((~vehicle->pitch + 1) >> 3) & 0xF) * 2;
+        chosen_seat = (((~vehicle->flatRideAnimationFrame + 1) >> 3) & 0xF) * 2;
         if (vehicle->next_free_seat & 1)
         {
             chosen_seat++;
@@ -2627,7 +2627,7 @@ static bool FindVehicleToEnter(
 
         if (ride.mode == RideMode::forwardRotation || ride.mode == RideMode::backwardRotation)
         {
-            uint8_t position = (((~vehicle->pitch + 1) >> 3) & 0xF) * 2;
+            uint8_t position = (((~vehicle->flatRideAnimationFrame + 1) >> 3) & 0xF) * 2;
             if (!vehicle->peep[position].IsNull())
                 continue;
         }

--- a/src/openrct2/paint/track/gentle/FerrisWheel.cpp
+++ b/src/openrct2/paint/track/gentle/FerrisWheel.cpp
@@ -56,7 +56,7 @@ static void PaintFerrisWheelRiders(
         if (peep == nullptr || peep->State != PeepState::OnRide)
             continue;
 
-        auto frameNum = (vehicle.pitch + i * 4) % 128;
+        auto frameNum = (vehicle.flatRideAnimationFrame + i * 4) % 128;
         auto imageIndex = rideEntry.Cars[0].base_image_id + 32 + direction * 128 + frameNum;
         auto imageId = ImageId(imageIndex, vehicle.peep_tshirt_colours[i], vehicle.peep_tshirt_colours[i + 1]);
         PaintAddImageAsChild(session, imageId, offset, bb);
@@ -88,7 +88,7 @@ static void PaintFerrisWheelStructure(
         wheelImageTemplate = stationColour;
     }
 
-    auto imageOffset = vehicle != nullptr ? vehicle->pitch % 8 : 0;
+    auto imageOffset = vehicle != nullptr ? vehicle->flatRideAnimationFrame % 8 : 0;
     auto leftSupportImageId = supportsImageTemplate.WithIndex(22150 + (direction & 1) * 2);
     auto wheelImageId = wheelImageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + direction * 8 + imageOffset);
     auto rightSupportImageId = leftSupportImageId.WithIndexOffset(1);

--- a/src/openrct2/paint/track/gentle/HauntedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/HauntedHouse.cpp
@@ -44,7 +44,7 @@ static void PaintHauntedHouseStructure(
     {
         session.InteractionType = ViewportInteractionItem::Entity;
         session.CurrentlyDrawnEntity = vehicle;
-        frameNum = vehicle->pitch;
+        frameNum = vehicle->flatRideAnimationFrame;
     }
 
     const auto& boundBox = kHauntedHouseData[part];

--- a/src/openrct2/paint/track/gentle/MerryGoRound.cpp
+++ b/src/openrct2/paint/track/gentle/MerryGoRound.cpp
@@ -82,7 +82,7 @@ static void PaintCarousel(
     if (vehicle != nullptr)
     {
         auto rotation = ((vehicle->Orientation >> 3) + session.CurrentRotation) << 5;
-        rotationOffset = (vehicle->pitch + rotation) % 128;
+        rotationOffset = (vehicle->flatRideAnimationFrame + rotation) % 128;
     }
 
     CoordsXYZ offset(xOffset, yOffset, height);

--- a/src/openrct2/paint/track/gentle/SpaceRings.cpp
+++ b/src/openrct2/paint/track/gentle/SpaceRings.cpp
@@ -58,7 +58,7 @@ static void PaintSpaceRingsStructure(
     {
         session.InteractionType = ViewportInteractionItem::Entity;
         session.CurrentlyDrawnEntity = vehicle;
-        frameNum += static_cast<int8_t>(vehicle->pitch) * 4;
+        frameNum += static_cast<int8_t>(vehicle->flatRideAnimationFrame) * 4;
     }
 
     if (ride.vehicleColourSettings != VehicleColourSettings::perTrain)

--- a/src/openrct2/paint/track/thrill/Enterprise.cpp
+++ b/src/openrct2/paint/track/thrill/Enterprise.cpp
@@ -72,7 +72,7 @@ static void PaintEnterpriseStructure(
     uint32_t imageOffset = trackElement.GetDirectionWithOffset(session.CurrentRotation);
     if (vehicle != nullptr)
     {
-        imageOffset = (vehicle->pitch << 2) + (((vehicle->Orientation >> 3) + session.CurrentRotation) % 4);
+        imageOffset = (vehicle->flatRideAnimationFrame << 2) + (((vehicle->Orientation >> 3) + session.CurrentRotation) % 4);
     }
 
     auto imageTemplate = ImageId(0, ride.vehicleColours[0].Body, ride.vehicleColours[0].Trim);

--- a/src/openrct2/paint/track/thrill/MagicCarpet.cpp
+++ b/src/openrct2/paint/track/thrill/MagicCarpet.cpp
@@ -192,7 +192,7 @@ static void PaintMagicCarpetStructure(
     auto* vehicle = GetFirstVehicle(ride);
     if (vehicle != nullptr)
     {
-        swing = vehicle->pitch;
+        swing = vehicle->flatRideAnimationFrame;
         session.InteractionType = ViewportInteractionItem::Entity;
         session.CurrentlyDrawnEntity = vehicle;
     }

--- a/src/openrct2/paint/track/thrill/MotionSimulator.cpp
+++ b/src/openrct2/paint/track/thrill/MotionSimulator.cpp
@@ -65,7 +65,7 @@ static void PaintMotionSimulatorVehicle(
         }
         else
         {
-            imageIndex += vehicle->pitch * 4;
+            imageIndex += vehicle->flatRideAnimationFrame * 4;
         }
     }
 

--- a/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
@@ -88,7 +88,7 @@ static void PaintSwingingInverterShipStructure(
     ImageIndex vehicleImageIndex = rideEntry->Cars[0].base_image_id + kSwingingInverterShipBaseSpriteOffset[direction];
     if (vehicle != nullptr)
     {
-        int32_t rotation = static_cast<int8_t>(vehicle->pitch);
+        int32_t rotation = static_cast<int8_t>(vehicle->flatRideAnimationFrame);
         if (rotation != 0)
         {
             vehicleImageIndex = rideEntry->Cars[0].base_image_id + kSwingingInverterShipAnimatingBaseSpriteOffset[direction];

--- a/src/openrct2/paint/track/thrill/SwingingShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingShip.cpp
@@ -110,7 +110,7 @@ static void PaintSwingingShipStructure(
     auto baseImageId = rideEntry->Cars[0].base_image_id + kSwingingShipBaseSpriteOffset[direction];
     if (vehicle != nullptr)
     {
-        int32_t rotation = static_cast<int8_t>(vehicle->pitch);
+        int32_t rotation = static_cast<int8_t>(vehicle->flatRideAnimationFrame);
         if (rotation != 0)
         {
             if (direction & 2)

--- a/src/openrct2/paint/track/thrill/TopSpin.cpp
+++ b/src/openrct2/paint/track/thrill/TopSpin.cpp
@@ -135,8 +135,8 @@ static void PaintTopSpinVehicle(
         session.InteractionType = ViewportInteractionItem::Entity;
         session.CurrentlyDrawnEntity = vehicle;
 
-        armRotation = vehicle->pitch;
-        seatRotation = vehicle->roll;
+        armRotation = vehicle->flatRideAnimationFrame;
+        seatRotation = vehicle->flatRideSecondaryAnimationFrame;
     }
 
     int32_t armImageOffset = armRotation;

--- a/src/openrct2/paint/track/thrill/Twist.cpp
+++ b/src/openrct2/paint/track/thrill/Twist.cpp
@@ -50,7 +50,7 @@ static void PaintTwistStructure(
     if (vehicle != nullptr)
     {
         frameNum += (vehicle->Orientation >> 3) << 4;
-        frameNum += vehicle->pitch;
+        frameNum += vehicle->flatRideAnimationFrame;
         frameNum = frameNum % 216;
     }
 

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -107,8 +107,16 @@ struct Vehicle : EntityBase
     };
 
     Type SubType;
-    uint8_t pitch;
-    uint8_t roll;
+    union
+    {
+        uint8_t pitch;
+        uint8_t flatRideAnimationFrame;
+    };
+    union
+    {
+        uint8_t roll;
+        uint8_t flatRideSecondaryAnimationFrame;
+    };
     int32_t remaining_distance;
     int32_t velocity;
     int32_t acceleration;


### PR DESCRIPTION
In preparation for strong-typing the pitch and roll enums, unions are created to properly document which users of the field are flat rides.

Next PR: https://github.com/OpenRCT2/OpenRCT2/pull/25093 should be ready for review when this merges.