### PR TITLE
Pass GameState and ParkData refs in more places

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -92,7 +92,8 @@ namespace OpenRCT2::Ui::Windows
         }
 
         // Set research required for rides in use
-        for (const auto& ride : GetRideManager())
+        const auto& gameState = getGameState();
+        for (const auto& ride : RideManager(gameState))
         {
             Editor::SetSelectedObject(
                 ObjectType::ride, ride.subtype, ObjectSelectionFlags::Selected | ObjectSelectionFlags::InUse);

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -538,7 +538,8 @@ namespace OpenRCT2::Ui::Windows
         bool AnyRidesExist()
         {
             // Check if there are any rides (not shops or facilities)
-            const auto& rideManager = GetRideManager();
+            const auto& gameState = getGameState();
+            const auto& rideManager = RideManager(gameState);
             return std::any_of(
                 rideManager.begin(), rideManager.end(), [](const Ride& rideToCheck) { return rideToCheck.isRide(); });
         }
@@ -2238,7 +2239,9 @@ namespace OpenRCT2::Ui::Windows
 
             const auto oldSize = _rideableRides.size();
             _rideableRides.clear();
-            for (auto& currentRide : GetRideManager())
+
+            const auto& gameState = getGameState();
+            for (auto& currentRide : RideManager(gameState))
             {
                 if (currentRide.isRide())
                 {

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1244,7 +1244,9 @@ namespace OpenRCT2::Ui::Windows
 
             const auto oldSize = _riddenRides.size();
             _riddenRides.clear();
-            for (const auto& r : GetRideManager())
+
+            const auto& gameState = getGameState();
+            for (const auto& r : RideManager(gameState))
             {
                 if (r.isRide() && guest->HasRidden(r))
                 {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -112,7 +112,8 @@ namespace OpenRCT2::Ui::Windows
         void GetShopItems()
         {
             BitSet<EnumValue(ShopItem::Count)> items = {};
-            for (auto& curRide : GetRideManager())
+            const auto& gameState = getGameState();
+            for (auto& curRide : RideManager(gameState))
             {
                 auto rideEntry = curRide.getRideEntry();
                 if (rideEntry != nullptr)
@@ -142,7 +143,8 @@ namespace OpenRCT2::Ui::Windows
         {
             // Get all applicable rides
             RideList.clear();
-            for (const auto& curRide : GetRideManager())
+            const auto& gameState = getGameState();
+            for (const auto& curRide : RideManager(gameState))
             {
                 if (curRide.status == RideStatus::open)
                 {

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -541,7 +541,8 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_CLOSE_LIGHT].type = WidgetType::imgBtn;
                 widgets[WIDX_OPEN_LIGHT].type = WidgetType::imgBtn;
 
-                const auto& rideManager = GetRideManager();
+                const auto& gameState = getGameState();
+                const auto& rideManager = RideManager(gameState);
                 auto allClosed = true;
                 auto allOpen = false;
                 if (_rideList.size() > 0 && std::size(rideManager) != 0)
@@ -950,7 +951,8 @@ namespace OpenRCT2::Ui::Windows
         void RefreshList()
         {
             _rideList.clear();
-            for (auto& rideRef : GetRideManager())
+            const auto& gameState = getGameState();
+            for (auto& rideRef : RideManager(gameState))
             {
                 if (rideRef.getClassification() != static_cast<RideClassification>(page)
                     || (rideRef.status == RideStatus::closed && !RideHasAnyTrackElements(rideRef)))
@@ -1093,7 +1095,8 @@ namespace OpenRCT2::Ui::Windows
         // window_ride_list_close_all
         void CloseAllRides()
         {
-            for (auto& rideRef : GetRideManager())
+            const auto& gameState = getGameState();
+            for (auto& rideRef : RideManager(gameState))
             {
                 if (rideRef.status != RideStatus::closed
                     && rideRef.getClassification() == static_cast<RideClassification>(page))
@@ -1107,7 +1110,8 @@ namespace OpenRCT2::Ui::Windows
         // window_ride_list_open_all
         void OpenAllRides()
         {
-            for (auto& rideRef : GetRideManager())
+            const auto& gameState = getGameState();
+            for (auto& rideRef : RideManager(gameState))
             {
                 if (rideRef.status != RideStatus::open && rideRef.getClassification() == static_cast<RideClassification>(page))
                 {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -500,7 +500,7 @@ namespace OpenRCT2::Editor
     {
         auto& gameState = getGameState();
         auto& park = gameState.park;
-        int32_t parkSize = Park::UpdateSize(park, gameState);
+        int32_t parkSize = Park::UpdateSize(park);
         if (parkSize == 0)
         {
             return { false, STR_PARK_MUST_OWN_SOME_LAND };

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -499,7 +499,8 @@ namespace OpenRCT2::Editor
     ResultWithMessage CheckPark()
     {
         auto& gameState = getGameState();
-        int32_t parkSize = Park::UpdateSize(gameState);
+        auto& park = gameState.park;
+        int32_t parkSize = Park::UpdateSize(park, gameState);
         if (parkSize == 0)
         {
             return { false, STR_PARK_MUST_OWN_SOME_LAND };

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -245,7 +245,8 @@ void SetupInUseSelectionFlags()
         }
     } while (TileElementIteratorNext(&iter));
 
-    for (auto& ride : GetRideManager())
+    auto& gameState = getGameState();
+    for (auto& ride : RideManager(gameState))
     {
         Editor::SetSelectedObject(ObjectType::ride, ride.subtype, ObjectSelectionFlags::InUse);
         Editor::SetSelectedObject(ObjectType::station, ride.entranceStyle, ObjectSelectionFlags::InUse);

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -316,7 +316,8 @@ namespace OpenRCT2
 
         if (!isInEditorMode())
         {
-            Park::Update(gameState, gameState.date);
+            auto& park = gameState.park;
+            Park::Update(park, gameState);
         }
 
         ResearchUpdate();

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -158,7 +158,7 @@ namespace OpenRCT2::GameActions
                 gameState.cheats.disableLittering = _param1 != 0;
                 break;
             case CheatType::NoMoney:
-                SetScenarioNoMoney(_param1 != 0);
+                SetScenarioNoMoney(gameState, _param1 != 0);
                 break;
             case CheatType::AddMoney:
                 AddMoney(_param1);
@@ -176,13 +176,13 @@ namespace OpenRCT2::GameActions
                 GenerateGuests(_param1);
                 break;
             case CheatType::RemoveAllGuests:
-                RemoveAllGuests();
+                RemoveAllGuests(gameState);
                 break;
             case CheatType::GiveAllGuests:
                 GiveObjectToGuests(_param1);
                 break;
             case CheatType::SetGrassLength:
-                SetGrassLength(_param1);
+                SetGrassLength(gameState, _param1);
                 break;
             case CheatType::WaterPlants:
                 WaterPlants();
@@ -191,7 +191,7 @@ namespace OpenRCT2::GameActions
                 FixVandalism();
                 break;
             case CheatType::RemoveLitter:
-                RemoveLitter();
+                RemoveLitter(gameState);
                 break;
             case CheatType::DisablePlantAging:
                 gameState.cheats.disablePlantAging = _param1 != 0;
@@ -200,20 +200,20 @@ namespace OpenRCT2::GameActions
                 SetStaffSpeed(_param1);
                 break;
             case CheatType::RenewRides:
-                RenewRides();
+                RenewRides(gameState);
                 break;
             case CheatType::MakeDestructible:
                 gameState.cheats.makeAllDestructible = _param1 != 0;
                 windowMgr->InvalidateByClass(WindowClass::Ride);
                 break;
             case CheatType::FixRides:
-                FixBrokenRides();
+                FixBrokenRides(gameState);
                 break;
             case CheatType::ResetCrashStatus:
-                ResetRideCrashStatus();
+                ResetRideCrashStatus(gameState);
                 break;
             case CheatType::TenMinuteInspections:
-                Set10MinuteInspection();
+                Set10MinuteInspection(gameState);
                 break;
             case CheatType::WinScenario:
                 ScenarioSuccess(gameState);
@@ -436,9 +436,8 @@ namespace OpenRCT2::GameActions
         return { { 0, 0 }, { 0, 0 } };
     }
 
-    void CheatSetAction::SetGrassLength(int32_t length) const
+    void CheatSetAction::SetGrassLength(GameState_t& gameState, int32_t length) const
     {
-        auto& gameState = getGameState();
         for (int32_t y = 0; y < gameState.mapSize.y; y++)
         {
             for (int32_t x = 0; x < gameState.mapSize.x; x++)
@@ -493,11 +492,11 @@ namespace OpenRCT2::GameActions
         GfxInvalidateScreen();
     }
 
-    void CheatSetAction::RemoveLitter() const
+    void CheatSetAction::RemoveLitter(GameState_t& gameState) const
     {
         for (auto litter : EntityList<Litter>())
         {
-            getGameState().entities.EntityRemove(litter);
+            gameState.entities.EntityRemove(litter);
         }
 
         TileElementIterator it{};
@@ -520,9 +519,9 @@ namespace OpenRCT2::GameActions
         GfxInvalidateScreen();
     }
 
-    void CheatSetAction::FixBrokenRides() const
+    void CheatSetAction::FixBrokenRides(GameState_t& gameState) const
     {
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
             {
@@ -548,9 +547,9 @@ namespace OpenRCT2::GameActions
         }
     }
 
-    void CheatSetAction::RenewRides() const
+    void CheatSetAction::RenewRides(GameState_t& gameState) const
     {
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             ride.renew();
         }
@@ -558,9 +557,9 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::Ride);
     }
 
-    void CheatSetAction::ResetRideCrashStatus() const
+    void CheatSetAction::ResetRideCrashStatus(GameState_t& gameState) const
     {
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             // Reset crash status and history
             ride.lifecycleFlags &= ~RIDE_LIFECYCLE_CRASHED;
@@ -570,9 +569,9 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::Ride);
     }
 
-    void CheatSetAction::Set10MinuteInspection() const
+    void CheatSetAction::Set10MinuteInspection(GameState_t& gameState) const
     {
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             // Set inspection interval to 10 minutes
             ride.inspectionInterval = RIDE_INSPECTION_EVERY_10_MINUTES;
@@ -581,9 +580,9 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::Ride);
     }
 
-    void CheatSetAction::SetScenarioNoMoney(bool enabled) const
+    void CheatSetAction::SetScenarioNoMoney(GameState_t& gameState, bool enabled) const
     {
-        auto& park = getGameState().park;
+        auto& park = gameState.park;
         if (enabled)
         {
             park.flags |= PARK_FLAGS_NO_MONEY;
@@ -717,9 +716,9 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::Peep);
     }
 
-    void CheatSetAction::RemoveAllGuests() const
+    void CheatSetAction::RemoveAllGuests(GameState_t& gameState) const
     {
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             ride.numRiders = 0;
 

--- a/src/openrct2/actions/CheatSetAction.h
+++ b/src/openrct2/actions/CheatSetAction.h
@@ -36,22 +36,22 @@ namespace OpenRCT2::GameActions
 
     private:
         ParametersRange GetParameterRange(CheatType cheatType) const;
-        void SetGrassLength(int32_t length) const;
+        void SetGrassLength(GameState_t& gameState, int32_t length) const;
         void WaterPlants() const;
         void FixVandalism() const;
-        void RemoveLitter() const;
-        void FixBrokenRides() const;
-        void RenewRides() const;
-        void ResetRideCrashStatus() const;
-        void Set10MinuteInspection() const;
-        void SetScenarioNoMoney(bool enabled) const;
+        void RemoveLitter(GameState_t& gameState) const;
+        void FixBrokenRides(GameState_t& gameState) const;
+        void RenewRides(GameState_t& gameState) const;
+        void ResetRideCrashStatus(GameState_t& gameState) const;
+        void Set10MinuteInspection(GameState_t& gameState) const;
+        void SetScenarioNoMoney(GameState_t& gameState, bool enabled) const;
         void SetMoney(money64 amount) const;
         void AddMoney(money64 amount) const;
         void ClearLoan(GameState_t& gameState) const;
         void GenerateGuests(int32_t count) const;
         void SetGuestParameter(int32_t parameter, int32_t value) const;
         void GiveObjectToGuests(int32_t object) const;
-        void RemoveAllGuests() const;
+        void RemoveAllGuests(GameState_t& gameState) const;
         void SetStaffSpeed(uint8_t value) const;
         void OwnAllLand() const;
         void ParkSetOpen(bool isOpen, GameState_t& gameState) const;

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -83,7 +83,9 @@ namespace OpenRCT2::GameActions
         auto* ctx = OpenRCT2::GetContext();
         auto& uiContext = ctx->GetUiContext();
         auto* windowManager = uiContext.GetWindowManager();
-        Park::UpdateSize(gameState);
+
+        auto& park = gameState.park;
+        Park::UpdateSize(park, gameState);
 
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));
         GfxInvalidateScreen();

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -85,7 +85,7 @@ namespace OpenRCT2::GameActions
         auto* windowManager = uiContext.GetWindowManager();
 
         auto& park = gameState.park;
-        Park::UpdateSize(park, gameState);
+        Park::UpdateSize(park);
 
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));
         GfxInvalidateScreen();

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -156,7 +156,8 @@ namespace OpenRCT2::GameActions
         }
 
         ride.remove();
-        getGameState().park.value = Park::CalculateParkValue();
+        auto& park = gameState.park;
+        park.value = Park::CalculateParkValue(park, gameState);
 
         // Close windows related to the demolished ride
         auto* windowMgr = Ui::GetWindowManager();

--- a/src/openrct2/actions/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/RideSetPriceAction.cpp
@@ -155,14 +155,14 @@ namespace OpenRCT2::GameActions
         }
 
         // Synchronize prices if enabled.
-        RideSetCommonPrice(shopItem);
+        RideSetCommonPrice(gameState, shopItem);
 
         return res;
     }
 
-    void RideSetPriceAction::RideSetCommonPrice(ShopItem shopItem) const
+    void RideSetPriceAction::RideSetCommonPrice(GameState_t& gameState, ShopItem shopItem) const
     {
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             auto invalidate = false;
             auto rideEntry = GetRideEntryByIndex(ride.subtype);

--- a/src/openrct2/actions/RideSetPriceAction.h
+++ b/src/openrct2/actions/RideSetPriceAction.h
@@ -33,6 +33,6 @@ namespace OpenRCT2::GameActions
         Result Execute(GameState_t& gameState) const override;
 
     private:
-        void RideSetCommonPrice(ShopItem shopItem) const;
+        void RideSetCommonPrice(GameState_t& gameState, ShopItem shopItem) const;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1884,7 +1884,8 @@ static OpenRCT2::BitSet<OpenRCT2::Limits::kMaxRidesInPark> GuestFindRidesToGoOn(
     if (guest.HasItem(ShopItem::Map))
     {
         // Consider rides that peep hasn't been on yet
-        for (auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (auto& ride : RideManager(gameState))
         {
             if (!guest.HasRidden(ride))
             {
@@ -1918,7 +1919,8 @@ static OpenRCT2::BitSet<OpenRCT2::Limits::kMaxRidesInPark> GuestFindRidesToGoOn(
         }
 
         // Always take the tall rides into consideration (realistic as you can usually see them from anywhere in the park)
-        for (auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (auto& ride : RideManager(gameState))
         {
             if (ride.highestDropHeight > 66 || ride.ratings.excitement >= RideRating::make(8, 00))
             {
@@ -1935,7 +1937,9 @@ static Ride* GuestFindBestRideToGoOn(Guest& guest)
     // Pick the most exciting ride
     auto rideConsideration = GuestFindRidesToGoOn(guest);
     Ride* mostExcitingRide = nullptr;
-    for (auto& ride : GetRideManager())
+
+    auto& gameState = getGameState();
+    for (auto& ride : RideManager(gameState))
     {
         const auto rideIndex = ride.id.ToUnderlying();
         if (rideConsideration.size() > rideIndex && rideConsideration[rideIndex])
@@ -3187,7 +3191,8 @@ static void PeepHeadForNearestRide(Guest& guest, bool considerOnlyCloseRides, T 
     if (!considerOnlyCloseRides && (guest.HasItem(ShopItem::Map)))
     {
         // Consider all rides in the park
-        for (const auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (const auto& ride : RideManager(gameState))
         {
             if (predicate(ride))
             {
@@ -3228,7 +3233,9 @@ static void PeepHeadForNearestRide(Guest& guest, bool considerOnlyCloseRides, T 
     // Filter the considered rides
     RideId potentialRides[OpenRCT2::Limits::kMaxRidesInPark];
     size_t numPotentialRides = 0;
-    for (auto& ride : GetRideManager())
+
+    auto& gameState = getGameState();
+    for (auto& ride : RideManager(gameState))
     {
         if (rideConsideration[ride.id.ToUnderlying()])
         {

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -152,7 +152,7 @@ static void ConsoleCommandRides(InteractiveConsole& console, const arguments_t& 
     {
         if (argv[0] == "list")
         {
-            for (const auto& ride : GetRideManager())
+            for (const auto& ride : RideManager(gameState))
             {
                 auto name = ride.getName();
                 console.WriteFormatLine(
@@ -401,7 +401,7 @@ static void ConsoleCommandRides(InteractiveConsole& console, const arguments_t& 
                         auto price = arg1;
                         if (int_valid[0])
                         {
-                            for (const auto& ride : GetRideManager())
+                            for (const auto& ride : RideManager(gameState))
                             {
                                 auto rideSetPrice = GameActions::RideSetPriceAction(ride.id, price, true);
                                 GameActions::Execute(&rideSetPrice, gameState);
@@ -419,7 +419,7 @@ static void ConsoleCommandRides(InteractiveConsole& console, const arguments_t& 
 
                         if (int_valid[0] && int_valid[1])
                         {
-                            for (const auto& ride : GetRideManager())
+                            for (const auto& ride : RideManager(gameState))
                             {
                                 if (ride.type == rideType)
                                 {

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -170,14 +170,15 @@ void FinancePayRideUpkeep()
 {
     PROFILED_FUNCTION();
 
-    for (auto& ride : GetRideManager())
+    auto& gameState = getGameState();
+    for (auto& ride : RideManager(gameState))
     {
         if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_EVER_BEEN_OPENED))
         {
             ride.renew();
         }
 
-        if (ride.status != RideStatus::closed && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
+        if (ride.status != RideStatus::closed && !(gameState.park.flags & PARK_FLAGS_NO_MONEY))
         {
             auto upkeep = ride.upkeepCost;
             if (upkeep != kMoney64Undefined)
@@ -284,7 +285,7 @@ void FinanceUpdateDailyProfit()
         current_profit -= current_loan / 600;
 
         // Ride costs
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             if (ride.status != RideStatus::closed && ride.upkeepCost != kMoney64Undefined)
             {

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -307,26 +307,6 @@ void FinanceUpdateDailyProfit()
     windowMgr->InvalidateByClass(WindowClass::Finances);
 }
 
-money64 FinanceGetInitialCash()
-{
-    return getGameState().scenarioOptions.initialCash;
-}
-
-money64 FinanceGetCurrentLoan()
-{
-    return getGameState().park.bankLoan;
-}
-
-money64 FinanceGetMaximumLoan()
-{
-    return getGameState().park.maxBankLoan;
-}
-
-money64 FinanceGetCurrentCash()
-{
-    return getGameState().park.cash;
-}
-
 /**
  * Shift the expenditure table history one month to the left
  * If the table is full, accumulate the sum of the oldest month first

--- a/src/openrct2/management/Finance.h
+++ b/src/openrct2/management/Finance.h
@@ -51,9 +51,4 @@ void FinanceUpdateDailyProfit();
 void FinanceShiftExpenditureTable();
 void FinanceResetCashToInitial();
 
-money64 FinanceGetInitialCash();
-money64 FinanceGetCurrentLoan();
-money64 FinanceGetMaximumLoan();
-money64 FinanceGetCurrentCash();
-
 money64 FinanceGetLastMonthShopProfit();

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -185,6 +185,8 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaignType)
 
 bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 {
+    auto& gameState = getGameState();
+
     switch (campaignType)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
@@ -200,7 +202,7 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
             [[fallthrough]];
         case ADVERTISING_CAMPAIGN_RIDE:
             // Check if any rides exist
-            for (auto& ride : GetRideManager())
+            for (auto& ride : RideManager(gameState))
             {
                 if (ride.isRide())
                 {
@@ -211,7 +213,7 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 
         case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
             // Check if any food or drink stalls exist
-            for (auto& ride : GetRideManager())
+            for (auto& ride : RideManager(gameState))
             {
                 auto rideEntry = ride.getRideEntry();
                 if (rideEntry != nullptr)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1382,7 +1382,7 @@ namespace OpenRCT2
         void ReadWriteRidesChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            os.readWriteChunk(ParkFileChunkType::RIDES, [this, &version, &os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::RIDES, [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
                 std::vector<RideId> rideIds;
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -1393,7 +1393,7 @@ namespace OpenRCT2
                     if (OmitTracklessRides)
                     {
                         auto tracklessRides = GetTracklessRides();
-                        for (const auto& ride : GetRideManager())
+                        for (const auto& ride : RideManager(gameState))
                         {
                             auto it = std::find(tracklessRides.begin(), tracklessRides.end(), ride.id);
                             if (it == tracklessRides.end())
@@ -1404,7 +1404,7 @@ namespace OpenRCT2
                     }
                     else
                     {
-                        for (const auto& ride : GetRideManager())
+                        for (const auto& ride : RideManager(gameState))
                         {
                             rideIds.push_back(ride.id);
                         }

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -40,7 +40,7 @@ namespace OpenRCT2
             .day = gameState.date.GetDay(),
             .parkUsesMoney = !(gameState.park.flags & PARK_FLAGS_NO_MONEY),
             .cash = gameState.park.cash,
-            .numRides = static_cast<uint16_t>(RideManager().size()),
+            .numRides = static_cast<uint16_t>(RideManager(gameState).size()),
             .numGuests = static_cast<uint16_t>(gameState.park.numGuestsInPark),
         };
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -211,7 +211,7 @@ namespace OpenRCT2::RCT1
             }
             FixNextGuestNumber(gameState);
             CountBlockSections();
-            SetDefaultNames();
+            SetDefaultNames(gameState);
             DetermineRideEntranceAndExitLocations();
 
             ResearchDetermineFirstOfType();
@@ -301,6 +301,7 @@ namespace OpenRCT2::RCT1
                 {
                     // Use the ratio between the old and new park value to calcute the ratio to
                     // use for the park value history and the goal.
+                    // TODO: split up this function so this can pass the actual park/gamestate as needed
                     _parkValueConversionFactor = (Park::CalculateParkValue() * 10) / _s4.ParkValue;
                 }
                 else
@@ -2682,9 +2683,9 @@ namespace OpenRCT2::RCT1
          * This has to be done after importing tile elements, because it needs those to detect if a pre-existing ride
          * name should be considered reserved.
          */
-        void SetDefaultNames()
+        void SetDefaultNames(GameState_t& gameState)
         {
-            for (auto& ride : GetRideManager())
+            for (auto& ride : RideManager(gameState))
             {
                 if (ride.customName.empty())
                 {

--- a/src/openrct2/ride/RideManager.cpp
+++ b/src/openrct2/ride/RideManager.cpp
@@ -13,10 +13,7 @@
 
 namespace OpenRCT2
 {
-    RideManager::RideManager()
-        : _gameState(getGameState()) {};
-
-    RideManager::RideManager(GameState_t& gameState)
+    RideManager::RideManager(const GameState_t& gameState)
         : _gameState(gameState) {};
 
     size_t RideManager::size() const
@@ -45,10 +42,5 @@ namespace OpenRCT2
     RideManager::Iterator RideManager::get(RideId rideId)
     {
         return RideManager::Iterator(*this, rideId.ToUnderlying(), _gameState.ridesEndOfUsedRange);
-    }
-
-    RideManager GetRideManager()
-    {
-        return {};
     }
 } // namespace OpenRCT2

--- a/src/openrct2/ride/RideManager.hpp
+++ b/src/openrct2/ride/RideManager.hpp
@@ -18,11 +18,10 @@ namespace OpenRCT2
     struct RideManager
     {
     private:
-        GameState_t& _gameState;
+        const GameState_t& _gameState;
 
     public:
-        RideManager();
-        RideManager(GameState_t& gameState);
+        RideManager(const GameState_t& gameState);
 
         const Ride* operator[](RideId id) const
         {
@@ -104,6 +103,4 @@ namespace OpenRCT2
             return (const_cast<RideManager*>(this))->end();
         }
     };
-
-    RideManager GetRideManager();
 } // namespace OpenRCT2

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -272,7 +272,8 @@ static bool ShouldSkipRatingCalculation(const Ride& ride)
 
 static RideId GetNextRideToUpdate(RideId currentRide)
 {
-    auto rm = GetRideManager();
+    auto& gameState = getGameState();
+    auto rm = RideManager(gameState);
     if (rm.size() == 0)
     {
         return RideId::GetNull();
@@ -1186,7 +1187,8 @@ static void RideRatingsCalculateValue(Ride& ride)
     }
 
     // Other ride of same type penalty
-    const auto& rideManager = GetRideManager();
+    const auto& gameState = getGameState();
+    const auto& rideManager = RideManager(gameState);
     auto rideType = ride.type;
     auto otherRidesOfSameType = std::count_if(rideManager.begin(), rideManager.end(), [rideType](const Ride& r) {
         return r.status == RideStatus::open && r.type == rideType;

--- a/src/openrct2/ride/ShopItem.cpp
+++ b/src/openrct2/ride/ShopItem.cpp
@@ -118,7 +118,8 @@ uint64_t ShopItemsGetAllContainers()
 
 money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem)
 {
-    for (const auto& ride : GetRideManager())
+    auto& gameState = getGameState();
+    for (const auto& ride : RideManager(gameState))
     {
         if (&ride != forRide)
         {

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -138,7 +138,7 @@ void ScenarioReset(GameState_t& gameState)
     ResetAllRideBuildDates();
     ResetDate();
     Duck::RemoveAll();
-    Park::UpdateSize(park, gameState);
+    Park::UpdateSize(park);
     MapCountRemainingLandRights();
     Staff::ResetStats();
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -102,9 +102,9 @@ void ScenarioReset(GameState_t& gameState)
     News::InitQueue(gameState);
 
     auto& park = gameState.park;
-    park.rating = Park::CalculateParkRating();
-    park.value = Park::CalculateParkValue();
-    park.companyValue = Park::CalculateCompanyValue();
+    park.rating = Park::CalculateParkRating(park, gameState);
+    park.value = Park::CalculateParkValue(park, gameState);
+    park.companyValue = Park::CalculateCompanyValue(park);
     park.historicalProfit = gameState.scenarioOptions.initialCash - park.bankLoan;
     park.cash = gameState.scenarioOptions.initialCash;
 
@@ -138,7 +138,7 @@ void ScenarioReset(GameState_t& gameState)
     ResetAllRideBuildDates();
     ResetDate();
     Duck::RemoveAll();
-    Park::UpdateSize(gameState);
+    Park::UpdateSize(park, gameState);
     MapCountRemainingLandRights();
     Staff::ResetStats();
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -530,7 +530,7 @@ static ResultWithMessage ScenarioPrepareRidesForSave(GameState_t& gameState)
     bool isFiveCoasterObjective = gameState.scenarioOptions.objective.Type == ObjectiveType::finishFiveRollercoasters;
     uint8_t rcs = 0;
 
-    for (auto& ride : GetRideManager())
+    for (auto& ride : RideManager(gameState))
     {
         const auto* rideEntry = ride.getRideEntry();
         if (rideEntry != nullptr)

--- a/src/openrct2/scenario/ScenarioObjective.cpp
+++ b/src/openrct2/scenario/ScenarioObjective.cpp
@@ -18,14 +18,14 @@
 
 namespace OpenRCT2::Scenario
 {
-    ObjectiveStatus Objective::CheckGuestsBy() const
+    ObjectiveStatus Objective::CheckGuestsBy(GameState_t& gameState) const
     {
-        auto parkRating = getGameState().park.rating;
+        auto parkRating = gameState.park.rating;
         int32_t currentMonthYear = GetDate().GetMonthsElapsed();
 
         if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
         {
-            if (parkRating >= 600 && getGameState().park.numGuestsInPark >= NumGuests)
+            if (parkRating >= 600 && gameState.park.numGuestsInPark >= NumGuests)
             {
                 return ObjectiveStatus::Success;
             }
@@ -39,11 +39,11 @@ namespace OpenRCT2::Scenario
         return ObjectiveStatus::Undecided;
     }
 
-    ObjectiveStatus Objective::CheckParkValueBy() const
+    ObjectiveStatus Objective::CheckParkValueBy(GameState_t& gameState) const
     {
         int32_t currentMonthYear = GetDate().GetMonthsElapsed();
         money64 objectiveParkValue = Currency;
-        money64 parkValue = getGameState().park.value;
+        money64 parkValue = gameState.park.value;
 
         if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
         {
@@ -66,11 +66,11 @@ namespace OpenRCT2::Scenario
      * excitement >= 600 .
      * rct2:
      **/
-    ObjectiveStatus Objective::Check10RollerCoasters() const
+    ObjectiveStatus Objective::Check10RollerCoasters(GameState_t& gameState) const
     {
         auto rcs = 0;
         BitSet<kMaxRideObjects> type_already_counted;
-        for (const auto& ride : GetRideManager())
+        for (const auto& ride : RideManager(gameState))
         {
             if (ride.status == RideStatus::open && ride.ratings.excitement >= RideRating::make(6, 00)
                 && ride.subtype != kObjectEntryIndexNull)
@@ -98,10 +98,9 @@ namespace OpenRCT2::Scenario
      *
      *  rct2: 0x0066A13C
      */
-    ObjectiveStatus Objective::CheckGuestsAndRating() const
+    ObjectiveStatus Objective::CheckGuestsAndRating(GameState_t& gameState) const
     {
-        auto& gameState = getGameState();
-        auto& park = getGameState().park;
+        auto& park = gameState.park;
 
         // TODO: make park-specific
         if (park.rating < 700 && GetDate().GetMonthsElapsed() >= 1)
@@ -155,10 +154,10 @@ namespace OpenRCT2::Scenario
         return ObjectiveStatus::Undecided;
     }
 
-    ObjectiveStatus Objective::CheckMonthlyRideIncome() const
+    ObjectiveStatus Objective::CheckMonthlyRideIncome(GameState_t& gameState) const
     {
         // TODO: pass park by ref
-        const auto& park = getGameState().park;
+        const auto& park = gameState.park;
 
         money64 lastMonthRideIncome = park.expenditureTable[1][EnumValue(ExpenditureType::parkRideTickets)];
         if (lastMonthRideIncome >= Currency)
@@ -174,11 +173,11 @@ namespace OpenRCT2::Scenario
      * excitement > 700 and a minimum length;
      *  rct2: 0x0066A6B5
      */
-    ObjectiveStatus Objective::Check10RollerCoastersLength() const
+    ObjectiveStatus Objective::Check10RollerCoastersLength(GameState_t& gameState) const
     {
         BitSet<kMaxRideObjects> type_already_counted;
         auto rcs = 0;
-        for (const auto& ride : GetRideManager())
+        for (const auto& ride : RideManager(gameState))
         {
             if (ride.status == RideStatus::open && ride.ratings.excitement >= RideRating::make(7, 00)
                 && ride.subtype != kObjectEntryIndexNull)
@@ -205,12 +204,12 @@ namespace OpenRCT2::Scenario
         return ObjectiveStatus::Undecided;
     }
 
-    ObjectiveStatus Objective::CheckFinish5RollerCoasters() const
+    ObjectiveStatus Objective::CheckFinish5RollerCoasters(GameState_t& gameState) const
     {
         // Originally, this did not check for null rides, neither did it check if
         // the rides are even rollercoasters, never mind the right rollercoasters to be finished.
         auto rcs = 0;
-        for (const auto& ride : GetRideManager())
+        for (const auto& ride : RideManager(gameState))
         {
             if (ride.status != RideStatus::closed && ride.ratings.excitement >= MinimumExcitement)
             {
@@ -233,10 +232,10 @@ namespace OpenRCT2::Scenario
         return ObjectiveStatus::Undecided;
     }
 
-    ObjectiveStatus Objective::CheckRepayLoanAndParkValue() const
+    ObjectiveStatus Objective::CheckRepayLoanAndParkValue(GameState_t& gameState) const
     {
         // TODO: pass park by ref
-        const auto& park = getGameState().park;
+        const auto& park = gameState.park;
         money64 parkValue = park.value;
         money64 currentLoan = park.bankLoan;
 
@@ -248,10 +247,10 @@ namespace OpenRCT2::Scenario
         return ObjectiveStatus::Undecided;
     }
 
-    ObjectiveStatus Objective::CheckMonthlyFoodIncome() const
+    ObjectiveStatus Objective::CheckMonthlyFoodIncome(GameState_t& gameState) const
     {
         // TODO: pass park by ref
-        const auto& park = getGameState().park;
+        const auto& park = gameState.park;
 
         const auto* lastMonthExpenditure = park.expenditureTable[1];
         auto lastMonthProfit = lastMonthExpenditure[EnumValue(ExpenditureType::shopSales)]
@@ -281,23 +280,23 @@ namespace OpenRCT2::Scenario
         switch (Type)
         {
             case ObjectiveType::guestsBy:
-                return CheckGuestsBy();
+                return CheckGuestsBy(gameState);
             case ObjectiveType::parkValueBy:
-                return CheckParkValueBy();
+                return CheckParkValueBy(gameState);
             case ObjectiveType::tenRollercoasters:
-                return Check10RollerCoasters();
+                return Check10RollerCoasters(gameState);
             case ObjectiveType::guestsAndRating:
-                return CheckGuestsAndRating();
+                return CheckGuestsAndRating(gameState);
             case ObjectiveType::monthlyRideIncome:
-                return CheckMonthlyRideIncome();
+                return CheckMonthlyRideIncome(gameState);
             case ObjectiveType::tenRollercoastersLength:
-                return Check10RollerCoastersLength();
+                return Check10RollerCoastersLength(gameState);
             case ObjectiveType::finishFiveRollercoasters:
-                return CheckFinish5RollerCoasters();
+                return CheckFinish5RollerCoasters(gameState);
             case ObjectiveType::repayLoanAndParkValue:
-                return CheckRepayLoanAndParkValue();
+                return CheckRepayLoanAndParkValue(gameState);
             case ObjectiveType::monthlyFoodIncome:
-                return CheckMonthlyFoodIncome();
+                return CheckMonthlyFoodIncome(gameState);
             default:
                 return ObjectiveStatus::Undecided;
         }

--- a/src/openrct2/scenario/ScenarioObjective.h
+++ b/src/openrct2/scenario/ScenarioObjective.h
@@ -79,14 +79,14 @@ namespace OpenRCT2::Scenario
         ObjectiveStatus Check(GameState_t& gameState) const;
 
     private:
-        ObjectiveStatus CheckGuestsBy() const;
-        ObjectiveStatus CheckParkValueBy() const;
-        ObjectiveStatus Check10RollerCoasters() const;
-        ObjectiveStatus CheckGuestsAndRating() const;
-        ObjectiveStatus CheckMonthlyRideIncome() const;
-        ObjectiveStatus Check10RollerCoastersLength() const;
-        ObjectiveStatus CheckFinish5RollerCoasters() const;
-        ObjectiveStatus CheckRepayLoanAndParkValue() const;
-        ObjectiveStatus CheckMonthlyFoodIncome() const;
+        ObjectiveStatus CheckGuestsBy(GameState_t& gameState) const;
+        ObjectiveStatus CheckParkValueBy(GameState_t& gameState) const;
+        ObjectiveStatus Check10RollerCoasters(GameState_t& gameState) const;
+        ObjectiveStatus CheckGuestsAndRating(GameState_t& gameState) const;
+        ObjectiveStatus CheckMonthlyRideIncome(GameState_t& gameState) const;
+        ObjectiveStatus Check10RollerCoastersLength(GameState_t& gameState) const;
+        ObjectiveStatus CheckFinish5RollerCoasters(GameState_t& gameState) const;
+        ObjectiveStatus CheckRepayLoanAndParkValue(GameState_t& gameState) const;
+        ObjectiveStatus CheckMonthlyFoodIncome(GameState_t& gameState) const;
     };
 } // namespace OpenRCT2::Scenario

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -51,7 +51,8 @@ namespace OpenRCT2::Scripting
 
     int32_t ScMap::numRides_get() const
     {
-        return static_cast<int32_t>(GetRideManager().size());
+        auto& gameState = getGameState();
+        return static_cast<int32_t>(RideManager(gameState).size());
     }
 
     int32_t ScMap::numEntities_get() const
@@ -62,7 +63,9 @@ namespace OpenRCT2::Scripting
     std::vector<std::shared_ptr<ScRide>> ScMap::rides_get() const
     {
         std::vector<std::shared_ptr<ScRide>> result;
-        auto rideManager = GetRideManager();
+
+        auto& gameState = getGameState();
+        auto rideManager = RideManager(gameState);
         for (const auto& ride : rideManager)
         {
             result.push_back(std::make_shared<ScRide>(ride.id));
@@ -72,7 +75,8 @@ namespace OpenRCT2::Scripting
 
     std::shared_ptr<ScRide> ScMap::getRide(int32_t id) const
     {
-        auto rideManager = GetRideManager();
+        auto& gameState = getGameState();
+        auto rideManager = RideManager(gameState);
         auto ride = rideManager[RideId::FromUnderlying(id)];
         if (ride != nullptr)
         {

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -224,7 +224,9 @@ RideId BannerGetClosestRideIndex(const CoordsXYZ& mapPos)
 
     auto rideIndex = RideId::GetNull();
     auto resultDistance = std::numeric_limits<int32_t>::max();
-    for (auto& ride : GetRideManager())
+
+    auto& gameState = getGameState();
+    for (auto& ride : RideManager(gameState))
     {
         if (ride.getRideTypeDescriptor().HasFlag(RtdFlag::isShopOrFacility))
             continue;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2348,7 +2348,7 @@ void ShiftMap(const TileCoordsXY& amount)
     UpdateConsolidatedPatrolAreas();
 
     // Rides
-    for (auto& ride : GetRideManager())
+    for (auto& ride : RideManager(gameState))
     {
         auto stations = ride.getStations();
         for (auto& station : stations)

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -356,8 +356,7 @@ namespace OpenRCT2::Park
         // Every ~102 seconds
         if (currentTicks % 4096 == 0)
         {
-            park.size = CalculateParkSize(park);
-            windowMgr->InvalidateByClass(WindowClass::ParkInformation);
+            Park::UpdateSize(park);
         }
 
         generateGuests(park, gameState);
@@ -378,14 +377,6 @@ namespace OpenRCT2::Park
                 }
             }
         } while (TileElementIteratorNext(&it));
-
-        // TODO: pass park by ref
-        if (tiles != park.size)
-        {
-            park.size = tiles;
-            auto* windowMgr = Ui::GetWindowManager();
-            windowMgr->InvalidateByClass(WindowClass::ParkInformation);
-        }
 
         return tiles;
     }
@@ -637,9 +628,9 @@ namespace OpenRCT2::Park
         windowMgr->InvalidateByClass(WindowClass::Finances);
     }
 
-    uint32_t UpdateSize(ParkData& park, GameState_t& gameState)
+    uint32_t UpdateSize(ParkData& park)
     {
-        auto tiles = CalculateParkSize(park, gameState);
+        auto tiles = CalculateParkSize(park);
         if (tiles != park.size)
         {
             park.size = tiles;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -78,11 +78,11 @@ namespace OpenRCT2::Park
         return result;
     }
 
-    static money64 calculateTotalRideValueForMoney()
+    static money64 calculateTotalRideValueForMoney(const ParkData& park, const GameState_t& gameState)
     {
         money64 totalRideValue = 0;
-        bool ridePricesUnlocked = RidePricesUnlocked() && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY);
-        for (auto& ride : GetRideManager())
+        bool ridePricesUnlocked = RidePricesUnlocked() && !(gameState.park.flags & PARK_FLAGS_NO_MONEY);
+        for (auto& ride : RideManager(gameState))
         {
             if (ride.status != RideStatus::open)
                 continue;
@@ -108,15 +108,12 @@ namespace OpenRCT2::Park
         return totalRideValue;
     }
 
-    static uint32_t calculateSuggestedMaxGuests()
+    static uint32_t calculateSuggestedMaxGuests(const ParkData& park, const GameState_t& gameState)
     {
         uint32_t suggestedMaxGuests = 0;
         uint32_t difficultGenerationBonus = 0;
 
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
-
-        for (auto& ride : GetRideManager())
+        for (auto& ride : RideManager(gameState))
         {
             if (ride.status != RideStatus::open)
                 continue;
@@ -172,11 +169,8 @@ namespace OpenRCT2::Park
         return suggestedMaxGuests;
     }
 
-    static uint32_t calculateGuestGenerationProbability()
+    static uint32_t calculateGuestGenerationProbability(ParkData& park)
     {
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
-
         // Begin with 50 + park rating
         uint32_t probability = 50 + std::clamp(park.rating - 200, 0, 650);
 
@@ -227,11 +221,8 @@ namespace OpenRCT2::Park
         return probability;
     }
 
-    static void generateGuests(GameState_t& gameState)
+    static void generateGuests(ParkData& park, GameState_t& gameState)
     {
-        // TODO: pass park by ref
-        auto& park = gameState.park;
-
         // Generate a new guest for some probability
         if (static_cast<int32_t>(ScenarioRand() & 0xFFFF) < park.guestGenerationProbability)
         {
@@ -350,12 +341,12 @@ namespace OpenRCT2::Park
         // Every ~13 seconds
         if (currentTicks % 512 == 0)
         {
-            park.rating = CalculateParkRating();
-            park.value = Park::CalculateParkValue();
-            park.companyValue = CalculateCompanyValue();
-            park.totalRideValueForMoney = calculateTotalRideValueForMoney();
-            park.suggestedGuestMaximum = calculateSuggestedMaxGuests();
-            park.guestGenerationProbability = calculateGuestGenerationProbability();
+            park.rating = CalculateParkRating(park, gameState);
+            park.value = CalculateParkValue(park, gameState);
+            park.companyValue = CalculateCompanyValue(park);
+            park.totalRideValueForMoney = calculateTotalRideValueForMoney(park, gameState);
+            park.suggestedGuestMaximum = calculateSuggestedMaxGuests(park, gameState);
+            park.guestGenerationProbability = calculateGuestGenerationProbability(park);
 
             windowMgr->InvalidateByClass(WindowClass::Finances);
             auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
@@ -365,14 +356,14 @@ namespace OpenRCT2::Park
         // Every ~102 seconds
         if (currentTicks % 4096 == 0)
         {
-            park.size = CalculateParkSize();
+            park.size = CalculateParkSize(park);
             windowMgr->InvalidateByClass(WindowClass::ParkInformation);
         }
 
-        generateGuests(gameState);
+        generateGuests(park, gameState);
     }
 
-    uint32_t CalculateParkSize()
+    uint32_t CalculateParkSize(ParkData& park)
     {
         uint32_t tiles = 0;
         TileElementIterator it;
@@ -389,7 +380,6 @@ namespace OpenRCT2::Park
         } while (TileElementIteratorNext(&it));
 
         // TODO: pass park by ref
-        auto& park = getGameState().park;
         if (tiles != park.size)
         {
             park.size = tiles;
@@ -400,17 +390,15 @@ namespace OpenRCT2::Park
         return tiles;
     }
 
-    int32_t CalculateParkRating()
+    int32_t CalculateParkRating(const ParkData& park, const GameState_t& gameState)
     {
-        auto& gameState = getGameState();
-
         if (gameState.cheats.forcedParkRating != kForcedParkRatingDisabled)
         {
             return gameState.cheats.forcedParkRating;
         }
 
         int32_t result = 1150;
-        if (gameState.park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING)
+        if (park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING)
         {
             result = 1050;
         }
@@ -418,7 +406,7 @@ namespace OpenRCT2::Park
         // Guests
         {
             // -150 to +3 based on a range of guests from 0 to 2000
-            result -= 150 - (std::min<int32_t>(2000, gameState.park.numGuestsInPark) / 13);
+            result -= 150 - (std::min<int32_t>(2000, park.numGuestsInPark) / 13);
 
             // Find the number of happy peeps and the number of peeps who can't find the park exit
             uint32_t happyGuestCount = 0;
@@ -440,9 +428,9 @@ namespace OpenRCT2::Park
 
             // Peep happiness -500 to +0
             result -= 500;
-            if (gameState.park.numGuestsInPark > 0)
+            if (park.numGuestsInPark > 0)
             {
-                result += 2 * std::min(250u, (happyGuestCount * 300) / gameState.park.numGuestsInPark);
+                result += 2 * std::min(250u, (happyGuestCount * 300) / park.numGuestsInPark);
             }
 
             // Up to 25 guests can be lost without affecting the park rating.
@@ -459,7 +447,7 @@ namespace OpenRCT2::Park
             int32_t totalRideUptime = 0;
             int32_t totalRideIntensity = 0;
             int32_t totalRideExcitement = 0;
-            for (auto& ride : GetRideManager())
+            for (auto& ride : RideManager(gameState))
             {
                 totalRideUptime += 100 - ride.downtime;
                 if (RideHasRatings(ride))
@@ -513,22 +501,19 @@ namespace OpenRCT2::Park
             result -= 600 - (4 * (150 - std::min<int32_t>(150, litterCount)));
         }
 
-        result -= gameState.park.ratingCasualtyPenalty;
+        result -= park.ratingCasualtyPenalty;
         result = std::clamp(result, 0, 999);
         return result;
     }
 
-    money64 CalculateParkValue()
+    money64 CalculateParkValue(const ParkData& park, const GameState_t& gameState)
     {
         // Sum ride values
         money64 result = 0;
-        for (const auto& ride : GetRideManager())
+        for (const auto& ride : RideManager(gameState))
         {
             result += calculateRideValue(ride);
         }
-
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
 
         // +7.00 per guest
         result += static_cast<money64>(park.numGuestsInPark) * 7.00_GBP;
@@ -536,11 +521,15 @@ namespace OpenRCT2::Park
         return result;
     }
 
-    money64 CalculateCompanyValue()
+    // TODO: refactor S4Importer so this hack is no longer needed
+    money64 CalculateParkValue()
     {
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
+        auto& gameState = getGameState();
+        return CalculateParkValue(gameState.park, gameState);
+    }
 
+    money64 CalculateCompanyValue(const ParkData& park)
+    {
         auto result = park.value - park.bankLoan;
 
         // Clamp addition to prevent overflow
@@ -648,12 +637,9 @@ namespace OpenRCT2::Park
         windowMgr->InvalidateByClass(WindowClass::Finances);
     }
 
-    uint32_t UpdateSize(GameState_t& gameState)
+    uint32_t UpdateSize(ParkData& park, GameState_t& gameState)
     {
-        // TODO: pass park by ref
-        auto& park = gameState.park;
-
-        auto tiles = CalculateParkSize();
+        auto tiles = CalculateParkSize(park, gameState);
         if (tiles != park.size)
         {
             park.size = tiles;
@@ -754,7 +740,9 @@ namespace OpenRCT2::Park
     {
         auto& gameState = getGameState();
         gameState.cheats.forcedParkRating = rating;
-        gameState.park.rating = CalculateParkRating();
+
+        auto& park = gameState.park;
+        park.rating = CalculateParkRating(park, gameState);
 
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         ContextBroadcastIntent(&intent);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -51,12 +51,6 @@ using namespace OpenRCT2::Scripting;
 
 namespace OpenRCT2::Park
 {
-    static money64 calculateRideValue(const Ride& ride);
-    static money64 calculateTotalRideValueForMoney();
-    static uint32_t calculateSuggestedMaxGuests();
-    static uint32_t calculateGuestGenerationProbability();
-
-    static void generateGuests(GameState_t& gameState);
     static Guest* generateGuestFromCampaign(int32_t campaign);
 
     /**

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -322,15 +322,12 @@ namespace OpenRCT2::Park
         gameState.scenarioOptions.details = String::toStd(LanguageGetString(STR_NO_DETAILS_YET));
     }
 
-    void Update(GameState_t& gameState, const Date& date)
+    void Update(ParkData& park, GameState_t& gameState)
     {
         PROFILED_FUNCTION();
 
-        // TODO: pass park by ref
-        auto& park = gameState.park;
-
         // Every new week
-        if (date.IsWeekStart())
+        if (gameState.date.IsWeekStart())
         {
             UpdateHistories(park);
         }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -533,7 +533,7 @@ namespace OpenRCT2::Park
         auto result = park.value - park.bankLoan;
 
         // Clamp addition to prevent overflow
-        result = AddClamp<money64>(result, FinanceGetCurrentCash());
+        result = AddClamp<money64>(result, park.cash);
 
         return result;
     }
@@ -611,7 +611,7 @@ namespace OpenRCT2::Park
         HistoryPushRecord<uint32_t, numGuestsHistorySize>(park.guestsInParkHistory, park.numGuestsInPark);
 
         constexpr auto cashHistorySize = std::extent_v<decltype(ParkData::cashHistory)>;
-        HistoryPushRecord<money64, cashHistorySize>(park.cashHistory, FinanceGetCurrentCash() - park.bankLoan);
+        HistoryPushRecord<money64, cashHistorySize>(park.cashHistory, park.cash - park.bankLoan);
 
         // Update weekly profit history
         auto currentWeeklyProfit = park.weeklyProfitAverageDividend;

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -40,7 +40,7 @@ namespace OpenRCT2::Park
     void SetForcedRating(int32_t rating);
     int32_t GetForcedRating();
 
-    uint32_t UpdateSize(ParkData& park, GameState_t& gameState);
+    uint32_t UpdateSize(ParkData& park);
 
     void UpdateFences(const CoordsXY& coords);
     void UpdateFencesAroundTile(const CoordsXY& coords);

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -16,7 +16,6 @@ struct Guest;
 
 namespace OpenRCT2
 {
-    struct Date;
     struct GameState_t;
 } // namespace OpenRCT2
 
@@ -25,7 +24,7 @@ namespace OpenRCT2::Park
     struct ParkData;
 
     void Initialise(GameState_t& gameState);
-    void Update(GameState_t& gameState, const Date& date);
+    void Update(ParkData& park, GameState_t& gameState);
 
     uint32_t CalculateParkSize(ParkData& park);
     int32_t CalculateParkRating(const ParkData& park, const GameState_t& gameState);

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -27,10 +27,11 @@ namespace OpenRCT2::Park
     void Initialise(GameState_t& gameState);
     void Update(GameState_t& gameState, const Date& date);
 
-    uint32_t CalculateParkSize();
-    int32_t CalculateParkRating();
+    uint32_t CalculateParkSize(ParkData& park);
+    int32_t CalculateParkRating(const ParkData& park, const GameState_t& gameState);
+    money64 CalculateParkValue(const ParkData& park, const GameState_t& gameState);
     money64 CalculateParkValue();
-    money64 CalculateCompanyValue();
+    money64 CalculateCompanyValue(const ParkData& park);
 
     Guest* GenerateGuest();
 
@@ -39,7 +40,7 @@ namespace OpenRCT2::Park
     void SetForcedRating(int32_t rating);
     int32_t GetForcedRating();
 
-    uint32_t UpdateSize(GameState_t& gameState);
+    uint32_t UpdateSize(ParkData& park, GameState_t& gameState);
 
     void UpdateFences(const CoordsXY& coords);
     void UpdateFencesAroundTile(const CoordsXY& coords);

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ParkImporter.h>
 #include <openrct2/core/String.hpp>
@@ -57,7 +58,8 @@ public:
 protected:
     static Ride* FindRideByName(const char* name)
     {
-        for (auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (auto& ride : RideManager(gameState))
         {
             auto thisName = ride.getName();
             if (String::startsWith(thisName, u8string{ name }, true))

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -107,7 +107,7 @@ TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)
     gameState.park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find ferris wheel
-    auto rideManager = GetRideManager();
+    auto rideManager = RideManager(gameState);
     auto it = std::find_if(
         rideManager.begin(), rideManager.end(), [](auto& ride) { return ride.type == RIDE_TYPE_FERRIS_WHEEL; });
     ASSERT_NE(it, rideManager.end());
@@ -167,7 +167,7 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
     gameState.park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
 
     // Find car ride
-    auto rideManager = GetRideManager();
+    auto rideManager = RideManager(gameState);
     auto it = std::find_if(rideManager.begin(), rideManager.end(), [](auto& ride) { return ride.type == RIDE_TYPE_CAR_RIDE; });
     ASSERT_NE(it, rideManager.end());
     Ride& carRide = *it;

--- a/test/tests/RideRatings.cpp
+++ b/test/tests/RideRatings.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
+#include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/audio/AudioContext.h>
 #include <openrct2/core/File.h>
@@ -30,7 +31,8 @@ class RideRatings : public testing::Test
 protected:
     void CalculateRatingsForAllRides()
     {
-        for (const auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (const auto& ride : RideManager(gameState))
         {
             OpenRCT2::RideRating::UpdateRide(ride);
         }
@@ -38,7 +40,8 @@ protected:
 
     void DumpRatings()
     {
-        for (const auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (const auto& ride : RideManager(gameState))
         {
             std::string line = FormatRatings(ride);
             printf("%s\n", line.c_str());
@@ -80,7 +83,8 @@ protected:
 
         // Check ride ratings
         int expI = 0;
-        for (const auto& ride : GetRideManager())
+        auto& gameState = getGameState();
+        for (const auto& ride : RideManager(gameState))
         {
             auto actual = FormatRatings(ride);
             auto expected = expectedRatings[expI];


### PR DESCRIPTION
This reworks the (implicit) use of `GameState_t` in several places, primarily centred around park-related functions. Notably, `RideManager` is reworked to now require passing an explicit `GameState_t` reference. Moreover, `ParkData` is passed as a reference to more functions, preparing them for multi-park maps.

While this currently increases verbosity, this will allow us to use the S4/S6/park importers without affecting the 'main' game state further down the line.