### PR TITLE
S4: Correctly import supports on ground paths

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#25286] Footpath area dragging tool.
 - Feature: [#25379] Add an option to the command line screenshot function to draw debug segment heights.
+- Improved: [#25297] Paths on the ground in SV4/SC4 no longer block supports of the paths above.
 - Improved: [#25349] ‘Recent Messages’ window can now be fully themed.
 - Change: [#25089] Peep actions and animations that cause them to stop moving no longer trigger when they are on a level crossing.
 - Change: [#25337] Placing track designs with scenery that is obstructed no longer disables all of the scenery.


### PR DESCRIPTION
RCT2 has a particularity with path supports, which is that paths with box supports (like the wooden truss) allow for a support at the side, which paths with pole supports do not. So far, so reasonable, but this rule also applies when the path is directly on the ground. That makes no sense, but we’re stuck with it.

RCT1 is more sensible in this regard. It will draw supports if the path is right on the ground. To replicate this and get our import a smidgen closer to how RCT1 renders, this PR changes the supports of ground paths (which again, are invisible) to the box type.

Two pictures speak more than a thousand words:

<img width="640" height="360" alt="Schermafdruk van 2025-10-03 23-20-16" src="https://github.com/user-attachments/assets/bf6848b9-07a1-41ff-b56c-407f5c6cd499" />
<img width="640" height="360" alt="Schermafdruk van 2025-10-03 23-20-22" src="https://github.com/user-attachments/assets/63bd5e01-a6e7-403f-9d8c-139f23b4e445" />
