### PR TITLE
Fix mine train coaster flat to steep track not blocking all supports

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#25299] The Mine Train Coaster left large helix draws incorrect sprites at certain angles (original bug).
 - Fix: [#25328] Spiral Slide in Blackpool Pleasure Beach has its entrance and exit the wrong way round (bug in the original scenario).
 - Fix: [#25342] The Go-Karts medium right gentle sloped turn does not have a tunnel at the end.
+- Fix: [#25363] The Mine Train Coaster flat-to-steep track pieces do not block all metal supports.
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
@@ -6968,8 +6968,6 @@ static void MineTrainRCTrackFlatTo60DegUpLongBase(
             {
                 PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
             }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48);
             break;
         case 1:
@@ -6999,8 +6997,6 @@ static void MineTrainRCTrackFlatTo60DegUpLongBase(
             WoodenASupportsPaintSetupRotated(
                 session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
                 WoodenSupportTransitionType::flatToUp60DegLongBaseSeq1);
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48);
             break;
         case 2:
@@ -7030,8 +7026,6 @@ static void MineTrainRCTrackFlatTo60DegUpLongBase(
             WoodenASupportsPaintSetupRotated(
                 session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
                 WoodenSupportTransitionType::flatToUp60DegLongBaseSeq2);
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 64);
             break;
         case 3:
@@ -7070,11 +7064,10 @@ static void MineTrainRCTrackFlatTo60DegUpLongBase(
                     PaintUtilPushTunnelLeft(session, height + 24, kTunnelGroup, TunnelSubType::SlopeEnd);
                     break;
             }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 80);
             break;
     }
+    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
 }
 static void MineTrainRCTrack60DegUpToFlatLongBase(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
@@ -7113,8 +7106,6 @@ static void MineTrainRCTrack60DegUpToFlatLongBase(
             {
                 PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::SlopeStart);
             }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 80);
             break;
         case 1:
@@ -7144,8 +7135,6 @@ static void MineTrainRCTrack60DegUpToFlatLongBase(
             WoodenASupportsPaintSetupRotated(
                 session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
                 WoodenSupportTransitionType::up60DegToFlatLongBaseSeq1);
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 80);
             break;
         case 2:
@@ -7175,8 +7164,6 @@ static void MineTrainRCTrack60DegUpToFlatLongBase(
             WoodenASupportsPaintSetupRotated(
                 session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
                 WoodenSupportTransitionType::up60DegToFlatLongBaseSeq2);
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 56);
             break;
         case 3:
@@ -7215,11 +7202,10 @@ static void MineTrainRCTrack60DegUpToFlatLongBase(
                     PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::FlatTo25Deg);
                     break;
             }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 40);
             break;
     }
+    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
 }
 
 static void MineTrainRCTrackFlatTo60DegDownLongBase(


### PR DESCRIPTION
This fixes the mine train coaster flat to steep track not blocking all supports. I didn't understand blocked segments back when I made these.
This blocks supports for the full tile which is consistent with the rest of the mine coaster track, and also prevents them glitching with the track and its supports.

<img width="917" height="807" alt="minetraincoasterflattosteepblockedsegmentsbug" src="https://github.com/user-attachments/assets/e1bd0ead-4666-4f4b-b83e-a089013c4427" />
<img width="917" height="807" alt="minetraincoasterflattosteepblockedsegmentsfix" src="https://github.com/user-attachments/assets/09334396-e517-4b0a-9537-586f48c5af34" />

Save:
[minetraincoasterflattosteepblockedsegments.zip](https://github.com/user-attachments/files/22980898/minetraincoasterflattosteepblockedsegments.zip)
