### PR TITLE
Order available costumes array by display name

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
 - Change: [#25161] Revert to the ‘fair ride price’ calculation of vanilla RCT2.
+- Change: [#25228] [Plugin] The available staff costumes array is now ordered alphabetically by name.
 - Fix: [#24513] Ride/track designs can now be shifted underground as well.
 - Fix: [#24682] The scenery window isn't enough to accommodate all tool buttons when there are multiple rows of groups/tabs.
 - Fix: [#24882] Guests are shown with hats and umbrellas whilst clapping.

--- a/src/openrct2/peep/PeepAnimations.cpp
+++ b/src/openrct2/peep/PeepAnimations.cpp
@@ -233,10 +233,13 @@ namespace OpenRCT2
                         .objectId = ObjectEntryIndex(i),
                         .group = group,
                         .legacyPosition = animObj->GetLegacyPosition(group),
+                        .rawName = animObj->GetCostumeName(),
                         .scriptName = scriptName,
                     });
             }
         }
+
+        std::sort(groups.begin(), groups.end(), [](const auto& a, const auto& b) { return a.rawName < b.rawName; });
 
         return groups;
     }

--- a/src/openrct2/peep/PeepAnimations.h
+++ b/src/openrct2/peep/PeepAnimations.h
@@ -85,6 +85,7 @@ namespace OpenRCT2
         ObjectEntryIndex objectId;
         PeepAnimationGroup group;
         RCT12PeepAnimationGroup legacyPosition;
+        std::string rawName;
         std::string_view scriptName;
     };
 


### PR DESCRIPTION
Plugins can change the costume for staff entities using the `costume` property. The costumes available to a particular staff member are listed in the `availableCostumes` property, while the `getCostumeStrings()` function yields user-friendly names. Currently, the two are not in sync: `availableCostumes` uses the internal object order, while `getCostumeStrings()` is ordered alphabetically.

This PR changes the order such that both `availableCostumes` and `getCostumeStrings()` use the same alphabetical order. This means plugins can reliably use the array index to consistently index on both arrays.