### PR TITLE
Fix return value of Widget::width()

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -211,7 +211,7 @@ namespace OpenRCT2
 
         if (scroll.flags & HSCROLLBAR_VISIBLE)
         {
-            int16_t size = widget.width() - 1;
+            int16_t size = widget.width() - 2;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 size -= 11;
             size = std::max(0, scroll.contentWidth - size);
@@ -671,7 +671,7 @@ namespace OpenRCT2
         const auto& widg = w.widgets[widgetIndex];
         auto& scroll = w.scrolls[scroll_id];
 
-        int32_t widget_width = widg.width() - 1;
+        int32_t widget_width = widg.width() - 2;
         if (scroll.flags & VSCROLLBAR_VISIBLE)
             widget_width -= kScrollBarWidth + 1;
         int32_t widget_content_width = std::max(scroll.contentWidth - widget_width, 0);
@@ -794,7 +794,7 @@ namespace OpenRCT2
             int32_t newLeft;
             newLeft = scroll.contentWidth;
             newLeft *= x;
-            x = widget.width() - 21;
+            x = widget.width() - 22;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 x -= kScrollBarWidth + 1;
             newLeft /= x;
@@ -804,7 +804,7 @@ namespace OpenRCT2
             newLeft += x;
             if (newLeft < 0)
                 newLeft = 0;
-            x = widget.width() - 1;
+            x = widget.width() - 2;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 x -= kScrollBarWidth + 1;
             x *= -1;
@@ -891,7 +891,7 @@ namespace OpenRCT2
             auto& scroll = w.scrolls[scroll_id];
             scroll.flags |= HSCROLLBAR_RIGHT_PRESSED;
             scroll.contentOffsetX += 3;
-            int32_t newLeft = widget.width() - 1;
+            int32_t newLeft = widget.width() - 2;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 newLeft -= kScrollBarWidth + 1;
             newLeft *= -1;

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -382,11 +382,11 @@ namespace OpenRCT2::Ui
         ScreenCoordsXY coords = { (topLeft.x + r + 1) / 2 - 1, topLeft.y };
         if (widget.type == WidgetType::labelCentred)
         {
-            DrawTextWrapped(rt, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::centre });
+            DrawTextWrapped(rt, coords, widget.width() - 3, stringId, ft, { colour, TextAlignment::centre });
         }
         else
         {
-            DrawTextEllipsised(rt, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::centre });
+            DrawTextEllipsised(rt, coords, widget.width() - 3, stringId, ft, { colour, TextAlignment::centre });
         }
     }
 
@@ -572,7 +572,7 @@ namespace OpenRCT2::Ui
             return;
 
         topLeft = w.windowPos + ScreenCoordsXY{ widget->left + 2, widget->top + 1 };
-        int32_t width = widget->width() - 4;
+        int32_t width = widget->width() - 5;
 
         if (static_cast<size_t>(widgetIndex + 1) < w.widgets.size()
             && (w.widgets[widgetIndex + 1]).type == WidgetType::closeBox)
