### PR TITLE
Add force redraw debug paint option

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3842,3 +3842,4 @@ STR_7000    :or
 STR_7001    :Ride name
 STR_7002    :{STRINGID} {STRINGID}
 STR_7003    :Audio file ‘{STRING}’ is truncated. Expected sample {INT32}, but only {INT32} are available. Consider reinstalling RCT2.
+STR_7004    :Force Redraw

--- a/src/openrct2-ui/UiStringIds.h
+++ b/src/openrct2-ui/UiStringIds.h
@@ -474,6 +474,7 @@ namespace OpenRCT2
         STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS = 5901,
         STR_DEBUG_PAINT_SHOW_WIDE_PATHS = 6261,
         STR_DEBUG_PAINT_STABLE_SORT = 6710,
+        STR_DEBUG_PAINT_FORCE_REDRAW = 7004,
 
         // Window: DemolishRidePrompt
         STR_DEMOLISH = 994,

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -366,7 +366,7 @@ public:
 
     void PaintWindows() override
     {
-        if (ClimateHasWeatherEffect())
+        if (ClimateHasWeatherEffect() || gPaintForceRedraw)
         {
             WindowUpdateAllViewports();
             // OpenGL doesn't support restoring pixels, always redraw.

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -29,9 +29,10 @@ namespace OpenRCT2::Ui::Windows
         WIDX_TOGGLE_SHOW_BOUND_BOXES,
         WIDX_TOGGLE_SHOW_DIRTY_VISUALS,
         WIDX_TOGGLE_STABLE_PAINT_SORT,
+        WIDX_TOGGLE_FORCE_REDRAW,
     };
 
-    static constexpr ScreenSize kWindowSize = { 200, 8 + (15 * 6) + 8 };
+    static constexpr ScreenSize kWindowSize = { 200, 8 + (15 * 7) + 8 };
 
     // clang-format off
     static constexpr Widget window_debug_paint_widgets[] = {
@@ -42,6 +43,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({8, 8 + 15 * 3}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_BOUND_BOXES    ),
         makeWidget({8, 8 + 15 * 4}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS  ),
         makeWidget({8, 8 + 15 * 5}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_STABLE_SORT  ),
+        makeWidget({8, 8 + 15 * 6}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_FORCE_REDRAW  ),
     };
     // clang-format on
 
@@ -97,6 +99,11 @@ namespace OpenRCT2::Ui::Windows
                     gPaintStableSort = !gPaintStableSort;
                     GfxInvalidateScreen();
                     break;
+
+                case WIDX_TOGGLE_FORCE_REDRAW:
+                    gPaintForceRedraw = !gPaintForceRedraw;
+                    GfxInvalidateScreen();
+                    break;
             }
         }
 
@@ -143,6 +150,7 @@ namespace OpenRCT2::Ui::Windows
             setCheckboxValue(WIDX_TOGGLE_SHOW_BOUND_BOXES, gPaintBoundingBoxes);
             setCheckboxValue(WIDX_TOGGLE_SHOW_DIRTY_VISUALS, gShowDirtyVisuals);
             setCheckboxValue(WIDX_TOGGLE_STABLE_PAINT_SORT, gPaintStableSort);
+            setCheckboxValue(WIDX_TOGGLE_FORCE_REDRAW, gPaintForceRedraw);
         }
 
         void onDraw(RenderTarget& rt) override

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -87,6 +87,8 @@ uint8_t gTextPalette[0x8] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
+bool gPaintForceRedraw{ false };
+
 enum
 {
     SPR_PALETTE_3100 = 3100,

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -505,6 +505,7 @@ extern const TranslucentWindowPalette kTranslucentWindowPalettes[COLOUR_COUNT];
 extern ImageId gPickupPeepImage;
 extern int32_t gPickupPeepX;
 extern int32_t gPickupPeepY;
+extern bool gPaintForceRedraw;
 
 bool ClipDrawPixelInfo(RenderTarget& dst, RenderTarget& src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
 void GfxSetDirtyBlocks(const ScreenRect& rect);

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -184,11 +184,19 @@ void X8DrawingEngine::EndDraw()
 
 void X8DrawingEngine::PaintWindows()
 {
-    // Redraw dirty regions before updating the viewports, otherwise
-    // when viewports get panned, they copy dirty pixels
-    DrawAllDirtyBlocks();
-    WindowUpdateAllViewports();
-    DrawAllDirtyBlocks();
+    if (gPaintForceRedraw)
+    {
+        WindowUpdateAllViewports();
+        WindowDrawAll(_mainRT, 0, 0, _width, _height);
+    }
+    else
+    {
+        // Redraw dirty regions before updating the viewports, otherwise
+        // when viewports get panned, they copy dirty pixels
+        DrawAllDirtyBlocks();
+        WindowUpdateAllViewports();
+        DrawAllDirtyBlocks();
+    }
 }
 
 void X8DrawingEngine::PaintWeather()


### PR DESCRIPTION
<img width="1006" height="705" alt="image" src="https://github.com/user-attachments/assets/81bb4868-6543-4e52-a96a-b3b74d813790" />

This is quite handy to measure the performance without having the simulation affect it, you can just pause the game and enable force redraw and that is purely the cost of rendering then.