### PR TITLE
Fix hybrid coaster diag flat support blocks and clearance height

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#25134] Vehicles visually glitch on diagonal steep slopes.
 - Fix: [#25146] The support clearance height of the diagonal brakes for the Junior, inverted Flying and inverted Lay-down Roller Coasters is too high.
 - Fix: [#25147] The wooden support clearance heights for steep Log Flume track pieces are too low.
+- Fix: [#25159] One of the tiles on the Hybrid Coaster diagonal flat track does not block metal or wooden supports correctly.
 - Fix: [#25160] The Go-Karts steep to flat track piece has incorrect wooden support clearance heights.
 
 0.4.26 (2025-09-06)

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -16,6 +16,7 @@
 #include "../../../world/tile_element/TrackElement.h"
 #include "../../Paint.h"
 #include "../../support/WoodenSupports.h"
+#include "../../support/WoodenSupports.hpp"
 #include "../../tile_element/Segment.h"
 #include "../../track/Segment.h"
 #include "../../track/Support.h"
@@ -1379,39 +1380,11 @@ namespace OpenRCT2::HybridRC
             session, 3, height, direction, trackSequence, images[trackElement.HasChain()], defaultDiagTileOffsets,
             defaultDiagBoundLengths, nullptr, 0, GetTrackColour(session));
 
-        switch (trackSequence)
-        {
-            case 0:
-                PaintUtilSetSegmentSupportHeight(
-                    session,
-                    PaintUtilRotateSegments(
-                        EnumsToFlags(
-                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
-                        direction),
-                    0xFFFF, 0);
-                break;
-            case 1:
-                WoodenASupportsPaintSetupRotated(
-                    session, supportType.wooden, WoodenSupportSubType::corner0, direction, height, session.SupportColours);
+        DrawSupportForSequenceA<TrackElemType::DiagFlat>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
 
-                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-
-                break;
-            case 2:
-                WoodenASupportsPaintSetupRotated(
-                    session, supportType.wooden, WoodenSupportSubType::corner2, direction, height, session.SupportColours);
-
-                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-
-                break;
-            case 3:
-                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-
-                break;
-        }
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
     }
 
     static void TrackDiagBrakes(


### PR DESCRIPTION
This fixes the hybrid coaster diagonal flat track blocked segments and general support height.
Generally there's another track piece there so you don't even see this, but it's inconsistent with other full tile wooden supported track types.

<img width="310" height="391" alt="hybriddiagonalsupportblocksheightsbug" src="https://github.com/user-attachments/assets/4139de63-12b1-48e8-a004-a62b1474e272" />
<img width="310" height="391" alt="hybriddiagonalsupportblocksheights" src="https://github.com/user-attachments/assets/1b542316-7923-4da0-951f-046f9bf04fb0" />

Save:
[hybrid diagonal support block heights.zip](https://github.com/user-attachments/files/22302386/hybrid.diagonal.support.block.heights.zip)