### PR TITLE
Update badge links in README for releases and commits

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@
 ### Download
 | Latest release                                                                                                       | Latest development build |
 |----------------------------------------------------------------------------------------------------------------------|--------------------------|
-| [![OpenRCT2.io](https://img.shields.io/badge/master-v0.4.29-green.svg)](https://openrct2.io/download/release/latest) | [![OpenRCT2.io](https://img.shields.io/github/last-commit/OpenRCT2/OpenRCT2/develop)](https://openrct2.io/download/develop/latest) |
+| [![OpenRCT2.io](https://img.shields.io/github/v/release/OpenRCT2/OpenRCT2.svg?color=green)](https://openrct2.io/download/release/latest) | [![OpenRCT2.io](https://img.shields.io/github/last-commit/OpenRCT2/OpenRCT2/develop?color=green)](https://openrct2.io/download/develop/latest) |
 
 ---
 


### PR DESCRIPTION
Update the badge link to use github's latest release automatically.

Update the colour to match for develop badge.