### PR TITLE
Simplify vertical tracked ride falling logic

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1057,7 +1057,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             {
                 acceleration = -3298;
             }
-            if (velocity < -131940)
+            else
             {
                 velocity -= velocity / 16;
                 acceleration = 0;


### PR DESCRIPTION
This logic dictates how vertical tracked rides behave when they're dropping down (hence why acceleration and velocity are negative) -- if we haven't hit a certain threshold yet, keep accelerating, otherwise, let's slow down a little. Evidently both conditions cannot be true in this switch case, so I simplified it a tiny bit. I doubt it results in a different binary because compilers will optimize this anyway, but I think it communicates intent better.