### PR TITLE
Vehicle/refactor boundbox

### DIFF
--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -934,6 +934,143 @@ const VehicleBoundBox VehicleBoundboxes[16][224] = {
     }
 };
 
+enum BoundBoxType : uint8_t
+{
+    flat,
+    slopeUp25,
+    slopeUp42,
+    slopeUp60,
+    slopeUp75,
+    slopeUp90,
+    slopeUp105,
+    slopeUp120,
+    slopeUp135,
+    slopeUp150,
+    slopeUp165,
+    inverted,
+    slopeUp16,
+    slopeUp50,
+    flatBankedLeft45,
+    flatBankedLeft67,
+    flatBankedLeft90,
+    flatBankedLeft112,
+    flatBankedLeft135,
+    flatBankedLeft157,
+    corkscrewUpRight0,
+    corkscrewUpRight1,
+    corkscrewUpRight2,
+    corkscrewUpRight3,
+    corkscrewUpRight4,
+    corkscrewDownLeft0,
+    corkscrewDownLeft1,
+    corkscrewDownLeft2,
+    corkscrewDownLeft3,
+    corkscrewDownLeft4,
+    corkscrewUpLeft0,
+    corkscrewUpLeft1,
+    corkscrewUpLeft2,
+    corkscrewUpLeft3,
+    corkscrewUpLeft4,
+    corkscrewDownRight0,
+    corkscrewDownRight1,
+    corkscrewDownRight2,
+    corkscrewDownRight3,
+    corkscrewDownRight4,
+    null,
+    count,
+    reverseBoundBox = (1 << 7),
+    slopeDown25 = slopeUp25 | reverseBoundBox,
+    slopeDown42 = slopeUp42 | reverseBoundBox,
+    slopeDown60 = slopeUp60 | reverseBoundBox,
+    slopeDown75 = slopeUp75 | reverseBoundBox,
+    slopeDown90 = slopeUp90 | reverseBoundBox,
+    slopeDown105 = slopeUp105 | reverseBoundBox,
+    slopeDown120 = slopeUp120 | reverseBoundBox,
+    slopeDown135 = slopeUp135 | reverseBoundBox,
+    slopeDown150 = slopeUp150 | reverseBoundBox,
+    slopeDown165 = slopeUp165 | reverseBoundBox,
+    slopeDown16 = slopeUp16 | reverseBoundBox,
+    slopeDown50 = slopeUp50 | reverseBoundBox,
+    flatBankedRight45 = flatBankedLeft45 | reverseBoundBox,
+    flatBankedRight67 = flatBankedLeft67 | reverseBoundBox,
+    flatBankedRight90 = flatBankedLeft90 | reverseBoundBox,
+    flatBankedRight112 = flatBankedLeft112 | reverseBoundBox,
+    flatBankedRight135 = flatBankedLeft135 | reverseBoundBox,
+    flatBankedRight157 = flatBankedLeft157 | reverseBoundBox,
+};
+
+constexpr uint32_t kBoundBoxIndexUndefined = std::numeric_limits<uint32_t>::max();
+
+struct BoundBoxTablePair
+{
+    uint32_t index;
+    SpritePrecision precision;
+};
+
+static constexpr auto kBoundBoxTablePairs = std::to_array<BoundBoxTablePair>({
+    { 0, SpritePrecision::sprites16 },   // flat
+    { 16, SpritePrecision::sprites16 },  // slopes25
+    { 32, SpritePrecision::sprites8 },   // slopes42
+    { 40, SpritePrecision::sprites16 },  // slopes60
+    { 56, SpritePrecision::sprites4 },   // slopes75
+    { 60, SpritePrecision::sprites16 },  // slopes90
+    { 76, SpritePrecision::sprites4 },   // slopes105
+    { 80, SpritePrecision::sprites4 },   // slopes120
+    { 84, SpritePrecision::sprites4 },   // slopes135
+    { 88, SpritePrecision::sprites4 },   // slopes150
+    { 92, SpritePrecision::sprites4 },   // slopes165
+    { 96, SpritePrecision::sprites4 },   // inverted
+    { 100, SpritePrecision::sprites4 },  // slopes16
+    { 104, SpritePrecision::sprites4 },  // slopes50
+    { 108, SpritePrecision::sprites16 }, // flatBanked45
+    { 124, SpritePrecision::sprites4 },  // flatBanked67
+    { 128, SpritePrecision::sprites4 },  // flatBanked90
+    { 132, SpritePrecision::sprites4 },  // flatBanked112
+    { 136, SpritePrecision::sprites4 },  // flatBanked135
+    { 140, SpritePrecision::sprites4 },  // flatbanked157
+    { 144, SpritePrecision::sprites4 },  // corkscrewUpRight0
+    { 148, SpritePrecision::sprites4 },  // corkscrewUpRight1
+    { 152, SpritePrecision::sprites4 },  // corkscrewUpRight2
+    { 156, SpritePrecision::sprites4 },  // corkscrewUpRight3
+    { 160, SpritePrecision::sprites4 },  // corkscrewUpRight4
+    { 164, SpritePrecision::sprites4 },  // corkscrewDownLeft0
+    { 168, SpritePrecision::sprites4 },  // corkscrewDownLeft1
+    { 172, SpritePrecision::sprites4 },  // corkscrewDownLeft2
+    { 176, SpritePrecision::sprites4 },  // corkscrewDownLeft3
+    { 180, SpritePrecision::sprites4 },  // corkscrewDownLeft4
+    { 184, SpritePrecision::sprites4 },  // corkscrewUpLeft0
+    { 188, SpritePrecision::sprites4 },  // corkscrewUpLeft1
+    { 192, SpritePrecision::sprites4 },  // corkscrewUpLeft2
+    { 196, SpritePrecision::sprites4 },  // corkscrewUpLeft3
+    { 200, SpritePrecision::sprites4 },  // corkscrewUpLeft4
+    { 204, SpritePrecision::sprites4 },  // corkscrewDownRight0
+    { 208, SpritePrecision::sprites4 },  // corkscrewDownRight1
+    { 212, SpritePrecision::sprites4 },  // corkscrewDownRight2
+    { 216, SpritePrecision::sprites4 },  // corkscrewDownRight3
+    { 220, SpritePrecision::sprites4 },  // corkscrewDownRight4
+    { 0, SpritePrecision::sprites16 },   // null
+});
+static_assert(std::size(kBoundBoxTablePairs) == BoundBoxType::count);
+
+static constexpr uint32_t getBoundBoxIndex(BoundBoxType type, uint32_t yaw)
+{
+    if (type & BoundBoxType::reverseBoundBox)
+    {
+        type = static_cast<BoundBoxType>(type ^ BoundBoxType::reverseBoundBox);
+        yaw = Add(yaw, kBaseRotation / 2);
+    }
+    if (type >= BoundBoxType::count)
+    {
+        type = BoundBoxType::null;
+    }
+    auto pair = kBoundBoxTablePairs[type];
+    return pair.index + YawToPrecision(yaw, pair.precision);
+}
+
+#pragma endregion
+
+#pragma region VehiclePaintUtil
+
 // Opposite Pitch values for reversed cars
 const VehiclePitch PitchInvertTable[] = {
     VehiclePitch::flat,
@@ -1039,33 +1176,6 @@ const VehicleRoll RollInvertTable[] = {
 };
 static_assert(std::size(RollInvertTable) == EnumValue(VehicleRoll::rollCount));
 
-constexpr uint32_t kBoundBoxIndexUndefined = std::numeric_limits<uint32_t>::max();
-constexpr uint32_t kBoundBoxIndexFlat = 0;
-constexpr uint32_t kBoundBoxIndex25 = 16;
-constexpr uint32_t kBoundBoxIndex42 = 32;
-constexpr uint32_t kBoundBoxIndex60 = 40;
-constexpr uint32_t kBoundBoxIndex75 = 56;
-constexpr uint32_t kBoundBoxIndex90 = 60;
-constexpr uint32_t kBoundBoxIndex105 = 76;
-constexpr uint32_t kBoundBoxIndex120 = 80;
-constexpr uint32_t kBoundBoxIndex135 = 84;
-constexpr uint32_t kBoundBoxIndex150 = 88;
-constexpr uint32_t kBoundBoxIndex165 = 92;
-constexpr uint32_t kBoundBoxIndexInverted = 96;
-constexpr uint32_t kBoundBoxIndex16 = 100;
-constexpr uint32_t kBoundBoxIndex50 = 104;
-constexpr uint32_t kBoundBoxIndexFlatBanked45 = 108;
-constexpr uint32_t kBoundBoxIndexFlatBanked67 = 124;
-constexpr uint32_t kBoundBoxIndexFlatBanked90 = 128;
-constexpr uint32_t kBoundBoxIndexFlatBanked112 = 132;
-constexpr uint32_t kBoundBoxIndexFlatBanked135 = 136;
-constexpr uint32_t kBoundBoxIndexFlatBanked157 = 140;
-constexpr uint32_t kBoundBoxIndexCorkscrew = 144;
-
-#pragma endregion
-
-#pragma region VehiclePaintUtil
-
 static void PaintVehicleRiders(
     PaintSession& session, const Vehicle* vehicle, const CarEntry* carEntry, uint32_t baseImageId, const int32_t z,
     const VehicleBoundBox& bb)
@@ -1149,7 +1259,7 @@ static void VehicleSpritePaintRestraints(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     auto restraintFrame = ((vehicle->restraints_position - 64) / 64);
     const auto spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::restraintAnimation, imageDirection, restraintFrame);
     vehicle_sprite_paint(session, vehicle, spriteIndex, VehicleBoundboxes[carEntry->drawOrder][boundingBoxIndex], z, carEntry);
@@ -1178,7 +1288,7 @@ static void VehiclePitchFlatUnbanked(
         return;
     }
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     const auto spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopeFlat, imageDirection, 0);
     VehicleSpritePaintWithSwinging(session, vehicle, spriteIndex, boundingBoxIndex, z, carEntry);
 }
