### PR TITLE
MapRange: do not inherit from RectRange

### DIFF
--- a/src/openrct2-ui/scripting/ScTileSelection.hpp
+++ b/src/openrct2-ui/scripting/ScTileSelection.hpp
@@ -57,10 +57,10 @@ namespace OpenRCT2::Scripting
                 auto range = GetMapRange(value);
                 if (range)
                 {
-                    gMapSelectPositionA.x = range->GetLeft();
-                    gMapSelectPositionA.y = range->GetTop();
-                    gMapSelectPositionB.x = range->GetRight();
-                    gMapSelectPositionB.y = range->GetBottom();
+                    gMapSelectPositionA.x = range->GetX1();
+                    gMapSelectPositionA.y = range->GetY1();
+                    gMapSelectPositionB.x = range->GetX2();
+                    gMapSelectPositionB.y = range->GetY2();
                     gMapSelectType = MapSelectType::full;
                     gMapSelectFlags.set(MapSelectFlag::enable);
                 }

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -67,8 +67,8 @@ namespace OpenRCT2::GameActions
         result.ErrorTitle = STR_UNABLE_TO_REMOVE_ALL_SCENERY_FROM_HERE;
         result.Expenditure = ExpenditureType::landscaping;
 
-        auto x = (_range.GetLeft() + _range.GetRight()) / 2 + 16;
-        auto y = (_range.GetTop() + _range.GetBottom()) / 2 + 16;
+        auto x = (_range.GetX1() + _range.GetX2()) / 2 + 16;
+        auto y = (_range.GetY1() + _range.GetY2()) / 2 + 16;
         auto z = TileElementHeight({ x, y });
         result.Position = CoordsXYZ(x, y, z);
 
