### PR TITLE
Refactor footpath placement functions

### DIFF
--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -103,6 +103,26 @@ static constexpr uint8_t connected_path_count[] = {
     4, // 0b1111
 };
 
+/** rct2: 0x0098D8B4 */
+static constexpr uint8_t kDefaultPathSlope[] = {
+    0,
+    SLOPE_IS_IRREGULAR_FLAG,
+    SLOPE_IS_IRREGULAR_FLAG,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 2,
+    SLOPE_IS_IRREGULAR_FLAG,
+    SLOPE_IS_IRREGULAR_FLAG,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 3,
+    RAISE_FOOTPATH_FLAG,
+    SLOPE_IS_IRREGULAR_FLAG,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 1,
+    SLOPE_IS_IRREGULAR_FLAG,
+    RAISE_FOOTPATH_FLAG,
+    FOOTPATH_PROPERTIES_FLAG_IS_SLOPED | 0,
+    RAISE_FOOTPATH_FLAG,
+    RAISE_FOOTPATH_FLAG,
+    SLOPE_IS_IRREGULAR_FLAG,
+};
+
 static bool entrance_has_direction(const EntranceElement& entranceElement, int32_t direction)
 {
     return entranceElement.GetDirections() & (1 << (direction & 3));
@@ -2059,4 +2079,26 @@ bool FootpathIsZAndDirectionValid(const PathElement& pathElement, int32_t curren
             return false;
     }
     return true;
+}
+
+FootpathPlacementResult FootpathGetOnTerrainPlacement(const TileCoordsXY& location)
+{
+    auto* surfaceElement = MapGetSurfaceElementAt(location);
+    if (surfaceElement == nullptr)
+        return {};
+
+    return FootpathGetOnTerrainPlacement(*surfaceElement);
+}
+
+FootpathPlacementResult FootpathGetOnTerrainPlacement(const SurfaceElement& surfaceElement)
+{
+    int32_t baseZ = surfaceElement.GetBaseZ();
+    uint8_t slope = kDefaultPathSlope[surfaceElement.GetSlope() & kTileSlopeRaisedCornersMask];
+    if (slope & RAISE_FOOTPATH_FLAG)
+    {
+        slope &= ~RAISE_FOOTPATH_FLAG;
+        baseZ += kPathHeightStep;
+    }
+
+    return { baseZ, slope };
 }

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -19,6 +19,7 @@ namespace OpenRCT2
     class FootpathRailingsObject;
 
     struct PathElement;
+    struct SurfaceElement;
     struct TileElement;
 } // namespace OpenRCT2
 
@@ -72,6 +73,17 @@ struct FootpathSelection
     OpenRCT2::ObjectEntryIndex GetSelectedSurface() const
     {
         return IsQueueSelected ? QueueSurface : NormalSurface;
+    }
+};
+
+struct FootpathPlacementResult
+{
+    int32_t baseZ{};
+    uint8_t slope{};
+
+    bool isValid()
+    {
+        return baseZ > 0;
     }
 };
 
@@ -157,3 +169,6 @@ const OpenRCT2::FootpathRailingsObject* GetPathRailingsEntry(OpenRCT2::ObjectEnt
 void FootpathQueueChainReset();
 void FootpathQueueChainPush(RideId rideIndex);
 bool FootpathIsZAndDirectionValid(const OpenRCT2::PathElement& tileElement, int32_t currentZ, int32_t currentDirection);
+
+FootpathPlacementResult FootpathGetOnTerrainPlacement(const TileCoordsXY& location);
+FootpathPlacementResult FootpathGetOnTerrainPlacement(const OpenRCT2::SurfaceElement& surfaceElement);


### PR DESCRIPTION
Currently, the slope and height are calculated independently, necessitating additional boilerplate if the slope requires raising the footpath by one step. This refactors that away into a function that just returns the correct height and slope.

The additional functions in `Footpath.h` will also be used by the upcoming footpath cluster PR.