### PR TITLE
Scenery window: increase minimum height

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
 - Change: [#25161] Revert to the ‘fair ride price’ calculation of vanilla RCT2.
 - Fix: [#24513] Ride/track designs can now be shifted underground as well.
+- Fix: [#24682] The scenery window isn't enough to accommodate all tool buttons when there are multiple rows of groups/tabs.
 - Fix: [#25131] The Reverse Freefall Coaster On-ride photo section track has incorrectly coloured ties.
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 - Fix: [#25134] Vehicles visually glitch on diagonal steep slopes.

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -74,7 +74,7 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t kSceneryButtonHeight = 80;
     constexpr int32_t kDescriptionHeight = 24;
     constexpr int32_t kInputMargin = 2;
-    constexpr int32_t kMaxWindowHeight = 473;
+    constexpr int32_t kMaxWindowHeight = 600;
     constexpr int32_t kTabMargin = 3;
     constexpr int32_t kTabWidth = 31;
     constexpr int32_t kTabHeight = 28;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1105,10 +1105,18 @@ namespace OpenRCT2::Ui::Windows
     private:
         int32_t GetMinimumHeight() const
         {
-            // Minimum window height: title, one scenery button, status bar, padding
-            int32_t newMinHeight = getTitleBarTargetHeight() + kSceneryButtonHeight + kDescriptionHeight + 2 * kTabMargin;
-            newMinHeight += static_cast<int32_t>(1 + (_tabEntries.size() / GetMaxTabCountInARow())) * kTabHeight;
+            // Minimum window height: title, status bar, padding
+            int32_t newMinHeight = getTitleBarTargetHeight() + kDescriptionHeight + 2 * kTabMargin;
+
+            // Room for the search/filter widget
             newMinHeight += widgets[WIDX_FILTER_TEXT_BOX].height() + 2 * kInputMargin;
+
+            // Fit *all* rows of tabs
+            newMinHeight += static_cast<int32_t>(1 + (_tabEntries.size() / GetMaxTabCountInARow())) * kTabHeight;
+
+            // And at least 1.5 rows of scenery items
+            newMinHeight += 1.5 * kSceneryButtonHeight;
+
             return newMinHeight;
         }
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -74,7 +74,7 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t kSceneryButtonHeight = 80;
     constexpr int32_t kDescriptionHeight = 24;
     constexpr int32_t kInputMargin = 2;
-    constexpr int32_t kMaxWindowHeight = 600;
+    constexpr int32_t kMaxWindowHeight = 473;
     constexpr int32_t kTabMargin = 3;
     constexpr int32_t kTabWidth = 31;
     constexpr int32_t kTabHeight = 28;


### PR DESCRIPTION
This increases the minimum height of the Scenery window to fit at least 1.5 rows of scenery items, instead of 1 row. This is done to ensure the eyedropper and scatter tools are visible with multiple rows of tabs as well.

Before:
<img width="634" height="224" alt="Imagination Megapark 2025-09-15 22-38-56" src="https://github.com/user-attachments/assets/dcce9fad-a8e1-4001-9552-dd1ff97c082c" />

After:
<img width="634" height="264" alt="Imagination Megapark 2025-09-15 22-38-46" src="https://github.com/user-attachments/assets/8e545aa7-8aef-4642-b78e-858bed2db1e8" />