### PR TITLE
Restore maximum ride price algo to vanilla

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ set(OPENMSX_SHA256  "994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89
 
 set(REPLAYS_VERSION "0.0.90")
 set(REPLAYS_URL     "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA256  "0725b25cbdef4d822a7b19e2193b19eb3f50a145df60d41ef3af0bcb37708d75")
+set(REPLAYS_SHA256  "f8474a927e155056e5729b6fa9f05af2a85ae7e1435f5fa89ba496242f9f255e")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,9 @@ set(OPENMSX_VERSION "1.6.1")
 set(OPENMSX_URL     "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA256  "994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1")
 
-set(REPLAYS_VERSION "0.0.89")
+set(REPLAYS_VERSION "0.0.90")
 set(REPLAYS_URL     "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA256  "04607bb1f67a0f31d841ed70b38d65b8f7a9e19749e414ff74b8a434bc90b42a")
+set(REPLAYS_SHA256  "0725b25cbdef4d822a7b19e2193b19eb3f50a145df60d41ef3af0bcb37708d75")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.27 (in development)
 ------------------------------------------------------------------------
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
+- Change: [#25161] Revert to the ‘fair ride price’ calculation of vanilla RCT2.
 - Fix: [#25131] The Reverse Freefall Coaster On-ride photo section track has incorrectly coloured ties.
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 - Fix: [#25134] Vehicles visually glitch on diagonal steep slopes.

--- a/openrct2.deps.targets
+++ b/openrct2.deps.targets
@@ -225,7 +225,7 @@
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha256>994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1</OpenMSXSha256>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.90/replays.zip</ReplaysUrl>
-    <ReplaysSha256>0725b25cbdef4d822a7b19e2193b19eb3f50a145df60d41ef3af0bcb37708d75</ReplaysSha256>
+    <ReplaysSha256>f8474a927e155056e5729b6fa9f05af2a85ae7e1435f5fa89ba496242f9f255e</ReplaysSha256>
   </PropertyGroup>
 
   <!-- Unified Dependency Target -->

--- a/openrct2.deps.targets
+++ b/openrct2.deps.targets
@@ -224,8 +224,8 @@
     <OpenSFXSha256>06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be</OpenSFXSha256>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha256>994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1</OpenMSXSha256>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.89/replays.zip</ReplaysUrl>
-    <ReplaysSha256>04607bb1f67a0f31d841ed70b38d65b8f7a9e19749e414ff74b8a434bc90b42a</ReplaysSha256>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.90/replays.zip</ReplaysUrl>
+    <ReplaysSha256>0725b25cbdef4d822a7b19e2193b19eb3f50a145df60d41ef3af0bcb37708d75</ReplaysSha256>
   </PropertyGroup>
 
   <!-- Unified Dependency Target -->

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 3;
+constexpr uint8_t kStreamVersion = 4;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -21,7 +21,7 @@ namespace OpenRCT2
     struct ObjectRepositoryItem;
 
     // Current version that is saved.
-    constexpr uint32_t kParkFileCurrentVersion = 57;
+    constexpr uint32_t kParkFileCurrentVersion = 58;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t kParkFileMinVersion = 57;
@@ -60,6 +60,7 @@ namespace OpenRCT2
     constexpr uint16_t kExtendedGoKartsVersion = 54;
     constexpr uint16_t kHigherInversionsHolesHelicesStatsVersion = 55;
     constexpr uint16_t kFixedObsoleteFootpathsVersion = 56;
+    constexpr uint16_t kRevertToVanillaFairRidePriceCalculation = 58;
 
     class ParkFileExporter
     {

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -1111,21 +1111,7 @@ static void RideRatingsCalculateValue(Ride& ride)
     {
         int32_t months, multiplier, divisor, summand;
     };
-    static const Row ageTableNew[] = {
-        { 5, 3, 2, 0 },       // 1.5x
-        { 13, 6, 5, 0 },      // 1.2x
-        { 40, 1, 1, 0 },      // 1x
-        { 64, 3, 4, 0 },      // 0.75x
-        { 88, 9, 16, 0 },     // 0.56x
-        { 104, 27, 64, 0 },   // 0.42x
-        { 120, 81, 256, 0 },  // 0.32x
-        { 128, 81, 512, 0 },  // 0.16x
-        { 200, 81, 1024, 0 }, // 0.08x
-        { 200, 9, 16, 0 },    // 0.56x "easter egg"
-    };
-
-#ifdef ORIGINAL_RATINGS
-    static const Row ageTableOld[] = {
+    static constexpr auto kAgeTable = std::to_array<Row>({
         { 5, 1, 1, 30 },      // +30
         { 13, 1, 1, 10 },     // +10
         { 40, 1, 1, 0 },      // 1x
@@ -1136,8 +1122,7 @@ static void RideRatingsCalculateValue(Ride& ride)
         { 128, 81, 512, 0 },  // 0.16x
         { 200, 81, 1024, 0 }, // 0.08x
         { 200, 9, 16, 0 },    // 0.56x "easter egg"
-    };
-#endif
+    });
 
     if (!RideHasRatings(ride))
     {
@@ -1156,15 +1141,7 @@ static void RideRatingsCalculateValue(Ride& ride)
         monthsOld = ride.getAge();
     }
 
-    const Row* ageTable = ageTableNew;
-    size_t tableSize = std::size(ageTableNew);
-
-#ifdef ORIGINAL_RATINGS
-    ageTable = ageTableOld;
-    tableSize = std::size(ageTableOld);
-#endif
-
-    Row lastRow = ageTable[tableSize - 1];
+    Row lastRow = kAgeTable[kAgeTable.size() - 1];
 
     // Ride is older than oldest age in the table?
     if (monthsOld >= lastRow.months)
@@ -1174,10 +1151,8 @@ static void RideRatingsCalculateValue(Ride& ride)
     else
     {
         // Find the first hit in the table that matches this ride's age
-        for (size_t it = 0; it < tableSize; it++)
+        for (const Row& curr : kAgeTable)
         {
-            Row curr = ageTable[it];
-
             if (monthsOld < curr.months)
             {
                 value = (value * curr.multiplier) / curr.divisor + curr.summand;


### PR DESCRIPTION
This reverses the functional changes made in #5294. While the new algorithm works out well for roller coaster and encourages better rides in general, it is hampered by the fact that the value of flat rides is abysmal and this means that you can never ask a decent price.

This should probably be fixed at the source instead of papered over by an absolute bonus, but fixing that is a lot more delicate and complicated than restoring vanilla’s behaviour. Something to revisit at a later date and with sufficient testing.

-------------------------

I took the opportunity to do some light spring cleaning and put my new toy (`std::to_array()`) to good use.

This fails the replay test, which is expected as it affects guest behaviour.

Marcel , could you test this PR and verify it restores vanilla behaviour?