### PR TITLE
Fix #25454: Pathing Tool Closes When Land Tool Opens

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#6228] The saved queue line path connections are not preserved when placing track designs (original bug).
 - Fix: [#14365] Track designs with scenery below the lowest track piece do not preview correctly.
 - Fix: [#25451] Dropdown item tooltips stay open if the mouse is moved over an empty space.
+- Fix: [#25454] Opening the land tool while building a path bridge or tunnel closes the Footpaths window.
 - Fix: [#25461] Path connections in raised track designs are sometimes broken when placed.
 - Fix: [#25467] Paths are not connected together correctly in track design previews.
 - Fix: [#25476] When both RCT2 and RCT1 are present, autodetection fails.

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -282,6 +282,11 @@ namespace OpenRCT2::Ui::Windows
                         close();
                     break;
                 case PathConstructionMode::dragArea:
+                    // If another window has enabled a tool, close ours.
+                    // If the user merely pressed Escape, we cancel the tool but don’t close the window.
+                    if (gInputFlags.has(InputFlag::toolActive)
+                        && gCurrentToolWidget.windowClassification != WindowClass::footpath)
+                        close();
                     break;
                 case PathConstructionMode::bridgeOrTunnelPick:
                     if (!isToolActive(WindowClass::footpath, WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL))
@@ -290,10 +295,6 @@ namespace OpenRCT2::Ui::Windows
                 case PathConstructionMode::bridgeOrTunnel:
                     break;
             }
-
-            // If another window has enabled a tool, close ours.
-            if (gInputFlags.has(InputFlag::toolActive) && gCurrentToolWidget.windowClassification != WindowClass::footpath)
-                close();
         }
 
         void onMouseDown(WidgetIndex widgetIndex) override


### PR DESCRIPTION
Compared the behaviour with v0.4.27 and it should now match for all tools (keeping the window open when in bridge mode, but closing when in land placement, bridge start picker or drag mode).