### PR TITLE
Prevent flying roller coaster drawing opposite inverted pieces and non flying inversions

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -425,6 +425,7 @@
     <ClInclude Include="paint\tile_element\Paint.Tunnel.h" />
     <ClInclude Include="paint\tile_element\Paint.Wall.h" />
     <ClInclude Include="paint\tile_element\Segment.h" />
+    <ClInclude Include="paint\track\coaster\FlyingRollerCoasterInverted.h" />
     <ClInclude Include="paint\track\coaster\WoodenRollerCoaster.hpp" />
     <ClInclude Include="paint\track\Segment.h" />
     <ClInclude Include="paint\track\Support.h" />

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoaster.cpp
@@ -9,6 +9,7 @@
 
 #include "../../../SpriteIds.h"
 #include "../../../drawing/Drawing.h"
+#include "../../../paint/track/coaster/FlyingRollerCoasterInverted.h"
 #include "../../../ride/RideData.h"
 #include "../../../ride/TrackPaint.h"
 #include "../../../world/tile_element/TrackElement.h"
@@ -21,8 +22,6 @@
 #include "TwisterRollerCoaster.h"
 
 using namespace OpenRCT2;
-
-static constexpr TunnelGroup kTunnelGroup = TunnelGroup::Square;
 
 /** rct2: 0x007C7244, 0x007C7254, 0x007C7264 */
 static void FlyingRCTrackStation(
@@ -63,764 +62,19 @@ static void FlyingRCTrackStation(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-static void FlyingRCTrack90DegToInvertedFlatQuarterLoopUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
-    {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18062), { 0, 0, height },
-                        { { 4, 6, height + 8 }, { 2, 20, 31 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18065), { 0, 0, height },
-                        { { 24, 6, height + 8 }, { 2, 20, 31 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18068), { 0, 0, height },
-                        { { 24, 6, height + 8 }, { 2, 20, 31 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18071), { 0, 0, height },
-                        { { 4, 6, height + 8 }, { 2, 20, 31 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 88);
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18063), { 0, 0, height },
-                        { { -8, 6, height }, { 2, 20, 31 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18066), { 0, 0, height },
-                        { { 24, 6, height + 8 }, { 2, 20, 63 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18069), { 0, 0, height },
-                        { { 24, 6, height + 8 }, { 2, 20, 63 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18072), { 0, 0, height },
-                        { { -8, 6, height }, { 2, 20, 31 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18064), { 0, 0, height },
-                        { { 0, 6, height + 24 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18067), { 0, 0, height },
-                        { { 24, 6, height + 8 }, { 2, 20, 31 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18070), { 0, 0, height },
-                        { { 24, 6, height + 8 }, { 2, 20, 31 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(18073), { 0, 0, height },
-                        { { 0, 6, height + 24 }, { 32, 20, 3 } });
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 16, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-    }
-}
-
-static void FlyingRCTrackInvertedFlatTo90DegQuarterLoopDown(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
-{
-    FlyingRCTrack90DegToInvertedFlatQuarterLoopUp(
-        session, ride, 2 - trackSequence, direction, height, trackElement, supportType);
-}
-
-static void FlyingRCTrackHalfLoopInvertedUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
-    {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27451), { 0, 6, height + 24 },
-                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27459), { 0, 6, height + 24 },
-                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27458), { 0, 6, height + 24 },
-                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27466), { 0, 6, height + 24 },
-                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
-                    break;
-            }
-
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            switch (direction)
-            {
-                case 0:
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 62, session.SupportColours);
-                    break;
-                case 1:
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::bottomRightSide, 0, height + 62, session.SupportColours);
-                    break;
-                case 2:
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::bottomLeftSide, 0, height + 62, session.SupportColours);
-                    break;
-                case 3:
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 62, session.SupportColours);
-                    break;
-            }
-
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
-            }
-            PaintUtilSetGeneralSupportHeight(session, height + 72);
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27452), { 0, 0, height + 24 },
-                        { { 0, 29, height + 29 }, { 32, 2, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27460), { 0, 14, height + 24 },
-                        { { 0, 29, height + 29 }, { 32, 2, 63 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27457), { 0, 6, height + 24 },
-                        { { 0, 0, height + 29 }, { 32, 2, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27465), { 0, 6, height + 24 },
-                        { { 29, 20, height + 29 }, { 2, 2, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 88);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27453), { 16, 0, height - 3 },
-                        { { 16, 29, height + 2 }, { 5, 2, 119 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27461), { 12, 0, height - 3 },
-                        { { 0, -6, height + 2 }, { 32, 2, 119 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27456), { 10, 16, height - 3 },
-                        { { 10, 0, height + 2 }, { 4, 2, 119 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27464), { 16, 16, height - 3 },
-                        { { 29, 29, height + 2 }, { 2, 2, 119 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 168);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27454), { 0, 0, height + 29 },
-                        { { 0, 6, height + 34 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27462), { 0, 0, height + 29 },
-                        { { 0, 0, height - 6 }, { 2, 2, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27455), { 0, 16, height + 29 },
-                        { { 0, 0, height - 6 }, { 32, 2, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27463), { 0, 16, height + 29 },
-                        { { 0, 6, height + 34 }, { 32, 20, 3 } });
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
-    }
-}
-
 static void FlyingRCTrackHalfLoopUninvertedDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    FlyingRCTrackHalfLoopInvertedUp(session, ride, 3 - trackSequence, direction, height, trackElement, supportType);
-}
-
-static void FlyingRCTrackLeftFlyingLargeHalfLoopInvertedUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
-    {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27639), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27646), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27653), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27660), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 56);
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27640), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27647), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 9 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27654), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27661), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 72);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27641), { 0, 0, height - 4 },
-                        { { 8, 0, height + 40 }, { 24, 16, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27648), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27655), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27662), { 0, 0, height - 4 },
-                        { { 30, 16, height + 70 }, { 2, 16, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::topRight, PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 88);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27642), { 0, 0, height - 4 },
-                        { { 24, 0, height + 29 }, { 8, 16, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27649), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27656), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27663), { 0, 0, height - 4 },
-                        { { 30, 16, height + 100 }, { 2, 16, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::topRight, PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 224);
-            break;
-        case 4:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27643), { 0, 0, height - 4 },
-                        { { 30, 30, height + 80 }, { 2, 2, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27650), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 16, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27657), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 16, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27664), { 0, 0, height - 4 },
-                        { { 30, 0, height + 90 }, { 2, 16, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 128);
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27644), { 0, 0, height - 4 },
-                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27651), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27658), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27665), { 0, 0, height - 4 },
-                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 224);
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27645), { 0, 0, height - 4 },
-                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27652), { 0, 0, height - 4 },
-                        { { 0, 6, height }, { 32, 20, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27659), { 0, 0, height - 4 },
-                        { { 0, 6, height }, { 32, 20, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27666), { 0, 0, height - 4 },
-                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
-                    break;
-            }
-
-            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 40);
-            break;
-    }
-}
-
-static void FlyingRCTrackRightFlyingLargeHalfLoopInvertedUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
-    {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27688), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27681), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27674), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27667), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 56);
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27689), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27682), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27675), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 19 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27668), { 0, 0, height - 4 },
-                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 72);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27690), { 0, 0, height - 4 },
-                        { { 0, 16, height + 70 }, { 32, 16, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27683), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27676), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27669), { 0, 0, height - 4 },
-                        { { 0, 0, height + 70 }, { 32, 16, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 88);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27691), { 0, 0, height - 4 },
-                        { { 0, 16, height + 100 }, { 32, 16, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27684), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27677), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27670), { 0, 0, height - 4 },
-                        { { 0, 0, height + 100 }, { 32, 16, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 224);
-            break;
-        case 4:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27692), { 0, 0, height - 4 },
-                        { { 16, 7, height + 90 }, { 16, 16, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27685), { 0, 0, height - 4 },
-                        { { 0, -7, height }, { 16, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27678), { 0, 0, height - 4 },
-                        { { -7, 16, height }, { 16, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27671), { 0, 0, height - 4 },
-                        { { 30, 23, height + 110 }, { 2, 16, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 128);
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27693), { 0, 0, height - 4 },
-                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27686), { 0, 0, height - 4 },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27679), { 0, 0, height - 4 },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27672), { 0, 0, height - 4 },
-                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::topRight, PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 224);
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27694), { 0, 0, height - 4 },
-                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
-                    break;
-                case 1:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27687), { 0, 0, height - 4 },
-                        { { 0, 6, height }, { 32, 20, 3 } });
-                    break;
-                case 2:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27680), { 0, 0, height - 4 },
-                        { { 0, 6, height }, { 32, 20, 3 } });
-                    break;
-                case 3:
-                    PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours.WithIndex(27673), { 0, 0, height - 4 },
-                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
-                    break;
-            }
-            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::topRight, PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 40);
-            break;
-    }
+    FlyingRCInverted::trackPaintHalfLoopInvertedUp(
+        session, ride, 3 - trackSequence, direction, height, trackElement, supportType);
 }
 
 static void FlyingRCTrackLeftFlyingLargeHalfLoopUninvertedDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    FlyingRCTrackRightFlyingLargeHalfLoopInvertedUp(
+    FlyingRCInverted::trackPaintRightFlyingLargeHalfLoopInvertedUp(
         session, ride, 6 - trackSequence, direction, height, trackElement, supportType);
 }
 
