### PR TITLE
Add IsEntertainer method to Staff class, small cleanup

### DIFF
--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -273,7 +273,7 @@ namespace OpenRCT2::Ui::Windows
 
                     auto clipCoords = ScreenCoordsXY{ 10, 19 };
                     auto* staff = peep->As<Staff>();
-                    if (staff != nullptr && staff->AssignedStaffType == StaffType::Entertainer)
+                    if (staff != nullptr && staff->IsEntertainer())
                     {
                         clipCoords.y += 3;
                     }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -273,7 +273,7 @@ namespace OpenRCT2::Ui::Windows
 
                     auto clipCoords = ScreenCoordsXY{ 10, 19 };
                     auto* staff = peep->As<Staff>();
-                    if (staff != nullptr && staff->IsEntertainer())
+                    if (staff != nullptr && staff->isEntertainer())
                     {
                         clipCoords.y += 3;
                     }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -518,7 +518,7 @@ namespace OpenRCT2::Ui::Windows
                             if (auto* staff = peep->As<Staff>(); staff != nullptr)
                             {
                                 spriteType = staff->AnimationGroup;
-                                if (staff->AssignedStaffType == StaffType::Entertainer)
+                                if (staff->IsEntertainer())
                                 {
                                     clipCoords.y += 3;
                                 }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -518,7 +518,7 @@ namespace OpenRCT2::Ui::Windows
                             if (auto* staff = peep->As<Staff>(); staff != nullptr)
                             {
                                 spriteType = staff->AnimationGroup;
-                                if (staff->IsEntertainer())
+                                if (staff->isEntertainer())
                                 {
                                     clipCoords.y += 3;
                                 }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -142,7 +142,7 @@ namespace OpenRCT2::Ui::Windows
             if (staff == nullptr)
                 return;
 
-            if (staff->AssignedStaffType == StaffType::Entertainer)
+            if (staff->IsEntertainer())
                 _availableCostumes = getAvailableCostumeStrings(AnimationPeepType::Entertainer);
 
             ViewportInit();
@@ -164,7 +164,7 @@ namespace OpenRCT2::Ui::Windows
             if (staff == nullptr)
                 return;
 
-            if (staff->AssignedStaffType == StaffType::Entertainer)
+            if (staff->IsEntertainer())
                 _availableCostumes = getAvailableCostumeStrings(AnimationPeepType::Entertainer);
         }
 
@@ -601,7 +601,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            if (staff->Is<Staff>() && staff->AssignedStaffType == StaffType::Entertainer)
+            if (staff->Is<Staff>() && staff->IsEntertainer())
                 screenCoords.y++;
 
             auto& objManager = GetContext()->GetObjectManager();

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -142,7 +142,7 @@ namespace OpenRCT2::Ui::Windows
             if (staff == nullptr)
                 return;
 
-            if (staff->IsEntertainer())
+            if (staff->isEntertainer())
                 _availableCostumes = getAvailableCostumeStrings(AnimationPeepType::Entertainer);
 
             ViewportInit();
@@ -164,7 +164,7 @@ namespace OpenRCT2::Ui::Windows
             if (staff == nullptr)
                 return;
 
-            if (staff->IsEntertainer())
+            if (staff->isEntertainer())
                 _availableCostumes = getAvailableCostumeStrings(AnimationPeepType::Entertainer);
         }
 
@@ -601,7 +601,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            if (staff->Is<Staff>() && staff->IsEntertainer())
+            if (staff->Is<Staff>() && staff->isEntertainer())
                 screenCoords.y++;
 
             auto& objManager = GetContext()->GetObjectManager();

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -601,7 +601,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            if (staff->Is<Staff>() && staff->isEntertainer())
+            if (staff->isEntertainer())
                 screenCoords.y++;
 
             auto& objManager = GetContext()->GetObjectManager();

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -422,7 +422,7 @@ namespace OpenRCT2::Ui::Windows
                     }
 
                     auto staffOrderIcon_x = nameColumnSize + 20;
-                    if (!peep->IsEntertainer())
+                    if (!peep->isEntertainer())
                     {
                         auto staffOrders = peep->StaffOrders;
                         auto staffOrderSprite = GetStaffOrderBaseSprite(GetSelectedStaffType());

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -422,7 +422,7 @@ namespace OpenRCT2::Ui::Windows
                     }
 
                     auto staffOrderIcon_x = nameColumnSize + 20;
-                    if (peep->AssignedStaffType != StaffType::Entertainer)
+                    if (!peep->IsEntertainer())
                     {
                         auto staffOrders = peep->StaffOrders;
                         auto staffOrderSprite = GetStaffOrderBaseSprite(GetSelectedStaffType());

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1728,6 +1728,11 @@ bool Staff::IsMechanic() const
     return AssignedStaffType == StaffType::Mechanic;
 }
 
+bool Staff::IsEntertainer() const
+{
+    return AssignedStaffType == StaffType::Entertainer;
+}
+
 void Staff::Update()
 {
     if (PeepFlags & PEEP_FLAGS_POSITION_FROZEN)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1728,7 +1728,7 @@ bool Staff::IsMechanic() const
     return AssignedStaffType == StaffType::Mechanic;
 }
 
-bool Staff::IsEntertainer() const
+bool Staff::isEntertainer() const
 {
     return AssignedStaffType == StaffType::Entertainer;
 }