@@ -677,7 +677,7 @@ namespace OpenRCT2::Ui
         }
 
         DrawTextEllipsised(
-            rt, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 14, stringId, ft, colour);
+            rt, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 15, stringId, ft, colour);
     }
 
     /**
@@ -708,7 +708,7 @@ namespace OpenRCT2::Ui
         bottomRight.x--;
         bottomRight.y--;
 
-        bool hScrollNeeded = scroll.contentWidth > widget.width() && (scroll.flags & HSCROLLBAR_VISIBLE);
+        bool hScrollNeeded = scroll.contentWidth > (widget.width() - 1) && (scroll.flags & HSCROLLBAR_VISIBLE);
         bool vScrollNeeded = scroll.contentHeight > widget.height() && (scroll.flags & VSCROLLBAR_VISIBLE);
 
         // Horizontal scrollbar
@@ -982,7 +982,7 @@ namespace OpenRCT2::Ui
         }
 
         const auto& scroll = w.scrolls[*scroll_id];
-        if ((scroll.flags & HSCROLLBAR_VISIBLE) && scroll.contentWidth > widget->width()
+        if ((scroll.flags & HSCROLLBAR_VISIBLE) && scroll.contentWidth > (widget->width() - 1)
             && screenCoords.y >= (w.windowPos.y + widget->bottom - (kScrollBarWidth + 1)))
         {
             // horizontal scrollbar
@@ -1236,7 +1236,7 @@ namespace OpenRCT2::Ui
                 return;
         }
 
-        const auto barWidth = widget.width() - 2;
+        const auto barWidth = widget.width() - 3;
         const int32_t fillSize = (barWidth * percentage) / 100;
         if (fillSize > 0)
         {
@@ -1283,7 +1283,7 @@ namespace OpenRCT2::Ui
 
         if (scroll.flags & HSCROLLBAR_VISIBLE)
         {
-            int32_t view_size = widget.width() - 21;
+            int32_t view_size = widget.width() - 22;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 view_size -= 11;
             int32_t x = scroll.contentOffsetX * view_size;
@@ -1291,7 +1291,7 @@ namespace OpenRCT2::Ui
                 x /= scroll.contentWidth;
             scroll.hThumbLeft = x + 11;
 
-            x = widget.width() - 2;
+            x = widget.width() - 3;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 x -= 11;
             x += scroll.contentOffsetX;

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -102,7 +102,7 @@ namespace OpenRCT2::Ui
         }
         else
         {
-            int32_t size = widget->width() - 1;
+            int32_t size = widget->width() - 2;
             if (scroll.flags & VSCROLLBAR_VISIBLE)
                 size -= 11;
             size = std::max(0, scroll.contentWidth - size);
@@ -492,7 +492,7 @@ namespace OpenRCT2::Ui
         assert(end_tab_id < w->widgets.size());
 
         int32_t i, x = w->widgets[start_tab_id].left;
-        int32_t tab_width = w->widgets[start_tab_id].width();
+        int32_t tab_width = w->widgets[start_tab_id].width() - 1;
 
         for (i = start_tab_id; i <= end_tab_id; i++)
         {

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -519,7 +519,7 @@ namespace OpenRCT2::Ui::Windows
                 if (widget.type == WidgetType::scroll)
                 {
                     auto& listView = _info.ListViews[scrollIndex];
-                    auto wwidth = widget.width() + 1 - 2;
+                    auto wwidth = widget.width() - 2;
                     auto wheight = widget.height() + 1 - 2;
                     if (listView.GetScrollbars() == ScrollbarType::Horizontal
                         || listView.GetScrollbars() == ScrollbarType::Both)
@@ -561,7 +561,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     RenderTarget widgetDpi;
                     if (ClipDrawPixelInfo(
-                            widgetDpi, rt, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
+                            widgetDpi, rt, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width() - 1,
                             widget.height()))
                     {
                         auto ctx = onDraw.context();
@@ -654,7 +654,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1,
-                        colours[widget->colour], 0, Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
+                        colours[widget->colour], 0, Dropdown::Flag::StayOpen, numItems, widget->width() - 4);
 
                     if (selectedIndex >= 0 && selectedIndex < static_cast<int32_t>(numItems))
                         gDropdown.items[selectedIndex].setChecked(true);
@@ -809,7 +809,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto left = windowPos.x + viewportWidget->left + 1;
                     auto top = windowPos.y + viewportWidget->top + 1;
-                    auto wwidth = viewportWidget->width() - 1;
+                    auto wwidth = viewportWidget->width() - 2;
                     auto wheight = viewportWidget->height() - 1;
                     if (viewport == nullptr)
                     {

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -211,7 +211,7 @@ namespace OpenRCT2::Scripting
             auto widget = GetWidget();
             if (widget != nullptr)
             {
-                return widget->width() + 1;
+                return widget->width();
             }
             return 0;
         }

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -234,7 +234,7 @@ namespace OpenRCT2::Ui::Windows
             auto centreX = versionWidget.midX();
             auto centreY = versionWidget.midY() - FontGetLineHeight(FontStyle::medium) / 2;
             auto centrePos = windowPos + ScreenCoordsXY(centreX, centreY);
-            DrawTextWrapped(rt, centrePos, versionWidget.width(), STR_STRING, ft, { colours[1], TextAlignment::centre });
+            DrawTextWrapped(rt, centrePos, versionWidget.width() - 1, STR_STRING, ft, { colours[1], TextAlignment::centre });
 
             // Shows the update available button
             if (OpenRCT2::GetContext()->HasNewVersionInfo())

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -88,7 +88,7 @@ namespace OpenRCT2::Ui::Windows
             const auto& viewportWidget = widgets[WIDX_VIEWPORT];
             ViewportCreate(
                 *this, windowPos + ScreenCoordsXY{ viewportWidget.left + 1, viewportWidget.top + 1 },
-                (viewportWidget.width()) - 1, (viewportWidget.height()) - 1, Focus(_bannerViewPos));
+                viewportWidget.width() - 2, (viewportWidget.height()) - 1, Focus(_bannerViewPos));
 
             if (viewport != nullptr)
                 viewport->flags = Config::Get().general.alwaysShowGridlines ? VIEWPORT_FLAG_GRIDLINES : VIEWPORT_FLAG_NONE;
@@ -177,7 +177,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { widget->left + windowPos.x, widget->top + windowPos.y }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, numItems, widget->width() + 3);
+                        Dropdown::Flag::StayOpen, numItems, widget->width() - 1 + 3);
 
                     gDropdown.items[EnumValue(banner->textColour) - 1].setChecked(true);
                     break;

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -142,7 +142,7 @@ namespace OpenRCT2::Ui::Windows
         {
             SetResizeDimensions();
 
-            auto downloadButtonWidth = widgets[WIDX_OPEN_URL].width();
+            auto downloadButtonWidth = widgets[WIDX_OPEN_URL].width() - 1;
             widgets[WIDX_OPEN_URL].left = (width - downloadButtonWidth) / 2;
             widgets[WIDX_OPEN_URL].right = widgets[WIDX_OPEN_URL].left + downloadButtonWidth;
         }

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -995,7 +995,7 @@ static StringId window_cheats_page_titles[] = {
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-                        colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 3);
+                        colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 4);
                     gDropdown.items[EnumValue(gameState.cheats.selectedStaffSpeed)].setChecked(true);
                 }
             }
@@ -1017,7 +1017,7 @@ static StringId window_cheats_page_titles[] = {
                     }
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-                        colours[1], 0, Dropdown::Flag::StayOpen, std::size(WeatherTypes), dropdownWidget->width() - 3);
+                        colours[1], 0, Dropdown::Flag::StayOpen, std::size(WeatherTypes), dropdownWidget->width() - 4);
 
                     auto currentWeather = gameState.weatherCurrent.weatherType;
                     gDropdown.items[EnumValue(currentWeather)].setChecked(true);

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -92,7 +92,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, 2, widget->width() - 3);
+                        Dropdown::Flag::StayOpen, 2, widget->width() - 4);
 
                     if (CurrencyDescriptors[EnumValue(CurrencyType::custom)].affix_unicode == CurrencyAffix::prefix)
                     {

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -277,7 +277,7 @@ namespace OpenRCT2::Ui::Windows
             uint8_t paletteIndex = ColourMapA[colours[1].colour].mid_light;
             GfxClear(rt, paletteIndex);
 
-            int16_t boxWidth = widgets[WIDX_RESEARCH_ORDER_SCROLL].width();
+            int16_t boxWidth = widgets[WIDX_RESEARCH_ORDER_SCROLL].width() - 1;
             int32_t itemY = -kScrollableRowHeight;
             auto* dragItem = WindowEditorInventionsListDragGetItem();
 
@@ -402,7 +402,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 RenderTarget clipDPI;
                 screenPos = windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 };
-                const auto clipWidth = bkWidget.width() - 1;
+                const auto clipWidth = bkWidget.width() - 2;
                 const auto clipHeight = bkWidget.height() - 1;
                 if (ClipDrawPixelInfo(clipDPI, rt, screenPos, clipWidth, clipHeight))
                 {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -783,7 +783,7 @@ namespace OpenRCT2::Ui::Windows
                         darkness = TextDarkness::dark;
                     }
 
-                    int32_t width_limit = widgets[WIDX_LIST].width() - screenCoords.x;
+                    int32_t width_limit = widgets[WIDX_LIST].width() - 1 - screenCoords.x;
 
                     if (ridePage)
                     {
@@ -859,7 +859,7 @@ namespace OpenRCT2::Ui::Windows
             auto& dropdownWidget = widgets[WIDX_FILTER_DROPDOWN];
             resizeDropdown(WIDX_FILTER_DROPDOWN, { width - kFilterWidth - 10, dropdownWidget.top }, { kFilterWidth, 14 });
             auto& installTrackWidget = widgets[WIDX_INSTALL_TRACK];
-            installTrackWidget.moveToX(dropdownWidget.left - installTrackWidget.width() - 10);
+            installTrackWidget.moveToX(dropdownWidget.left - installTrackWidget.width() - 11);
 
             // Set pressed widgets
             pressedWidgets |= 1uLL << WIDX_PREVIEW;
@@ -978,7 +978,7 @@ namespace OpenRCT2::Ui::Windows
             bool isRideTab = GetSelectedObjectType() == ObjectType::ride;
             if (isRideTab)
             {
-                int32_t width_limit = (widgets[WIDX_LIST].width() - 15) / 2;
+                int32_t width_limit = (widgets[WIDX_LIST].width() - 16) / 2;
 
                 widgets[WIDX_LIST_SORT_TYPE].type = WidgetType::tableHeader;
                 widgets[WIDX_LIST_SORT_TYPE].top = widgets[WIDX_FILTER_TEXT_BOX].bottom + 3;
@@ -1091,7 +1091,7 @@ namespace OpenRCT2::Ui::Windows
                                                                 : kStringIdNone;
                 ft.Add<StringId>(stringId);
                 auto screenPos = windowPos + ScreenCoordsXY{ listSortTypeWidget.left + 1, listSortTypeWidget.top + 1 };
-                DrawTextEllipsised(rt, screenPos, listSortTypeWidget.width(), STR_OBJECTS_SORT_TYPE, ft, { colours[1] });
+                DrawTextEllipsised(rt, screenPos, listSortTypeWidget.width() - 1, STR_OBJECTS_SORT_TYPE, ft, { colours[1] });
             }
             const auto& listSortRideWidget = widgets[WIDX_LIST_SORT_RIDE];
             if (listSortRideWidget.type != WidgetType::empty)
@@ -1101,7 +1101,7 @@ namespace OpenRCT2::Ui::Windows
                                                                 : kStringIdNone;
                 ft.Add<StringId>(stringId);
                 auto screenPos = windowPos + ScreenCoordsXY{ listSortRideWidget.left + 1, listSortRideWidget.top + 1 };
-                DrawTextEllipsised(rt, screenPos, listSortRideWidget.width(), STR_OBJECTS_SORT_RIDE, ft, { colours[1] });
+                DrawTextEllipsised(rt, screenPos, listSortRideWidget.width() - 1, STR_OBJECTS_SORT_RIDE, ft, { colours[1] });
             }
 
             if (selectedListItem == -1 || _loadedObject == nullptr)
@@ -1111,7 +1111,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 RenderTarget clipDPI;
                 auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
-                int32_t previewWidth = previewWidget.width() - 1;
+                int32_t previewWidth = previewWidget.width() - 2;
                 int32_t previewHeight = previewWidget.height() - 1;
                 if (ClipDrawPixelInfo(clipDPI, rt, screenPos, previewWidth, previewHeight))
                 {

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -767,7 +767,7 @@ namespace OpenRCT2::Ui::Windows
             Widget* dropdownWidget = &widgets[WIDX_OBJECTIVE];
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-                colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 3);
+                colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 4);
         }
 
         void ShowCategoryDropdown()
@@ -780,7 +780,7 @@ namespace OpenRCT2::Ui::Windows
             Widget* dropdownWidget = &widgets[WIDX_CATEGORY];
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-                colours[1], 0, Dropdown::Flag::StayOpen, 5, dropdownWidget->width() - 3);
+                colours[1], 0, Dropdown::Flag::StayOpen, 5, dropdownWidget->width() - 4);
 
             gDropdown.items[EnumValue(getGameState().scenarioOptions.category)].setChecked(true);
         }
@@ -1562,7 +1562,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() - 1,
-                        colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 3);
+                        colours[1], 0, Dropdown::Flag::StayOpen, 3, dropdownWidget->width() - 4);
 
                     if (gameState.park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
                         gDropdown.items[2].setChecked(true);
@@ -1900,7 +1900,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + dropdownWidget.left, windowPos.y + dropdownWidget.top }, dropdownWidget.height() - 1,
-                        colours[1], 0, Dropdown::Flag::StayOpen, 4, dropdownWidget.width() - 3);
+                        colours[1], 0, Dropdown::Flag::StayOpen, 4, dropdownWidget.width() - 4);
 
                     const auto preferLess = gameState.park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
                     const auto preferMore = gameState.park.flags & PARK_FLAGS_PREF_MORE_INTENSE_RIDES;

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -403,7 +403,7 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = ScreenCoordsXY{ 0, kTableCellHeight + 2 };
 
             auto& self = widgets[WIDX_SUMMARY_SCROLL];
-            int32_t row_width = std::max<uint16_t>(scrolls[0].contentWidth, self.width());
+            int32_t row_width = std::max<uint16_t>(scrolls[0].contentWidth, self.width() - 1);
 
             // Expenditure / Income row labels
             for (int32_t i = 0; i < static_cast<int32_t>(ExpenditureType::count); i++)
@@ -847,7 +847,7 @@ namespace OpenRCT2::Ui::Windows
         void initialiseScrollPosition(WidgetIndex widgetIndex, int32_t scrollId)
         {
             const auto& widget = this->widgets[widgetIndex];
-            scrolls[scrollId].contentOffsetX = std::max(0, scrolls[scrollId].contentWidth - (widget.width() - 2));
+            scrolls[scrollId].contentOffsetX = std::max(0, scrolls[scrollId].contentWidth - (widget.width() - 3));
 
             widgetScrollUpdateThumbs(*this, widgetIndex);
         }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -252,7 +252,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Text
             auto screenCoords = windowPos + ScreenCoordsXY{ middleOutsetWidget.midX(), middleOutsetWidget.top + 11 };
-            int32_t itemWidth = middleOutsetWidget.width() - 62;
+            int32_t itemWidth = middleOutsetWidget.width() - 63;
             DrawNewsTicker(
                 rt, screenCoords, itemWidth, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->text,
                 newsItem->ticks);
@@ -368,7 +368,7 @@ namespace OpenRCT2::Ui::Windows
 
             ScreenCoordsXY middleWidgetCoords(
                 windowPos.x + middleOutsetWidget->midX(), windowPos.y + middleOutsetWidget->top + line_height + 1);
-            int32_t panelWidth = middleOutsetWidget->width() - 62;
+            int32_t panelWidth = middleOutsetWidget->width() - 63;
 
             // Check if there is a map tooltip to draw
             StringId stringId;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -549,7 +549,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             const auto& widget = widgets[WIDX_TAB_1];
-            int32_t widgWidth = widget.width() - 1;
+            int32_t widgWidth = widget.width() - 2;
             int32_t widgHeight = widget.height() - 1;
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
             if (page == WINDOW_GUEST_OVERVIEW)
@@ -624,7 +624,7 @@ namespace OpenRCT2::Ui::Windows
             if (viewport != nullptr)
             {
                 const auto& widget = widgets[WIDX_VIEWPORT];
-                const auto reqViewportWidth = widget.width() - 1;
+                const auto reqViewportWidth = widget.width() - 2;
                 const auto reqViewportHeight = widget.height() - 1;
                 viewport->pos = windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
                 if (viewport->width != reqViewportWidth || viewport->height != reqViewportHeight)
@@ -766,7 +766,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 const auto& viewWidget = widgets[WIDX_VIEWPORT];
                 auto screenPos = ScreenCoordsXY{ viewWidget.left + 1 + windowPos.x, viewWidget.top + 1 + windowPos.y };
-                int32_t widgWidth = viewWidget.width() - 1;
+                int32_t widgWidth = viewWidget.width() - 2;
                 int32_t widgHeight = viewWidget.height() - 1;
 
                 ViewportCreate(*this, screenPos, widgWidth, widgHeight, focus.value());
@@ -814,13 +814,13 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto ft = Formatter();
                 peep->FormatActionTo(ft);
-                int32_t textWidth = actionLabelWidget.width();
+                int32_t textWidth = actionLabelWidget.width() - 1;
                 DrawTextEllipsised(rt, screenPos, textWidth, STR_BLACK_STRING, ft, { TextAlignment::centre });
             }
 
             // Draw the marquee thought
             const auto& marqueeWidget = widgets[WIDX_MARQUEE];
-            auto marqWidth = marqueeWidget.width() - 3;
+            auto marqWidth = marqueeWidget.width() - 4;
             int32_t left = marqueeWidget.left + 2 + windowPos.x;
             int32_t top = marqueeWidget.top + windowPos.y;
             int32_t marqHeight = marqueeWidget.height();
@@ -849,7 +849,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            screenPos.x = marqueeWidget.width() - _marqueePosition;
+            screenPos.x = marqueeWidget.width() - 1 - _marqueePosition;
             {
                 auto ft = Formatter();
                 PeepThoughtSetFormatArgs(&peep->Thoughts[i], ft);
@@ -1757,7 +1757,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto& widget = widgets[WIDX_PAGE_BACKGROUND];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left + 4, widget.top + 12 };
-            int32_t itemNameWidth = widget.width() - 24;
+            int32_t itemNameWidth = widget.width() - 25;
 
             int32_t maxY = windowPos.y + height - 22;
             int32_t numItems = 0;

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -336,7 +336,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, _numPages, widget->width() - 3);
+                        Dropdown::Flag::StayOpen, _numPages, widget->width() - 4);
 
                     for (size_t i = 0; i < _numPages; i++)
                     {
@@ -355,7 +355,7 @@ namespace OpenRCT2::Ui::Windows
                     auto* widget = &widgets[widgetIndex - 1];
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, 2, widget->width() - 3);
+                        Dropdown::Flag::StayOpen, 2, widget->width() - 4);
 
                     gDropdown.items[static_cast<int32_t>(_selectedView)].setChecked(true);
                     break;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -772,7 +772,7 @@ namespace OpenRCT2::Ui::Windows
 
                     auto cdpi = const_cast<const RenderTarget&>(rt);
                     DrawTextEllipsised(
-                        cdpi, windowPos + ScreenCoordsXY{ widget.left + 5, widget.top + 1 }, widget.width(), strId, ft,
+                        cdpi, windowPos + ScreenCoordsXY{ widget.left + 5, widget.top + 1 }, widget.width() - 1, strId, ft,
                         { COLOUR_GREY });
                 };
 
@@ -1082,7 +1082,7 @@ namespace OpenRCT2::Ui::Windows
             Rectangle::fill(
                 rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);
 
-            const int32_t listWidth = widgets[WIDX_SCROLL].width();
+            const int32_t listWidth = widgets[WIDX_SCROLL].width() - 1;
             const auto sizeColumnLeft = widgets[WIDX_SORT_SIZE].left;
             const auto dateColumnLeft = widgets[WIDX_SORT_DATE].left;
             const int32_t dateAnchor = dateColumnLeft + maxDateWidth + kDateTimeGap;
@@ -1124,7 +1124,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<StringId>(STR_STRING);
                 ft.Add<char*>(_listItems[i].name.c_str());
-                int32_t max_file_width = widgets[WIDX_SORT_NAME].width() - 15;
+                int32_t max_file_width = widgets[WIDX_SORT_NAME].width() - 16;
                 DrawTextEllipsised(rt, { 15, y }, max_file_width, stringId, ft);
 
                 // Print formatted modified date, if this is a file

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -533,7 +533,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Adjust for hidden scrollbars if needed
             auto& mapArea = widgets[WIDX_MAP];
-            if (size.width >= mapArea.width())
+            if (size.width >= mapArea.width() - 1)
                 size.width -= kScrollBarWidth;
             if (size.height >= mapArea.height())
                 size.height -= kScrollBarWidth;
@@ -738,7 +738,7 @@ namespace OpenRCT2::Ui::Windows
 
             // calculate width and height of minimap
             auto& widget = widgets[WIDX_MAP];
-            auto mapWidth = widget.width() - kScrollBarWidth - 1;
+            auto mapWidth = widget.width() - 1 - kScrollBarWidth - 1;
             auto mapHeight = widget.height() - kScrollBarWidth - 1;
 
             centreX = std::max(centreX - (mapWidth >> 1), 0);

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -462,7 +462,7 @@ namespace OpenRCT2::Ui::Windows
                     Widget* ddWidget = &widgets[widgetIndex - 1];
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + ddWidget->left, windowPos.y + ddWidget->top }, ddWidget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, std::size(items), ddWidget->width() - 2);
+                        Dropdown::Flag::StayOpen, std::size(items), ddWidget->width() - 3);
 
                     gDropdown.items[EnumValue(_settings.algorithm)].setChecked(true);
                     break;

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -360,7 +360,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<const char*>(_buffer.c_str());
                 DrawTextEllipsised(
-                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, STR_STRING, ft,
                     { TextAlignment::centre });
             }
 
@@ -384,7 +384,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<const char*>(_buffer.c_str());
                 DrawTextEllipsised(
-                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, STR_STRING, ft,
                     { TextAlignment::centre });
             }
         }

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -221,7 +221,7 @@ namespace OpenRCT2::Ui::Windows
                             WindowDropdownShowTextCustomWidth(
                                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top },
                                 dropdownWidget->height() + 1, colours[1], 0, Dropdown::Flag::StayOpen, numItems,
-                                dropdownWidget->width() - 3);
+                                dropdownWidget->width() - 4);
                         }
                     }
                     else
@@ -242,7 +242,7 @@ namespace OpenRCT2::Ui::Windows
                         WindowDropdownShowTextCustomWidth(
                             { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top },
                             dropdownWidget->height() + 1, colours[1], 0, Dropdown::Flag::StayOpen, numItems,
-                            dropdownWidget->width() - 3);
+                            dropdownWidget->width() - 4);
                     }
                     break;
                     // In RCT2, the maximum was 6 weeks

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -447,7 +447,7 @@ namespace OpenRCT2::Ui::Windows
                 count++;
                 listItem++;
             }
-            return { widgets[WIDX_RIDE_LIST].width(), ((count + 4) / 5) * 116 };
+            return { widgets[WIDX_RIDE_LIST].width() - 1, ((count + 4) / 5) * 116 };
         }
 
         void onScrollMouseOver(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -516,7 +516,7 @@ namespace OpenRCT2::Ui::Windows
             Rectangle::fill(
                 rt, { rtCoords, rtCoords + ScreenCoordsXY{ rt.width - 1, rt.height - 1 } },
                 ColourMapA[colours[1].colour].mid_light);
-            const int32_t listWidth = widgets[WIDX_SCROLL].width();
+            const int32_t listWidth = widgets[WIDX_SCROLL].width() - 1;
 
             for (int32_t i = 0; i < numListItems; i++)
             {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1803,7 +1803,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
+                        Dropdown::Flag::StayOpen, numItems, widget->width() - 4);
 
                     gDropdown.items[static_cast<int32_t>(ThemeManagerGetAvailableThemeIndex())].setChecked(true);
                     invalidateWidget(WIDX_THEMES_DROPDOWN);
@@ -1934,7 +1934,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
+                        Dropdown::Flag::StayOpen, numItems, widget->width() - 4);
 
                     gDropdown.items[Config::Get().interface.scenarioPreviewScreenshots].setChecked(true);
                     break;
@@ -2245,7 +2245,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
 
             auto screenCoords = windowPos + ScreenCoordsXY{ pathWidget.left + 1, pathWidget.top + padding };
-            DrawTextEllipsised(rt, screenCoords, pathWidget.width(), STR_BLACK_STRING, ft);
+            DrawTextEllipsised(rt, screenCoords, pathWidget.width() - 1, STR_BLACK_STRING, ft);
         }
 
         OpenRCT2String AdvancedTooltip(WidgetIndex widgetIndex, StringId fallback)
@@ -2297,7 +2297,7 @@ namespace OpenRCT2::Ui::Windows
             // helper function, all dropdown boxes have similar properties
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
+                Dropdown::Flag::StayOpen, num_items, widget->width() - 4);
         }
 
         void DrawTabImages(RenderTarget& rt)
@@ -2352,7 +2352,7 @@ namespace OpenRCT2::Ui::Windows
 
         uint8_t GetScrollPercentage(const Widget& widget, const ScrollArea& scroll)
         {
-            uint8_t w = widget.width() - 1;
+            uint8_t w = widget.width() - 2;
             return static_cast<float>(scroll.contentOffsetX) / (scroll.contentWidth - w) * 100;
         }
 
@@ -2361,7 +2361,7 @@ namespace OpenRCT2::Ui::Windows
             const auto& widget = widgets[widgetIndex];
             auto& scroll = scrolls[scrollId];
 
-            int32_t widgetSize = scroll.contentWidth - (widget.width() - 1);
+            int32_t widgetSize = scroll.contentWidth - (widget.width() - 2);
             scroll.contentOffsetX = ceil(volume / 100.0f * widgetSize);
 
             widgetScrollUpdateThumbs(*this, widgetIndex);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -604,8 +604,8 @@ namespace OpenRCT2::Ui::Windows
 
             auto* labelWidget = &widgets[WIDX_STATUS];
             DrawTextEllipsised(
-                rt, windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width(), STR_BLACK_STRING,
-                ft, { TextAlignment::centre });
+                rt, windowPos + ScreenCoordsXY{ labelWidget->midX(), labelWidget->top }, labelWidget->width() - 1,
+                STR_BLACK_STRING, ft, { TextAlignment::centre });
         }
 
         void initViewport()
@@ -646,7 +646,7 @@ namespace OpenRCT2::Ui::Windows
                     Widget* viewportWidget = &widgets[WIDX_VIEWPORT];
                     ViewportCreate(
                         *this, windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-                        viewportWidget->width() - 1, viewportWidget->height() - 1, focus.value());
+                        viewportWidget->width() - 2, viewportWidget->height() - 1, focus.value());
                     flags |= WindowFlag::noScrolling;
                     invalidate();
                 }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -390,7 +390,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_VIEWPORT].right = width - 26;
             widgets[WIDX_VIEWPORT].bottom = height - 14;
 
-            int32_t groupDropdownWidth = widgets[WIDX_GROUP].width();
+            int32_t groupDropdownWidth = widgets[WIDX_GROUP].width() - 1;
             widgets[WIDX_GROUP].left = (width - groupDropdownWidth) / 2;
             widgets[WIDX_GROUP].right = widgets[WIDX_GROUP].left + groupDropdownWidth;
             widgets[WIDX_GROUP_DROPDOWN].left = widgets[WIDX_GROUP].right - 10;
@@ -403,7 +403,7 @@ namespace OpenRCT2::Ui::Windows
                 Widget* viewportWidget = &widgets[WIDX_VIEWPORT];
 
                 viewport->pos = windowPos + ScreenCoordsXY{ viewportWidget->left, viewportWidget->top };
-                viewport->width = viewportWidget->width();
+                viewport->width = viewportWidget->width() - 1;
                 viewport->height = viewportWidget->height();
             }
 
@@ -439,7 +439,7 @@ namespace OpenRCT2::Ui::Windows
                 ft.Add<const char*>(_buffer.c_str());
 
                 DrawTextEllipsised(
-                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, STR_STRING, ft,
                     { TextAlignment::centre });
             }
 

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -483,7 +483,7 @@ namespace OpenRCT2::Ui::Windows
         }
         WindowDropdownShowTextCustomWidth(
             { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-            w->colours[1], 0, Dropdown::Flag::StayOpen, 4, dropdownWidget->width() - 3);
+            w->colours[1], 0, Dropdown::Flag::StayOpen, 4, dropdownWidget->width() - 4);
 
         int32_t currentResearchLevel = gameState.researchFundingLevel;
         gDropdown.items[currentResearchLevel].setChecked(true);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1582,7 +1582,7 @@ namespace OpenRCT2::Ui::Windows
                 const auto& viewWidget = widgets[WIDX_VIEWPORT];
 
                 auto screenPos = windowPos + ScreenCoordsXY{ viewWidget.left + 1, viewWidget.top + 1 };
-                int32_t viewWidth = viewWidget.width() - 1;
+                int32_t viewWidth = viewWidget.width() - 2;
                 int32_t viewHeight = viewWidget.height() - 1;
 
                 ViewportCreate(*this, screenPos, viewWidth, viewHeight, focus.value());
@@ -2086,7 +2086,7 @@ namespace OpenRCT2::Ui::Windows
             Widget* dropdownWidget = widget - 1;
             WindowDropdownShowTextCustomWidth(
                 { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-                colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width());
+                colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 1);
 
             // Find the current vehicle type in the ordered list.
             int32_t pos = 0;
@@ -2616,8 +2616,8 @@ namespace OpenRCT2::Ui::Windows
             widget = &widgets[WIDX_STATUS];
             StringId rideStatus = GetStatus(ft);
             DrawTextEllipsised(
-                rt, windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width(), rideStatus,
-                ft, { TextAlignment::centre });
+                rt, windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width() - 1,
+                rideStatus, ft, { TextAlignment::centre });
         }
 
 #pragma endregion
@@ -2957,7 +2957,7 @@ namespace OpenRCT2::Ui::Windows
             Rectangle::fill(rt, { { rt.x, rt.y }, { rt.x + rt.width, rt.y + rt.height } }, PaletteIndex::pi12);
 
             Widget* widget = &widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
-            int32_t startX = std::max(2, (widget->width() - ((ride->numTrains - 1) * 36)) / 2 - 25);
+            int32_t startX = std::max(2, (widget->width() - 1 - ((ride->numTrains - 1) * 36)) / 2 - 25);
             int32_t startY = widget->height() - 4;
 
             bool isReversed = ride->hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS);
@@ -4890,7 +4890,7 @@ namespace OpenRCT2::Ui::Windows
                 if (ClipDrawPixelInfo(
                         clippedDpi, rt,
                         windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
-                        entrancePreviewWidget.width(), entrancePreviewWidget.height()))
+                        entrancePreviewWidget.width() - 1, entrancePreviewWidget.height()))
                 {
                     GfxClear(clippedDpi, PaletteIndex::pi12);
 
@@ -5137,7 +5137,7 @@ namespace OpenRCT2::Ui::Windows
             // Figure out minimum size
             ScreenSize size{};
             size.height = widgets[WIDX_MUSIC_DATA].height() - 2;
-            size.width = widgets[WIDX_MUSIC_DATA].width() - 2;
+            size.width = widgets[WIDX_MUSIC_DATA].width() - 3;
 
             auto ride = GetRide(rideId);
             if (ride == nullptr)
@@ -5251,7 +5251,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Figure out where the image should go
             const auto& previewWidget = widgets[WIDX_MUSIC_IMAGE];
-            int32_t clipWidth = previewWidget.width() - 1;
+            int32_t clipWidth = previewWidget.width() - 2;
             int32_t clipHeight = previewWidget.height() - 1;
 
             // Draw the preview image
@@ -5614,7 +5614,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
-                ScreenCoordsXY widgetCoords(windowPos.x + widget->width() / 2, windowPos.y + widget->top + 40);
+                ScreenCoordsXY widgetCoords(windowPos.x + widget->midX(), windowPos.y + widget->top + 40);
                 DrawTextWrapped(
                     rt, widgetCoords, width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::centre });
 
@@ -5937,11 +5937,11 @@ namespace OpenRCT2::Ui::Windows
                 {
                     RideMeasurement* measurement{};
                     std::tie(measurement, std::ignore) = ride->getMeasurement();
-                    x = measurement == nullptr ? 0 : measurement->current_item - ((widget->width() / 4) * 3);
+                    x = measurement == nullptr ? 0 : measurement->current_item - (((widget->width() - 1) / 4) * 3);
                 }
             }
 
-            scrolls[0].contentOffsetX = std::clamp(x, 0, scrolls[0].contentWidth - (widget->width() - 2));
+            scrolls[0].contentOffsetX = std::clamp(x, 0, scrolls[0].contentWidth - (widget->width() - 3));
             widgetScrollUpdateThumbs(*this, WIDX_GRAPH);
         }
 
@@ -5951,7 +5951,7 @@ namespace OpenRCT2::Ui::Windows
 
             ScreenSize size{};
             // Set minimum size
-            size.width = widgets[WIDX_GRAPH].width() - 2;
+            size.width = widgets[WIDX_GRAPH].width() - 3;
 
             // Get measurement size
             auto ride = GetRide(rideId);
@@ -6072,7 +6072,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 // No measurement message
                 ScreenCoordsXY stringCoords(widget->width() / 2, widget->height() / 2 - 5);
-                int32_t txtWidth = widget->width() - 2;
+                int32_t txtWidth = widget->width() - 3;
                 DrawTextWrapped(rt, stringCoords, txtWidth, message.str, message.args, { TextAlignment::centre });
                 return;
             }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1705,7 +1705,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw track piece
             auto screenCoords = ScreenCoordsXY{ windowPos.x + widget->left + 1, windowPos.y + widget->top + 1 };
-            widgetWidth = widget->width() - 1;
+            widgetWidth = widget->width() - 2;
             widgetHeight = widget->height() - 1;
             if (ClipDrawPixelInfo(clippedRT, rt, screenCoords, widgetWidth, widgetHeight))
             {
@@ -2626,7 +2626,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Tune dropdown to the elements it contains
-            auto ddWidth = widget->width();
+            auto ddWidth = widget->width() - 1;
             auto targetColumnSize = _specialElementDropdownState.PreferredNumRows;
             if (targetColumnSize < _specialElementDropdownState.Elements.size())
                 ddWidth -= 30;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -343,7 +343,7 @@ namespace OpenRCT2::Ui::Windows
 
                 const auto& headerWidget = widgets[WIDX_HEADER_OTHER];
                 const auto& customWidget = widgets[WIDX_HEADER_CUSTOMISE];
-                auto totalWidth = headerWidget.width() + customWidget.width();
+                auto totalWidth = headerWidget.width() - 1 + customWidget.width() - 1;
 
                 WindowDropdownShowTextCustomWidth(
                     { windowPos.x + headerWidget.left, windowPos.y + headerWidget.top }, headerWidget.height(), colours[1], 0,
@@ -526,7 +526,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_HEADER_CUSTOMISE].right = widgets[WIDX_LIST].right - 1;
             widgets[WIDX_HEADER_CUSTOMISE].left = widgets[WIDX_HEADER_CUSTOMISE].right - 14;
 
-            auto columnWidth = (widgets[WIDX_LIST].width() - widgets[WIDX_HEADER_CUSTOMISE].width()) / 2;
+            auto columnWidth = (widgets[WIDX_LIST].width() - 1 - widgets[WIDX_HEADER_CUSTOMISE].width() - 1) / 2;
 
             widgets[WIDX_HEADER_OTHER].right = widgets[WIDX_HEADER_CUSTOMISE].left - 1;
             widgets[WIDX_HEADER_OTHER].left = widgets[WIDX_HEADER_OTHER].right - columnWidth + 1;
@@ -603,7 +603,7 @@ namespace OpenRCT2::Ui::Windows
 
                 auto cdpi = const_cast<const RenderTarget&>(rt);
                 DrawTextEllipsised(
-                    cdpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 }, widget.width(),
+                    cdpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 }, widget.width() - 1,
                     STR_RIDE_LIST_HEADER_FORMAT, ft, { colours[1] });
             };
 
@@ -659,7 +659,7 @@ namespace OpenRCT2::Ui::Windows
                 ridePtr->formatNameTo(ft);
 
                 auto& nameHeader = widgets[WIDX_HEADER_NAME];
-                DrawTextEllipsised(rt, { 0, y - 1 }, nameHeader.width() - 2, format, ft);
+                DrawTextEllipsised(rt, { 0, y - 1 }, nameHeader.width() - 3, format, ft);
 
                 // Ride information
                 ft = Formatter();
@@ -866,7 +866,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 auto infoHeader = widgets[WIDX_HEADER_OTHER];
-                DrawTextEllipsised(rt, { infoHeader.left - 4, y - 1 }, infoHeader.width() - 2, format, ft);
+                DrawTextEllipsised(rt, { infoHeader.left - 4, y - 1 }, infoHeader.width() - 3, format, ft);
                 y += kScrollableRowHeight;
             }
         }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -554,7 +554,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& listWidget = widgets[WIDX_SCENARIOLIST];
-            int32_t listWidth = listWidget.width() - 12;
+            int32_t listWidth = listWidget.width() - 13;
 
             const int32_t scenarioItemHeight = GetScenarioListItemSize();
 
@@ -611,7 +611,7 @@ namespace OpenRCT2::Ui::Windows
                         if (isCompleted)
                         {
                             // Draw completion tick
-                            GfxDrawSprite(rt, ImageId(SPR_MENU_CHECKMARK), { widgets[WIDX_SCENARIOLIST].width() - 45, y + 1 });
+                            GfxDrawSprite(rt, ImageId(SPR_MENU_CHECKMARK), { widgets[WIDX_SCENARIOLIST].width() - 46, y + 1 });
 
                             // Draw completion score
                             u8string completedByName = "???";

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1058,7 +1058,7 @@ namespace OpenRCT2::Ui::Windows
         int32_t GetNumColumns() const
         {
             const auto& listWidget = widgets[WIDX_SCENERY_LIST];
-            const auto contentWidth = listWidget.width() - kScrollBarWidth;
+            const auto contentWidth = listWidget.width() - 1 - kScrollBarWidth;
             return contentWidth / kSceneryButtonWidth;
         }
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -248,7 +248,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                const int32_t iconX = listWidget.width() - kScrollBarWidth - 7 - 10;
+                const int32_t iconX = listWidget.width() - 1 - kScrollBarWidth - 7 - 10;
                 showNetworkVersionTooltip = screenCoords.x > iconX;
             }
 
@@ -332,7 +332,7 @@ namespace OpenRCT2::Ui::Windows
             GfxClear(rt, paletteIndex);
 
             auto& listWidget = widgets[WIDX_LIST];
-            int32_t listWidgetWidth = listWidget.width();
+            int32_t listWidgetWidth = listWidget.width() - 1;
 
             ScreenCoordsXY screenCoords;
             screenCoords.y = 0;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -135,7 +135,7 @@ namespace OpenRCT2::Ui::Windows
             Widget& viewportWidget = widgets[WIDX_VIEWPORT];
             ViewportCreate(
                 *this, windowPos + ScreenCoordsXY{ viewportWidget.left + 1, viewportWidget.top + 1 },
-                viewportWidget.width() - 1, viewportWidget.height() - 1, Focus(CoordsXYZ{ signViewPosition, viewZ }));
+                viewportWidget.width() - 2, viewportWidget.height() - 1, Focus(CoordsXYZ{ signViewPosition, viewZ }));
 
             viewport->flags = Config::Get().general.alwaysShowGridlines ? VIEWPORT_FLAG_GRIDLINES : VIEWPORT_FLAG_NONE;
             invalidate();
@@ -318,7 +318,7 @@ namespace OpenRCT2::Ui::Windows
             Widget* viewportWidget = &widgets[WIDX_VIEWPORT];
             ViewportCreate(
                 *this, windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 },
-                viewportWidget->width() - 1, viewportWidget->height() - 1, Focus(CoordsXYZ{ signViewPos }));
+                viewportWidget->width() - 2, viewportWidget->height() - 1, Focus(CoordsXYZ{ signViewPos }));
             if (viewport != nullptr)
                 viewport->flags = Config::Get().general.alwaysShowGridlines ? VIEWPORT_FLAG_GRIDLINES : VIEWPORT_FLAG_NONE;
             invalidate();

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -563,7 +563,7 @@ namespace OpenRCT2::Ui::Windows
             staff->FormatActionTo(ft);
             const auto& widget = widgets[WIDX_BTM_LABEL];
             auto screenPos = windowPos + ScreenCoordsXY{ widget.midX(), widget.top };
-            int32_t widgetWidth = widget.width();
+            int32_t widgetWidth = widget.width() - 1;
             DrawTextEllipsised(rt, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::centre });
         }
 
@@ -573,7 +573,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             const auto& widget = widgets[WIDX_TAB_1];
-            int32_t widgetWidth = widget.width() - 1;
+            int32_t widgetWidth = widget.width() - 2;
             int32_t widgetHeight = widget.height() - 1;
             auto screenCoords = windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
             if (page == WINDOW_STAFF_OVERVIEW)
@@ -615,7 +615,7 @@ namespace OpenRCT2::Ui::Windows
             if (viewport != nullptr)
             {
                 const Widget& viewportWidget = widgets[WIDX_VIEWPORT];
-                const auto reqViewportWidth = viewportWidget.width() - 1;
+                const auto reqViewportWidth = viewportWidget.width() - 2;
                 const auto reqViewportHeight = viewportWidget.height() - 1;
 
                 viewport->pos = windowPos + ScreenCoordsXY{ viewportWidget.left + 1, viewportWidget.top + 1 };
@@ -803,7 +803,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto ddPos = ScreenCoordsXY{ ddWidget->left + windowPos.x, ddWidget->top + windowPos.y };
             int32_t ddHeight = ddWidget->height() + 1;
-            int32_t ddWidth = ddWidget->width() - 3;
+            int32_t ddWidth = ddWidget->width() - 4;
             WindowDropdownShowTextCustomWidth(ddPos, ddHeight, colours[1], 0, Dropdown::Flag::StayOpen, numCostumes, ddWidth);
 
             // Set selection
@@ -1158,7 +1158,7 @@ namespace OpenRCT2::Ui::Windows
                     const auto& viewWidget = widgets[WIDX_VIEWPORT];
 
                     auto screenPos = ScreenCoordsXY{ viewWidget.left + 1 + windowPos.x, viewWidget.top + 1 + windowPos.y };
-                    int32_t viewportWidth = viewWidget.width() - 1;
+                    int32_t viewportWidth = viewWidget.width() - 2;
                     int32_t viewportHeight = viewWidget.height() - 1;
 
                     ViewportCreate(*this, screenPos, viewportWidth, viewportHeight, focus.value());

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -322,7 +322,7 @@ namespace OpenRCT2::Ui::Windows
                 invalidate();
             }
 
-            auto scrollWidth = widgets[WIDX_STAFF_LIST_LIST].width() - 15;
+            auto scrollWidth = widgets[WIDX_STAFF_LIST_LIST].width() - 16;
             return { scrollWidth, scrollHeight };
         }
 
@@ -375,7 +375,7 @@ namespace OpenRCT2::Ui::Windows
                 ColourMapA[colours[1].colour].mid_light);
 
             // How much space do we have for the name and action columns? (Discount scroll area and icons.)
-            const int32_t nonIconSpace = widgets[WIDX_STAFF_LIST_LIST].width() - 15 - 68;
+            const int32_t nonIconSpace = widgets[WIDX_STAFF_LIST_LIST].width() - 1 - 15 - 68;
             const int32_t nameColumnSize = nonIconSpace * 0.42;
             const int32_t actionColumnSize = nonIconSpace * 0.58;
             const int32_t actionOffset = widgets[WIDX_STAFF_LIST_LIST].right - actionColumnSize - 15;

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -454,7 +454,7 @@ namespace OpenRCT2::Ui::Windows
 
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                        Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
+                        Dropdown::Flag::StayOpen, num_items, widget->width() - 4);
 
                     gDropdown.items[static_cast<int32_t>(ThemeManagerGetAvailableThemeIndex())].setChecked(true);
                     break;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -905,7 +905,7 @@ static uint64_t PageDisabledWidgets[] = {
                             gDropdown.items[2] = Dropdown::MenuLabel(STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT);
                             WindowDropdownShowTextCustomWidth(
                                 { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
-                                Dropdown::Flag::StayOpen, 3, widget->width() - 3);
+                                Dropdown::Flag::StayOpen, 3, widget->width() - 4);
 
                             // Set current value as checked
                             gDropdown.items[tileElement->AsWall()->GetSlope()].setChecked(true);
@@ -1586,7 +1586,7 @@ static uint64_t PageDisabledWidgets[] = {
 
         void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
-            const int32_t listWidth = widgets[WIDX_LIST].width();
+            const int32_t listWidth = widgets[WIDX_LIST].width() - 1;
             Rectangle::fill(
                 rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1298,7 +1298,7 @@ namespace OpenRCT2::Ui::Windows
                 if (firstItem && widgetIndex == WIDX_SEPARATOR)
                     continue;
 
-                totalWidth += widget->width() + 1;
+                totalWidth += widget->width();
                 firstItem = false;
             }
             return totalWidth;
@@ -1318,7 +1318,7 @@ namespace OpenRCT2::Ui::Windows
                 if (firstItem && widgetIndex == WIDX_SEPARATOR)
                     continue;
 
-                auto widgetWidth = widget->width();
+                auto widgetWidth = widget->width() - 1;
                 widget->left = xPos;
                 xPos += widgetWidth;
                 widget->right = xPos;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -181,7 +181,7 @@ namespace OpenRCT2::Ui::Windows
         {
             const auto& widget = widgets[WIDX_CLIP_HEIGHT_SLIDER];
             const ScrollArea* const scroll = &this->scrolls[0];
-            const int16_t scroll_width = widget.width() - 1;
+            const int16_t scroll_width = widget.width() - 2;
             const uint8_t clip_height = static_cast<uint8_t>(
                 (static_cast<float>(scroll->contentOffsetX) / (scroll->contentWidth - scroll_width)) * 255);
             if (clip_height != gClipHeight)
@@ -402,7 +402,7 @@ namespace OpenRCT2::Ui::Windows
             const auto& widget = widgets[WIDX_CLIP_HEIGHT_SLIDER];
             const float clip_height_ratio = static_cast<float>(gClipHeight) / 255;
             this->scrolls[0].contentOffsetX = static_cast<int16_t>(
-                std::ceil(clip_height_ratio * (this->scrolls[0].contentWidth - (widget.width() - 1))));
+                std::ceil(clip_height_ratio * (this->scrolls[0].contentWidth - (widget.width() - 2))));
         }
 
         bool IsActive()

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -199,7 +199,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 Widget* viewportWidget = &widgets[WIDX_VIEWPORT];
                 viewport->pos = windowPos + ScreenCoordsXY{ viewportWidget->left + 1, viewportWidget->top + 1 };
-                viewport->width = widgets[WIDX_VIEWPORT].width() - 1;
+                viewport->width = widgets[WIDX_VIEWPORT].width() - 2;
                 viewport->height = widgets[WIDX_VIEWPORT].height() - 1;
             }
         }

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -102,7 +102,7 @@ namespace OpenRCT2
 
         int16_t width() const
         {
-            return right - left;
+            return right - left + 1;
         }
 
         int16_t height() const
@@ -112,7 +112,7 @@ namespace OpenRCT2
 
         int16_t midX() const
         {
-            return (left + right) / 2;
+            return left + (width() / 2);
         }
 
         int16_t midY() const


### PR DESCRIPTION
It was off by one. By taking the fixed value and subtracting 1, the windows should all behave the same.

Some of them should ditch the `- 1`, while others already subtracted a number of pixels and should just merge the two. I deliberately left this out so it can easily be discussed in review.