### PR TITLE
 Don't show "custom-designed layout" string in the shops tab of NewRide window

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -949,11 +949,14 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            auto count = GetNumTrackDesigns(item);
-            auto designCountStringId = GetDesignsAvailableStringId(count);
-            ft = Formatter();
-            ft.Add<int32_t>(count);
-            DrawTextBasic(rt, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
+            if (_currentTab != SHOP_TAB)
+            {
+                auto count = GetNumTrackDesigns(item);
+                auto designCountStringId = GetDesignsAvailableStringId(count);
+                ft = Formatter();
+                ft.Add<int32_t>(count);
+                DrawTextBasic(rt, screenPos + ScreenCoordsXY{ 0, 51 }, designCountStringId, ft);
+            }
 
             // Price
             if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))


### PR DESCRIPTION
This string is used to indicate to the player if they have a design saved for a particular attraction, but since it's impossible to save designs for shops and stalls this string isn't necessary in this tab (in fact the wording might even cause confusion, frankly). Not sure if this needs a changelog entry since it's so small.