### PR TITLE
Fix chairlift station end tunnels not drawing at certain angles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#25529] The map selection grid no longer redraws every frame if it has not changed.
 - Improved: [#25530] Wall dragging can now be cancelled without closing the Scenery window.
 - Fix: [#25524] The track construction arrow does not immediately change position when deleting track pieces.
+- Fix: [#25565] Chairlift station ends are missing tunnels at certain rotations.
 
 0.4.29 (2025-11-22)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/transport/Chairlift.cpp
+++ b/src/openrct2/paint/track/transport/Chairlift.cpp
@@ -368,10 +368,9 @@ static void ChairliftPaintStationSeNw(
         imageId = session.TrackColours.WithIndex(SPR_CHAIRLIFT_STATION_COLUMN_SE_NW);
         PaintAddImageAsParent(
             session, imageId, { 16, 30, height + 2 }, { { 16, 1, height + 2 }, { 1, 1, 7 } }); // bound offset x is wrong?
-
-        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
     }
 
+    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }


### PR DESCRIPTION
RCT1 (same in 2):
<img width="411" height="181" alt="chairliftstationtunnelrct1" src="https://github.com/user-attachments/assets/88343d33-f750-45c0-b358-a94c83d87af1" />
Current bug:
<img width="411" height="181" alt="chairliftstationtunnelbug" src="https://github.com/user-attachments/assets/719d66e0-4f17-4b23-9b78-540315901ee0" />
Fix:
<img width="411" height="181" alt="chairliftstationtunnelfix" src="https://github.com/user-attachments/assets/9533ff77-c92d-46e2-9afd-51c3f4f33221" />

Bug video:

https://github.com/user-attachments/assets/2807228d-1f56-4d38-b421-347a519fee9b

RCT1 save:
[chair lift station tunnels.zip](https://github.com/user-attachments/files/23756347/chair.lift.station.tunnels.zip)

The other angle of the station end always draws the tunnel:
https://github.com/OpenRCT2/OpenRCT2/blob/66188a108ad226711a4dbe0e83fde3c3e17d11c2/src/openrct2/paint/track/transport/Chairlift.cpp#L271-L281
For this angle it was inside an if. This moves it to the same place.

(Really need to do something about all the station fences. Need to investigate when and how that broke. And yeah, chairlift stations are quite glitchy in tunnels anyway.)