### PR TITLE
Fix hybrid coaster diag brakes not blocking supports consistently

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#25358] The Stand Up Roller Coaster left corkscrew does not block supports correctly.
 - Fix: [#25363] The Mine Train Coaster flat-to-steep track pieces do not block all metal supports.
 - Fix: [#25369] The Go-Karts medium turns and small flat and sloped turns do not block metal supports correctly.
+- Fix: [#25370] The Hybrid Coaster diagonal brakes and block brakes do not block metal supports consistently.
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -1402,13 +1402,7 @@ namespace OpenRCT2::HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                PaintUtilSetSegmentSupportHeight(
-                    session,
-                    PaintUtilRotateSegments(
-                        EnumsToFlags(
-                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
-                        direction),
-                    0xFFFF, 0);
+                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
                 break;
             case 1:
@@ -1504,13 +1498,7 @@ namespace OpenRCT2::HybridRC
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                         break;
                 }
-                PaintUtilSetSegmentSupportHeight(
-                    session,
-                    PaintUtilRotateSegments(
-                        EnumsToFlags(
-                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
-                        direction),
-                    0xFFFF, 0);
+                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
                 PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
                 break;
             case 1:


### PR DESCRIPTION
Similar to #25159, I didn't catch that it also affects the brakes.

This is an incredibly minor one as there will almost always be a track piece connected so you won't even notice this. It removes a pointless special case though. Not sure whether it even needs a changelog entry tbh.

<img width="246" height="293" alt="hybriddiagbrakesbug" src="https://github.com/user-attachments/assets/eb537635-e491-4a90-93b5-1905e2527562" />
<img width="246" height="293" alt="hybriddiagbrakesfix" src="https://github.com/user-attachments/assets/a6f9ef54-040b-49fc-9e21-710a4d1813f9" />

Save:
[hybriddiagbrakesblockedsegments.zip](https://github.com/user-attachments/files/22984800/hybriddiagbrakesblockedsegments.zip)
