### PR TITLE
Fix verbose CLI server starvation

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -124,6 +124,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * John Dolph (johnwdolph) - Ride music UI, misc.
 * Harry Hopkinson (Harry-Hopkinson) - Added Cheat for guests ignoring price of rides and stalls.
 * Kendall Frey (kendfrey) - Add plugin API for spawning guests
+* Talor Berthelson (pacnpal) - Headless server verbose logging fixes
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)

--- a/src/openrct2/actions/BalloonPressAction.cpp
+++ b/src/openrct2/actions/BalloonPressAction.cpp
@@ -43,7 +43,6 @@ namespace OpenRCT2::GameActions
         auto balloon = gameState.entities.TryGetEntity<Balloon>(_spriteIndex);
         if (balloon == nullptr)
         {
-            LOG_ERROR("Balloon not found for spriteIndex %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_BALLOON_NOT_FOUND);
         }
         return Result();

--- a/src/openrct2/actions/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/BannerPlaceAction.cpp
@@ -67,7 +67,6 @@ namespace OpenRCT2::GameActions
 
         if (!MapCheckCapacityAndReorganise(_loc))
         {
-            LOG_ERROR("No free map elements.");
             return Result(Status::NoFreeElements, STR_CANT_POSITION_THIS_HERE, STR_TILE_ELEMENT_LIMIT_REACHED);
         }
 
@@ -92,14 +91,12 @@ namespace OpenRCT2::GameActions
 
         if (HasReachedBannerLimit())
         {
-            LOG_ERROR("No free banners available");
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_TOO_MANY_BANNERS_IN_GAME);
         }
 
         auto* bannerEntry = OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(_bannerType);
         if (bannerEntry == nullptr)
         {
-            LOG_ERROR("Banner entry not found for bannerType %u", _bannerType);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
         res.Cost = bannerEntry->price;

--- a/src/openrct2/actions/BannerRemoveAction.cpp
+++ b/src/openrct2/actions/BannerRemoveAction.cpp
@@ -65,22 +65,18 @@ namespace OpenRCT2::GameActions
         BannerElement* bannerElement = GetBannerElementAt();
         if (bannerElement == nullptr)
         {
-            LOG_ERROR(
-                "Invalid banner location, x = %d, y = %d, z = %d, direction = %d", _loc.x, _loc.y, _loc.z, _loc.direction);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
 
         auto bannerIndex = bannerElement->GetIndex();
         if (bannerIndex == BannerIndex::GetNull())
         {
-            LOG_ERROR("Invalid banner index %u", bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
 
         auto banner = bannerElement->GetBanner();
         if (banner == nullptr)
         {
-            LOG_ERROR("Invalid banner index %u", bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
 

--- a/src/openrct2/actions/BannerSetColourAction.cpp
+++ b/src/openrct2/actions/BannerSetColourAction.cpp
@@ -65,13 +65,11 @@ namespace OpenRCT2::GameActions
 
         if (!LocationValid(_loc))
         {
-            LOG_ERROR("Invalid x / y coordinates: x = %d, y = %d", _loc.x, _loc.y);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_OFF_EDGE_OF_MAP);
         }
 
         if (_primaryColour > 31)
         {
-            LOG_ERROR("Invalid primary colour %u", _primaryColour);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
         }
 
@@ -84,7 +82,6 @@ namespace OpenRCT2::GameActions
 
         if (bannerElement == nullptr)
         {
-            LOG_ERROR("No banner at x = %d, y = %d, z = %d, direction = %u", _loc.x, _loc.y, _loc.z, _loc.direction);
             return Result(Status::Unknown, STR_CANT_REPAINT_THIS, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
 
@@ -92,7 +89,6 @@ namespace OpenRCT2::GameActions
         auto banner = GetBanner(index);
         if (banner == nullptr)
         {
-            LOG_ERROR("Invalid banner index %u", index);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
         }
 

--- a/src/openrct2/actions/BannerSetNameAction.cpp
+++ b/src/openrct2/actions/BannerSetNameAction.cpp
@@ -50,7 +50,6 @@ namespace OpenRCT2::GameActions
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
         {
-            LOG_ERROR("Banner not found for bannerIndex %d", _bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_RENAME_BANNER, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
 
@@ -58,7 +57,6 @@ namespace OpenRCT2::GameActions
 
         if (tileElement == nullptr)
         {
-            LOG_ERROR("Banner tile element not found for bannerIndex %d", _bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_RENAME_BANNER, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/BannerSetStyleAction.cpp
+++ b/src/openrct2/actions/BannerSetStyleAction.cpp
@@ -60,7 +60,6 @@ namespace OpenRCT2::GameActions
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
         {
-            LOG_ERROR("Banner not found for bannerIndex %d", _bannerIndex);
             return Result(Status::InvalidParameters, errorTitle, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
 
@@ -72,7 +71,6 @@ namespace OpenRCT2::GameActions
 
         if (tileElement == nullptr)
         {
-            LOG_ERROR("Banner tile element not found for bannerIndex %d", _bannerIndex);
             return Result(Status::InvalidParameters, errorTitle, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
 
@@ -93,7 +91,6 @@ namespace OpenRCT2::GameActions
             case BannerSetStyleType::PrimaryColour:
                 if (_parameter > COLOUR_COUNT)
                 {
-                    LOG_ERROR("Invalid primary colour %u", _parameter);
                     return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
                 }
                 break;
@@ -101,19 +98,16 @@ namespace OpenRCT2::GameActions
             case BannerSetStyleType::TextColour:
                 if (_parameter > 13)
                 {
-                    LOG_ERROR("Invalid text colour %u", _parameter);
                     return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
                 }
                 break;
             case BannerSetStyleType::NoEntry:
                 if (tileElement->AsBanner() == nullptr)
                 {
-                    LOG_ERROR("Tile element was not a banner.");
                     return Result(Status::Unknown, STR_CANT_RENAME_BANNER, kStringIdNone);
                 }
                 break;
             default:
-                LOG_ERROR("Invalid banner style type %u", _type);
                 return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         return res;

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -78,7 +78,6 @@ namespace OpenRCT2::GameActions
     {
         if (static_cast<uint32_t>(_cheatType) >= static_cast<uint32_t>(CheatType::count))
         {
-            LOG_ERROR("Invalid cheat type %u", _cheatType);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
@@ -86,16 +85,10 @@ namespace OpenRCT2::GameActions
 
         if (_param1 < validRange.first.first || _param1 > validRange.first.second)
         {
-            LOG_ERROR(
-                "The first cheat parameter is out of range. Value = %d, min = %d, max = %d", _param1, validRange.first.first,
-                validRange.first.second);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         if (_param2 < validRange.second.first || _param2 > validRange.second.second)
         {
-            LOG_ERROR(
-                "The second cheat parameter is out of range. Value = %d, min = %d, max = %d", _param2, validRange.second.first,
-                validRange.second.second);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
@@ -79,7 +79,6 @@ namespace OpenRCT2::GameActions
         auto tileElement = MapGetFootpathElement(_loc);
         if (tileElement == nullptr)
         {
-            LOG_ERROR("No path element at x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_PATH_ELEMENT_NOT_FOUND);
         }
 
@@ -100,7 +99,6 @@ namespace OpenRCT2::GameActions
         auto* pathAdditionEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(_entryIndex);
         if (pathAdditionEntry == nullptr)
         {
-            LOG_ERROR("Unknown footpath addition entry for entryIndex %d", _entryIndex);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_UNKNOWN_OBJECT_TYPE);
         }
         uint16_t sceneryFlags = pathAdditionEntry->flags;

--- a/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
@@ -71,20 +71,17 @@ namespace OpenRCT2::GameActions
         auto tileElement = MapGetFootpathElement(_loc);
         if (tileElement == nullptr)
         {
-            LOG_ERROR("No path element at x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, STR_ERR_PATH_ELEMENT_NOT_FOUND);
         }
 
         auto pathElement = tileElement->AsPath();
         if (pathElement == nullptr)
         {
-            LOG_ERROR("No path element at x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, STR_ERR_PATH_ELEMENT_NOT_FOUND);
         }
 
         if (!pathElement->AdditionIsGhost() && (GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            LOG_WARNING("Tried to remove non ghost during ghost removal.");
             return Result(Status::Disallowed, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
         auto res = Result();

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -110,7 +110,6 @@ namespace OpenRCT2::GameActions
 
         if (_direction != kInvalidDirection && !DirectionValid(_direction))
         {
-            LOG_ERROR("Direction invalid. direction = %u", _direction);
             return Result(Status::InvalidParameters, STR_CANT_BUILD_FOOTPATH_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/GameSetSpeedAction.cpp
+++ b/src/openrct2/actions/GameSetSpeedAction.cpp
@@ -43,7 +43,6 @@ namespace OpenRCT2::GameActions
 
         if (!IsValidSpeed(_speed))
         {
-            LOG_ERROR("Invalid speed %u", _speed);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/GuestSetFlagsAction.cpp
+++ b/src/openrct2/actions/GuestSetFlagsAction.cpp
@@ -46,7 +46,6 @@ namespace OpenRCT2::GameActions
         auto* peep = gameState.entities.TryGetEntity<Guest>(_peepId);
         if (peep == nullptr)
         {
-            LOG_ERROR("Guest entity not found for peepID %u", _peepId.ToUnderlying());
             return Result(Status::InvalidParameters, STR_CANT_CHANGE_THIS, kStringIdNone);
         }
         return Result();

--- a/src/openrct2/actions/GuestSetNameAction.cpp
+++ b/src/openrct2/actions/GuestSetNameAction.cpp
@@ -66,7 +66,6 @@ namespace OpenRCT2::GameActions
         auto guest = getGameState().entities.TryGetEntity<Guest>(_spriteIndex);
         if (guest == nullptr)
         {
-            LOG_ERROR("Guest entity not found for spriteIndex %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_CANT_NAME_GUEST, kStringIdNone);
         }
 

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -80,29 +80,24 @@ namespace OpenRCT2::GameActions
 
         if (_primaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Invalid primary colour %u", _primaryColour);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_INVALID_COLOUR);
         }
         else if (_secondaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Invalid secondary colour %u", _secondaryColour);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_INVALID_COLOUR);
         }
         else if (_tertiaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Invalid tertiary colour %u", _tertiaryColour);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_INVALID_COLOUR);
         }
         else if (_sceneryType >= kMaxLargeSceneryObjects)
         {
-            LOG_ERROR("Invalid sceneryType %u", _sceneryType);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
         auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
         if (sceneryEntry == nullptr)
         {
-            LOG_ERROR("Large scenery entry not found for sceneryType %u", _sceneryType);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_UNKNOWN_OBJECT_TYPE);
         }
 
@@ -120,7 +115,6 @@ namespace OpenRCT2::GameActions
         {
             if (HasReachedBannerLimit())
             {
-                LOG_ERROR("No free banners available");
                 return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_TOO_MANY_BANNERS_IN_GAME);
             }
         }
@@ -179,7 +173,6 @@ namespace OpenRCT2::GameActions
 
         if (!CheckMapCapacity(sceneryEntry->tiles, totalNumTiles))
         {
-            LOG_ERROR("No free map elements available");
             return Result(Status::NoFreeElements, STR_CANT_POSITION_THIS_HERE, STR_TILE_ELEMENT_LIMIT_REACHED);
         }
 

--- a/src/openrct2/actions/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/LargeSceneryRemoveAction.cpp
@@ -64,7 +64,6 @@ namespace OpenRCT2::GameActions
         TileElement* tileElement = FindLargeSceneryElement(_loc, _tileIndex);
         if (tileElement == nullptr)
         {
-            LOG_ERROR("No large scenery element to remove at x = %d, y = %d", _loc.x, _loc.y);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, STR_INVALID_SELECTION_OF_OBJECTS);
         }
 
@@ -72,7 +71,6 @@ namespace OpenRCT2::GameActions
         // If we have a bugged scenery entry, do not touch the tile element.
         if (sceneryEntry == nullptr)
         {
-            LOG_WARNING("Scenery entry at x = %d, y = %d not removed because it is an unknown object type", _loc.x, _loc.y);
             return Result(Status::Unknown, STR_CANT_REMOVE_THIS, STR_UNKNOWN_OBJECT_TYPE);
         }
 

--- a/src/openrct2/actions/LargeScenerySetColourAction.cpp
+++ b/src/openrct2/actions/LargeScenerySetColourAction.cpp
@@ -74,23 +74,19 @@ namespace OpenRCT2::GameActions
         auto mapSizeMax = GetMapSizeMaxXY();
         if (_loc.x < 0 || _loc.y < 0 || _loc.x > mapSizeMax.x || _loc.y > mapSizeMax.y)
         {
-            LOG_ERROR("Invalid x / y coordinates: x = %d, y = %d", _loc.x, _loc.y);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
         if (_primaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Invalid primary colour %u", _primaryColour);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
         }
         else if (_secondaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Invalid secondary colour %u", _secondaryColour);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
         }
         else if (_tertiaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Invalid tertiary colour %u", _tertiaryColour);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
         }
 
@@ -98,9 +94,6 @@ namespace OpenRCT2::GameActions
 
         if (largeElement == nullptr)
         {
-            LOG_ERROR(
-                "Could not find large scenery at: x = %d, y = %d, z = %d, direction = %d, tileIndex = %u", _loc.x, _loc.y,
-                _loc.z, _loc.direction, _tileIndex);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
         }
 
@@ -113,7 +106,6 @@ namespace OpenRCT2::GameActions
 
         if (sceneryEntry == nullptr)
         {
-            LOG_ERROR("Scenery element doesn't have scenery entry");
             return Result(Status::Unknown, STR_CANT_REPAINT_THIS, kStringIdNone);
         }
         // Work out the base tile coordinates (Tile with index 0)
@@ -145,9 +137,6 @@ namespace OpenRCT2::GameActions
 
             if (tileElement == nullptr)
             {
-                LOG_ERROR(
-                    "Large scenery element not found at: x = %d, y = %d, z = %d, direction = %d", _loc.x, _loc.y, _loc.z,
-                    _loc.direction);
                 return Result(Status::Unknown, STR_CANT_REPAINT_THIS, kStringIdNone);
             }
             if (isExecuting)

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -133,7 +133,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr || ride->type == kRideTypeNull)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex);
             res.Error = Status::InvalidParameters;
             res.ErrorMessage = STR_ERR_RIDE_NOT_FOUND;
             return res;

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -174,7 +174,6 @@ namespace OpenRCT2::GameActions
             auto ride = GetRide(_rideIndex);
             if (ride == nullptr || !RideTypeIsValid(ride->type))
             {
-                LOG_ERROR("Ride not found for rideIndex %u", _rideIndex);
                 res.Error = Status::NoClearance;
                 res.ErrorMessage = STR_ERR_RIDE_NOT_FOUND;
                 return res;

--- a/src/openrct2/actions/ParkEntranceRemoveAction.cpp
+++ b/src/openrct2/actions/ParkEntranceRemoveAction.cpp
@@ -60,7 +60,6 @@ namespace OpenRCT2::GameActions
         }
         if (ParkEntranceGetIndex(_loc) == -1)
         {
-            LOG_ERROR("No park entrance at x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);
             return Result(Status::InvalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
         return res;

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -49,17 +49,14 @@ namespace OpenRCT2::GameActions
     {
         if (_year < 0 || _year >= kMaxYear)
         {
-            LOG_ERROR("Invalid park date year %d", _year);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         else if (_month < 0 || _month >= MONTH_COUNT)
         {
-            LOG_ERROR("Invalid park date month %d", _year);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         else if (_day < 0 || _day >= 31)
         {
-            LOG_ERROR("Invalid park date day %d", _year);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/ParkSetEntranceFeeAction.cpp
+++ b/src/openrct2/actions/ParkSetEntranceFeeAction.cpp
@@ -45,17 +45,14 @@ namespace OpenRCT2::GameActions
     {
         if ((getGameState().park.flags & PARK_FLAGS_NO_MONEY) != 0)
         {
-            LOG_ERROR("Can't set park entrance fee because the park has no money");
             return Result(Status::Disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, kStringIdNone);
         }
         else if (!Park::EntranceFeeUnlocked())
         {
-            LOG_ERROR("Park entrance fee is locked");
             return Result(Status::Disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, kStringIdNone);
         }
         else if (_fee < 0.00_GBP || _fee > kMaxEntranceFee)
         {
-            LOG_ERROR("Invalid park entrance fee %d", _fee);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/ParkSetNameAction.cpp
+++ b/src/openrct2/actions/ParkSetNameAction.cpp
@@ -47,7 +47,6 @@ namespace OpenRCT2::GameActions
     {
         if (_name.empty())
         {
-            LOG_ERROR("Can't set park name to empty string");
             return Result(Status::InvalidParameters, STR_CANT_RENAME_PARK, STR_INVALID_NAME_FOR_PARK);
         }
         return Result();

--- a/src/openrct2/actions/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/ParkSetParameterAction.cpp
@@ -45,7 +45,6 @@ namespace OpenRCT2::GameActions
     {
         if (_parameter >= ParkParameter::Count)
         {
-            LOG_ERROR("Invalid park parameter %d", _parameter);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/ParkSetResearchFundingAction.cpp
+++ b/src/openrct2/actions/ParkSetResearchFundingAction.cpp
@@ -47,7 +47,6 @@ namespace OpenRCT2::GameActions
     {
         if (_fundingAmount >= RESEARCH_FUNDING_COUNT)
         {
-            LOG_ERROR("Invalid research funding amount %d", _fundingAmount);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         return Result();

--- a/src/openrct2/actions/PeepPickupAction.cpp
+++ b/src/openrct2/actions/PeepPickupAction.cpp
@@ -50,7 +50,6 @@ namespace OpenRCT2::GameActions
     {
         if (_entityId.ToUnderlying() >= kMaxEntities || _entityId.IsNull())
         {
-            LOG_ERROR("Failed to pick up peep for sprite %d", _entityId);
             return Result(Status::InvalidParameters, STR_ERR_CANT_PLACE_PERSON_HERE, kStringIdNone);
         }
 
@@ -62,7 +61,6 @@ namespace OpenRCT2::GameActions
         auto* const peep = getGameState().entities.TryGetEntity<Peep>(_entityId);
         if (peep == nullptr)
         {
-            LOG_ERROR("Failed to pick up peep for sprite %d", _entityId);
             return Result(Status::InvalidParameters, STR_ERR_CANT_PLACE_PERSON_HERE, kStringIdNone);
         }
 
@@ -109,7 +107,6 @@ namespace OpenRCT2::GameActions
                 }
                 break;
             default:
-                LOG_ERROR("Invalid peep pickup type %u", _type);
                 return Result(Status::InvalidParameters, STR_ERR_CANT_PLACE_PERSON_HERE, kStringIdNone);
         }
         return res;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -84,28 +84,24 @@ namespace OpenRCT2::GameActions
 
         if (_rideType >= RIDE_TYPE_COUNT)
         {
-            LOG_ERROR("Invalid ride type %d", _rideType);
             return Result(Status::InvalidParameters, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, STR_INVALID_RIDE_TYPE);
         }
 
         int32_t rideEntryIndex = RideGetEntryIndex(_rideType, _subType);
         if (rideEntryIndex >= kMaxRideObjects)
         {
-            LOG_ERROR("Ride entry not found for rideType %d, subType %d", _rideType, _subType);
             return Result(Status::InvalidParameters, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, STR_INVALID_RIDE_TYPE);
         }
 
         const auto& colourPresets = GetRideTypeDescriptor(_rideType).ColourPresets;
         if (_colour1 >= colourPresets.count)
         {
-            LOG_ERROR("Can't create ride, invalid colour preset %d", _colour1);
             return Result(Status::InvalidParameters, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, STR_ERR_INVALID_COLOUR);
         }
 
         const auto* rideEntry = GetRideEntryByIndex(rideEntryIndex);
         if (rideEntry == nullptr)
         {
-            LOG_ERROR("Ride entry not found for rideEntryIndex %d", rideEntryIndex);
             return Result(Status::InvalidParameters, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, STR_UNKNOWN_OBJECT_TYPE);
         }
 

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -60,7 +60,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_CANT_DEMOLISH_RIDE, STR_ERR_RIDE_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -63,13 +63,11 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, errorTitle, STR_ERR_RIDE_NOT_FOUND);
         }
 
         if (_stationNum.ToUnderlying() >= Limits::kMaxStationsPerRide)
         {
-            LOG_ERROR("Invalid station number for ride. stationNum: %u", _stationNum.ToUnderlying());
             return Result(Status::InvalidParameters, errorTitle, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
@@ -72,7 +72,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_RIDE_NOT_FOUND);
         }
 
@@ -101,9 +100,6 @@ namespace OpenRCT2::GameActions
         }
         else if (entranceElement == nullptr)
         {
-            LOG_ERROR(
-                "Entrance/exit element not found. x = %d, y = %d, ride = %u, station = %u", _loc.x, _loc.y,
-                _rideIndex.ToUnderlying(), _stationNum.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_ENTRANCE_ELEMENT_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/RideFreezeRatingAction.cpp
+++ b/src/openrct2/actions/RideFreezeRatingAction.cpp
@@ -39,13 +39,11 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_RIDE_NOT_FOUND);
         }
 
         if (_value <= 0)
         {
-            LOG_ERROR("Rating value must be positive: %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/RideSetNameAction.cpp
+++ b/src/openrct2/actions/RideSetNameAction.cpp
@@ -51,7 +51,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_CANT_RENAME_RIDE_ATTRACTION, STR_ERR_RIDE_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/RideSetPriceAction.cpp
@@ -55,20 +55,17 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_RIDE_NOT_FOUND);
         }
 
         const auto* rideEntry = GetRideEntryByIndex(ride->subtype);
         if (rideEntry == nullptr)
         {
-            LOG_ERROR("Ride entry not found for ride subtype %u", ride->subtype);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_RIDE_OBJECT_ENTRY_NOT_FOUND);
         }
 
         if (_price < kRideMinPrice || _price > kRideMaxPrice)
         {
-            LOG_ERROR("Attempting to set an invalid price for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, kStringIdEmpty);
         }
 

--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -51,7 +51,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u.", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_RIDE_NOT_FOUND);
         }
 
@@ -70,7 +69,6 @@ namespace OpenRCT2::GameActions
 
                 if (!RideIsModeValid(*ride) && !getGameState().cheats.showAllOperatingModes)
                 {
-                    LOG_ERROR("Invalid ride mode: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
@@ -79,28 +77,24 @@ namespace OpenRCT2::GameActions
             case RideSetSetting::MinWaitingTime:
                 if (_value > 250)
                 {
-                    LOG_ERROR("Invalid minimum waiting time: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
             case RideSetSetting::MaxWaitingTime:
                 if (_value > 250)
                 {
-                    LOG_ERROR("Invalid maximum waiting time: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
             case RideSetSetting::Operation:
                 if (!RideIsValidOperationOption(*ride))
                 {
-                    LOG_ERROR("Invalid operation option value: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, GetOperationErrorMessage(*ride));
                 }
                 break;
             case RideSetSetting::InspectionInterval:
                 if (_value > RIDE_INSPECTION_NEVER)
                 {
-                    LOG_ERROR("Invalid inspection interval: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
@@ -112,7 +106,6 @@ namespace OpenRCT2::GameActions
                 auto musicObj = objManager.GetLoadedObject<MusicObject>(_value);
                 if (musicObj == nullptr)
                 {
-                    LOG_ERROR("Invalid music style: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
@@ -120,7 +113,6 @@ namespace OpenRCT2::GameActions
             case RideSetSetting::LiftHillSpeed:
                 if (!RideIsValidLiftHillSpeed(*ride))
                 {
-                    LOG_ERROR("Invalid lift hill speed: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
@@ -134,19 +126,16 @@ namespace OpenRCT2::GameActions
 
                 if (!RideIsValidNumCircuits())
                 {
-                    LOG_ERROR("Invalid number of circuits: %u", _value);
                     return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 break;
             case RideSetSetting::RideType:
                 if (!getGameState().cheats.allowArbitraryRideTypeChanges)
                 {
-                    LOG_ERROR("Arbitrary ride type changes not allowed.");
                     return Result(Status::Disallowed, STR_CANT_CHANGE_OPERATING_MODE, kStringIdNone);
                 }
                 break;
             default:
-                LOG_ERROR("Invalid ride setting %u", static_cast<uint8_t>(_setting));
                 return Result(Status::InvalidParameters, STR_CANT_CHANGE_OPERATING_MODE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/RideSetStatusAction.cpp
@@ -60,7 +60,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             res.Error = Status::InvalidParameters;
             res.ErrorTitle = STR_RIDE_DESCRIPTION_UNKNOWN;
             res.ErrorMessage = STR_ERR_RIDE_NOT_FOUND;
@@ -69,7 +68,6 @@ namespace OpenRCT2::GameActions
 
         if (_status >= RideStatus::count)
         {
-            LOG_ERROR("Invalid ride status %u for ride %u", EnumValue(_status), _rideIndex.ToUnderlying());
             res.Error = Status::InvalidParameters;
             res.ErrorTitle = STR_RIDE_DESCRIPTION_UNKNOWN;
             res.ErrorMessage = kStringIdNone;

--- a/src/openrct2/actions/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/RideSetVehicleAction.cpp
@@ -65,14 +65,12 @@ namespace OpenRCT2::GameActions
     {
         if (_type >= RideSetVehicleType::Count)
         {
-            LOG_ERROR("Invalid ride vehicle type %d", _type);
         }
         auto errTitle = kSetVehicleTypeErrorTitle[EnumValue(_type)];
 
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %u", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, errTitle, STR_ERR_RIDE_NOT_FOUND);
         }
 
@@ -96,13 +94,11 @@ namespace OpenRCT2::GameActions
             {
                 if (!RideIsVehicleTypeValid(*ride))
                 {
-                    LOG_ERROR("Invalid vehicle type %d", _value);
                     return Result(Status::InvalidParameters, errTitle, STR_ERR_VALUE_OUT_OF_RANGE);
                 }
                 auto rideEntry = GetRideEntryByIndex(_value);
                 if (rideEntry == nullptr)
                 {
-                    LOG_ERROR("Ride entry not found for _value %d", _value);
                     return Result(Status::InvalidParameters, errTitle, kStringIdNone);
                 }
 
@@ -110,14 +106,12 @@ namespace OpenRCT2::GameActions
                 VehicleColourPresetList* presetList = rideEntry->vehicle_preset_list;
                 if (_colour >= presetList->count && _colour != 255 && _colour != 0)
                 {
-                    LOG_ERROR("Unknown vehicle colour preset. colour = %d", _colour);
                     return Result(Status::InvalidParameters, errTitle, STR_ERR_INVALID_COLOUR);
                 }
                 break;
             }
 
             default:
-                LOG_ERROR("Invalid ride vehicle setting %d", _type);
                 return Result(Status::InvalidParameters, errTitle, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/ScenarioSetSettingAction.cpp
@@ -37,7 +37,6 @@ namespace OpenRCT2::GameActions
     {
         if (_setting >= ScenarioSetSetting::Count)
         {
-            LOG_ERROR("Invalid scenario setting: %u", _setting);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/SignSetNameAction.cpp
+++ b/src/openrct2/actions/SignSetNameAction.cpp
@@ -49,7 +49,6 @@ namespace OpenRCT2::GameActions
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
         {
-            LOG_ERROR("Banner not found for bannerIndex %d", _bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_RENAME_SIGN, kStringIdNone);
         }
 
@@ -57,7 +56,6 @@ namespace OpenRCT2::GameActions
 
         if (tileElement == nullptr)
         {
-            LOG_ERROR("Banner tile element not found for bannerIndex %d", _bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_RENAME_BANNER, STR_ERR_BANNER_ELEMENT_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/SignSetStyleAction.cpp
+++ b/src/openrct2/actions/SignSetStyleAction.cpp
@@ -55,7 +55,6 @@ namespace OpenRCT2::GameActions
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
         {
-            LOG_ERROR("Banner not found for bannerIndex %u", _bannerIndex);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
         }
 
@@ -66,14 +65,10 @@ namespace OpenRCT2::GameActions
             TileElement* tileElement = BannerGetTileElement(_bannerIndex);
             if (tileElement == nullptr)
             {
-                LOG_ERROR("Banner tile element not found for bannerIndex %u", _bannerIndex);
                 return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
             }
             if (tileElement->GetType() != TileElementType::LargeScenery)
             {
-                LOG_ERROR(
-                    "Tile element has type %u, expected %d (LargeScenery)", tileElement->GetType(),
-                    TileElementType::LargeScenery);
                 return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
             }
             loc = { banner->position.ToCoordsXY(), tileElement->GetBaseZ() };
@@ -84,7 +79,6 @@ namespace OpenRCT2::GameActions
 
             if (wallElement == nullptr)
             {
-                LOG_ERROR("Wall element not found for bannerIndex", _bannerIndex);
                 return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
             }
             loc = { banner->position.ToCoordsXY(), wallElement->GetBaseZ() };

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -125,7 +125,6 @@ namespace OpenRCT2::GameActions
         auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
         if (sceneryEntry == nullptr)
         {
-            LOG_ERROR("Small scenery object entry not found for sceneryType %u", _sceneryType);
             return Result(Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_UNKNOWN_OBJECT_TYPE);
         }
 

--- a/src/openrct2/actions/SmallScenerySetColourAction.cpp
+++ b/src/openrct2/actions/SmallScenerySetColourAction.cpp
@@ -95,7 +95,6 @@ namespace OpenRCT2::GameActions
 
         if (sceneryElement == nullptr)
         {
-            LOG_ERROR("Small scenery not found at: x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
         }
 

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -42,14 +42,12 @@ namespace OpenRCT2::GameActions
     {
         if (_spriteId.ToUnderlying() >= kMaxEntities || _spriteId.IsNull())
         {
-            LOG_ERROR("Invalid spriteId %u", _spriteId);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
         auto staff = getGameState().entities.TryGetEntity<Staff>(_spriteId);
         if (staff == nullptr)
         {
-            LOG_ERROR("Staff entity not found for spriteId %u", _spriteId);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_STAFF_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -79,7 +79,6 @@ namespace OpenRCT2::GameActions
 
         if (_staffType >= static_cast<uint8_t>(StaffType::count))
         {
-            LOG_ERROR("Invalid staff type %u", static_cast<uint32_t>(_staffType));
             return Result(Status::InvalidParameters, STR_CANT_HIRE_NEW_STAFF, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
@@ -93,7 +92,6 @@ namespace OpenRCT2::GameActions
             auto costumes = findAllPeepAnimationsIndexesForType(AnimationPeepType::entertainer);
             if (std::find(costumes.begin(), costumes.end(), _costumeIndex) == costumes.end())
             {
-                LOG_ERROR("Unavailable entertainer costume %u", static_cast<uint32_t>(_costumeIndex));
                 return Result(Status::InvalidParameters, STR_CANT_HIRE_NEW_STAFF, STR_ERR_VALUE_OUT_OF_RANGE);
             }
         }

--- a/src/openrct2/actions/StaffSetColourAction.cpp
+++ b/src/openrct2/actions/StaffSetColourAction.cpp
@@ -49,7 +49,6 @@ namespace OpenRCT2::GameActions
         auto staffType = static_cast<StaffType>(_staffType);
         if (staffType != StaffType::handyman && staffType != StaffType::mechanic && staffType != StaffType::security)
         {
-            LOG_ERROR("Staff color can't be changed for staff type %d", _staffType);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_ACTION_INVALID_FOR_THAT_STAFF_TYPE);
         }
         return Result();

--- a/src/openrct2/actions/StaffSetCostumeAction.cpp
+++ b/src/openrct2/actions/StaffSetCostumeAction.cpp
@@ -49,14 +49,12 @@ namespace OpenRCT2::GameActions
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
-            LOG_ERROR("Invalid sprite index %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
         auto* staff = getGameState().entities.TryGetEntity<Staff>(_spriteIndex);
         if (staff == nullptr)
         {
-            LOG_ERROR("Staff entity not found for spriteIndex %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_STAFF_NOT_FOUND);
         }
 
@@ -66,7 +64,6 @@ namespace OpenRCT2::GameActions
         auto animPeepType = AnimationPeepType(static_cast<uint8_t>(staff->AssignedStaffType) + 1);
         if (animObj->GetPeepType() != animPeepType)
         {
-            LOG_ERROR("Invalid entertainer costume %u", _costume);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         return Result();

--- a/src/openrct2/actions/StaffSetNameAction.cpp
+++ b/src/openrct2/actions/StaffSetNameAction.cpp
@@ -51,14 +51,12 @@ namespace OpenRCT2::GameActions
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
-            LOG_ERROR("Invalid sprite index %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
         auto staff = getGameState().entities.TryGetEntity<Staff>(_spriteIndex);
         if (staff == nullptr)
         {
-            LOG_ERROR("Staff entity not found for spriteIndex %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_STAFF_ERROR_CANT_NAME_STAFF_MEMBER, STR_ERR_STAFF_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/StaffSetOrdersAction.cpp
+++ b/src/openrct2/actions/StaffSetOrdersAction.cpp
@@ -48,7 +48,6 @@ namespace OpenRCT2::GameActions
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
-            LOG_ERROR("Invalid sprite index %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
@@ -56,7 +55,6 @@ namespace OpenRCT2::GameActions
         if (staff == nullptr
             || (staff->AssignedStaffType != StaffType::handyman && staff->AssignedStaffType != StaffType::mechanic))
         {
-            LOG_ERROR("Staff orders can't be changed for staff of type %u", _spriteIndex);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_ACTION_INVALID_FOR_THAT_STAFF_TYPE);
         }
 

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
@@ -65,7 +65,6 @@ namespace OpenRCT2::GameActions
         auto staff = getGameState().entities.TryGetEntity<Staff>(_spriteId);
         if (staff == nullptr)
         {
-            LOG_ERROR("Staff entity not found for spriteID %u", _spriteId.ToUnderlying());
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_STAFF_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -60,7 +60,6 @@ namespace OpenRCT2::GameActions
 
             if (surfaceObj == nullptr)
             {
-                LOG_ERROR("Invalid surface style %u", _surfaceStyle);
                 return Result(Status::InvalidParameters, STR_CANT_CHANGE_LAND_TYPE, STR_UNKNOWN_OBJECT_TYPE);
             }
         }
@@ -71,7 +70,6 @@ namespace OpenRCT2::GameActions
 
             if (edgeObj == nullptr)
             {
-                LOG_ERROR("Invalid edge style %u", _edgeStyle);
                 return Result(Status::InvalidParameters, STR_CANT_CHANGE_LAND_TYPE, STR_UNKNOWN_OBJECT_TYPE);
             }
         }

--- a/src/openrct2/actions/TileModifyAction.cpp
+++ b/src/openrct2/actions/TileModifyAction.cpp
@@ -239,7 +239,6 @@ namespace OpenRCT2::GameActions
                 break;
             }
             default:
-                LOG_ERROR("Invalid tile modification type %u", _setting);
                 return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -92,7 +92,6 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %d", rideIndex);
             return Result(Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_ERR_RIDE_NOT_FOUND);
         }
 

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -82,19 +82,16 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %d", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_ERR_RIDE_NOT_FOUND);
         }
         const auto* rideEntry = GetRideEntryByIndex(ride->subtype);
         if (rideEntry == nullptr)
         {
-            LOG_ERROR("Invalid ride subtype for track placement, rideIndex = %d", _rideIndex.ToUnderlying());
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_UNKNOWN_OBJECT_TYPE);
         }
 
         if (!DirectionValid(_origin.direction))
         {
-            LOG_ERROR("Invalid direction for track placement, direction = %d", _origin.direction);
             return Result(
                 Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
@@ -106,14 +103,12 @@ namespace OpenRCT2::GameActions
 
         if (_rideType > RIDE_TYPE_COUNT)
         {
-            LOG_ERROR("Invalid ride type for track placement, rideType = %d", _rideType);
             return Result(
                 Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
         if (_brakeSpeed > kMaximumTrackSpeed)
         {
-            LOG_WARNING("Invalid speed for track placement, speed = %d", _brakeSpeed);
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_SPEED_TOO_HIGH);
         }
 
@@ -198,7 +193,6 @@ namespace OpenRCT2::GameActions
 
         if (!CheckMapCapacity(numElements))
         {
-            LOG_ERROR("Not enough free map elements to place track.");
             return Result(
                 Status::NoFreeElements, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_TILE_ELEMENT_LIMIT_REACHED);
         }

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -110,9 +110,6 @@ namespace OpenRCT2::GameActions
 
         if (!found)
         {
-            LOG_ERROR(
-                "Track Element not found. x = %d, y = %d, z = %d, d = %d, seq = %d.", _origin.x, _origin.y, _origin.z,
-                _origin.direction, _sequence);
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_TRACK_ELEMENT_NOT_FOUND);
         }
 
@@ -128,20 +125,17 @@ namespace OpenRCT2::GameActions
         auto ride = GetRide(rideIndex);
         if (ride == nullptr)
         {
-            LOG_ERROR("Ride not found for rideIndex %d.", rideIndex);
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_RIDE_NOT_FOUND);
         }
 
         if (ride->type >= RIDE_TYPE_COUNT)
         {
-            LOG_ERROR("Ride type not found. ride type = %d.", ride->type);
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_VALUE_OUT_OF_RANGE);
         }
         const auto& ted = GetTrackElementDescriptor(trackType);
         auto sequenceIndex = tileElement->AsTrack()->GetSequenceIndex();
         if (sequenceIndex >= ted.numSequences)
         {
-            LOG_ERROR("Track block %d not found for track type %d.", sequenceIndex, trackType);
             return Result(Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_TRACK_BLOCK_NOT_FOUND);
         }
         const auto& currentTrackBlock = ted.sequences[sequenceIndex].clearance;
@@ -203,9 +197,6 @@ namespace OpenRCT2::GameActions
 
             if (!found)
             {
-                LOG_ERROR(
-                    "Track Element not found. x = %d, y = %d, z = %d, d = %d, seq = %d.", mapLoc.x, mapLoc.y, mapLoc.z,
-                    _origin.direction, i);
                 return Result(Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_TRACK_ELEMENT_NOT_FOUND);
             }
 
@@ -222,7 +213,6 @@ namespace OpenRCT2::GameActions
             auto* surfaceElement = MapGetSurfaceElementAt(mapLoc);
             if (surfaceElement == nullptr)
             {
-                LOG_ERROR("Surface Element not found. x = %d, y = %d", mapLoc.x, mapLoc.y);
                 return Result(Status::Unknown, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
             }
 

--- a/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/TrackSetBrakeSpeedAction.cpp
@@ -70,13 +70,11 @@ namespace OpenRCT2::GameActions
         TileElement* tileElement = MapGetTrackElementAtOfType(_loc, _trackType);
         if (tileElement == nullptr)
         {
-            LOG_ERROR("Track element of type %u not found at x = %d, y = %d, z = %d", _trackType, _loc.x, _loc.y, _loc.z);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_TILE_ELEMENT_NOT_FOUND);
         }
 
         if (_brakeSpeed > kMaximumTrackSpeed)
         {
-            LOG_WARNING("Invalid speed for track, speed = %d", _brakeSpeed);
             return Result(Status::InvalidParameters, STR_SPEED_TOO_HIGH, kStringIdNone);
         }
 

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -109,7 +109,6 @@ namespace OpenRCT2::GameActions
         }
         else if (!_trackDesignDrawingPreview && (_loc.x > mapSizeMax.x || _loc.y > mapSizeMax.y))
         {
-            LOG_ERROR("Invalid x/y coordinates. x = %d y = %d", _loc.x, _loc.y);
             return Result(Status::InvalidParameters, STR_CANT_BUILD_THIS_HERE, STR_OFF_EDGE_OF_MAP);
         }
 
@@ -125,7 +124,6 @@ namespace OpenRCT2::GameActions
             auto* surfaceElement = MapGetSurfaceElementAt(_loc);
             if (surfaceElement == nullptr)
             {
-                LOG_ERROR("Surface element not found at %d, %d.", _loc.x, _loc.y);
                 return Result(Status::InvalidParameters, STR_CANT_BUILD_THIS_HERE, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
             }
             targetHeight = surfaceElement->GetBaseZ();
@@ -142,7 +140,6 @@ namespace OpenRCT2::GameActions
         auto* surfaceElement = MapGetSurfaceElementAt(_loc);
         if (surfaceElement == nullptr)
         {
-            LOG_ERROR("Surface element not found at %d, %d.", _loc.x, _loc.y);
             return Result(Status::InvalidParameters, STR_CANT_BUILD_THIS_HERE, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
         }
 
@@ -227,7 +224,6 @@ namespace OpenRCT2::GameActions
 
         if (wallEntry == nullptr)
         {
-            LOG_ERROR("Wall Type not found %d", _wallType);
             return Result(Status::InvalidParameters, STR_CANT_BUILD_THIS_HERE, STR_UNKNOWN_OBJECT_TYPE);
         }
 
@@ -235,7 +231,6 @@ namespace OpenRCT2::GameActions
         {
             if (HasReachedBannerLimit())
             {
-                LOG_ERROR("No free banners available");
                 return Result(Status::InvalidParameters, STR_CANT_BUILD_THIS_HERE, STR_TOO_MANY_BANNERS_IN_GAME);
             }
         }

--- a/src/openrct2/actions/WallSetColourAction.cpp
+++ b/src/openrct2/actions/WallSetColourAction.cpp
@@ -75,9 +75,6 @@ namespace OpenRCT2::GameActions
         auto wallElement = MapGetWallElementAt(_loc);
         if (wallElement == nullptr)
         {
-            LOG_ERROR(
-                "Could not find wall element at: x = %d, y = %d, z = %d, direction = %u", _loc.x, _loc.y, _loc.z,
-                _loc.direction);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_WALL_ELEMENT_NOT_FOUND);
         }
 
@@ -89,27 +86,21 @@ namespace OpenRCT2::GameActions
         auto* wallEntry = wallElement->GetEntry();
         if (wallEntry == nullptr)
         {
-            LOG_ERROR(
-                "Wall element does not have wall entry at x = %d, y = %d, z = %d, direction = %u", _loc.x, _loc.y, _loc.z,
-                _loc.direction);
             return Result(Status::Unknown, STR_CANT_REPAINT_THIS, kStringIdNone);
         }
 
         if (_primaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Primary colour invalid: colour = %d", _primaryColour);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
         }
         else if (_secondaryColour >= COLOUR_COUNT)
         {
-            LOG_ERROR("Secondary colour invalid: colour = %d", _secondaryColour);
             return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, STR_ERR_INVALID_COLOUR);
         }
         else if (wallEntry->flags & WALL_SCENERY_HAS_TERTIARY_COLOUR)
         {
             if (_tertiaryColour >= COLOUR_COUNT)
             {
-                LOG_ERROR("Tertiary colour invalid: colour = %d", _tertiaryColour);
                 return Result(Status::InvalidParameters, STR_CANT_REPAINT_THIS, kStringIdNone);
             }
         }

--- a/src/openrct2/actions/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/WaterSetHeightAction.cpp
@@ -80,7 +80,6 @@ namespace OpenRCT2::GameActions
         SurfaceElement* surfaceElement = MapGetSurfaceElementAt(_coords);
         if (surfaceElement == nullptr)
         {
-            LOG_ERROR("No surface element at: x %u, y %u", _coords.x, _coords.y);
             return Result(Status::InvalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
         }
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1967,10 +1967,14 @@ namespace OpenRCT2
      */
     uint8_t GetCurrentRotation()
     {
+        if (gOpenRCT2Headless)
+        {
+            return 0;
+        }
+
         auto* viewport = ViewportGetMain();
         if (viewport == nullptr)
         {
-            LOG_VERBOSE("No viewport found! Will return 0.");
             return 0;
         }
         uint8_t rotation = viewport->rotation;


### PR DESCRIPTION
## Summary
- silence DiagnosticLevel::Verbose while GameAction queries run so headless servers keep servicing network sockets when --verbose is set
- suppress redundant viewport warnings in headless mode to keep verbose logs focused on networking
- credit the contribution in contributors.md

Fixes #16421

## Testing
- CCACHE_DISABLE=1 cmake --build build --target openrct2-cli
- OPENRCT2_NO_REPL=1 ./openrct2-cli host '../test/tests/testdata/parks/small_park_with_ferris_wheel.sv6' --user-data-path './tmp-headless' --openrct2-data-path '/Users/talor/Library/Mobile Documents/com~apple~CloudDocs/Games/OpenRCT2/bin/OpenRCT2.app/Contents/Resources' --rct2-data-path '/Users/talor/Games/RollerCoaster Tycoon 2 Triple Thrill Pack' --port 12610 --password secret123 --headless --verbose
- OPENRCT2_NO_REPL=1 ./openrct2-cli join 127.0.0.1 --port 12610 --password secret123 --user-data-path './tmp-headless-client' --openrct2-data-path '/Users/talor/Library/Mobile Documents/com~apple~CloudDocs/Games/OpenRCT2/bin/OpenRCT2.app/Contents/Resources' --rct2-data-path '/Users/talor/Games/RollerCoaster Tycoon 2 Triple Thrill Pack' --headless --verbose