### PR TITLE
Update en-GB.txt - Capitalize film names

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -473,14 +473,14 @@ STR_1076    :Shop stall mode
 STR_1077    :Rotation mode
 STR_1078    :Forward rotation
 STR_1079    :Backward rotation
-STR_1080    :Film: “Avenging aviators”
-STR_1081    :3D film: “Mouse tails”
+STR_1080    :Film: “Avenging Aviators”
+STR_1081    :3D film: “Mouse Tails”
 STR_1082    :Space rings mode
 STR_1083    :Beginners mode
 STR_1084    :LIM-powered launch
-STR_1085    :Film: “Thrill riders”
-STR_1086    :3D film: “Storm chasers”
-STR_1087    :3D film: “Space raiders”
+STR_1085    :Film: “Thrill Riders”
+STR_1086    :3D film: “Storm Chasers”
+STR_1087    :3D film: “Space Raiders”
 STR_1088    :Intense mode
 STR_1089    :Berserk mode
 STR_1090    :Haunted house mode


### PR DESCRIPTION
This capitalizes the names of the films that can be shown in the 3D Cinema and Motion Simulator in accordance with English rules for proper nouns. I am unsure on how this affects other languages because these capitalization rules are very specific to the English language (for example, I know for certain that Latin-derived languages only capitalize the first letter of movie titles, so the way it was originally written would be grammatically correct in those languages, thus it wouldn't be necessary to ask for revised translations for them).