### PR TITLE
Fix Wooden RC small banked turns blocking more supports than RCT2

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#25363] The Mine Train Coaster flat-to-steep track pieces do not block all metal supports.
 - Fix: [#25369] The Go-Karts medium turns and small flat and sloped turns do not block metal supports correctly.
 - Fix: [#25370] The Hybrid Coaster diagonal brakes and block brakes do not block metal supports consistently.
+- Fix: [#25371] The Wooden Roller Coaster small banked turns block too many metal supports.
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Segment.h
+++ b/src/openrct2/paint/tile_element/Segment.h
@@ -27,6 +27,7 @@ enum class PaintSegment : uint16_t
     topLeft = 7,
     centre = 8,
 };
+constexpr uint16_t kSegmentsNone = 0;
 constexpr int32_t kSegmentsAll = EnumsToFlags(
     PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::centre,
     PaintSegment::topLeft, PaintSegment::topRight, PaintSegment::bottomLeft, PaintSegment::bottomRight);

--- a/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
@@ -1070,7 +1070,7 @@ static void ClassicWoodenRCTrackRightQuarterTurn3Bank(
 
     static constexpr int blockedSegments[4] = {
         kSegmentsAll,
-        kSegmentsAll,
+        kSegmentsNone,
         EnumsToFlags(PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
         kSegmentsAll,
     };

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
@@ -298,7 +298,7 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
 
     static constexpr int blockedSegments[4] = {
         kSegmentsAll,
-        kSegmentsAll,
+        kSegmentsNone,
         EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
         kSegmentsAll,
     };


### PR DESCRIPTION
Regression from 759f38a9ec1fcb5749c6b43e561b4341dcb23681
This changes the blocks on this inside tile back to how it was in RCT1/2, which is also consistent with other wide wooden supported tracks. This changes it for all 3 wooden coaster types (twister type shares impl with regular).

Current:
<img width="247" height="203" alt="wooden3tilebankturnbug" src="https://github.com/user-attachments/assets/024c017b-5f60-420e-893e-39f584d3a58c" />

From RCT2 and this fix:
<img width="247" height="203" alt="wooden3tilebankturnrct2" src="https://github.com/user-attachments/assets/9882ca41-2798-42fe-8b8a-4d694f87e5a8" />

RCT2 save:
[wooden3tileturnblockedsegments.zip](https://github.com/user-attachments/files/22985007/wooden3tileturnblockedsegments.zip)