--- a/src/openrct2/entity/Staff.h
+++ b/src/openrct2/entity/Staff.h
@@ -69,7 +69,7 @@ public:
     void Update();
     void Tick128UpdateStaff();
     bool IsMechanic() const;
-    bool IsEntertainer() const;
+    bool isEntertainer() const;
     bool IsPatrolAreaSet(const CoordsXY& coords) const;
     bool IsLocationInPatrol(const CoordsXY& loc) const;
     bool IsLocationOnPatrolEdge(const CoordsXY& loc) const;

--- a/src/openrct2/entity/Staff.h
+++ b/src/openrct2/entity/Staff.h
@@ -69,6 +69,7 @@ public:
     void Update();
     void Tick128UpdateStaff();
     bool IsMechanic() const;
+    bool IsEntertainer() const;
     bool IsPatrolAreaSet(const CoordsXY& coords) const;
     bool IsLocationInPatrol(const CoordsXY& loc) const;
     bool IsLocationOnPatrolEdge(const CoordsXY& loc) const;
@@ -85,7 +86,6 @@ public:
     void SetPatrolArea(const CoordsXY& coords, bool value);
     void SetPatrolArea(const MapRange& range, bool value);
     bool HasPatrolArea() const;
-    void SetPatrolArea(const std::vector<TileCoordsXY>& area);
 
 private:
     void UpdatePatrolling();
@@ -167,6 +167,5 @@ colour_t StaffGetColour(StaffType staffType);
 OpenRCT2::GameActions::Result StaffSetColour(StaffType staffType, colour_t value);
 
 money64 GetStaffWage(StaffType type);
-PeepAnimationGroup EntertainerCostumeToSprite(EntertainerCostume entertainerType);
 
 const PatrolArea& GetMergedPatrolArea(const StaffType type);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -525,7 +525,7 @@ static void ConsoleCommandStaff(InteractiveConsole& console, const arguments_t& 
                     console.WriteLineError("Invalid staff ID");
                     return;
                 }
-                if (staff->AssignedStaffType != StaffType::Entertainer)
+                if (!staff->IsEntertainer())
                 {
                     console.WriteLineError("Specified staff is not entertainer");
                     return;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -525,7 +525,7 @@ static void ConsoleCommandStaff(InteractiveConsole& console, const arguments_t& 
                     console.WriteLineError("Invalid staff ID");
                     return;
                 }
-                if (!staff->IsEntertainer())
+                if (!staff->isEntertainer())
                 {
                     console.WriteLineError("Specified staff is not entertainer");
                     return;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::Scripting
                 peep->AnimationObjectIndex = findPeepAnimationsIndexForType(AnimationPeepType::Handyman);
                 peep->AnimationGroup = PeepAnimationGroup::Normal;
             }
-            else if (value == "mechanic" && peep->AssignedStaffType != StaffType::Mechanic)
+            else if (value == "mechanic" && !peep->IsMechanic())
             {
                 peep->AssignedStaffType = StaffType::Mechanic;
                 peep->AnimationObjectIndex = findPeepAnimationsIndexForType(AnimationPeepType::Mechanic);
@@ -93,7 +93,7 @@ namespace OpenRCT2::Scripting
                 peep->AnimationObjectIndex = findPeepAnimationsIndexForType(AnimationPeepType::Security);
                 peep->AnimationGroup = PeepAnimationGroup::Normal;
             }
-            else if (value == "entertainer" && peep->AssignedStaffType != StaffType::Entertainer)
+            else if (value == "entertainer" && !peep->IsEntertainer())
             {
                 peep->AssignedStaffType = StaffType::Entertainer;
                 peep->AnimationObjectIndex = findPeepAnimationsIndexForType(AnimationPeepType::Entertainer);
@@ -510,7 +510,7 @@ namespace OpenRCT2::Scripting
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
         auto peep = GetMechanic();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
+        if (peep != nullptr && peep->IsMechanic())
         {
             duk_push_uint(ctx, peep->StaffRidesFixed);
         }
@@ -526,7 +526,7 @@ namespace OpenRCT2::Scripting
         auto& scriptEngine = GetContext()->GetScriptEngine();
         auto* ctx = scriptEngine.GetContext();
         auto peep = GetMechanic();
-        if (peep != nullptr && peep->AssignedStaffType == StaffType::Mechanic)
+        if (peep != nullptr && peep->IsMechanic())
         {
             duk_push_uint(ctx, peep->StaffRidesInspected);
         }

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -93,7 +93,7 @@ namespace OpenRCT2::Scripting
                 peep->AnimationObjectIndex = findPeepAnimationsIndexForType(AnimationPeepType::Security);
                 peep->AnimationGroup = PeepAnimationGroup::Normal;
             }
-            else if (value == "entertainer" && !peep->IsEntertainer())
+            else if (value == "entertainer" && !peep->isEntertainer())
             {
                 peep->AssignedStaffType = StaffType::Entertainer;
                 peep->AnimationObjectIndex = findPeepAnimationsIndexForType(AnimationPeepType::Entertainer);


### PR DESCRIPTION
I noticed there were checks for StaffType::Entertainer in quite a few places, so I added this function. I also replaced checks for StaffType::Mechanic where appropriate, and removed two function declarations in Staff.h that were unused (Visual Studio was giving warnings about this).