### PR TITLE
Fix UB for empty string_views

### DIFF
--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -671,7 +671,10 @@ namespace OpenRCT2
                 {
                     len = s.size();
                 }
-                _buffer.Write(s.data(), len);
+                if (len > 0)
+                {
+                    _buffer.Write(s.data(), len);
+                }
                 _buffer.Write(&nullt, sizeof(nullt));
             }
 


### PR DESCRIPTION
Without this guard, when passed an empty `string_view` `_buffer.Write()` will call `memcpy` with `nullptr` which is UB even when passed a length of zero.