### PR TITLE
Bugfix #25190 - Inserting a block brake while a coaster is simulating will cause the simulation to behave strangely

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#25163] Some of the Junior Roller Coaster flat to steep track wooden support clearance heights are different to RCT1.
 - Fix: [#25173] Desync when placing a park entrance in multiplayer.
 - Fix: [#25179] The LIM Launched Roller Coaster inline twists have incorrect wooden support clearance heights (original bug).
+- Fix: [#25190] Inserting a block brake while a coaster is simulating will cause the simulation to behave strangely.
 
 0.4.26 (2025-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 5;
+constexpr uint8_t kStreamVersion = 6;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1133,18 +1133,9 @@ void Ride::update()
     // If ride is simulating but crashed, reset the vehicles
     if (status == RideStatus::simulating && (lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        if (mode == RideMode::continuousCircuitBlockSectioned || mode == RideMode::poweredLaunchBlockSectioned)
-        {
-            // We require this to execute right away during the simulation, always ignore network and queue.
-            auto gameAction = GameActions::RideSetStatusAction(id, RideStatus::closed);
-            GameActions::ExecuteNested(&gameAction, getGameState());
-        }
-        else
-        {
-            // We require this to execute right away during the simulation, always ignore network and queue.
-            auto gameAction = GameActions::RideSetStatusAction(id, RideStatus::simulating);
-            GameActions::ExecuteNested(&gameAction, getGameState());
-        }
+        // We require this to execute right away during the simulation, always ignore network and queue.
+        auto gameAction = GameActions::RideSetStatusAction(id, RideStatus::simulating);
+        GameActions::ExecuteNested(&gameAction, getGameState());
     }
 }
 


### PR DESCRIPTION
Fix a couple bugged states involving simulating in block-sectioned modes, which were missed in the original PR.

- Adding a block brake piece while the ride is simulating will no longer cause visual bugs with the simulate flag.
- Adding a block brake piece while the ride is simulating will no longer reset the ghost train, provided the ride is already in a block-sectioned operating mode (The first block section placed will still end the simulation, since the operating mode is being changed)
- When the ghost train reaches the end of the track, it will now reset properly.