### PR TITLE
Fix Junior RC flat to steep general support heights different to RCT1

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#25146] The support clearance height of the diagonal brakes for the Junior, inverted Flying and inverted Lay-down Roller Coasters is too high.
 - Fix: [#25147] The wooden support clearance heights for steep Log Flume track pieces are too low.
 - Fix: [#25160] The Go-Karts steep to flat track piece has incorrect wooden support clearance heights.
+- Fix: [#25163] Some of the Junior Roller Coaster flat to steep track wooden support clearance heights are different to RCT1.
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
@@ -4733,7 +4733,7 @@ static void JuniorRCPaintTrackDiagFlatTo60DegDown(
 
     int32_t blockedSegments = BlockedSegments::kDiagStraightFlat[trackSequence];
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments, direction), 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 48);
+    PaintUtilSetGeneralSupportHeight(session, height + 72);
 }
 
 template<JuniorRCSubType TSubType>
@@ -5617,7 +5617,7 @@ static void JuniorRCFlatTo60DegUpPaintSetup(
         PaintUtilRotateSegments(
             EnumsToFlags(PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::topRight), direction),
         0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 72);
+    PaintUtilSetGeneralSupportHeight(session, height + 64);
 }
 
 static void JuniorRC60DegDownToFlatPaintSetup(


### PR DESCRIPTION
This fixes some of the junior roller coaster flat to steep general support heights that are different to RCT1. The diagonal down piece is inconsistent with the up slope. These heights are also the same as all other track types.

RCT1 - current ORCT2 - this fix:
<img width="566" height="261" alt="juniorrollercoasterflattosteeprct1" src="https://github.com/user-attachments/assets/da025afe-3083-4f7f-8ddc-e90d45d75199" />
<img width="566" height="261" alt="juniorrollercoasterflattosteeporct2" src="https://github.com/user-attachments/assets/0e5a2faf-2465-4593-8813-be580bd1af24" />
<img width="566" height="261" alt="juniorrollercoasterflattosteepfix" src="https://github.com/user-attachments/assets/47a8a920-117b-439d-93fb-8224d19526b1" />

Save:
[junior roller coaster flat to steep general support heights.zip](https://github.com/user-attachments/files/22307978/junior.roller.coaster.flat.to.steep.general.support.heights.zip)