### PR TITLE
Fix virtual floor invalidating incorrectly if expanded on x and y axes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#25480] The mini track design preview and price are misaligned in Enlarged UI mode.
 - Fix: [#25488] Crash in headless mode.
 - Fix: [#25494] The Go-Karts steep to flat track does not draw correctly in the flat side tunnel.
+- Fix: [#25518] The virtual floor does not draw correctly if expanded on the positive x and y axes.
 - Fix: [objects#401] Round tunnels on down slopes glitch.
 - Fix: [objects#404] Wooden Wild Mine cars incorrectly allow setting a third remap colour.
 - Fix: [objects#408] Australian fountain sets have confusing naming.

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -138,7 +138,8 @@ void VirtualFloorInvalidate(const bool alwaysInvalidate)
     }
 
     // Do not invalidate new region if floor hasn't moved.
-    if (min_position == _virtualFloorLastMinPos && _virtualFloorLastMinPos.z == _virtualFloorHeight)
+    if (min_position == _virtualFloorLastMinPos && max_position == _virtualFloorLastMaxPos
+        && _virtualFloorLastMinPos.z == _virtualFloorHeight)
     {
         return;
     }


### PR DESCRIPTION
This fixes the virtual floor not invalidating correctly if expanded on the x and y axes.
It was not checking if the max position was the same before early returning.

https://github.com/user-attachments/assets/aa82472e-9383-4838-a6ad-8ecc74dc2816


https://github.com/user-attachments/assets/a614df8e-60b8-4657-8ba4-9a4be4b4e082

