### PR TITLE
Fix log flume steep track pieces general support heights

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
 - Fix: [#25131] The Reverse Freefall Coaster On-ride photo section track has incorrectly coloured ties.
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
+- Fix: [#25147] The wooden support clearance heights for steep Log Flume track pieces are too low.
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/water/LogFlume.cpp
+++ b/src/openrct2/paint/track/water/LogFlume.cpp
@@ -902,7 +902,7 @@ static void LogFlumeTrack25Down60(
         PaintUtilPushTunnelRotated(session, direction, height + 24, kTunnelGroup, TunnelSubType::SlopeEnd);
     }
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+    PaintUtilSetGeneralSupportHeight(session, height + 72);
 }
 
 static void LogFlumeTrack60Down(
@@ -942,7 +942,7 @@ static void LogFlumeTrack60Down(
         PaintUtilPushTunnelRotated(session, direction, height + 56, kTunnelGroup, TunnelSubType::SlopeEnd);
     }
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+    PaintUtilSetGeneralSupportHeight(session, height + 104);
 }
 
 static void LogFlumeTrack60Down25(
@@ -982,7 +982,7 @@ static void LogFlumeTrack60Down25(
         }
     }
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
+    PaintUtilSetGeneralSupportHeight(session, height + 72);
 }
 
 TrackPaintFunction GetTrackPaintFunctionLogFlume(OpenRCT2::TrackElemType trackType)


### PR DESCRIPTION
This fixes the general support heights for log flume steep track pieces. They are too low and clip in to the track on the steep piece. This makes them the same as all the other track types.

<img width="343" height="333" alt="logflumesteepgeneralsupportheightsbug" src="https://github.com/user-attachments/assets/4a9cd549-7299-4deb-bbd0-700280f2060e" />
<img width="343" height="333" alt="logflumesteepgeneralsupportheightsfix" src="https://github.com/user-attachments/assets/35591dc4-f8ee-4ff4-966c-706ceac81275" />

Comparison with other track types:
<img width="343" height="333" alt="standardsteepgeneralsupportheights" src="https://github.com/user-attachments/assets/0a4d86be-202d-4319-a6b4-ee5c44dc64e5" />

Save:
[log flume steep general support heights.zip](https://github.com/user-attachments/files/22276499/log.flume.steep.general.support.heights.zip)