@@ -828,7 +82,7 @@ static void FlyingRCTrackRightFlyingLargeHalfLoopUninvertedDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    FlyingRCTrackLeftFlyingLargeHalfLoopInvertedUp(
+    FlyingRCInverted::trackPaintLeftFlyingLargeHalfLoopInvertedUp(
         session, ride, 6 - trackSequence, direction, height, trackElement, supportType);
 }
 
@@ -841,31 +95,60 @@ TrackPaintFunction GetTrackPaintFunctionFlyingRC(TrackElemType trackType)
         case TrackElemType::middleStation:
             return FlyingRCTrackStation;
         // OpenRCT2-specific paint code
-        case TrackElemType::multiDimInvertedFlatToDown90QuarterLoop:
-            return FlyingRCTrackInvertedFlatTo90DegQuarterLoopDown;
         case TrackElemType::multiDimUp90ToInvertedFlatQuarterLoop:
-            return FlyingRCTrack90DegToInvertedFlatQuarterLoopUp;
+            return TwisterRCTrack90DegToInvertedFlatQuarterLoopUp;
             // OpenRCT2-specific track elements
         case TrackElemType::leftFlyerLargeHalfLoopUninvertedUp:
             return TwisterRCTrackLeftLargeHalfLoopUp;
         case TrackElemType::rightFlyerLargeHalfLoopUninvertedUp:
             return TwisterRCTrackRightLargeHalfLoopUp;