@@ -85,9 +85,9 @@ namespace OpenRCT2::GameActions
         money64 totalCost = 0;
 
         auto validRange = ClampRangeWithinMap(_range);
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (LocationValid({ x, y }) && MapCanClearAt(gameState, { x, y }))
                 {

--- a/src/openrct2/actions/LandBuyRightsAction.cpp
+++ b/src/openrct2/actions/LandBuyRightsAction.cpp
@@ -74,24 +74,24 @@ namespace OpenRCT2::GameActions
         MapRange normRange = _range.Normalise();
         // Keep big coordinates within map boundaries
         auto mapSizeMaxXY = GetMapSizeMaxXY();
-        auto aX = std::max<decltype(normRange.GetLeft())>(32, normRange.GetLeft());
-        auto bX = std::min<decltype(normRange.GetRight())>(mapSizeMaxXY.x, normRange.GetRight());
-        auto aY = std::max<decltype(normRange.GetTop())>(32, normRange.GetTop());
-        auto bY = std::min<decltype(normRange.GetBottom())>(mapSizeMaxXY.y, normRange.GetBottom());
+        auto aX = std::max<decltype(normRange.GetX1())>(32, normRange.GetX1());
+        auto bX = std::min<decltype(normRange.GetX2())>(mapSizeMaxXY.x, normRange.GetX2());
+        auto aY = std::max<decltype(normRange.GetY1())>(32, normRange.GetY1());
+        auto bY = std::min<decltype(normRange.GetY2())>(mapSizeMaxXY.y, normRange.GetY2());
 
         MapRange validRange = MapRange{ aX, aY, bX, bY };
 
-        CoordsXYZ centre{ (validRange.GetLeft() + validRange.GetRight()) / 2 + 16,
-                          (validRange.GetTop() + validRange.GetBottom()) / 2 + 16, 0 };
+        CoordsXYZ centre{ (validRange.GetX1() + validRange.GetX2()) / 2 + 16,
+                          (validRange.GetY1() + validRange.GetY2()) / 2 + 16, 0 };
         centre.z = TileElementHeight(centre);
 
         res.Position = centre;
         res.Expenditure = ExpenditureType::landPurchase;
 
         // Game command modified to accept selection size
-        for (auto y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (auto y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (auto x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (auto x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                     continue;

--- a/src/openrct2/actions/LandLowerAction.cpp
+++ b/src/openrct2/actions/LandLowerAction.cpp
@@ -87,9 +87,9 @@ namespace OpenRCT2::GameActions
         uint8_t maxHeight = MapGetHighestLandHeight(validRange);
         bool withinOwnership = false;
 
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                     continue;

--- a/src/openrct2/actions/LandRaiseAction.cpp
+++ b/src/openrct2/actions/LandRaiseAction.cpp
@@ -88,9 +88,9 @@ namespace OpenRCT2::GameActions
         uint8_t minHeight = MapGetLowestLandHeight(validRange);
         bool withinOwnership = false;
 
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                     continue;

--- a/src/openrct2/actions/LandSetRightsAction.cpp
+++ b/src/openrct2/actions/LandSetRightsAction.cpp
@@ -79,8 +79,8 @@ namespace OpenRCT2::GameActions
         auto res = Result();
 
         auto validRange = ClampRangeWithinMap(_range.Normalise());
-        CoordsXYZ centre{ (validRange.GetLeft() + validRange.GetRight()) / 2 + 16,
-                          (validRange.GetTop() + validRange.GetBottom()) / 2 + 16, 0 };
+        CoordsXYZ centre{ (validRange.GetX1() + validRange.GetX2()) / 2 + 16,
+                          (validRange.GetY1() + validRange.GetY2()) / 2 + 16, 0 };
         centre.z = TileElementHeight(centre);
 
         res.Position = centre;
@@ -92,9 +92,9 @@ namespace OpenRCT2::GameActions
         }
 
         // Game command modified to accept selection size
-        for (auto y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (auto y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (auto x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (auto x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                     continue;

--- a/src/openrct2/actions/LandSmoothAction.cpp
+++ b/src/openrct2/actions/LandSmoothAction.cpp
@@ -342,10 +342,10 @@ namespace OpenRCT2::GameActions
 
         auto normRange = _range.Normalise();
         // Cap bounds to map
-        auto l = std::max(normRange.GetLeft(), 32);
-        auto t = std::max(normRange.GetTop(), 32);
-        auto r = std::clamp(normRange.GetRight(), 0, kMaximumTileStartXY);
-        auto b = std::clamp(normRange.GetBottom(), 0, kMaximumTileStartXY);
+        auto l = std::max(normRange.GetX1(), 32);
+        auto t = std::max(normRange.GetY1(), 32);
+        auto r = std::clamp(normRange.GetX2(), 0, kMaximumTileStartXY);
+        auto b = std::clamp(normRange.GetY2(), 0, kMaximumTileStartXY);
         auto validRange = MapRange{ l, t, r, b };
 
         int32_t centreZ = TileElementHeight(_coords);
@@ -365,51 +365,51 @@ namespace OpenRCT2::GameActions
 
                 // Smooth the 4 corners
                 { // top-left
-                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetLeft(), validRange.GetTop() });
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX1(), validRange.GetY1() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 2)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, -32, 0, 2);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, -32, 0, 2);
                     }
                 }
                 { // bottom-left
-                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetLeft(), validRange.GetBottom() });
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX1(), validRange.GetY2() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 3)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetBottom() }, z, -32, 32, 1, 3);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY2() }, z, -32, 32, 1, 3);
                     }
                 }
                 { // bottom-right
-                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetRight(), validRange.GetBottom() });
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX2(), validRange.GetY2() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 0)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetRight(), validRange.GetBottom() }, z, 32, 32, 2, 0);
+                            gameState, isExecuting, { validRange.GetX2(), validRange.GetY2() }, z, 32, 32, 2, 0);
                     }
                 }
                 { // top-right
-                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetRight(), validRange.GetTop() });
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX2(), validRange.GetY1() });
                     if (surfaceElement != nullptr)
                     {
                         int32_t z = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 1)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetRight(), validRange.GetTop() }, z, 32, -32, 3, 1);
+                            gameState, isExecuting, { validRange.GetX2(), validRange.GetY1() }, z, 32, -32, 3, 1);
                     }
                 }
 
                 // Smooth the edges
                 int32_t z1, z2;
-                for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+                for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
                 {
-                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetLeft(), y });
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX1(), y });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp(
@@ -417,10 +417,10 @@ namespace OpenRCT2::GameActions
                         z2 = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 2)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByEdge(
-                            gameState, isExecuting, { validRange.GetLeft(), y }, z1, z2, -32, 0, 0, 1, 3, 2);
+                            gameState, isExecuting, { validRange.GetX1(), y }, z1, z2, -32, 0, 0, 1, 3, 2);
                     }
 
