### PR TITLE
Tests remove test/tests/testdata/sprites/result.dat again after creating it

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -256,6 +256,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Ruohao (Jater) Xu (jaterx)
 * Marcel Vos (MarcelVos96)
 * Jonas Doggart
+* (TyRoXx)
 
 ## Toolchain
 * (Balletie) - macOS


### PR DESCRIPTION
Solves the issue that a file is created during tests but not removed afterwards. These tests were creating untracked files that shouldn't be committed.

Before this fix:
```
$ git status
On branch develop
Your branch is up to date with 'origin/develop'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	test/tests/testdata/replays/
	test/tests/testdata/sprites/result.dat

nothing added to commit but untracked files present (use "git add" to track)
```

After this fix:
```
$ git status
On branch remove-temp-test-file
Your branch is up to date with 'origin/remove-temp-test-file'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	test/tests/testdata/replays/

nothing added to commit but untracked files present (use "git add" to track)
```

The `replays` directory remains, but this is a different issue.