### PR TITLE
Categorize toilet income as shop sales instead of ride tickets

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#25575] Updated the network protocol to a new format that supports larger packets, allowing clients to connect reliably to servers with many objects or large maps.
 - Improved: [#25621] Added the Polish Złoty (PLN) to the list of available currencies.
 - Improved: [#25625] Renewing and refurbishing rides now also resets the downtime.
+- Change: [#21912] Toilet income is now categorised as shop sales instead of ride tickets.
 - Change: [#25485] Make the enlarged pressed swatch sprite more pronounced.
 - Fix: [#9895] Stand-up coaster gets wrong intensity boost from the synchronisation bonus.
 - Fix: [#22484] Lingering ghost entrance after placing park entrance.

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2292,7 +2292,7 @@ static bool PeepInteractWithShop(Peep* peep, const CoordsXYE& coords)
         {
             ride->totalProfit = AddClamp(ride->totalProfit, cost);
             ride->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME;
-            guest->SpendMoney(cost, ExpenditureType::parkRideTickets);
+            guest->SpendMoney(cost, ExpenditureType::shopSales);
         }
 
         auto coordsCentre = coords.ToTileCentre();


### PR DESCRIPTION
Closes #21912

Make restroom income appear under the Shop Sales category on the Financial Summary.

### Changes
- Modified PeepInteractWithShop in Peep.cpp.
- Added a check for `RIDE_TYPE_TOILETS` when a guest pays to enter a facility.
- If the facility is a toilet, the expenditure type is set to `ExpenditureType::shopSales` instead of the default `ExpenditureType::parkRideTickets`.

### Verification
To verify, load the following save, open the financial summary, and run the game. Observe shop sales increase every time a guest uses the restroom. : [Restroom Shops.zip](https://github.com/user-attachments/files/23970371/Restroom.Shops.zip)