-                    surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetRight(), y });
+                    surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX2(), y });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp(
@@ -428,13 +428,13 @@ namespace OpenRCT2::GameActions
                         z2 = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 0)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByEdge(
-                            gameState, isExecuting, { validRange.GetRight(), y }, z1, z2, 32, 0, 2, 3, 1, 0);
+                            gameState, isExecuting, { validRange.GetX2(), y }, z1, z2, 32, 0, 2, 3, 1, 0);
                     }
                 }
 
-                for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+                for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
                 {
-                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ x, validRange.GetTop() });
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ x, validRange.GetY1() });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp(
@@ -442,10 +442,10 @@ namespace OpenRCT2::GameActions
                         z2 = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 2)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByEdge(
-                            gameState, isExecuting, { x, validRange.GetTop() }, z1, z2, 0, -32, 0, 3, 1, 2);
+                            gameState, isExecuting, { x, validRange.GetY1() }, z1, z2, 0, -32, 0, 3, 1, 2);
                     }
 
-                    surfaceElement = MapGetSurfaceElementAt(CoordsXY{ x, validRange.GetBottom() });
+                    surfaceElement = MapGetSurfaceElementAt(CoordsXY{ x, validRange.GetY2() });
                     if (surfaceElement != nullptr)
                     {
                         z1 = std::clamp(
@@ -453,7 +453,7 @@ namespace OpenRCT2::GameActions
                         z2 = std::clamp(
                             static_cast<uint8_t>(TileElementGetCornerHeight(surfaceElement, 3)), minHeight, maxHeight);
                         res.Cost += SmoothLandRowByEdge(
-                            gameState, isExecuting, { x, validRange.GetBottom() }, z1, z2, 0, 32, 1, 2, 0, 3);
+                            gameState, isExecuting, { x, validRange.GetY2() }, z1, z2, 0, 32, 1, 2, 0, 3);
                     }
                 }
                 break;
@@ -463,7 +463,7 @@ namespace OpenRCT2::GameActions
             case MapSelectType::corner2:
             case MapSelectType::corner3:
             {
-                auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetLeft(), validRange.GetTop() });
+                auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX1(), validRange.GetY1() });
                 if (surfaceElement == nullptr)
                     break;
                 uint8_t newBaseZ = surfaceElement->BaseHeight;
@@ -488,16 +488,16 @@ namespace OpenRCT2::GameActions
                 // Smooth the corners
                 int32_t z = MapGetCornerHeight(newBaseZ, newSlope, 2);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, -32, 0, 2);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, -32, 0, 2);
                 z = MapGetCornerHeight(newBaseZ, newSlope, 0);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, 32, 2, 0);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, 32, 2, 0);
                 z = MapGetCornerHeight(newBaseZ, newSlope, 3);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, 32, 1, 3);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, 32, 1, 3);
                 z = MapGetCornerHeight(newBaseZ, newSlope, 1);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, -32, 3, 1);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, -32, 3, 1);
 
                 // Smooth the edges
                 switch (selectionType)
@@ -505,54 +505,54 @@ namespace OpenRCT2::GameActions
                     case MapSelectType::corner0:
                         z = MapGetCornerHeight(newBaseZ, newSlope, 0);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, 0, 3, 0);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, 0, 3, 0);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, 32, 1, 0);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, 32, 1, 0);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 3);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, 0, 0, 3);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, 0, 0, 3);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 1);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, -32, 0, 1);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, -32, 0, 1);
                         break;
                     case MapSelectType::corner1:
                         z = MapGetCornerHeight(newBaseZ, newSlope, 1);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, 0, 2, 1);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, 0, 2, 1);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, -32, 0, 1);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, -32, 0, 1);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 2);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, 0, 1, 2);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, 0, 1, 2);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 0);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, 32, 1, 0);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, 32, 1, 0);
                         break;
                     case MapSelectType::corner2:
                         z = MapGetCornerHeight(newBaseZ, newSlope, 2);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, 0, 1, 2);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, 0, 1, 2);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, -32, 3, 2);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, -32, 3, 2);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 1);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, 0, 2, 1);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, 0, 2, 1);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 3);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, 32, 2, 3);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, 32, 2, 3);
                         break;
                     case MapSelectType::corner3:
                         z = MapGetCornerHeight(newBaseZ, newSlope, 3);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, 0, 0, 3);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, 0, 0, 3);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, 32, 2, 3);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, 32, 2, 3);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 0);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, 0, 3, 0);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, 0, 3, 0);
                         z = MapGetCornerHeight(newBaseZ, newSlope, 2);
                         res.Cost += SmoothLandRowByCorner(
-                            gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 0, -32, 3, 2);
+                            gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 0, -32, 3, 2);
                         break;
                     default:
                         break;
