### PR TITLE
Fix #24998: Some custom small scenery objects do not load

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#24513] Ride/track designs can now be shifted underground as well.
 - Fix: [#24682] The scenery window isn't enough to accommodate all tool buttons when there are multiple rows of groups/tabs.
 - Fix: [#24882] Guests are shown with hats and umbrellas whilst clapping.
+- Fix: [#24998] Some custom small scenery objects do not load.
 - Fix: [#25131] The Reverse Freefall Coaster On-ride photo section track has incorrectly coloured ties.
 - Fix: [#25132] Crash when trying to use simulate on incomplete ride.
 - Fix: [#25134] Vehicles visually glitch on diagonal steep slopes.

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -35,6 +35,7 @@ namespace OpenRCT2
         _legacyType.animation_mask = stream->ReadValue<uint16_t>();
         _legacyType.num_frames = stream->ReadValue<uint16_t>();
         _legacyType.scenery_tab_id = kObjectEntryIndexNull;
+        stream->Seek(2, STREAM_SEEK_CURRENT);
 
         GetStringTable().Read(context, stream, ObjectStringID::NAME);
 


### PR DESCRIPTION
The string table of a small scenery object starts at offset 0x1C, as can be seen [on the TID](https://tid.rctspace.com/objdata.html) and in [Trigger’s library](https://github.com/trigger-segfault/RCT2Tools/blob/master/ObjectData/DataObjects/Types/SmallScenery.cs#L338-L339).

However, OpenRCT2 starts reading at offset 0x1A, which means it reads two bytes as if they’re part of the string table. Byte 0x1A reserves space for the scenery tab ID, byte 0x1B appears unused. In 99.9% of objects, these bytes happen to be zero. That also just happens to be a valid string table entry (representing a zero-length string for UK English, and overwritten by the real entry immediately after), which is why we haven’t noticed until now. Checking Git, this error appears to have been there since [the beginning](https://github.com/OpenRCT2/OpenRCT2/commit/daa5a0c506bc654a56e68b6628f877b1df6dfe82).

The objects from issue #24998 now load:

<img width="640" height="441" alt="Schermafdruk van 2025-09-22 18-52-19" src="https://github.com/user-attachments/assets/63dccbba-1765-41dd-8103-f43c013f4786" />
