### PR TITLE
Fix #25201: Maintain ride list sort order, apply natural sorting

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#25163] Some of the Junior Roller Coaster flat to steep track wooden support clearance heights are different to RCT1.
 - Fix: [#25173] Desync when placing a park entrance in multiplayer.
 - Fix: [#25179] The LIM Launched Roller Coaster inline twists have incorrect wooden support clearance heights (original bug).
+- Fix: [#25201] Ride list sort order can be unstable when sorted in descending order, change the order for unknown popularity and satisfaction to be last not first.
 - Fix: [#25207] Building a block brake on an LIM coaster does not automatically switch it to powered launch block sectioned mode.
 - Fix: [#25238] The chance of thunder and lightning effects happening is lower than vanilla.
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -995,7 +995,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case INFORMATION_TYPE_POPULARITY:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.popularity < otherRide.popularity;
+                        return static_cast<int8_t>(thisRide.popularity) < static_cast<int8_t>(otherRide.popularity);
                     });
                     break;
                 case INFORMATION_TYPE_SATISFACTION:

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -983,6 +983,11 @@ namespace OpenRCT2::Ui::Windows
 
         void SortList()
         {
+            // Maintain stability by first sorting by ride id.
+            SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
+                return thisRide.id.ToUnderlying() < otherRide.id.ToUnderlying();
+            });
+
             switch (listInformationType)
             {
                 case INFORMATION_TYPE_STATUS:
@@ -990,77 +995,77 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case INFORMATION_TYPE_POPULARITY:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.popularity * 4 <= otherRide.popularity * 4;
+                        return thisRide.popularity < otherRide.popularity;
                     });
                     break;
                 case INFORMATION_TYPE_SATISFACTION:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.satisfaction * 5 <= otherRide.satisfaction * 5;
+                        return thisRide.satisfaction < otherRide.satisfaction;
                     });
                     break;
                 case INFORMATION_TYPE_PROFIT:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.profit <= otherRide.profit;
+                        return thisRide.profit < otherRide.profit;
                     });
                     break;
                 case INFORMATION_TYPE_TOTAL_CUSTOMERS:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.totalCustomers <= otherRide.totalCustomers;
+                        return thisRide.totalCustomers < otherRide.totalCustomers;
                     });
                     break;
                 case INFORMATION_TYPE_TOTAL_PROFIT:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.totalProfit <= otherRide.totalProfit;
+                        return thisRide.totalProfit < otherRide.totalProfit;
                     });
                     break;
                 case INFORMATION_TYPE_CUSTOMERS:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return RideCustomersPerHour(thisRide) <= RideCustomersPerHour(otherRide);
+                        return RideCustomersPerHour(thisRide) < RideCustomersPerHour(otherRide);
                     });
                     break;
                 case INFORMATION_TYPE_AGE:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.buildDate <= otherRide.buildDate;
+                        return thisRide.buildDate < otherRide.buildDate;
                     });
                     break;
                 case INFORMATION_TYPE_INCOME:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.incomePerHour <= otherRide.incomePerHour;
+                        return thisRide.incomePerHour < otherRide.incomePerHour;
                     });
                     break;
                 case INFORMATION_TYPE_RUNNING_COST:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.upkeepCost <= otherRide.upkeepCost;
+                        return thisRide.upkeepCost < otherRide.upkeepCost;
                     });
                     break;
                 case INFORMATION_TYPE_QUEUE_LENGTH:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.getTotalQueueLength() <= otherRide.getTotalQueueLength();
+                        return thisRide.getTotalQueueLength() < otherRide.getTotalQueueLength();
                     });
                     break;
                 case INFORMATION_TYPE_QUEUE_TIME:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.getMaxQueueTime() <= otherRide.getMaxQueueTime();
+                        return thisRide.getMaxQueueTime() < otherRide.getMaxQueueTime();
                     });
                     break;
                 case INFORMATION_TYPE_RELIABILITY:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.reliabilityPercentage <= otherRide.reliabilityPercentage;
+                        return thisRide.reliabilityPercentage < otherRide.reliabilityPercentage;
                     });
                     break;
                 case INFORMATION_TYPE_DOWN_TIME:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.downtime <= otherRide.downtime;
+                        return thisRide.downtime < otherRide.downtime;
                     });
                     break;
                 case INFORMATION_TYPE_LAST_INSPECTION:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.lastInspection <= otherRide.lastInspection;
+                        return thisRide.lastInspection < otherRide.lastInspection;
                     });
                     break;
                 case INFORMATION_TYPE_GUESTS_FAVOURITE:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.guestsFavourite <= otherRide.guestsFavourite;
+                        return thisRide.guestsFavourite < otherRide.guestsFavourite;
                     });
                     break;
                 case INFORMATION_TYPE_EXCITEMENT:
@@ -1068,7 +1073,7 @@ namespace OpenRCT2::Ui::Windows
                         const auto leftValue = thisRide.ratings.isNull() ? RideRating::kUndefined : thisRide.ratings.excitement;
                         const auto rightValue = otherRide.ratings.isNull() ? RideRating::kUndefined
                                                                            : otherRide.ratings.excitement;