@@ -566,7 +566,7 @@ namespace OpenRCT2::GameActions
             {
                 // TODO: Handle smoothing by edge
                 // Get the two corners to raise
-                auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetLeft(), validRange.GetTop() });
+                auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ validRange.GetX1(), validRange.GetY1() });
                 if (surfaceElement == nullptr)
                     break;
                 uint8_t newBaseZ = surfaceElement->BaseHeight;
@@ -612,32 +612,32 @@ namespace OpenRCT2::GameActions
                 uint8_t z4 = MapGetCornerHeight(newBaseZ, newSlope, c4);
                 // Smooth the edge at the top of the new slope
                 res.Cost += SmoothLandRowByEdge(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z1, z2, stepOffsets[edge].x,
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z1, z2, stepOffsets[edge].x,
                     stepOffsets[edge].y, c3, c4, c1, c2);
                 // Smooth the edge at the bottom of the new slope
                 res.Cost += SmoothLandRowByEdge(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z3, z4, -stepOffsets[edge].x,
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z3, z4, -stepOffsets[edge].x,
                     -stepOffsets[edge].y, c1, c2, c3, c4);
 
                 // Smooth corners
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z1, -stepOffsets[edge].y,
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z1, -stepOffsets[edge].y,
                     stepOffsets[edge].x, c2, c1);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z2, stepOffsets[edge].y,
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z2, stepOffsets[edge].y,
                     -stepOffsets[edge].x, c1, c2);
                 int32_t z = MapGetCornerHeight(newBaseZ, newSlope, 2);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, -32, 0, 2);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, -32, 0, 2);
                 z = MapGetCornerHeight(newBaseZ, newSlope, 0);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, 32, 2, 0);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, 32, 2, 0);
                 z = MapGetCornerHeight(newBaseZ, newSlope, 3);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, -32, 32, 1, 3);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, -32, 32, 1, 3);
                 z = MapGetCornerHeight(newBaseZ, newSlope, 1);
                 res.Cost += SmoothLandRowByCorner(
-                    gameState, isExecuting, { validRange.GetLeft(), validRange.GetTop() }, z, 32, -32, 3, 1);
+                    gameState, isExecuting, { validRange.GetX1(), validRange.GetY1() }, z, 32, -32, 3, 1);
                 break;
             }
             default:

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
@@ -70,9 +70,9 @@ namespace OpenRCT2::GameActions
         }
 
         auto validRange = ClampRangeWithinMap(_range);
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                 {

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -76,8 +76,8 @@ namespace OpenRCT2::GameActions
             }
         }
 
-        auto xMid = (validRange.GetLeft() + validRange.GetRight()) / 2 + 16;
-        auto yMid = (validRange.GetTop() + validRange.GetBottom()) / 2 + 16;
+        auto xMid = (validRange.GetX1() + validRange.GetX2()) / 2 + 16;
+        auto yMid = (validRange.GetY1() + validRange.GetY2()) / 2 + 16;
         auto heightMid = TileElementHeight({ xMid, yMid });
 
         res.Position.x = xMid;
@@ -93,10 +93,10 @@ namespace OpenRCT2::GameActions
 
         money64 surfaceCost = 0;
         money64 edgeCost = 0;
