### PR TITLE
String optimizations

### DIFF
--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -149,7 +149,7 @@ ShortcutInput::ShortcutInput(std::string_view value)
         }
         else
         {
-            auto number = String::parse<int32_t>(rem);
+            auto number = String::tryParse<int32_t>(rem);
             if (number.has_value())
             {
                 Kind = InputDeviceKind::JoyButton;
@@ -161,7 +161,7 @@ ShortcutInput::ShortcutInput(std::string_view value)
     else if (String::startsWith(rem, "MOUSE ", true))
     {
         rem = rem.substr(6);
-        auto number = String::parse<int32_t>(rem);
+        auto number = String::tryParse<int32_t>(rem);
         if (number)
         {
             Kind = InputDeviceKind::Mouse;

--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -149,7 +149,7 @@ ShortcutInput::ShortcutInput(std::string_view value)
         }
         else
         {
-            auto number = String::Parse<int32_t>(rem);
+            auto number = String::parse<int32_t>(rem);
             if (number.has_value())
             {
                 Kind = InputDeviceKind::JoyButton;
@@ -161,7 +161,7 @@ ShortcutInput::ShortcutInput(std::string_view value)
     else if (String::startsWith(rem, "MOUSE ", true))
     {
         rem = rem.substr(6);
-        auto number = String::Parse<int32_t>(rem);
+        auto number = String::parse<int32_t>(rem);
         if (number)
         {
             Kind = InputDeviceKind::Mouse;

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -174,7 +174,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
 
                 case WIDX_RATE:
-                    const auto res = String::Parse<int32_t>(text);
+                    const auto res = String::parse<int32_t>(text);
                     if (res.has_value())
                     {
                         int32_t rate = res.value();

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -174,7 +174,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
 
                 case WIDX_RATE:
-                    const auto res = String::parse<int32_t>(text);
+                    const auto res = String::tryParse<int32_t>(text);
                     if (res.has_value())
                     {
                         int32_t rate = res.value();

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -236,7 +236,7 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_PREVIEW)
                 return;
 
-            const auto res = String::parse<int32_t>(text);
+            const auto res = String::tryParse<int32_t>(text);
             if (res.has_value())
             {
                 uint16_t size;

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -236,7 +236,7 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_PREVIEW)
                 return;
 
-            const auto res = String::Parse<int32_t>(text);
+            const auto res = String::parse<int32_t>(text);
             if (res.has_value())
             {
                 uint16_t size;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -241,7 +241,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // List all files with the wanted extensions
                 bool showExtension = false;
-                for (const u8string& extToken : String::split(extensionPattern, ";"))
+                for (const u8string_view extToken : String::split(extensionPattern, ";"))
                 {
                     const u8string filter = Path::Combine(directory, extToken);
                     auto scanner = Path::ScanDirectory(filter, false);

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -109,7 +109,7 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_PREVIEW)
                 return;
 
-            const auto res = String::Parse<int32_t>(text);
+            const auto res = String::parse<int32_t>(text);
             if (res.has_value())
             {
                 int32_t size;

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -109,7 +109,7 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_PREVIEW)
                 return;
 
-            const auto res = String::parse<int32_t>(text);
+            const auto res = String::tryParse<int32_t>(text);
             if (res.has_value())
             {
                 int32_t size;

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -141,7 +141,7 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_PREVIEW || text.empty())
                 return;
 
-            const auto res = String::Parse<int32_t>(text);
+            const auto res = String::parse<int32_t>(text);
 
             if (res.has_value())
             {

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -141,7 +141,7 @@ namespace OpenRCT2::Ui::Windows
             if (widgetIndex != WIDX_PREVIEW || text.empty())
                 return;
 
-            const auto res = String::parse<int32_t>(text);
+            const auto res = String::tryParse<int32_t>(text);
 
             if (res.has_value())
             {

--- a/src/openrct2/command_line/UriHandler.cpp
+++ b/src/openrct2/command_line/UriHandler.cpp
@@ -18,9 +18,9 @@ namespace OpenRCT2
     static exitcode_t HandleUri(const std::string& uri);
 
 #ifndef DISABLE_NETWORK
-    static exitcode_t HandleUriJoin(const std::vector<std::string>& args);
+    static exitcode_t HandleUriJoin(const std::vector<std::string_view>& args);
     static bool TryParseHostnamePort(
-        const std::string& hostnamePort, std::string* outHostname, int32_t* outPort, int32_t defaultPort);
+        const std::string_view hostnamePort, std::string* outHostname, int32_t* outPort, int32_t defaultPort);
 #endif
 
     exitcode_t CommandLine::HandleCommandUri(CommandLineArgEnumerator* enumerator)
@@ -46,7 +46,7 @@ namespace OpenRCT2
         if (!args.empty())
         {
 #ifndef DISABLE_NETWORK
-            std::string arg = args[0];
+            const auto arg = args[0];
             if (arg == "join")
             {
                 result = HandleUriJoin(args);
@@ -58,7 +58,7 @@ namespace OpenRCT2
 
 #ifndef DISABLE_NETWORK
 
-    static exitcode_t HandleUriJoin(const std::vector<std::string>& args)
+    static exitcode_t HandleUriJoin(const std::vector<std::string_view>& args)
     {
         std::string hostname;
         int32_t port;
@@ -76,18 +76,18 @@ namespace OpenRCT2
     }
 
     static bool TryParseHostnamePort(
-        const std::string& hostnamePort, std::string* outHostname, int32_t* outPort, int32_t defaultPort)
+        const std::string_view hostnamePort, std::string* outHostname, int32_t* outPort, int32_t defaultPort)
     {
         try
         {
             // Argument is in hostname:port format, so we need to split
-            std::string hostname = hostnamePort;
+            std::string hostname{ hostnamePort };
             int32_t port = defaultPort;
             size_t colonIndex = hostnamePort.find_first_of(':');
             if (colonIndex != std::string::npos)
             {
                 hostname = hostnamePort.substr(0, colonIndex);
-                port = std::stoi(hostnamePort.substr(colonIndex + 1));
+                port = String::parse<int32_t>(hostnamePort.substr(colonIndex + 1));
             }
             *outPort = port;
             *outHostname = std::move(hostname);

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -394,27 +394,23 @@ namespace OpenRCT2::String
     {
         if (delimiter.empty())
         {
-            throw std::invalid_argument("delimiter can not be empty.");
+            throw std::invalid_argument("delimiter can notbe empty.");
         }
-
         std::vector<std::string> results;
-        if (!s.empty())
+        if (s.empty())
         {
-            size_t index = 0;
-            size_t nextIndex;
-            do
+            return results;
+        }
+        size_t start = 0;
+        while (true)
+        {
+            size_t end = s.find(delimiter, start);
+            results.emplace_back(s.substr(start, end == std::string_view::npos ? std::string_view::npos : end - start));
+            if (end == std::string_view::npos)
             {
-                nextIndex = s.find(delimiter, index);
-                if (nextIndex == std::string::npos)
-                {
-                    results.emplace_back(s.substr(index));
-                }
-                else
-                {
-                    results.emplace_back(s.substr(index, nextIndex - index));
-                }
-                index = nextIndex + delimiter.size();
-            } while (nextIndex != SIZE_MAX);
+                break;
+            }
+            start = end + delimiter.size();
         }
         return results;
     }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -390,13 +390,13 @@ namespace OpenRCT2::String
         return buffer;
     }
 
-    std::vector<std::string> split(std::string_view s, std::string_view delimiter)
+    std::vector<std::string_view> split(std::string_view s, std::string_view delimiter)
     {
         if (delimiter.empty())
         {
-            throw std::invalid_argument("delimiter can notbe empty.");
+            throw std::invalid_argument("delimiter can not be empty.");
         }
-        std::vector<std::string> results;
+        std::vector<std::string_view> results;
         if (s.empty())
         {
             return results;

--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -11,6 +11,7 @@
 
 #include "StringTypes.h"
 
+#include <charconv>
 #include <cstdarg>
 #include <cstddef>
 #include <optional>
@@ -112,33 +113,19 @@ namespace OpenRCT2::String
     std::string toUpper(std::string_view src);
 
     template<typename T>
-    std::optional<T> Parse(std::string_view input)
+    std::optional<T> parse(std::string_view input)
     {
-        if (input.size() == 0)
-            return std::nullopt;
-
-        T result = 0;
-        for (size_t i = 0; i < input.size(); i++)
+        if (input.empty())
         {
-            auto chr = input[i];
-            if (chr >= '0' && chr <= '9')
-            {
-                auto digit = chr - '0';
-                auto last = result;
-                result = static_cast<T>((result * 10) + digit);
-                if (result <= last)
-                {
-                    // Overflow, number too large for type
-                    return std::nullopt;
-                }
-            }
-            else
-            {
-                // Bad character
-                return std::nullopt;
-            }
+            return std::nullopt;
         }
-        return result;
+        T result;
+        auto [ptr, ec] = std::from_chars(input.data(), input.data() + input.size(), result);
+        if (ec == std::errc() && ptr == input.data() + input.size())
+        {
+            return result;
+        }
+        return std::nullopt;
     }
 
     /**

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -353,12 +353,12 @@ namespace OpenRCT2
             auto parts = String::split(s, "..");
             if (parts.size() == 1)
             {
-                result.push_back(std::stoi(parts[0]));
+                result.push_back(String::parse<int32_t>(parts[0]));
             }
             else
             {
-                auto left = std::stoi(parts[0]);
-                auto right = std::stoi(parts[1]);
+                auto left = String::parse<int32_t>(parts[0]);
+                auto right = String::parse<int32_t>(parts[1]);
                 if (left <= right)
                 {
                     for (auto i = left; i <= right; i++)

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -433,7 +433,7 @@ namespace OpenRCT2
             size_t highestIndex = std::min(nums.size(), VersionNumFields);
             for (size_t i = 0; i < highestIndex; i++)
             {
-                auto value = stoll(nums.at(i));
+                auto value = String::parse<int64_t>(nums.at(i));
                 constexpr auto maxValue = std::numeric_limits<uint16_t>().max();
                 if (value > maxValue)
                 {

--- a/src/openrct2/object/ResourceTable.cpp
+++ b/src/openrct2/object/ResourceTable.cpp
@@ -26,12 +26,12 @@ namespace OpenRCT2
             auto parts = String::split(s, "..");
             if (parts.size() == 1)
             {
-                result = Range<int32_t>(std::stoi(parts[0]));
+                result = Range<int32_t>(String::parse<int32_t>(parts[0]));
             }
             else
             {
-                auto left = std::stoi(parts[0]);
-                auto right = std::stoi(parts[1]);
+                auto left = String::parse<int32_t>(parts[0]);
+                auto right = String::parse<int32_t>(parts[1]);
                 if (left <= right)
                 {
                     result = Range<int32_t>(left, right);

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -287,3 +287,160 @@ TEST_F(StringTest, LogicalCompare)
 
     AssertVector<std::string>(inputs, expected);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// Tests for String::parse
+///////////////////////////////////////////////////////////////////////////////
+
+TEST_F(StringTest, Parse_Basic)
+{
+    auto actual = String::parse<std::int32_t>("123");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_EQ(*actual, 123);
+}
+
+TEST_F(StringTest, Parse_Empty)
+{
+    auto actual = String::parse<std::int32_t>("");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_Zero)
+{
+    auto actual = String::parse<std::int32_t>("0");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_EQ(*actual, 0);
+}
+
+TEST_F(StringTest, Parse_LeadingZero)
+{
+    auto actual = String::parse<std::int32_t>("00123");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_EQ(*actual, 123);
+}
+
+TEST_F(StringTest, Parse_InvalidChar)
+{
+    auto actual = String::parse<std::int32_t>("12a3");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_LeadingNonDigit)
+{
+    auto actual = String::parse<std::int32_t>("a123");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_Negative)
+{
+    auto actual = String::parse<std::int32_t>("-123");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_EQ(*actual, -123);
+}
+
+TEST_F(StringTest, Parse_Overflow)
+{
+    auto actual = String::parse<std::int32_t>("2147483648");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_LargeNumber)
+{
+    auto actual = String::parse<std::int64_t>("9223372036854775807");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_EQ(*actual, 9223372036854775807LL);
+}
+
+TEST_F(StringTest, Parse_FloatBasic)
+{
+    auto actual = String::parse<float>("123.45");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_FLOAT_EQ(*actual, 123.45f);
+}
+
+TEST_F(StringTest, Parse_FloatZero)
+{
+    auto actual = String::parse<float>("0.0");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_FLOAT_EQ(*actual, 0.0f);
+}
+
+TEST_F(StringTest, Parse_FloatScientific)
+{
+    auto actual = String::parse<float>("1.23e4");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_FLOAT_EQ(*actual, 12300.0f);
+}
+
+TEST_F(StringTest, Parse_FloatInvalid)
+{
+    auto actual = String::parse<float>("123.4a5");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_FloatLeadingDot)
+{
+    auto actual = String::parse<float>(".123");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_FLOAT_EQ(*actual, 0.123f);
+}
+
+TEST_F(StringTest, Parse_FloatNegative)
+{
+    auto actual = String::parse<float>("-123.45");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_FLOAT_EQ(*actual, -123.45f);
+}
+
+TEST_F(StringTest, Parse_FloatOverflow)
+{
+    auto actual = String::parse<float>("3.4028235e39");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_DoubleBasic)
+{
+    auto actual = String::parse<double>("123.456789");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_DOUBLE_EQ(*actual, 123.456789);
+}
+
+TEST_F(StringTest, Parse_DoubleZero)
+{
+    auto actual = String::parse<double>("0.0");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_DOUBLE_EQ(*actual, 0.0);
+}
+
+TEST_F(StringTest, Parse_DoubleScientific)
+{
+    auto actual = String::parse<double>("1.23e10");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_DOUBLE_EQ(*actual, 12300000000.0);
+}
+
+TEST_F(StringTest, Parse_DoubleInvalid)
+{
+    auto actual = String::parse<double>("123.4a5");
+    ASSERT_FALSE(actual.has_value());
+}
+
+TEST_F(StringTest, Parse_DoubleLeadingDot)
+{
+    auto actual = String::parse<double>(".123");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_DOUBLE_EQ(*actual, 0.123);
+}
+
+TEST_F(StringTest, Parse_DoubleNegative)
+{
+    auto actual = String::parse<double>("-123.45");
+    ASSERT_TRUE(actual.has_value());
+    ASSERT_DOUBLE_EQ(*actual, -123.45);
+}
+
+TEST_F(StringTest, Parse_DoubleOverflow)
+{
+    auto actual = String::parse<double>("1.7976931348623158e309");
+    ASSERT_FALSE(actual.has_value());
+}

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -66,17 +66,17 @@ TEST_P(StringTest, TrimStart)
 TEST_F(StringTest, Split_ByComma)
 {
     auto actual = String::split("a,bb,ccc,dd", ",");
-    AssertVector<std::string>(actual, { "a", "bb", "ccc", "dd" });
+    AssertVector<std::string_view>(actual, { "a", "bb", "ccc", "dd" });
 }
 TEST_F(StringTest, Split_ByColonColon)
 {
     auto actual = String::split("a::bb:ccc:::::dd", "::");
-    AssertVector<std::string>(actual, { "a", "bb:ccc", "", ":dd" });
+    AssertVector<std::string_view>(actual, { "a", "bb:ccc", "", ":dd" });
 }
 TEST_F(StringTest, Split_Empty)
 {
     auto actual = String::split("", ".");
-    AssertVector<std::string>(actual, {});
+    AssertVector<std::string_view>(actual, {});
 }
 TEST_F(StringTest, Split_ByEmpty)
 {
@@ -294,153 +294,153 @@ TEST_F(StringTest, LogicalCompare)
 
 TEST_F(StringTest, Parse_Basic)
 {
-    auto actual = String::parse<std::int32_t>("123");
+    auto actual = String::tryParse<std::int32_t>("123");
     ASSERT_TRUE(actual.has_value());
     ASSERT_EQ(*actual, 123);
 }
 
 TEST_F(StringTest, Parse_Empty)
 {
-    auto actual = String::parse<std::int32_t>("");
+    auto actual = String::tryParse<std::int32_t>("");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_Zero)
 {
-    auto actual = String::parse<std::int32_t>("0");
+    auto actual = String::tryParse<std::int32_t>("0");
     ASSERT_TRUE(actual.has_value());
     ASSERT_EQ(*actual, 0);
 }
 
 TEST_F(StringTest, Parse_LeadingZero)
 {
-    auto actual = String::parse<std::int32_t>("00123");
+    auto actual = String::tryParse<std::int32_t>("00123");
     ASSERT_TRUE(actual.has_value());
     ASSERT_EQ(*actual, 123);
 }
 
 TEST_F(StringTest, Parse_InvalidChar)
 {
-    auto actual = String::parse<std::int32_t>("12a3");
+    auto actual = String::tryParse<std::int32_t>("12a3");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_LeadingNonDigit)
 {
-    auto actual = String::parse<std::int32_t>("a123");
+    auto actual = String::tryParse<std::int32_t>("a123");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_Negative)
 {
-    auto actual = String::parse<std::int32_t>("-123");
+    auto actual = String::tryParse<std::int32_t>("-123");
     ASSERT_TRUE(actual.has_value());
     ASSERT_EQ(*actual, -123);
 }
 
 TEST_F(StringTest, Parse_Overflow)
 {
-    auto actual = String::parse<std::int32_t>("2147483648");
+    auto actual = String::tryParse<std::int32_t>("2147483648");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_LargeNumber)
 {
-    auto actual = String::parse<std::int64_t>("9223372036854775807");
+    auto actual = String::tryParse<std::int64_t>("9223372036854775807");
     ASSERT_TRUE(actual.has_value());
     ASSERT_EQ(*actual, 9223372036854775807LL);
 }
 
 TEST_F(StringTest, Parse_FloatBasic)
 {
-    auto actual = String::parse<float>("123.45");
+    auto actual = String::tryParse<float>("123.45");
     ASSERT_TRUE(actual.has_value());
     ASSERT_FLOAT_EQ(*actual, 123.45f);
 }
 
 TEST_F(StringTest, Parse_FloatZero)
 {
-    auto actual = String::parse<float>("0.0");
+    auto actual = String::tryParse<float>("0.0");
     ASSERT_TRUE(actual.has_value());
     ASSERT_FLOAT_EQ(*actual, 0.0f);
 }
 
 TEST_F(StringTest, Parse_FloatScientific)
 {
-    auto actual = String::parse<float>("1.23e4");
+    auto actual = String::tryParse<float>("1.23e4");
     ASSERT_TRUE(actual.has_value());
     ASSERT_FLOAT_EQ(*actual, 12300.0f);
 }
 
 TEST_F(StringTest, Parse_FloatInvalid)
 {
-    auto actual = String::parse<float>("123.4a5");
+    auto actual = String::tryParse<float>("123.4a5");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_FloatLeadingDot)
 {
-    auto actual = String::parse<float>(".123");
+    auto actual = String::tryParse<float>(".123");
     ASSERT_TRUE(actual.has_value());
     ASSERT_FLOAT_EQ(*actual, 0.123f);
 }
 
 TEST_F(StringTest, Parse_FloatNegative)
 {
-    auto actual = String::parse<float>("-123.45");
+    auto actual = String::tryParse<float>("-123.45");
     ASSERT_TRUE(actual.has_value());
     ASSERT_FLOAT_EQ(*actual, -123.45f);
 }
 
 TEST_F(StringTest, Parse_FloatOverflow)
 {
-    auto actual = String::parse<float>("3.4028235e39");
+    auto actual = String::tryParse<float>("3.4028235e39");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_DoubleBasic)
 {
-    auto actual = String::parse<double>("123.456789");
+    auto actual = String::tryParse<double>("123.456789");
     ASSERT_TRUE(actual.has_value());
     ASSERT_DOUBLE_EQ(*actual, 123.456789);
 }
 
 TEST_F(StringTest, Parse_DoubleZero)
 {
-    auto actual = String::parse<double>("0.0");
+    auto actual = String::tryParse<double>("0.0");
     ASSERT_TRUE(actual.has_value());
     ASSERT_DOUBLE_EQ(*actual, 0.0);
 }
 
 TEST_F(StringTest, Parse_DoubleScientific)
 {
-    auto actual = String::parse<double>("1.23e10");
+    auto actual = String::tryParse<double>("1.23e10");
     ASSERT_TRUE(actual.has_value());
     ASSERT_DOUBLE_EQ(*actual, 12300000000.0);
 }
 
 TEST_F(StringTest, Parse_DoubleInvalid)
 {
-    auto actual = String::parse<double>("123.4a5");
+    auto actual = String::tryParse<double>("123.4a5");
     ASSERT_FALSE(actual.has_value());
 }
 
 TEST_F(StringTest, Parse_DoubleLeadingDot)
 {
-    auto actual = String::parse<double>(".123");
+    auto actual = String::tryParse<double>(".123");
     ASSERT_TRUE(actual.has_value());
     ASSERT_DOUBLE_EQ(*actual, 0.123);
 }
 
 TEST_F(StringTest, Parse_DoubleNegative)
 {
-    auto actual = String::parse<double>("-123.45");
+    auto actual = String::tryParse<double>("-123.45");
     ASSERT_TRUE(actual.has_value());
     ASSERT_DOUBLE_EQ(*actual, -123.45);
 }
 
 TEST_F(StringTest, Parse_DoubleOverflow)
 {
-    auto actual = String::parse<double>("1.7976931348623158e309");
+    auto actual = String::tryParse<double>("1.7976931348623158e309");
     ASSERT_FALSE(actual.has_value());
 }


### PR DESCRIPTION
Make String::split return string_views instead of newly constructed strings. Refactor the existing Parse function to use from_chars, rename that to tryParse and add a throwing version, also added a bunch of tests to make sure this does actually parse the stuff as expected.