### PR TITLE
Fix missing tunnel at end of go-karts medium right gentle sloped turn

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Fix: [#22779, #25330] Incorrect queue paths in Nevermore Park and Six Flags Holland scenarios (bug in the original scenarios).
 - Fix: [#25299] The Mine Train Coaster left large helix draws incorrect sprites at certain angles (original bug).
 - Fix: [#25328] Spiral Slide in Blackpool Pleasure Beach has its entrance and exit the wrong way round (bug in the original scenario).
+- Fix: [#25342] The Go-Karts medium right gentle sloped turn does not have a tunnel at the end.
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/thrill/GoKarts.cpp
+++ b/src/openrct2/paint/track/thrill/GoKarts.cpp
@@ -2474,7 +2474,7 @@ static void TrackRightQuarterTurn5TilesUp25(
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
     }
-    else if (trackSequence == 6 && (direction == 2 || direction == 3))
+    else if (trackSequence == 6 && (direction == 0 || direction == 1))
     {
         PaintUtilPushTunnelRotated(session, DirectionNext(direction), height + 8, kTunnelGroup, TunnelSubType::SlopeEnd);
     }


### PR DESCRIPTION
<img width="530" height="171" alt="gokarttunnelbug" src="https://github.com/user-attachments/assets/7c45c4f4-be48-4bbf-8e96-6d5a34a3b94f" />
<img width="530" height="171" alt="gokarttunnelfix" src="https://github.com/user-attachments/assets/c4f1d349-3e33-4c5f-95c8-79a513ffe0d5" />
<img width="158" height="209" alt="gokarttunnelfix2" src="https://github.com/user-attachments/assets/876f8e06-3c5b-4d76-b4ff-c00ec5ec1ed3" />

Save:
[gokartmediumgentleturntunnels.zip](https://github.com/user-attachments/files/22905490/gokartmediumgentleturntunnels.zip)
