### PR TITLE
Update process execution flow for Linux

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#24975] The Corkscrew and LIM Launched (original bug) roller coaster quarter loop tunnels are too high.
 - Fix: [#25139] Steam locomotive and tram claxons can sound louder than normal when approaching crossings that span multiple tiles.
 - Fix: [#25190] Inserting a block brake while a coaster is simulating will cause the simulation to behave strangely.
+- Fix: [#25206] System file picker does not show up on the Steam Deck.
 - Fix: [#25272] Text colour dropdown in the Banner window is too narrow, resulting in truncated labels.
 - Fix: [#25299] The Mine Train Coaster left large helix draws incorrect sprites at certain angles (original bug).
 - Fix: [#25328] Spiral Slide in Blackpool Pleasure Beach has its entrance and exit the wrong way round (bug in the original scenario).

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -807,10 +807,9 @@ namespace OpenRCT2::Config
             LOG_ERROR("Please install innoextract to extract files from GOG.");
             return false;
         }
-        int32_t exit_status = Platform::Execute(
-            String::stdFormat(
-                "%s '%s' --exclude-temp --output-dir '%s'", path.c_str(), installerPath.c_str(), targetPath.c_str()),
-            &output);
+        const char* args[] = { path.c_str(),   installerPath.c_str(), "--exclude-temp", "--silent",
+                               "--output-dir", targetPath.c_str(),    nullptr };
+        int32_t exit_status = Platform::Execute(args, &output);
         LOG_INFO("Exit status %d", exit_status);
         return exit_status == 0;
     }

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -494,7 +494,7 @@ namespace OpenRCT2::Platform
         return false;
     }
 
-    int32_t Execute(std::string_view command, std::string* output)
+    int32_t Execute(const char* args[], std::string* output)
     {
         LOG_WARNING("Execute() not implemented for Windows!");
         return -1;

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -92,7 +92,7 @@ namespace OpenRCT2::Platform
     RealWorldDate GetDateLocal();
 
     bool FindApp(std::string_view app, std::string* output);
-    int32_t Execute(std::string_view command, std::string* output = nullptr);
+    int32_t Execute(const char* args[], std::string* output = nullptr);
     bool ProcessIsElevated();
     float GetDefaultScale();
 


### PR DESCRIPTION
Previously zenity/kdialog were launched in a way that would prevent events from getting pumped to the new application in some scenarios.

This new approach, mimicked from
https://github.com/libsdl-org/SDL/blob/9859c051781771015356e31f941bab40a763bea9/src/video/wayland/SDL_waylandmessagebox.c#L40-L75 fixes this problem for compositors where it used to be a problem.

In particular, this fixes the system dialog not launching on the Steam Deck.