@@ -1189,7 +1299,7 @@ static void VehiclePitchFlatBankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked22, imageDirection, 0);
@@ -1206,8 +1316,9 @@ static void VehiclePitchFlatBankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft45, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked45, imageDirection, 0);
@@ -1225,7 +1336,7 @@ static void VehiclePitchFlatBankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked22, imageDirection, 1);
@@ -1242,8 +1353,9 @@ static void VehiclePitchFlatBankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight45, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked45, imageDirection, 1);
@@ -1264,8 +1376,9 @@ static void VehiclePitchFlatBankedLeft67(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked67;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft67, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked67, imageDirection, 0);
@@ -1286,8 +1399,9 @@ static void VehiclePitchFlatBankedLeft90(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked90, imageDirection, 0);
@@ -1308,8 +1422,9 @@ static void VehiclePitchFlatBankedLeft112(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked112;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft112, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::inlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::inlineTwists, imageDirection, 0);
@@ -1330,8 +1445,9 @@ static void VehiclePitchFlatBankedLeft135(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::inlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::inlineTwists, imageDirection, 2);
@@ -1352,8 +1468,9 @@ static void VehiclePitchFlatBankedLeft157(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked157;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft157, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::inlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::inlineTwists, imageDirection, 4);
@@ -1374,8 +1491,9 @@ static void VehiclePitchFlatBankedRight67(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked67;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight67, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked67, imageDirection, 1);
@@ -1396,8 +1514,9 @@ static void VehiclePitchFlatBankedRight90(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::flatBanked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::flatBanked90, imageDirection, 1);
@@ -1418,8 +1537,9 @@ static void VehiclePitchFlatBankedRight112(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked112;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight112, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::inlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::inlineTwists, imageDirection, 1);
@@ -1440,8 +1560,9 @@ static void VehiclePitchFlatBankedRight135(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::inlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::inlineTwists, imageDirection, 3);
@@ -1462,8 +1583,9 @@ static void VehiclePitchFlatBankedRight157(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked157;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight157, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::inlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::inlineTwists, imageDirection, 5);
@@ -1596,7 +1718,7 @@ static void VehiclePitchUp12Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12, imageDirection, 0);
@@ -1614,7 +1736,7 @@ static void VehiclePitchUp12BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked22, imageDirection, 0);
@@ -1632,7 +1754,7 @@ static void VehiclePitchUp12BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked45, imageDirection, 0);
@@ -1650,7 +1772,7 @@ static void VehiclePitchUp12BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked22, imageDirection, 1);
@@ -1668,7 +1790,7 @@ static void VehiclePitchUp12BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked45, imageDirection, 1);
@@ -1733,7 +1855,7 @@ static void VehiclePitchUp25Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex25;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp25, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25, imageDirection, 0);
@@ -1751,7 +1873,7 @@ static void VehiclePitchUp25BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndex25;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp25, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked22, imageDirection, 0);
@@ -1770,11 +1892,10 @@ static void VehiclePitchUp25BankedLeft45(
 {
     if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
-        boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->drawOrder < 5)
-            boundingBoxIndex += kBoundBoxIndexFlatBanked45;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::flatBankedLeft45, imageDirection);
         else
