### PR TITLE
Don't print the trailing comma in sprite exportalldat JSON output

### DIFF
--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -446,15 +446,8 @@ namespace OpenRCT2
                 }
 
                 path = fs::u8path(path).generic_u8string();
-                if (spriteIndex + 1 != maxIndex)
-                {
-                    fprintf(stdout, "{ \"path\": \"%s\", \"x\": %d, \"y\": %d },\n", path.c_str(), g1.x_offset, g1.y_offset);
-                }
-                else
-                {
-                    // Do not print the trailing comma
-                    fprintf(stdout, "{ \"path\": \"%s\", \"x\": %d, \"y\": %d }\n", path.c_str(), g1.x_offset, g1.y_offset);
-                }
+                fprintf(stdout, "{ \"path\": \"%s\", \"x\": %d, \"y\": %d }", path.c_str(), g1.x_offset, g1.y_offset);
+                fprintf(stdout, (spriteIndex + 1 != maxIndex) ? ",\n" : "\n");
             }
             return 1;
         }

--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -446,7 +446,15 @@ namespace OpenRCT2
                 }
 
                 path = fs::u8path(path).generic_u8string();
-                fprintf(stdout, "{ \"path\": \"%s\", \"x\": %d, \"y\": %d },\n", path.c_str(), g1.x_offset, g1.y_offset);
+                if (spriteIndex + 1 != maxIndex)
+                {
+                    fprintf(stdout, "{ \"path\": \"%s\", \"x\": %d, \"y\": %d },\n", path.c_str(), g1.x_offset, g1.y_offset);
+                }
+                else
+                {
+                    // Do not print the trailing comma
+                    fprintf(stdout, "{ \"path\": \"%s\", \"x\": %d, \"y\": %d }\n", path.c_str(), g1.x_offset, g1.y_offset);
+                }
             }
             return 1;
         }


### PR DESCRIPTION
The JSON generated by `sprite exportalldat` is actually invalid because it contains a trailing comma, which might confuse someone who is trying to make their first parkobj. This makes sure the trailing comma isn't printed.