### PR TITLE
Capture track location for callback by value

### DIFF
--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -289,7 +289,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto tdAction = GameActions::TrackDesignAction(
                 { trackLoc, _currentTrackPieceDirection }, *_trackDesign, !gTrackDesignSceneryToggle);
-            tdAction.SetCallback([&](const GameActions::GameAction*, const GameActions::Result* result) {
+            tdAction.SetCallback([&, trackLoc](const GameActions::GameAction*, const GameActions::Result* result) {
                 if (result->Error != GameActions::Status::Ok)
                 {
                     Audio::Play3D(Audio::SoundId::error, result->Position);


### PR DESCRIPTION
Previously it was getting captured by reference and the action using it was queued up for execution in next tick, resulting in reference going out of scope. Capturing it by value fixes this issue as it is POD struct.