### PR TITLE
Add missing getCostumeStrings to openrct2.d.ts

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3710,6 +3710,11 @@ declare global {
         readonly availableCostumes: StaffCostume[];
 
         /**
+         * Returns an array of costume strings with inline sprites.
+         */
+        getCostumeStrings(): string[];
+
+        /**
          * The staff member's costume.
          */
         costume: StaffCostume | string | number;


### PR DESCRIPTION
This API was introduced way back in #23328, but somehow didn't find its way to the TypeScript definitions file.