### PR TITLE
Fix audio crackling

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#25488] Crash in headless mode.
 - Fix: [#25494] The Go-Karts steep to flat track does not draw correctly in the flat side tunnel.
 - Fix: [#25518] The virtual floor does not draw correctly if expanded on the positive x and y axes.
+- Fix: [#25519] Crackling audio when sampling frequencies do not match.
 - Fix: [objects#401] Round tunnels on down slopes glitch.
 - Fix: [objects#404] Wooden Wild Mine cars incorrectly allow setting a third remap colour.
 - Fix: [objects#408] Australian fountain sets have confusing naming.

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -200,7 +200,7 @@ void AudioMixer::MixChannel(ISDLAudioChannel* channel, uint8_t* data, size_t len
 
     // Read raw PCM from channel
     int32_t readSamples = numSamples * rate;
-    auto readLength = static_cast<size_t>(readSamples / cvt.len_ratio) * outputByteRate;
+    auto readLength = static_cast<size_t>(ceil(readSamples / cvt.len_ratio)) * outputByteRate;
     _channelBuffer.resize(readLength);
     size_t bytesRead = channel->Read(_channelBuffer.data(), readLength);
 


### PR DESCRIPTION
For me, this solved the problem when resampling a 48 kHz OGG to 22.05 kHz, or a 22.05 kHz file to 48 kHz. It seems that the length was getting truncated by rounding errors.

I removed _everything_ from this PR except the fix, as it seems that people were getting distracted by the sample rate change.

Here is a test file. You can test as follows:
1. Add the object to a park
2. Add it to a Merry-go-round and play.
3. Observe there is crackling on `develop`, but not on this branch.

[gymnasiast.music.crackletest.parkobj.zip](https://github.com/user-attachments/files/23564383/gymnasiast.music.crackletest.parkobj.zip)
