### PR TITLE
Fix #25601: Preserve inspection interval when closing the constructio…

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -324,7 +324,9 @@ namespace OpenRCT2::Ui::Windows
                     }
                 }
 
-                currentRide->setToDefaultInspectionInterval();
+                // Do not reset inspection interval when closing the construction window.
+                // The player may have changed this in the ride window (see issue #25601).
+                // currentRide->setToDefaultInspectionInterval();
                 auto intent = Intent(WindowClass::ride);
                 intent.PutExtra(INTENT_EXTRA_RIDE_ID, currentRide->id.ToUnderlying());
                 ContextOpenIntent(&intent);


### PR DESCRIPTION
Fixes #25601.

### Reproduction
1. Set a ride's inspection interval to a non-default value (e.g., every 10 minutes)
2. Open the ride's construction window
3. Close the window
4. The inspection interval incorrectly resets to 30 minutes

### Cause
RideConstructionWindow::onClose() always calls:
    currentRide->setToDefaultInspectionInterval();
This overwrites the user-selected interval whenever the window closes.

### Fix
Removed the call to setToDefaultInspectionInterval() so the construction window
no longer overrides operational settings.

### Testing
Tested with multiple ride types (Monorail, Carousel).
Inspection interval now remains unchanged after opening/closing the construction window.