-        case TrackElemType::leftFlyerLargeHalfLoopInvertedDown:
-            return TwisterRCTrackLeftLargeHalfLoopDown;
-        case TrackElemType::rightFlyerLargeHalfLoopInvertedDown:
-            return TwisterRCTrackRightLargeHalfLoopDown;
-        case TrackElemType::flyerHalfLoopInvertedUp:
-            return FlyingRCTrackHalfLoopInvertedUp;
         case TrackElemType::flyerHalfLoopUninvertedDown:
             return FlyingRCTrackHalfLoopUninvertedDown;
-        case TrackElemType::leftFlyerLargeHalfLoopInvertedUp:
-            return FlyingRCTrackLeftFlyingLargeHalfLoopInvertedUp;
-        case TrackElemType::rightFlyerLargeHalfLoopInvertedUp:
-            return FlyingRCTrackRightFlyingLargeHalfLoopInvertedUp;
         case TrackElemType::leftFlyerLargeHalfLoopUninvertedDown:
             return FlyingRCTrackLeftFlyingLargeHalfLoopUninvertedDown;
         case TrackElemType::rightFlyerLargeHalfLoopUninvertedDown:
             return FlyingRCTrackRightFlyingLargeHalfLoopUninvertedDown;
+        case TrackElemType::leftTwistDownToUp:
+        case TrackElemType::rightTwistDownToUp:
+        case TrackElemType::leftTwistUpToDown:
+        case TrackElemType::rightTwistUpToDown:
+        case TrackElemType::halfLoopUp:
+        case TrackElemType::halfLoopDown:
+        case TrackElemType::leftCorkscrewUp:
+        case TrackElemType::rightCorkscrewUp:
+        case TrackElemType::leftCorkscrewDown:
+        case TrackElemType::rightCorkscrewDown:
+        case TrackElemType::leftBarrelRollUpToDown:
+        case TrackElemType::rightBarrelRollUpToDown:
+        case TrackElemType::leftBarrelRollDownToUp:
+        case TrackElemType::rightBarrelRollDownToUp:
+        case TrackElemType::leftLargeHalfLoopUp:
+        case TrackElemType::rightLargeHalfLoopUp:
+        case TrackElemType::leftLargeHalfLoopDown:
+        case TrackElemType::rightLargeHalfLoopDown:
+        case TrackElemType::up90ToInvertedFlatQuarterLoop:
+        case TrackElemType::invertedFlatToDown90QuarterLoop:
+        case TrackElemType::leftLargeCorkscrewUp:
+        case TrackElemType::rightLargeCorkscrewUp:
+        case TrackElemType::leftLargeCorkscrewDown:
+        case TrackElemType::rightLargeCorkscrewDown:
+        case TrackElemType::leftMediumHalfLoopUp:
+        case TrackElemType::rightMediumHalfLoopUp:
+        case TrackElemType::leftMediumHalfLoopDown:
+        case TrackElemType::rightMediumHalfLoopDown:
+        case TrackElemType::leftZeroGRollUp:
+        case TrackElemType::rightZeroGRollUp:
+        case TrackElemType::leftZeroGRollDown:
+        case TrackElemType::rightZeroGRollDown:
+        case TrackElemType::leftLargeZeroGRollUp:
+        case TrackElemType::rightLargeZeroGRollUp:
+        case TrackElemType::leftLargeZeroGRollDown:
+        case TrackElemType::rightLargeZeroGRollDown:
+        case TrackElemType::leftEighthDiveLoopUpToOrthogonal:
+        case TrackElemType::rightEighthDiveLoopUpToOrthogonal:
+        case TrackElemType::leftEighthDiveLoopDownToDiag:
+        case TrackElemType::rightEighthDiveLoopDownToDiag:
+            return TrackPaintFunctionDummy;
         default:
             return GetTrackPaintFunctionTwisterRC(trackType);
     }

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.cpp
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.cpp
@@ -7,7 +7,10 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "FlyingRollerCoasterInverted.h"
+
 #include "../../../SpriteIds.h"
