### PR TITLE
Fix data race on gWindowList

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -680,6 +680,14 @@ namespace OpenRCT2
 
         void OpenProgress(StringId captionStringId) override
         {
+            // Don't open progress window from non-main threads, such as worker threads that
+            // update progress with no progress window being available yet
+            const auto isMainThread = _mainThreadId == std::this_thread::get_id();
+            if (!gOpenRCT2Headless && !isMainThread)
+            {
+                return;
+            }
+
             auto captionString = _localisationService->GetString(captionStringId);
             auto intent = Intent(INTENT_ACTION_PROGRESS_OPEN);
             intent.PutExtra(INTENT_EXTRA_MESSAGE, captionString);
@@ -713,6 +721,12 @@ namespace OpenRCT2
 
         void CloseProgress() override
         {
+            const auto isMainThread = _mainThreadId == std::this_thread::get_id();
+            if (!gOpenRCT2Headless && !isMainThread)
+            {
+                return;
+            }
+
             auto intent = Intent(INTENT_ACTION_PROGRESS_CLOSE);
             ContextOpenIntent(&intent);
         }


### PR DESCRIPTION
This fixes a data race that happened on `gWindowList` when a progress update was requested from a worker thread, but no progress window was available yet. The worker would open up the progress window, but other threads could do the same without any checks.

Rather than adding mutex to guard `gWindowList`, I've made the progress only open from the main thread.

This would've happened with following stack trace:
```
Thread 446 "openrct2" hit Breakpoint 1, OpenRCT2::Context::OpenProgress (this=this@entry=0x555555ada510, captionStringId=captionStringId@entry=6635) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:684
684	            const auto isMainThread = _mainThreadId == std::this_thread::get_id();
(gdb) bt
#0  OpenRCT2::Context::OpenProgress (this=this@entry=0x555555ada510, captionStringId=captionStringId@entry=6635) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:684
#1  0x00007ffff70a233f in OpenRCT2::Context::InitialiseRepositories (this=0x555555ada510) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:576
#2  0x00007ffff714169e in std::function<void()>::operator() (this=0x7fff445a9080) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/std_function.h:593
#3  JobPool::ProcessQueue (this=0x555555e77b40) at /home/janisozaur/workspace/openrct2/src/openrct2/core/JobPool.cpp:117
#4  0x00007ffff5ee55a4 in std::execute_native_thread_routine (__p=0x555556d33550) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
#5  0x00007ffff5a969cb in start_thread (arg=<optimized out>) at pthread_create.c:448
#6  0x00007ffff5b1aa0c in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

I've confirmed the progress still opens correctly in the same stage:
```
Thread 1 "openrct2" hit Breakpoint 1, OpenRCT2::Context::OpenProgress (this=0x555555ada510, captionStringId=6637) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:684
684	            const auto isMainThread = _mainThreadId == std::this_thread::get_id();
(gdb) bt
#0  OpenRCT2::Context::OpenProgress (this=0x555555ada510, captionStringId=6637) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:684
#1  0x00005555556556f4 in OpenRCT2::Title::TitleSequencePlayer::ReportProgress (this=0x5555559c0570, progress=0 '\000') at /home/janisozaur/workspace/openrct2/src/openrct2-ui/title/TitleSequencePlayer.cpp:291
#2  OpenRCT2::Title::TitleSequencePlayer::LoadParkFromStream (this=this@entry=0x5555559c0570, stream=0x555557015ef0, hintPath="Kahuna Point by Enrico Dandolo & Kyphii & RobMan.park") at /home/janisozaur/workspace/openrct2/src/openrct2-ui/title/TitleSequencePlayer.cpp:374
#3  0x0000555555654f76 in OpenRCT2::Title::TitleSequencePlayer::Update (this=0x5555559c0570) at /home/janisozaur/workspace/openrct2/src/openrct2-ui/title/TitleSequencePlayer.cpp:138
#4  0x00007ffff7651f0b in OpenRCT2::TitleScene::TryLoadSequence (this=this@entry=0x555555e6ccd0, loadPreview=false) at /home/janisozaur/workspace/openrct2/src/openrct2/scenes/title/TitleScene.cpp:301
#5  0x00007ffff7652146 in OpenRCT2::TitleScene::Load (this=0x555555e6ccd0) at /home/janisozaur/workspace/openrct2/src/openrct2/scenes/title/TitleScene.cpp:120
#6  0x00007ffff709ec0f in OpenRCT2::Context::SetActiveScene (this=0x555555ada510, screen=0x555555e6ccd0) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:375
#7  OpenRCT2::Context::SwitchToStartUpScene (this=0x555555ada510) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:1163
#8  0x00007ffff7651aa6 in OpenRCT2::PreloaderScene::Tick (this=0x555555e77b10) at /home/janisozaur/workspace/openrct2/src/openrct2/scenes/preloader/PreloaderScene.cpp:64
#9  0x00007ffff70a141c in OpenRCT2::Context::Tick (this=this@entry=0x555555ada510) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:1435
#10 0x00007ffff70a1156 in OpenRCT2::Context::RunVariableFrame (this=this@entry=0x555555ada510, deltaTime=<optimized out>) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:1387
#11 0x00007ffff70a1023 in OpenRCT2::Context::RunFrame (this=this@entry=0x555555ada510) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:1318
#12 0x00007ffff709ee68 in OpenRCT2::Context::RunGameLoop (this=this@entry=0x555555ada510) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:1289
#13 0x00007ffff709e47b in OpenRCT2::Context::Launch (this=this@entry=0x555555ada510) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:1251
#14 0x00007ffff7099b81 in OpenRCT2::Context::RunOpenRCT2 (this=0x555555ada510, argc=<optimized out>, argv=<optimized out>) at /home/janisozaur/workspace/openrct2/src/openrct2/Context.cpp:316
#15 0x00005555555a982c in main (argc=1, argv=0x7fffffffd8c8) at /home/janisozaur/workspace/openrct2/src/openrct2-ui/Ui.cpp:84
```

There is already such guard in `SetProgress`, it is working as intended.