-            boundingBoxIndex += kBoundBoxIndex25;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::slopeUp25, imageDirection);
     }
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked45))
     {
@@ -1793,7 +1914,7 @@ static void VehiclePitchUp25BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndex25;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp25, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked22, imageDirection, 1);
@@ -1812,11 +1933,10 @@ static void VehiclePitchUp25BankedRight45(
 {
     if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
-        boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->drawOrder < 5)
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndexFlatBanked45;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::flatBankedRight45, imageDirection);
         else
-            boundingBoxIndex += kBoundBoxIndex25;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::slopeUp25, imageDirection);
     }
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked45))
     {
@@ -1833,8 +1953,9 @@ static void VehiclePitchUp25BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked67;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft67, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked67, imageDirection, 0);
@@ -1850,8 +1971,9 @@ static void VehiclePitchUp25BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked90, imageDirection, 0);
@@ -1867,8 +1989,9 @@ static void VehiclePitchUp25BankedLeft112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked112;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft112, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 0);
@@ -1884,8 +2007,9 @@ static void VehiclePitchUp25BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 4);
@@ -1901,8 +2025,9 @@ static void VehiclePitchUp25BankedLeft157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked157;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft157, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 8);
@@ -1918,8 +2043,9 @@ static void VehiclePitchUp25BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked67;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight67, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked67, imageDirection, 1);
@@ -1935,8 +2061,9 @@ static void VehiclePitchUp25BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked90, imageDirection, 1);
@@ -1952,8 +2079,9 @@ static void VehiclePitchUp25BankedRight112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked112;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight112, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 1);
@@ -1969,8 +2097,9 @@ static void VehiclePitchUp25BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 5);
@@ -1986,8 +2115,9 @@ static void VehiclePitchUp25BankedRight157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked157;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight157, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 9);
@@ -2084,7 +2214,7 @@ static void VehiclePitchUp42Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42, imageDirection, 0);
@@ -2101,7 +2231,7 @@ static void VehiclePitchUp42BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked22, imageDirection, 0);
@@ -2118,7 +2248,7 @@ static void VehiclePitchUp42BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked45, imageDirection, 0);
@@ -2135,7 +2265,7 @@ static void VehiclePitchUp42BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked22, imageDirection, 1);
@@ -2152,7 +2282,7 @@ static void VehiclePitchUp42BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked45, imageDirection, 1);
@@ -2169,7 +2299,7 @@ static void VehiclePitchUp42BankedLeft67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked67, imageDirection, 0);
@@ -2186,7 +2316,7 @@ static void VehiclePitchUp42BankedLeft90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked90, imageDirection, 0);
@@ -2203,7 +2333,7 @@ static void VehiclePitchUp42BankedRight67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked67, imageDirection, 1);
@@ -2220,7 +2350,7 @@ static void VehiclePitchUp42BankedRight90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked90, imageDirection, 1);
@@ -2240,7 +2370,7 @@ static void VehiclePitchUp42BankedLeft135(
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : YawTo4(modifiedImageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
+        : getBoundBoxIndex(BoundBoxType::corkscrewUpLeft3, modifiedImageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::corkscrews))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(
@@ -2260,7 +2390,7 @@ static void VehiclePitchUp42BankedRight135(
     constexpr uint32_t corkscrewFrame = 3;
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : YawTo4(imageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
+        : getBoundBoxIndex(BoundBoxType::corkscrewUpRight3, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::corkscrews))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::corkscrews, imageDirection, corkscrewFrame);
@@ -2323,7 +2453,7 @@ static void VehiclePitchUp60Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60, imageDirection, 0);
@@ -2340,7 +2470,7 @@ static void VehiclePitchUp60BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60Banked22, imageDirection, 0);
@@ -2357,7 +2487,7 @@ static void VehiclePitchUp60BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60Banked22, imageDirection, 1);
@@ -2401,7 +2531,7 @@ static void VehiclePitchDown12Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12, imageDirection, 1);
@@ -2419,7 +2549,7 @@ static void VehiclePitchDown12BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked22, imageDirection, 2);
@@ -2437,7 +2567,7 @@ static void VehiclePitchDown12BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked45, imageDirection, 2);
@@ -2455,7 +2585,7 @@ static void VehiclePitchDown12BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked22, imageDirection, 3);
@@ -2473,7 +2603,7 @@ static void VehiclePitchDown12BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes12Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes12Banked45, imageDirection, 3);
@@ -2570,8 +2700,9 @@ static void VehiclePitchDown25Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex25;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown25, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25, imageDirection, 1);
@@ -2588,8 +2719,9 @@ static void VehiclePitchDown25BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex25;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown25, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked22, imageDirection, 2);
@@ -2608,11 +2740,10 @@ static void VehiclePitchDown25BankedLeft45(
 {
     if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
-        boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->drawOrder < 5)
-            boundingBoxIndex += kBoundBoxIndexFlatBanked45;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::flatBankedLeft45, imageDirection);
         else
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndex25;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::slopeDown25, imageDirection);
     }
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked45))
     {
@@ -2630,8 +2761,9 @@ static void VehiclePitchDown25BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex25;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown25, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked22, imageDirection, 3);
@@ -2650,11 +2782,10 @@ static void VehiclePitchDown25BankedRight45(
 {
     if (boundingBoxIndex == kBoundBoxIndexUndefined)
     {
-        boundingBoxIndex = YawTo16(imageDirection);
         if (carEntry->drawOrder < 5)
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndexFlatBanked45;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::flatBankedRight45, imageDirection);
         else
-            boundingBoxIndex = (boundingBoxIndex ^ 8) + kBoundBoxIndex25;
+            boundingBoxIndex = getBoundBoxIndex(BoundBoxType::slopeDown25, imageDirection);
     }
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked45))
     {
@@ -2671,8 +2802,9 @@ static void VehiclePitchDown25BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked67;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft67, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked67, imageDirection, 2);
@@ -2688,8 +2820,9 @@ static void VehiclePitchDown25BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked90, imageDirection, 2);
@@ -2705,8 +2838,9 @@ static void VehiclePitchDown25BankedLeft112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked112;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft112, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 2);
@@ -2722,8 +2856,9 @@ static void VehiclePitchDown25BankedLeft135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 6);
@@ -2739,8 +2874,9 @@ static void VehiclePitchDown25BankedLeft157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndexFlatBanked157;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedLeft157, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 10);
@@ -2756,8 +2892,9 @@ static void VehiclePitchDown25BankedRight67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked67;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight67, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked67, imageDirection, 3);
@@ -2773,8 +2910,9 @@ static void VehiclePitchDown25BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25Banked90, imageDirection, 3);
@@ -2790,8 +2928,9 @@ static void VehiclePitchDown25BankedRight112(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked112;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight112, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 3);
@@ -2807,8 +2946,9 @@ static void VehiclePitchDown25BankedRight135(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 7);
@@ -2824,8 +2964,9 @@ static void VehiclePitchDown25BankedRight157(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection) ^ 2) + kBoundBoxIndexFlatBanked157;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::flatBankedRight157, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes25InlineTwists))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes25InlineTwists, imageDirection, 11);
@@ -2921,8 +3062,9 @@ static void VehiclePitchDown42Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo8(imageDirection)) ^ 4) + kBoundBoxIndex42;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42, imageDirection, 1);
@@ -2939,7 +3081,7 @@ static void VehiclePitchDown42BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked22, imageDirection, 2);
@@ -2956,7 +3098,7 @@ static void VehiclePitchDown42BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked45, imageDirection, 2);
@@ -2973,7 +3115,7 @@ static void VehiclePitchDown42BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked22, imageDirection, 3);
@@ -2990,7 +3132,7 @@ static void VehiclePitchDown42BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked45, imageDirection, 3);
@@ -3007,7 +3149,7 @@ static void VehiclePitchDown42BankedLeft67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked67, imageDirection, 2);
@@ -3024,7 +3166,7 @@ static void VehiclePitchDown42BankedLeft90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked90, imageDirection, 2);
@@ -3041,7 +3183,7 @@ static void VehiclePitchDown42BankedRight67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked67, imageDirection, 3);
@@ -3058,7 +3200,7 @@ static void VehiclePitchDown42BankedRight90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo8(imageDirection)) + kBoundBoxIndex42;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked90, imageDirection, 3);
@@ -3077,7 +3219,7 @@ static void VehiclePitchDown42BankedLeft135(
     constexpr uint32_t corkscrewFrame = 8;
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : YawTo4(imageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
+        : getBoundBoxIndex(BoundBoxType::corkscrewDownLeft3, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::corkscrews))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::corkscrews, imageDirection, corkscrewFrame);
@@ -3097,7 +3239,7 @@ static void VehiclePitchDown42BankedRight135(
     const int32_t modifiedImageDirection = (imageDirection + 8) % 32;
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : YawTo4(modifiedImageDirection) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
+        : getBoundBoxIndex(BoundBoxType::corkscrewDownRight3, modifiedImageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::corkscrews))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(
@@ -3159,8 +3301,9 @@ static void VehiclePitchDown60Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex60;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60, imageDirection, 1);
@@ -3177,7 +3320,7 @@ static void VehiclePitchDown60BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60Banked22, imageDirection, 2);
@@ -3194,7 +3337,7 @@ static void VehiclePitchDown60BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60Banked22, imageDirection, 3);
@@ -3236,7 +3379,7 @@ static void VehiclePitchUp75(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex75;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp75, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes75))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes75, imageDirection, 0);
@@ -3254,7 +3397,7 @@ static void VehiclePitchUp90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex90;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes90, imageDirection, 0);
@@ -3276,7 +3419,7 @@ static void VehiclePitchUp105(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex105;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp105, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 0);
@@ -3294,7 +3437,7 @@ static void VehiclePitchUp120(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex120;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp120, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 2);
@@ -3312,7 +3455,7 @@ static void VehiclePitchUp135(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex135;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 4);
@@ -3330,7 +3473,7 @@ static void VehiclePitchUp150(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex150;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp150, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 6);
@@ -3348,7 +3491,7 @@ static void VehiclePitchUp165(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndex165;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp165, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 8);
@@ -3370,7 +3513,7 @@ static void VehiclePitchInverted(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo4(imageDirection)) + kBoundBoxIndexInverted;
+                                                                   : getBoundBoxIndex(BoundBoxType::inverted, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopeInverted))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopeInverted, imageDirection, 0);
@@ -3399,8 +3542,9 @@ static void VehiclePitchDown75(
             carEntry--;
         }
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex75;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown75, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes75))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes75, imageDirection, 1);
@@ -3425,8 +3569,9 @@ static void VehiclePitchDown90(
             carEntry--;
         }
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo16(imageDirection)) ^ 8) + kBoundBoxIndex90;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown90, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes90, imageDirection, 1);
@@ -3451,8 +3596,9 @@ static void VehiclePitchDown105(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex105;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown105, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 1);
@@ -3473,8 +3619,9 @@ static void VehiclePitchDown120(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex120;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown120, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 3);
@@ -3495,8 +3642,9 @@ static void VehiclePitchDown135(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex135;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown135, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 5);
@@ -3517,8 +3665,9 @@ static void VehiclePitchDown150(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex150;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown150, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 7);
@@ -3539,8 +3688,9 @@ static void VehiclePitchDown165(
     {
         carEntry--;
     }
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex165;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown165, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopesLoop))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopesLoop, imageDirection, 9);
@@ -3568,7 +3718,7 @@ void VehiclePitchCorkscrew(
     }
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
         ? boundingBoxIndex
