### PR TITLE
Use primitive for loop for window iterations, iterators can invalidate

### DIFF
--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -83,8 +83,9 @@ static constexpr float kWindowScrollLocations[][2] = {
 
     void WindowVisitEach(std::function<void(WindowBase*)> func)
     {
-        for (auto& w : gWindowList)
+        for (size_t i = 0; i < gWindowList.size(); i++)
         {
+            auto& w = gWindowList[i];
             if (w->flags.has(WindowFlag::dead))
                 continue;
             func(w.get());


### PR DESCRIPTION
Just a safety measure, was looking at some backtrace issues and none of them really make much sense in regards to dereferencing null on a window, perhaps this helps, this can potentially happen if new windows are created during iterations causing a resize so the iterator would be junk.