### PR TITLE
Pass the actual parameter down

### DIFF
--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2090,7 +2090,7 @@ void TrackDesignDrawPreview(TrackDesign& td, uint8_t* pixels, bool placeScenery)
 
     Ride* ride;
     TrackDesignGameStateData updatedGameStateData = td.gameStateData;
-    if (!TrackDesignPlacePreview(tds, td, &ride, updatedGameStateData, !gTrackDesignSceneryToggle))
+    if (!TrackDesignPlacePreview(tds, td, &ride, updatedGameStateData, placeScenery))
     {
         std::fill_n(pixels, kTrackPreviewImageSize * 4, 0x00);
         UnstashMap();


### PR DESCRIPTION
Noticed this after going over the PR again, it will be always !gTrackDesignSceneryToggle but lets keep it logical.