### PR TITLE
Fix #25449: Colour dropdown selection visibility and spacing

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -252,6 +252,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * David Sungaila (sungaila)
 * Garrett Leach (GarrettLeach)
 * Ruohao (Jater) Xu (jaterx)
+* Joshua Maldonado (DrDoodle)
 
 ## Toolchain
 * (Balletie) - macOS


### PR DESCRIPTION

### **Summary**

This PR improves the clarity and usability of the colour dropdown selector in both normal and enlarged UI modes.

Previously:

-   The selected colour was not visually indicated after moving the mouse away.
    
-   Enlarged UI mode displayed the swatches directly adjacent to each other, making them difficult to distinguish.
    

This fix ensures that the user can always see which colour is currently selected, and that the palette remains comfortably spaced and easy to scan.

----------

### **Changes**

-   Always draw a visible border around the selected colour (using `gDropdown.defaultIndex`).
    
-   Keep the selected colour highlighted even when the cursor is not over any swatch.
    
-   Add small cell padding (2 px normal / 4 px enlarged UI) to space out colour icons.
    
-   Centre colour icons within their cells to match new padding.
    
-   Verified behaviour with:
    
    -   Normal and enlarged UI modes
        
    -   Special colour schemes (cheat on/off)
        
    -   Tooltips active and inactive
 ----------
### **Testing**

-   Tested in ride vehicle, track colour, and scenery paint pickers.
    
-   Checked both mouse hover and click behaviour.
    
-   No regression in text or image dropdowns verified.