### PR TITLE
Remove guarded assertion in Ride.cpp

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -246,7 +246,6 @@ Ride* GetRide(RideId index)
 
     auto& gameState = getGameState();
     const auto idx = index.ToUnderlying();
-    assert(idx < gameState.rides.size());
     if (idx >= gameState.rides.size())
     {
         return nullptr;


### PR DESCRIPTION
We have code to return null for invalid indices immediately after the assertion. 

The assertion results in plugin code like `map.getRide(1000)` failing on a debug build but working (with the expected null return value) on a release build.