-                        return leftValue <= rightValue;
+                        return leftValue < rightValue;
                     });
                     break;
                 case INFORMATION_TYPE_INTENSITY:
@@ -1076,14 +1081,14 @@ namespace OpenRCT2::Ui::Windows
                         const auto leftValue = thisRide.ratings.isNull() ? RideRating::kUndefined : thisRide.ratings.intensity;
                         const auto rightValue = otherRide.ratings.isNull() ? RideRating::kUndefined
                                                                            : otherRide.ratings.intensity;
-                        return leftValue <= rightValue;
+                        return leftValue < rightValue;
                     });
                     break;
                 case INFORMATION_TYPE_NAUSEA:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
                         const auto leftValue = thisRide.ratings.isNull() ? RideRating::kUndefined : thisRide.ratings.nausea;
                         const auto rightValue = otherRide.ratings.isNull() ? RideRating::kUndefined : otherRide.ratings.nausea;
-                        return leftValue <= rightValue;
+                        return leftValue < rightValue;
                     });
                     break;
             }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -1000,7 +1000,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case INFORMATION_TYPE_SATISFACTION:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.satisfaction < otherRide.satisfaction;
+                        return static_cast<int8_t>(thisRide.satisfaction) < static_cast<int8_t>(otherRide.satisfaction);
                     });
                     break;
                 case INFORMATION_TYPE_PROFIT:

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -1004,9 +1004,8 @@ namespace OpenRCT2::Ui::Windows
                     });
                     break;
                 case INFORMATION_TYPE_PROFIT:
-                    SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {
-                        return thisRide.profit < otherRide.profit;
-                    });
+                    SortListByPredicate(
+                        [](const Ride& thisRide, const Ride& otherRide) -> bool { return thisRide.profit < otherRide.profit; });
                     break;
                 case INFORMATION_TYPE_TOTAL_CUSTOMERS:
                     SortListByPredicate([](const Ride& thisRide, const Ride& otherRide) -> bool {

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -10,6 +10,7 @@
 #include "AssertHelpers.hpp"
 #include "helpers/StringHelpers.hpp"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 #include <openrct2/core/CodepointView.hpp>
 #include <openrct2/core/EnumUtils.hpp>
@@ -17,6 +18,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 using namespace OpenRCT2;
 
@@ -249,4 +251,39 @@ TEST_F(CodepointViewTest, CodepointView_iterate)
     AssertCodepoints("test", { 't', 'e', 's', 't' });
     AssertCodepoints("ゲスト", { U'ゲ', U'ス', U'ト' });
     AssertCodepoints("<🎢>", { U'<', U'🎢', U'>' });
+}
+
+TEST_F(StringTest, LogicalCompare)
+{
+    std::vector<std::string> expected = {
+        "1001 Troubles", "3D Cinema 1", "Aerial Cycles", "Batflyer",  "bpb",
+        "bpb.sv6",       "Drive-by",    "foo",           "foobar",    "Guest 10",
+        "Guest 99",      "Guest 100",   "John v2.0",     "John v2.1", "River of the Damned",
+        "Terror-dactyl",
+    };
+
+    std::vector<std::string> inputs = {
+        "Guest 99",
+        "Batflyer",
+        "John v2.1",
+        "bpb",
+        "3D Cinema 1",
+        "Drive-by",
+        "John v2.0",
+        "Guest 10",
+        "Terror-dactyl",
+        "Aerial Cycles",
+        "foobar",
+        "1001 Troubles",
+        "River of the Damned",
+        "bpb.sv6",
+        "Guest 100",
+        "foo",
+    };
+
+    std::sort(inputs.begin(), inputs.end(), [](const auto& a, const auto& b) {
+        return String::logicalCmp(a.c_str(), b.c_str()) < 0;
+    });
+
+    AssertVector<std::string>(inputs, expected);
 }


### PR DESCRIPTION
This PR keeps the sort consistent no matter the sort direction and keeps it stable. Also fixes the logical compare, this now matches the output of what Notepad++ or VSCode/VS will do.
develop:
<img width="341" height="242" alt="image" src="https://github.com/user-attachments/assets/dfdd4f62-a348-41c4-9dfc-c7436f04ac40" />

PR:
<img width="344" height="244" alt="image" src="https://github.com/user-attachments/assets/4cddef88-9f56-4649-863d-324f16f88668" />

Also changes the order for unknown popularity and satisfaction:
develop:
<img width="343" height="242" alt="image" src="https://github.com/user-attachments/assets/bdb5f53b-d7ef-4e9d-ae13-5ebb6dba95f5" /> <img width="343" height="243" alt="image" src="https://github.com/user-attachments/assets/abddcc76-1aef-43f8-90cc-628fb004bd86" />

PR:
<img width="340" height="243" alt="image" src="https://github.com/user-attachments/assets/3cef6a2f-b3f5-42b1-bf2b-ae14fae4daf8" /> <img width="341" height="245" alt="image" src="https://github.com/user-attachments/assets/4d322588-77cc-49da-a587-e029f7382e1c" />

Close #25201