### PR TITLE
Fix Mine Train Coaster left large helix drawing incorrect sprites

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.28 (in development)
 ------------------------------------------------------------------------
+- Fix: [#25299] The Mine Train Coaster left large helix draws incorrect sprites at certain angles (original bug).
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
@@ -3553,9 +3553,6 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(20348), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(20178), { 0, 0, height },
-                        { { 16, 16, height + 27 }, { 16, 16, 1 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
                     break;
@@ -3609,9 +3606,6 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(20347), { 0, 0, height },
-                        { { 0, 0, height + 27 }, { 16, 32, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(20177), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 1 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
@@ -3832,9 +3826,6 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(20348), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(20178), { 0, 0, height },
-                        { { 16, 16, height + 27 }, { 16, 16, 1 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
                     break;
@@ -3888,9 +3879,6 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(20347), { 0, 0, height },
-                        { { 0, 0, height + 27 }, { 32, 16, 1 } });
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(20177), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 1 } });
                     WoodenASupportsPaintSetup(
                         session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);


### PR DESCRIPTION
This fixes the mine train coaster left large helix drawing incorrect sprites. It draws some sprites from the banked medium turn over the actual sprites by mistake. The right helix does not have this issue. This is an original bug from RCT1.

<img width="244" height="218" alt="minetrainlefthelixbug" src="https://github.com/user-attachments/assets/e2c75e78-9273-458c-be78-20f69a973e7d" />
<img width="244" height="218" alt="minetrainlefthelixfix" src="https://github.com/user-attachments/assets/a599c6a7-1891-4d4b-8700-75c42d16c32c" />

RCT1 save:
[mine train coaster left large helix.zip](https://github.com/user-attachments/files/22702442/mine.train.coaster.left.large.helix.zip)
