### PR TITLE
Don't set rightMousePressed flag in InputViewportDragBegin

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -559,7 +559,6 @@ namespace OpenRCT2
         {
             WindowUnfollowSprite(w);
         }
-        gInputFlags.set(InputFlag::rightMousePressed);
     }
 
     static void InputViewportDragContinue()


### PR DESCRIPTION
Accidentally uncommented, causes right click to get stuck down when right click dragging a viewport.