### PR TITLE
Fix #25437: no mouse over highlight on new ride window previews

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -491,14 +491,14 @@ namespace OpenRCT2::Ui::Windows
             while (listItem->Type != kRideTypeNull || listItem->EntryIndex != kObjectEntryIndexNull)
             {
                 // Draw flat button rectangle
-                auto borderStyle = Rectangle::BorderStyle::none;
-                if (_newRideVars.SelectedRide == *listItem)
-                    borderStyle = Rectangle::BorderStyle::inset;
-
-                if (_newRideVars.HighlightedRide == *listItem || borderStyle != Rectangle::BorderStyle::none)
+                const bool isSelected = _newRideVars.SelectedRide == *listItem;
+                if (_newRideVars.HighlightedRide == *listItem || isSelected)
+                {
+                    const auto borderStyle = isSelected ? Rectangle::BorderStyle::inset : Rectangle::BorderStyle::outset;
                     Rectangle::fillInset(
                         rt, { coords, coords + ScreenCoordsXY{ 115, 115 } }, colours[1], borderStyle,
                         Rectangle::FillBrightness::dark);
+                }
 
                 // Draw ride image with feathered border
                 auto mask = ImageId(SPR_NEW_RIDE_MASK);


### PR DESCRIPTION
Fixes #25437.

I believe that before the rectangle refactor the default with no flags was effectively `Rectangle::BorderStyle::outset`. It was now passing `BorderStyle::none` in when the ride was highlighted. This rearranges the logic a little bit so that it's clearer what's happening. Highlighting and clicking should be working the same as it did before.

Bug:

https://github.com/user-attachments/assets/89ed9751-f0e4-47ff-ab4a-798ae268158a

Pre refactor:
<img width="386" height="247" alt="before" src="https://github.com/user-attachments/assets/2035255e-5b49-41cb-9b34-21c2cef5e3bf" />
This PR:
<img width="386" height="247" alt="fix" src="https://github.com/user-attachments/assets/a20ec1a8-d2cd-4e3b-afec-fa7c2e9b6537" />