+#include "../../../paint/track/coaster/TwisterRollerCoaster.h"
 #include "../../../ride/Ride.h"
 #include "../../../ride/TrackPaint.h"
 #include "../../../ride/ted/TrackElemType.h"
@@ -8912,6 +8915,647 @@ static void FlyingRCTrackFlyerHalfLoopDown(
     }
 }
 
+void OpenRCT2::FlyingRCInverted::trackPaintHalfLoopInvertedUp(
+    PaintSession& session, const Ride& ride, const uint8_t trackSequence, const Direction direction, const int32_t height,
+    const TrackElement& trackElement, const SupportType supportType)
+{
+    switch (trackSequence)
+    {
+        case 0:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27451), { 0, 6, height + 24 },
+                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27459), { 0, 6, height + 24 },
+                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27458), { 0, 6, height + 24 },
+                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27466), { 0, 6, height + 24 },
+                        { { 0, 6, height + 45 }, { 32, 20, 3 } });
+                    break;
+            }
+
+            PaintUtilSetSegmentSupportHeight(
+                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
+            switch (direction)
+            {
+                case 0:
+                    MetalASupportsPaintSetup(
+                        session, supportType.metal, MetalSupportPlace::topRightSide, 0, height + 62, session.SupportColours);
+                    break;
+                case 1:
+                    MetalASupportsPaintSetup(
+                        session, supportType.metal, MetalSupportPlace::bottomRightSide, 0, height + 62, session.SupportColours);
+                    break;
+                case 2:
+                    MetalASupportsPaintSetup(
+                        session, supportType.metal, MetalSupportPlace::bottomLeftSide, 0, height + 62, session.SupportColours);
+                    break;
+                case 3:
+                    MetalASupportsPaintSetup(
+                        session, supportType.metal, MetalSupportPlace::topLeftSide, 0, height + 62, session.SupportColours);
+                    break;
+            }
+
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
+            }
+            PaintUtilSetGeneralSupportHeight(session, height + 72);
+            break;
+        case 1:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27452), { 0, 0, height + 24 },
+                        { { 0, 29, height + 29 }, { 32, 2, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27460), { 0, 14, height + 24 },
+                        { { 0, 29, height + 29 }, { 32, 2, 63 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27457), { 0, 6, height + 24 },
+                        { { 0, 0, height + 29 }, { 32, 2, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27465), { 0, 6, height + 24 },
+                        { { 29, 20, height + 29 }, { 2, 2, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 88);
+            break;
+        case 2:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27453), { 16, 0, height - 3 },
+                        { { 16, 29, height + 2 }, { 5, 2, 119 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27461), { 12, 0, height - 3 },
+                        { { 0, -6, height + 2 }, { 32, 2, 119 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27456), { 10, 16, height - 3 },
+                        { { 10, 0, height + 2 }, { 4, 2, 119 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27464), { 16, 16, height - 3 },
+                        { { 29, 29, height + 2 }, { 2, 2, 119 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
+                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 168);
+            break;
+        case 3:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27454), { 0, 0, height + 29 },
+                        { { 0, 6, height + 34 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27462), { 0, 0, height + 29 },
+                        { { 0, 0, height - 6 }, { 2, 2, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27455), { 0, 16, height + 29 },
+                        { { 0, 0, height - 6 }, { 32, 2, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27463), { 0, 16, height + 29 },
+                        { { 0, 6, height + 34 }, { 32, 20, 3 } });
+                    break;
+            }
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 64);
+            break;
+    }
+}
+
+void OpenRCT2::FlyingRCInverted::trackPaintLeftFlyingLargeHalfLoopInvertedUp(
+    PaintSession& session, const Ride& ride, const uint8_t trackSequence, const Direction direction, const int32_t height,
+    const TrackElement& trackElement, const SupportType supportType)
+{
+    switch (trackSequence)
+    {
+        case 0:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27639), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27646), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27653), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27660), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+            }
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 56);
+            break;
+        case 1:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27640), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27647), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 9 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27654), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27661), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 72);
+            break;
+        case 2:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27641), { 0, 0, height - 4 },
+                        { { 8, 0, height + 40 }, { 24, 16, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27648), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 32, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27655), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 32, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27662), { 0, 0, height - 4 },
+                        { { 30, 16, height + 70 }, { 2, 16, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
+                        PaintSegment::topRight, PaintSegment::bottomLeft),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 88);
+            break;
+        case 3:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27642), { 0, 0, height - 4 },
+                        { { 24, 0, height + 29 }, { 8, 16, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27649), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 32, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27656), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 32, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27663), { 0, 0, height - 4 },
+                        { { 30, 16, height + 100 }, { 2, 16, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
+                        PaintSegment::topRight, PaintSegment::bottomLeft),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 224);
+            break;
+        case 4:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27643), { 0, 0, height - 4 },
+                        { { 30, 30, height + 80 }, { 2, 2, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27650), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 16, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27657), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 16, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27664), { 0, 0, height - 4 },
+                        { { 30, 0, height + 90 }, { 2, 16, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 128);
+            break;
+        case 5:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27644), { 0, 0, height - 4 },
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27651), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 32, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27658), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 32, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27665), { 0, 0, height - 4 },
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 224);
+            break;
+        case 6:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27645), { 0, 0, height - 4 },
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27652), { 0, 0, height - 4 },
+                        { { 0, 6, height }, { 32, 20, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27659), { 0, 0, height - 4 },
+                        { { 0, 6, height }, { 32, 20, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27666), { 0, 0, height - 4 },
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    break;
+            }
+
+            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 40);
+            break;
+    }
+}
+
+void OpenRCT2::FlyingRCInverted::trackPaintRightFlyingLargeHalfLoopInvertedUp(
+    PaintSession& session, const Ride& ride, const uint8_t trackSequence, const Direction direction, const int32_t height,
+    const TrackElement& trackElement, const SupportType supportType)
+{
+    switch (trackSequence)
+    {
+        case 0:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27688), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27681), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27674), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27667), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+            }
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::SlopeStart);
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 56);
+            break;
+        case 1:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27689), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27682), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27675), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 19 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27668), { 0, 0, height - 4 },
+                        { { 0, 6, height + 29 }, { 32, 20, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session, PaintUtilRotateSegments(BlockedSegments::kStraightFlat, direction), 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 72);
+            break;
+        case 2:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27690), { 0, 0, height - 4 },
+                        { { 0, 16, height + 70 }, { 32, 16, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27683), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 32, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27676), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 32, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27669), { 0, 0, height - 4 },
+                        { { 0, 0, height + 70 }, { 32, 16, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 88);
+            break;
+        case 3:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27691), { 0, 0, height - 4 },
+                        { { 0, 16, height + 100 }, { 32, 16, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27684), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 32, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27677), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 32, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27670), { 0, 0, height - 4 },
+                        { { 0, 0, height + 100 }, { 32, 16, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 224);
+            break;
+        case 4:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27692), { 0, 0, height - 4 },
+                        { { 16, 7, height + 90 }, { 16, 16, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27685), { 0, 0, height - 4 },
+                        { { 0, -7, height }, { 16, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27678), { 0, 0, height - 4 },
+                        { { -7, 16, height }, { 16, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27671), { 0, 0, height - 4 },
+                        { { 30, 23, height + 110 }, { 2, 16, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 128);
+            break;
+        case 5:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27693), { 0, 0, height - 4 },
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27686), { 0, 0, height - 4 },
+                        { { 0, 0, height }, { 32, 16, 0 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27679), { 0, 0, height - 4 },
+                        { { 0, 16, height }, { 32, 16, 0 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27672), { 0, 0, height - 4 },
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
+                        PaintSegment::topRight, PaintSegment::bottomLeft),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 224);
+            break;
+        case 6:
+            switch (direction)
+            {
+                case 0:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27694), { 0, 0, height - 4 },
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    break;
+                case 1:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27687), { 0, 0, height - 4 },
+                        { { 0, 6, height }, { 32, 20, 3 } });
+                    break;
+                case 2:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27680), { 0, 0, height - 4 },
+                        { { 0, 6, height }, { 32, 20, 3 } });
+                    break;
+                case 3:
+                    PaintAddImageAsParentRotated(
+                        session, direction, session.TrackColours.WithIndex(27673), { 0, 0, height - 4 },
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
+                    break;
+            }
+            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
+            }
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
+                        PaintSegment::topRight, PaintSegment::bottomLeft),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 40);
+            break;
+    }
+}
+
 TrackPaintFunction GetTrackPaintFunctionFlyingRCInverted(TrackElemType trackType)
 {
     switch (trackType)
@@ -9180,6 +9824,18 @@ TrackPaintFunction GetTrackPaintFunctionFlyingRCInverted(TrackElemType trackType
             return InvertedFlyingRCTrackRightFlyerTwistDown;
         case TrackElemType::flyerHalfLoopInvertedDown:
             return FlyingRCTrackFlyerHalfLoopDown;
+        case TrackElemType::multiDimInvertedFlatToDown90QuarterLoop:
+            return TwisterRCTrackInvertedFlatTo90DegQuarterLoopDown;
+        case TrackElemType::flyerHalfLoopInvertedUp:
+            return FlyingRCInverted::trackPaintHalfLoopInvertedUp;
+        case TrackElemType::leftFlyerLargeHalfLoopInvertedDown:
+            return TwisterRCTrackLeftLargeHalfLoopDown;
+        case TrackElemType::rightFlyerLargeHalfLoopInvertedDown:
+            return TwisterRCTrackRightLargeHalfLoopDown;
+        case TrackElemType::leftFlyerLargeHalfLoopInvertedUp:
+            return FlyingRCInverted::trackPaintLeftFlyingLargeHalfLoopInvertedUp;
+        case TrackElemType::rightFlyerLargeHalfLoopInvertedUp:
+            return FlyingRCInverted::trackPaintRightFlyingLargeHalfLoopInvertedUp;
         // OpenRCT2-specific paint code
         case TrackElemType::booster:
             return InvertedFlyingRCTrackBooster;
@@ -9194,6 +9850,6 @@ TrackPaintFunction GetTrackPaintFunctionFlyingRCInverted(TrackElemType trackType
             return InvertedFlyingRCTrackDiagBlockBrakes;
 
         default:
-            return GetTrackPaintFunctionFlyingRC(trackType);
+            return TrackPaintFunctionDummy;
     }
 }

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.h
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.h
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+struct Ride;
+struct SupportType;
+
+using Direction = uint8_t;
+
+namespace OpenRCT2
+{
+    struct TrackElement;
+} // namespace OpenRCT2
+
+namespace OpenRCT2::FlyingRCInverted
+{
+    void trackPaintHalfLoopInvertedUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+        const OpenRCT2::TrackElement& trackElement, SupportType supportType);
+    void trackPaintLeftFlyingLargeHalfLoopInvertedUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+        const OpenRCT2::TrackElement& trackElement, SupportType supportType);
+    void trackPaintRightFlyingLargeHalfLoopInvertedUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+        const OpenRCT2::TrackElement& trackElement, SupportType supportType);
+} // namespace OpenRCT2::FlyingRCInverted

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -13257,7 +13257,7 @@ void TwisterRCTrackRightLargeHalfLoopDown(
     TwisterRCTrackLeftLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, trackElement, supportType);
 }
 