-        : (YawTo4(imageDirection)) + corkscrewFrame * kNumOrthogonalDirections + kBoundBoxIndexCorkscrew;
+        : getBoundBoxIndex(static_cast<BoundBoxType>(BoundBoxType::corkscrewUpRight0 + corkscrewFrame), imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::corkscrews))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::corkscrews, imageDirection, corkscrewFrame);
@@ -3592,7 +3742,7 @@ static void VehiclePitchUp8Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8, imageDirection, 0);
@@ -3610,7 +3760,7 @@ static void VehiclePitchUp8BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked22, imageDirection, 0);
@@ -3628,7 +3778,7 @@ static void VehiclePitchUp8BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked22, imageDirection, 1);
@@ -3645,7 +3795,7 @@ static void VehiclePitchUp8BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked45, imageDirection, 0);
@@ -3662,7 +3812,7 @@ static void VehiclePitchUp8BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked45, imageDirection, 1);
@@ -3715,7 +3865,7 @@ static void VehiclePitchUp16Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndex16;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp16, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16, imageDirection, 0);
@@ -3732,7 +3882,7 @@ static void VehiclePitchUp16BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked22, imageDirection, 0);
@@ -3749,7 +3899,7 @@ static void VehiclePitchUp16BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked22, imageDirection, 1);
@@ -3766,7 +3916,7 @@ static void VehiclePitchUp16BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked45, imageDirection, 0);
@@ -3783,7 +3933,7 @@ static void VehiclePitchUp16BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked45, imageDirection, 1);
@@ -3832,7 +3982,7 @@ static void VehiclePitchUp50Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo4(imageDirection) + kBoundBoxIndex50;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp50, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50, imageDirection, 0);
@@ -3849,7 +3999,7 @@ static void VehiclePitchUp50BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked45, imageDirection, 0);
@@ -3866,7 +4016,7 @@ static void VehiclePitchUp50BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked45, imageDirection, 1);
@@ -3883,7 +4033,7 @@ static void VehiclePitchUp50BankedLeft67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked67, imageDirection, 0);
@@ -3900,7 +4050,7 @@ static void VehiclePitchUp50BankedRight67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked67, imageDirection, 1);
@@ -3917,7 +4067,7 @@ static void VehiclePitchUp50BankedLeft90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked90, imageDirection, 0);
@@ -3934,7 +4084,7 @@ static void VehiclePitchUp50BankedRight90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked90, imageDirection, 1);
@@ -3992,7 +4142,7 @@ static void VehiclePitchDown8Unbanked(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8, imageDirection, 1);
@@ -4010,7 +4160,7 @@ static void VehiclePitchDown8BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked22, imageDirection, 2);
@@ -4028,7 +4178,7 @@ static void VehiclePitchDown8BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked22, imageDirection, 3);
@@ -4045,7 +4195,7 @@ static void VehiclePitchDown8BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked45, imageDirection, 2);
@@ -4062,7 +4212,7 @@ static void VehiclePitchDown8BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes8Banked45, imageDirection, 3);
@@ -4114,8 +4264,9 @@ static void VehiclePitchDown16Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex16;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown16, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16, imageDirection, 1);
@@ -4132,7 +4283,7 @@ static void VehiclePitchDown16BankedLeft22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked22, imageDirection, 2);
@@ -4149,7 +4300,7 @@ static void VehiclePitchDown16BankedRight22(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked22, imageDirection, 3);
@@ -4166,7 +4317,7 @@ static void VehiclePitchDown16BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked45, imageDirection, 2);
@@ -4183,7 +4334,7 @@ static void VehiclePitchDown16BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes16Banked45, imageDirection, 3);
@@ -4231,8 +4382,9 @@ static void VehiclePitchDown50Unbanked(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : ((YawTo4(imageDirection)) ^ 2) + kBoundBoxIndex50;
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown50, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50, imageDirection, 1);
@@ -4249,7 +4401,7 @@ static void VehiclePitchDown50BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked45, imageDirection, 2);
@@ -4266,7 +4418,7 @@ static void VehiclePitchDown50BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked45, imageDirection, 3);
@@ -4283,7 +4435,7 @@ static void VehiclePitchDown50BankedLeft67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked67, imageDirection, 2);
@@ -4300,7 +4452,7 @@ static void VehiclePitchDown50BankedRight67(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked67, imageDirection, 3);
@@ -4317,7 +4469,7 @@ static void VehiclePitchDown50BankedLeft90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked90, imageDirection, 2);
@@ -4334,7 +4486,7 @@ static void VehiclePitchDown50BankedRight90(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : (YawTo16(imageDirection)) + kBoundBoxIndex60;
+                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes50Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes50Banked90, imageDirection, 3);
@@ -4421,7 +4573,7 @@ static void VehiclePitchSpiralLiftUp(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::curvedLiftHillUp))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::curvedLiftHillUp, imageDirection, 0);
@@ -4438,7 +4590,7 @@ static void VehiclePitchSpiralLiftDown(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : getBoundBoxIndex(BoundBoxType::flat, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::curvedLiftHillDown))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::curvedLiftHillDown, imageDirection, 0);

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -3080,8 +3080,9 @@ static void VehiclePitchDown42BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked22, imageDirection, 2);
@@ -3097,8 +3098,9 @@ static void VehiclePitchDown42BankedLeft45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked45, imageDirection, 2);
@@ -3114,8 +3116,9 @@ static void VehiclePitchDown42BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked22, imageDirection, 3);
@@ -3131,8 +3134,9 @@ static void VehiclePitchDown42BankedRight45(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked45))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked45, imageDirection, 3);
@@ -3148,8 +3152,9 @@ static void VehiclePitchDown42BankedLeft67(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked67))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked67, imageDirection, 2);
@@ -3165,8 +3170,9 @@ static void VehiclePitchDown42BankedLeft90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked90, imageDirection, 2);
@@ -3199,8 +3205,9 @@ static void VehiclePitchDown42BankedRight90(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp42, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown42, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes42Banked90))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes42Banked90, imageDirection, 3);
@@ -3319,8 +3326,9 @@ static void VehiclePitchDown60BankedLeft22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60Banked22, imageDirection, 2);
@@ -3336,8 +3344,9 @@ static void VehiclePitchDown60BankedRight22(
     PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, const int32_t z, const CarEntry* carEntry,
     uint32_t boundingBoxIndex)
 {
-    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : getBoundBoxIndex(BoundBoxType::slopeUp60, imageDirection);
+    boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined
+        ? boundingBoxIndex
+        : getBoundBoxIndex(BoundBoxType::slopeDown60, imageDirection);
     if (carEntry->groupEnabled(SpriteGroupType::slopes60Banked22))
     {
         const int32_t spriteIndex = carEntry->getSpriteOffset(SpriteGroupType::slopes60Banked22, imageDirection, 3);


### PR DESCRIPTION
Spun off from #25125

This simplifies the magic number-ridden boundbox calculations and makes it easier to compare before/after in #25125 (once it is fully rewritten). The first commit changes the calculations to use the new function while keeping all existing behavior. The second commit addresses an error in the implementation of the new sprite group paint code, where downward slopes used upward boundboxes.