### PR TITLE
Fix #24952: Duplicate track designs when running via Steam without having RCT1 linked

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#25529] The map selection grid no longer redraws every frame if it has not changed.
 - Improved: [#25530] Wall dragging can now be cancelled without closing the Scenery window.
 - Change: [#25485] Make the enlarged pressed swatch sprite more pronounced.
+- Fix: [#24952] Duplicate track designs when running via Steam without having RCT1 linked.
 - Fix: [#25524] The track construction arrow does not immediately change position when deleting track pieces.
 - Fix: [#25565] Chairlift station ends are missing tunnels at certain rotations.
 

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -108,6 +108,9 @@ public:
         {
             default:
             case DirBase::rct1:
+                if (basePath.empty())
+                    return {};
+
                 directoryName = kDirectoryNamesRCT2[EnumValue(did)];
                 break;
             case DirBase::rct2:

--- a/src/openrct2/core/FileIndex.hpp
+++ b/src/openrct2/core/FileIndex.hpp
@@ -144,6 +144,9 @@ private:
         std::vector<std::string> files;
         for (const auto& directory : SearchPaths)
         {
+            if (directory.empty())
+                continue;
+
             auto absoluteDirectory = OpenRCT2::Path::GetAbsolute(directory);
             LOG_VERBOSE("FileIndex:Scanning for %s in '%s'", _pattern.c_str(), absoluteDirectory.c_str());
 


### PR DESCRIPTION
Thanks to "Moreau le Nam" on Discord for investigating.