-static void TwisterRCTrack90DegToInvertedFlatQuarterLoopUp(
+void TwisterRCTrack90DegToInvertedFlatQuarterLoopUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
@@ -13354,7 +13354,7 @@ static void TwisterRCTrack90DegToInvertedFlatQuarterLoopUp(
     }
 }
 
-static void TwisterRCTrackInvertedFlatTo90DegQuarterLoopDown(
+void TwisterRCTrackInvertedFlatTo90DegQuarterLoopDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.h
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.h
@@ -47,3 +47,9 @@ void TwisterRCTrackLeftLargeHalfLoopDown(
 void TwisterRCTrackRightLargeHalfLoopDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const OpenRCT2::TrackElement& trackElement, SupportType supportType);
+void TwisterRCTrack90DegToInvertedFlatQuarterLoopUp(
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType);
+void TwisterRCTrackInvertedFlatTo90DegQuarterLoopDown(
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType);


### PR DESCRIPTION
Since #22711 the inverted flying roller coaster falls through to the upright twister track paint functions if it doesn't have its own function.

This PR removes that fall back and tidies up all the track paint functions so that the upright and inverted flying coasters only draw pieces that are actually correct for that track type.

Some of the paint functions have been rearranged in order for them to be visible to the correct type without falling through. An unnecessarily duplicated quarter loop function was removed.

Here's some saves with all the track pieces to check what is different:
[flyingrollercoasters.zip](https://github.com/user-attachments/files/23064237/flyingrollercoasters.zip)

There's obviously been a period of time now where somebody somewhere may have started relying on this for some reason, however I wasn't able to find a park that does. All the parks I looked at still work fine.

[This park](https://www.nedesigns.com/park/5842/apothicon-servant/) is an example of one that currently draws upright twister pieces on an inverted flying rollercoaster that it didn't when it was made. This will fix that.
<img width="408" height="281" alt="Untitled" src="https://github.com/user-attachments/assets/dd21f916-1523-4806-9e23-436d52a8b5f3" />