### PR TITLE
Fix #14365: Previews broken for track designs with scenery below track

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.29 (in development)
 ------------------------------------------------------------------------
+- Fix: [#14365] Track designs with scenery below the lowest track piece do not preview correctly.
 - Fix: [#25451] Dropdown item tooltips stay open if the mouse is moved over an empty space.
 
 0.4.28 (2025-11-01)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1942,15 +1942,13 @@ static bool TrackDesignPlacePreview(
     auto mapSize = TileCoordsXY{ gameState.mapSize.x * 16, gameState.mapSize.y * 16 };
 
     _currentTrackPieceDirection = 0;
-    int32_t z = TrackDesignGetZPlacement(
-        tds, td, RideGetTemporaryForPreview(), { mapSize.x, mapSize.y, 16, _currentTrackPieceDirection });
+    const CoordsXYZD coords = { mapSize.x, mapSize.y, kMinimumLandZ, _currentTrackPieceDirection };
+    const int32_t z = kMinimumLandZ + TrackDesignGetZPlacement(tds, td, RideGetTemporaryForPreview(), coords);
 
     if (tds.hasScenery)
     {
         gameStateData.setFlag(TrackDesignGameStateFlag::HasScenery, true);
     }
-
-    z += 16 - tds.placeSceneryZ;
 
     if (_trackDesignPlaceStateSceneryUnavailable)
     {


### PR DESCRIPTION
Fixes #14365

If a track design has scenery below the lowest track piece it doesn't preview correctly. It raises it up too high drawing more supports and doesn't draw trees that need to be on land. It also causes the cost estimate to be incorrect.

The track preview code was subtracting the negative scenery height twice (`tds.placeSceneryZ`). It was already being handled inside `TrackDesignGetZPlacement`. `placeSceneryZ` appears to be only 0 or negative, even for track designs with scenery only at a higher height.
This also tidies it up a tiny bit and uses the relevant constants.

bug:
<img width="605" height="360" alt="Image" src="https://github.com/user-attachments/assets/64804413-3031-4f6f-97df-85108b3e4040" />

fix:
<img width="602" height="347" alt="fix" src="https://github.com/user-attachments/assets/0515dbbc-e222-4fb2-9cf1-f5b72b4ed927" />

Path connections are already broken in the track preview by the way. Needs a separate fix.

Some vanilla track designs that were broken:
Bobsleigh "La Vibora"
Monorail cycles "Aerial Cycles"
Inverted impulse coaster "Impulsive" and "Circulator"

As far as I can tell, all other track designs I looked at are still working correctly.