### PR TITLE
Fix LIM launched inline twists general support heights

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#25160] The Go-Karts steep to flat track piece has incorrect wooden support clearance heights.
 - Fix: [#25163] Some of the Junior Roller Coaster flat to steep track wooden support clearance heights are different to RCT1.
 - Fix: [#25173] Desync when placing a park entrance in multiplayer.
+- Fix: [#25179] The LIM Launched Roller Coaster inline twists have incorrect wooden support clearance heights (original bug).
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
@@ -684,7 +684,7 @@ static void LimLaunchedRCTrackLeftTwistDownToUp(
                         PaintSegment::topRight, PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
+            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
         case 2:
             switch (direction)
@@ -739,7 +739,7 @@ static void LimLaunchedRCTrackLeftTwistDownToUp(
                         PaintSegment::topRight, PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height);
+            PaintUtilSetGeneralSupportHeight(session, height + 16);
             break;
     }
 }
@@ -846,7 +846,7 @@ static void LimLaunchedRCTrackRightTwistDownToUp(
                         PaintSegment::bottomLeft, PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
+            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
         case 2:
             switch (direction)
@@ -901,7 +901,7 @@ static void LimLaunchedRCTrackRightTwistDownToUp(
                         PaintSegment::bottomLeft, PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height);
+            PaintUtilSetGeneralSupportHeight(session, height + 16);
             break;
     }
 }
@@ -961,7 +961,7 @@ static void LimLaunchedRCTrackLeftTwistUpToDown(
                         PaintSegment::bottomLeft, PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height);
+            PaintUtilSetGeneralSupportHeight(session, height + 16);
             break;
         case 1:
             switch (direction)
@@ -1007,7 +1007,7 @@ static void LimLaunchedRCTrackLeftTwistUpToDown(
                         PaintSegment::bottomLeft, PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
+            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
         case 2:
             switch (direction)
@@ -1123,7 +1123,7 @@ static void LimLaunchedRCTrackRightTwistUpToDown(
                         PaintSegment::topRight, PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
+            PaintUtilSetGeneralSupportHeight(session, height + 16);
             break;
         case 1:
             switch (direction)
@@ -1169,7 +1169,7 @@ static void LimLaunchedRCTrackRightTwistUpToDown(
                         PaintSegment::topRight, PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
+            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
         case 2:
             switch (direction)


### PR DESCRIPTION
This fixes the LIM launched inline twist general support heights. This is an original bug from RCT2. Is there anything else wrong with these poor cursed track pieces?

These heights are not the same as the corkscrew and twister inline twists, because it seems wrong to only partially fix this. As they were added in OpenRCT2, maybe they should be changed too?

<img width="439" height="396" alt="liminlinetwists" src="https://github.com/user-attachments/assets/9ac0dd5e-8885-4fbe-a44a-c5280e3f9a0e" />
<img width="439" height="396" alt="liminlinetwistsfix" src="https://github.com/user-attachments/assets/0c1968b4-e437-4fe3-9e93-6e2e015bcbcd" />

Save:
[liminlinetwistsgeneralsupportheight.zip](https://github.com/user-attachments/files/22323950/liminlinetwistsgeneralsupportheight.zip)
