### PR TITLE
Make frozen guests no longer finish food or drinks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#25218] `sprite exportobject` command, which allows extracting images from an object.
 - Improved: [#2296, #2307] The land tool now takes sloped track and paths into account when modifying land.
+- Change: [#25111] Frozen guests no longer finish consuming any food or drink they are carrying.
 - Change: [#25161] Revert to the ‘fair ride price’ calculation of vanilla RCT2.
 - Change: [#25228] [Plugin] The available staff costumes array is now ordered alphabetically by name.
 - Removed: [#25225] `sprite exportalldat`, replaced with `sprite exportobject`.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -924,7 +924,8 @@ void Guest::UpdateConsumptionMotives()
 void Guest::Tick128UpdateGuest(uint32_t index)
 {
     const auto currentTicks = getGameState().currentTicks;
-    if ((index & 0x1FF) != (currentTicks & 0x1FF))
+    const bool ticksMatchIndex = (index & 0x1FF) != (currentTicks & 0x1FF);
+    if (ticksMatchIndex && !(PeepFlags & PEEP_FLAGS_POSITION_FROZEN))
     {
         UpdateConsumptionMotives();
         return;


### PR DESCRIPTION
Since #22210, we've allowed guests and staff to be explicitly frozen by plugins using two flags: one for their animation, and one for their position. This has worked well for sandbox purposes, except for one snag: any consumables being held by guests would still be (fully) consumed, resetting their animation. This PR addresses this by ignoring the update function when animations are frozen.

Closes #25111.