-        for (CoordsXY coords = { validRange.GetLeft(), validRange.GetTop() }; coords.x <= validRange.GetRight();
+        for (CoordsXY coords = { validRange.GetX1(), validRange.GetY1() }; coords.x <= validRange.GetX2();
              coords.x += kCoordsXYStep)
         {
-            for (coords.y = validRange.GetTop(); coords.y <= validRange.GetBottom(); coords.y += kCoordsXYStep)
+            for (coords.y = validRange.GetY1(); coords.y <= validRange.GetY2(); coords.y += kCoordsXYStep)
             {
                 if (!LocationValid(coords))
                     continue;
@@ -150,8 +150,8 @@ namespace OpenRCT2::GameActions
         res.Expenditure = ExpenditureType::landscaping;
 
         auto validRange = ClampRangeWithinMap(_range.Normalise());
-        auto xMid = (validRange.GetLeft() + validRange.GetRight()) / 2 + 16;
-        auto yMid = (validRange.GetTop() + validRange.GetBottom()) / 2 + 16;
+        auto xMid = (validRange.GetX1() + validRange.GetX2()) / 2 + 16;
+        auto yMid = (validRange.GetY1() + validRange.GetY2()) / 2 + 16;
         auto heightMid = TileElementHeight({ xMid, yMid });
 
         res.Position.x = xMid;
@@ -160,10 +160,10 @@ namespace OpenRCT2::GameActions
 
         money64 surfaceCost = 0;
         money64 edgeCost = 0;
-        for (CoordsXY coords = { validRange.GetLeft(), validRange.GetTop() }; coords.x <= validRange.GetRight();
+        for (CoordsXY coords = { validRange.GetX1(), validRange.GetY1() }; coords.x <= validRange.GetX2();
              coords.x += kCoordsXYStep)
         {
-            for (coords.y = validRange.GetTop(); coords.y <= validRange.GetBottom(); coords.y += kCoordsXYStep)
+            for (coords.y = validRange.GetY1(); coords.y <= validRange.GetY2(); coords.y += kCoordsXYStep)
             {
                 if (!LocationValid(coords))
                     continue;

--- a/src/openrct2/actions/WaterLowerAction.cpp
+++ b/src/openrct2/actions/WaterLowerAction.cpp
@@ -56,8 +56,8 @@ namespace OpenRCT2::GameActions
         auto res = Result();
 
         auto validRange = ClampRangeWithinMap(_range);
-        res.Position.x = ((validRange.GetLeft() + validRange.GetRight()) / 2) + 16;
-        res.Position.y = ((validRange.GetTop() + validRange.GetBottom()) / 2) + 16;
+        res.Position.x = ((validRange.GetX1() + validRange.GetX2()) / 2) + 16;
+        res.Position.y = ((validRange.GetY1() + validRange.GetY2()) / 2) + 16;
         int16_t z = TileElementHeight(res.Position);
         int16_t waterHeight = TileElementWaterHeight(res.Position);
         if (waterHeight != 0)
@@ -70,9 +70,9 @@ namespace OpenRCT2::GameActions
         uint8_t minHeight = GetLowestHeight(gameState, validRange);
         bool hasChanged = false;
         bool withinOwnership = false;
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                     continue;
@@ -135,9 +135,9 @@ namespace OpenRCT2::GameActions
     {
         // The lowest height to lower the water to is the highest water level in the selection
         uint8_t minHeight{ 0 };
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
                 {

--- a/src/openrct2/actions/WaterRaiseAction.cpp
+++ b/src/openrct2/actions/WaterRaiseAction.cpp
@@ -56,8 +56,8 @@ namespace OpenRCT2::GameActions
         auto res = Result();
 
         auto validRange = ClampRangeWithinMap(_range);
-        res.Position.x = ((validRange.GetLeft() + validRange.GetRight()) / 2) + 16;
-        res.Position.y = ((validRange.GetTop() + validRange.GetBottom()) / 2) + 16;
+        res.Position.x = ((validRange.GetX1() + validRange.GetX2()) / 2) + 16;
+        res.Position.y = ((validRange.GetY1() + validRange.GetY2()) / 2) + 16;
         int32_t z = TileElementHeight(res.Position);
         int16_t waterHeight = TileElementWaterHeight(res.Position);
         if (waterHeight != 0)
@@ -70,9 +70,9 @@ namespace OpenRCT2::GameActions
         auto maxHeight = GetHighestHeight(gameState, validRange) / kCoordsZStep;
         bool hasChanged = false;
         bool withinOwnership = false;
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (!LocationValid({ x, y }))
                     continue;
@@ -148,9 +148,9 @@ namespace OpenRCT2::GameActions
     {
         // The highest height to raise the water to is the lowest water level in the selection
         uint16_t maxHeight = 255 * kCoordsZStep;
-        for (int32_t y = validRange.GetTop(); y <= validRange.GetBottom(); y += kCoordsXYStep)
+        for (int32_t y = validRange.GetY1(); y <= validRange.GetY2(); y += kCoordsXYStep)
         {
-            for (int32_t x = validRange.GetLeft(); x <= validRange.GetRight(); x += kCoordsXYStep)
+            for (int32_t x = validRange.GetX1(); x <= validRange.GetX2(); x += kCoordsXYStep)
             {
                 if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
                 {

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -422,10 +422,10 @@ struct DataSerializerTraitsT<MapRange>
 {
     static void encode(OpenRCT2::IStream* stream, const MapRange& v)
     {
-        stream->WriteValue(ByteSwapBE(v.GetLeft()));
-        stream->WriteValue(ByteSwapBE(v.GetTop()));
-        stream->WriteValue(ByteSwapBE(v.GetRight()));
-        stream->WriteValue(ByteSwapBE(v.GetBottom()));
+        stream->WriteValue(ByteSwapBE(v.GetX1()));
+        stream->WriteValue(ByteSwapBE(v.GetY1()));
+        stream->WriteValue(ByteSwapBE(v.GetX2()));
+        stream->WriteValue(ByteSwapBE(v.GetY2()));
     }
     static void decode(OpenRCT2::IStream* stream, MapRange& v)
     {
@@ -439,8 +439,7 @@ struct DataSerializerTraitsT<MapRange>
     {
         char coords[128] = {};
         snprintf(
-            coords, sizeof(coords), "MapRange(l = %d, t = %d, r = %d, b = %d)", v.GetLeft(), v.GetTop(), v.GetRight(),
-            v.GetBottom());
+            coords, sizeof(coords), "MapRange(x1 = %d, y1 = %d, x2 = %d, y2 = %d)", v.GetX1(), v.GetY1(), v.GetX2(), v.GetY2());
 
         stream->Write(coords, strlen(coords));
     }

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -295,9 +295,9 @@ void Staff::SetPatrolArea(const CoordsXY& coords, bool value)
 
 void Staff::SetPatrolArea(const MapRange& range, bool value)
 {
-    for (int32_t yy = range.GetTop(); yy <= range.GetBottom(); yy += kCoordsXYStep)
+    for (int32_t yy = range.GetY1(); yy <= range.GetY2(); yy += kCoordsXYStep)
     {
-        for (int32_t xx = range.GetLeft(); xx <= range.GetRight(); xx += kCoordsXYStep)
+        for (int32_t xx = range.GetX1(); xx <= range.GetX2(); xx += kCoordsXYStep)
         {
             SetPatrolArea({ xx, yy }, value);
         }

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -606,9 +606,9 @@ namespace OpenRCT2::Scripting
             else
             {
                 auto mapRange = FromDuk<MapRange>(coordsOrRange);
-                for (int32_t y = mapRange.GetTop(); y <= mapRange.GetBottom(); y += kCoordsXYStep)
+                for (int32_t y = mapRange.GetY1(); y <= mapRange.GetY2(); y += kCoordsXYStep)
                 {
-                    for (int32_t x = mapRange.GetLeft(); x <= mapRange.GetRight(); x += kCoordsXYStep)
+                    for (int32_t x = mapRange.GetX1(); x <= mapRange.GetX2(); x += kCoordsXYStep)
                     {
                         CoordsXY coord(x, y);
                         staff->SetPatrolArea(coord, value);

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -848,19 +848,19 @@ struct RectRange : public CoordsRange<T>
  * Represents a rectangular range of the map using regular coordinates (32 per tile).
  */
 
-struct MapRange : public RectRange<CoordsXY>
+struct MapRange : public CoordsRange<CoordsXY>
 {
-    using RectRange::RectRange;
+    using CoordsRange::CoordsRange;
 
     constexpr MapRange Normalise() const
     {
         // Don't use std::min/max, as they require <algorithm>, one of C++'s heaviest
         // in this very common header.
         auto result = MapRange(
-            GetLeft() < GetRight() ? GetLeft() : GetRight(), // min
-            GetTop() < GetBottom() ? GetTop() : GetBottom(), // min
-            GetLeft() > GetRight() ? GetLeft() : GetRight(), // max
-            GetTop() > GetBottom() ? GetTop() : GetBottom()  // max
+            GetX1() < GetX2() ? GetX1() : GetX2(), // min
+            GetY1() < GetY2() ? GetY1() : GetY2(), // min
+            GetX1() > GetX2() ? GetX1() : GetX2(), // max
+            GetY1() > GetY2() ? GetY1() : GetY2()  // max
         );
         return result;
     }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -944,13 +944,13 @@ int32_t TileElementGetCornerHeight(const SurfaceElement* surfaceElement, int32_t
 uint8_t MapGetLowestLandHeight(const MapRange& range)
 {
     auto mapSizeMax = GetMapSizeMaxXY();
-    MapRange validRange = { std::max(range.GetLeft(), 32), std::max(range.GetTop(), 32),
-                            std::min(range.GetRight(), mapSizeMax.x), std::min(range.GetBottom(), mapSizeMax.y) };
+    MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
+                            std::min(range.GetY2(), mapSizeMax.y) };
 
     uint8_t minHeight = 0xFF;
-    for (int32_t yi = validRange.GetTop(); yi <= validRange.GetBottom(); yi += kCoordsXYStep)
+    for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
     {
-        for (int32_t xi = validRange.GetLeft(); xi <= validRange.GetRight(); xi += kCoordsXYStep)
+        for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
         {
             auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
 
@@ -974,13 +974,13 @@ uint8_t MapGetLowestLandHeight(const MapRange& range)
 uint8_t MapGetHighestLandHeight(const MapRange& range)
 {
     auto mapSizeMax = GetMapSizeMaxXY();
-    MapRange validRange = { std::max(range.GetLeft(), 32), std::max(range.GetTop(), 32),
-                            std::min(range.GetRight(), mapSizeMax.x), std::min(range.GetBottom(), mapSizeMax.y) };
+    MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
+                            std::min(range.GetY2(), mapSizeMax.y) };
 
     uint8_t maxHeight = 0;
-    for (int32_t yi = validRange.GetTop(); yi <= validRange.GetBottom(); yi += kCoordsXYStep)
+    for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
     {
-        for (int32_t xi = validRange.GetLeft(); xi <= validRange.GetRight(); xi += kCoordsXYStep)
+        for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
         {
             auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
             if (surfaceElement != nullptr)
@@ -1074,10 +1074,10 @@ void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* top, int3
 {
     uint32_t rotation = GetCurrentRotation();
     const std::array corners{
-        CoordsXY{ _range.GetLeft(), _range.GetTop() },
-        CoordsXY{ _range.GetRight(), _range.GetTop() },
-        CoordsXY{ _range.GetRight(), _range.GetBottom() },
-        CoordsXY{ _range.GetLeft(), _range.GetBottom() },
+        CoordsXY{ _range.GetX1(), _range.GetY1() },
+        CoordsXY{ _range.GetX2(), _range.GetY1() },
+        CoordsXY{ _range.GetX2(), _range.GetY2() },
+        CoordsXY{ _range.GetX1(), _range.GetY2() },
     };
 
     *left = std::numeric_limits<int32_t>::max();
@@ -2187,10 +2187,10 @@ void FixLandOwnershipTilesWithOwnership(std::vector<TileCoordsXY> tiles, uint8_t
 MapRange ClampRangeWithinMap(const MapRange& range)
 {
     auto mapSizeMax = GetMapSizeMaxXY();
-    auto aX = std::max<decltype(range.GetLeft())>(kCoordsXYStep, range.GetLeft());
-    auto bX = std::min<decltype(range.GetRight())>(mapSizeMax.x, range.GetRight());
-    auto aY = std::max<decltype(range.GetTop())>(kCoordsXYStep, range.GetTop());
-    auto bY = std::min<decltype(range.GetBottom())>(mapSizeMax.y, range.GetBottom());
+    auto aX = std::max<decltype(range.GetX1())>(kCoordsXYStep, range.GetX1());
+    auto bX = std::min<decltype(range.GetX2())>(mapSizeMax.x, range.GetX2());
+    auto aY = std::max<decltype(range.GetY1())>(kCoordsXYStep, range.GetY1());
+    auto bY = std::min<decltype(range.GetY2())>(mapSizeMax.y, range.GetY2());
     MapRange validRange = MapRange{ aX, aY, bX, bY };
     return validRange;
 }


### PR DESCRIPTION
The use of left/right/top/bottom is only suitable for screen coordinates, as the map does not work that way. Rather, inherit from CoordsRange directly.

Spun off from #25286.