### PR TITLE
Fix land tool clearance checks underneath maze track pieces

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#25369] The Go-Karts medium turns and small flat and sloped turns do not block metal supports correctly.
 - Fix: [#25370] The Hybrid Coaster diagonal brakes and block brakes do not block metal supports consistently.
 - Fix: [#25371] The Wooden Roller Coaster small banked turns block too many metal supports.
+- Fix: [#25378] The land tool sometimes allows land to be raised through a maze.
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 2;
+constexpr uint8_t kStreamVersion = 3;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -107,8 +107,10 @@ static bool MapLoc68BABCShouldContinue(
         const auto [slopeNorthZ, slopeEastZ, slopeSouthZ, slopeWestZ] = GetSlopeCornerHeights(pos.baseZ, slope);
 
         const TrackElement* const trackElement = tileElement->AsTrack();
-        const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackElement->GetTrackType());
-        const auto& trackClearances = ted.sequences[trackElement->GetSequenceIndex()].clearance;
+        const TrackElemType trackElemType = trackElement->GetTrackType();
+        const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackElemType);
+        const uint8_t sequenceIndex = trackElemType == TrackElemType::Maze ? 0 : trackElement->GetSequenceIndex();
+        const auto& trackClearances = ted.sequences[sequenceIndex].clearance;
         const auto trackQuarters = trackClearances.quarterTile.Rotate(trackElement->GetDirection());
         const auto trackQuarterHeights = trackQuarters.GetQuarterHeights(trackElement->GetBaseZ());
         const uint8_t trackOccupiedQuarters = trackQuarters.GetBaseQuarterOccupied();


### PR DESCRIPTION
I forgot about this in #25032. Mazes reuse the track sequence index, this takes the minimum of the track sequence and the track element sequence count (1 for maze track piece) so that it doesn't look up the wrong thing.

I dont know whether this fixes #25367 or not. I can't reproduce a crash and the issue talks about entrances too which this shouldn't affect? Nonetheless this needs to be fixed anyway.

https://github.com/user-attachments/assets/3927ae7c-c8be-4da2-94d3-f26335864695

https://github.com/user-attachments/assets/a2b87807-f1fa-4d83-ba05-c3014c2e9684

Save, although this might not happen for you on the same piece:
[mazelandtoolbug.zip](https://github.com/user-attachments/files/22987712/mazelandtoolbug.zip)
