### PR TITLE
Fix mazes being able to be built 2 units above support limits

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#25378] The land tool sometimes allows land to be raised through a maze.
 - Fix: [#25380] The Lay-down Roller Coaster left corkscrew supports are incorrect at one angle (original bug).
 - Fix: [#25388] The Shortcut Keys window uses the wrong colours for separators, scrollbars and buttons.
+- Fix: [#25401] Mazes can be built 2 units higher than their support limits.
 
 0.4.27 (2025-10-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -91,7 +91,7 @@ namespace OpenRCT2::GameActions
         auto baseHeight = _loc.z;
         auto clearanceHeight = _loc.z + kMazeClearanceHeight;
 
-        auto heightDifference = baseHeight - surfaceElement->GetBaseZ();
+        auto heightDifference = clearanceHeight - surfaceElement->GetBaseZ();
         if (heightDifference >= 0 && !gameState.cheats.disableSupportLimits)
         {
             heightDifference /= kCoordsZPerTinyZ;

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -123,9 +123,9 @@ namespace OpenRCT2::GameActions
         }
 
         auto baseHeight = _loc.z;
-        auto clearanceHeight = _loc.z + 32;
+        auto clearanceHeight = _loc.z + kMazeClearanceHeight;
 
-        auto heightDifference = baseHeight - surfaceElement->GetBaseZ();
+        auto heightDifference = clearanceHeight - surfaceElement->GetBaseZ();
         if (heightDifference >= 0 && !gameState.cheats.disableSupportLimits)
         {
             heightDifference /= kCoordsZPerTinyZ;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 3;
+constexpr uint8_t kStreamVersion = 4;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
This fixes mazes being able to be built too high. The way that mazes calculate support limits is different to how other track pieces and land modification calculates it. They calculate the distance from clearance rather than the base. This also causes you to not be able to change the land underneath these maze pieces.
This will restore the original support height limit from RCT1/2. (4 land notches)

https://github.com/user-attachments/assets/dd4c5edb-7ad9-4b5f-a98c-ec6d0cc0f7a0

For reference:
Land height action:
https://github.com/OpenRCT2/OpenRCT2/blob/6f58c2e7d0e035710d748219bd7522bfa6a1dad8/src/openrct2/actions/LandSetHeightAction.cpp#L291

Track place action:
https://github.com/OpenRCT2/OpenRCT2/blob/6f58c2e7d0e035710d748219bd7522bfa6a1dad8/src/openrct2/actions/TrackPlaceAction.cpp#L369