### PR TITLE
Fix reverse freefall coaster on ride photo using the wrong track sprite and add bases

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.27 (in development)
 ------------------------------------------------------------------------
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
+- Fix: [#25131] The Reverse Freefall Coaster On-ride photo section track has incorrectly coloured ties.
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 
 0.4.26 (2025-09-06)

--- a/src/openrct2/paint/track/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ReverseFreefallCoaster.cpp
@@ -391,27 +391,12 @@ static void PaintReverseFreefallRCOnridePhoto(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    static constexpr uint32_t imageIds[4] = {
-        SPR_AIR_POWERED_VERTICAL_RC_FLAT_SW_NE,
-        SPR_AIR_POWERED_VERTICAL_RC_FLAT_NW_SE,
-        SPR_AIR_POWERED_VERTICAL_RC_FLAT_SW_NE,
-        SPR_AIR_POWERED_VERTICAL_RC_FLAT_NW_SE,
-    };
-
-    // The straight track without booster is borrowed from the APVC.
-    // It has one track colour, instead of the two that the Reverse Freefall Colour has.
-    auto colour = session.TrackColours;
-    if (!trackElement.IsGhost() && !trackElement.IsHighlighted())
-    {
-        colour = colour.WithPrimary(colour.GetSecondary());
-    }
-
     PaintAddImageAsParentRotated(
-        session, direction, colour.WithIndex(imageIds[direction]), { 0, 0, height }, { { 0, 6, height }, { 32, 20, 1 } });
+        session, direction, session.TrackColours.WithIndex(kPiecesStation[direction]), { 0, 0, height },
+        { { 0, 6, height }, { 32, 20, 1 } });
 
     DrawSupportForSequenceA<TrackElemType::OnRidePhoto>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    ;
 
     TrackPaintUtilOnridePhotoPaint2(session, direction, trackElement, height);
 }


### PR DESCRIPTION
This fixes the on ride photo of the reverse freefall coaster having incorrectly coloured ties due to using a sprite from the air powered coaster. This uses the station sprite from the reverse freefall coaster instead.

This removes this special case in the paint code. If I remember right, it's the only function that changes colors in this way.

It also adds the usual base to the photo sections of the air powered and reverse freefall coasters.

<img width="265" height="252" alt="photos" src="https://github.com/user-attachments/assets/fcf6d9c9-7b26-4e7c-8c7e-25420a08f30f" />

Save:
[photos.zip](https://github.com/user-attachments/files/22236987/photos.zip)
