### PR TITLE
Fix go karts steep to flat general support heights

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#25134] Vehicles visually glitch on diagonal steep slopes.
 - Fix: [#25146] The support clearance height of the diagonal brakes for the Junior, inverted Flying and inverted Lay-down Roller Coasters is too high.
 - Fix: [#25147] The wooden support clearance heights for steep Log Flume track pieces are too low.
+- Fix: [#25160] The Go-Karts steep to flat track piece has incorrect wooden support clearance heights.
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/thrill/GoKarts.cpp
+++ b/src/openrct2/paint/track/thrill/GoKarts.cpp
@@ -1895,7 +1895,7 @@ static void TrackUp60ToFlatLongBase(
         PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
     }
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-    static constexpr std::array generalSupportHeights = { 80, 64, 48, 48 };
+    static constexpr std::array generalSupportHeights = { 80, 80, 56, 40 };
     PaintUtilSetGeneralSupportHeight(session, height + generalSupportHeights[trackSequence]);
 }
 


### PR DESCRIPTION
This fixes the go karts steep to flat general support heights. One tile is lower than the track clearance, the other is too high. Just a mistake I made when making them. This makes them the same as all other track types.

<img width="272" height="387" alt="gokartsteeptoflatgeneralsupportheightsbug" src="https://github.com/user-attachments/assets/ddf6898e-acc4-4eb6-8b94-95aad741754a" />
<img width="272" height="387" alt="gokartsteeptoflatgeneralsupportheightsfix" src="https://github.com/user-attachments/assets/44085913-f9a9-4bc3-8421-1c823ab4f047" />

Save:
[go kart steep to flat general support heights.zip](https://github.com/user-attachments/files/22302776/go.kart.steep.to.flat.general.support.heights.zip)
