### PR TITLE
Fix #25549 – footpath ghost regeneration by comparing startZ to place…

### DIFF
--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1039,12 +1039,14 @@ namespace OpenRCT2::Ui::Windows
 
             // Get current map pos and handle key modifier state
             auto mapPos = FootpathGetPlacePositionFromScreenPosition(screenCoords);
+            
             if (!mapPos)
                 return;
 
             // Check for change
+            auto placement = WindowFootpathGetPlacementFromScreenCoords(screenCoords);
             if ((_provisionalFootpath.flags.has(ProvisionalPathFlag::placed)) && _provisionalFootpath.positionA == mapPos
-                && _provisionalFootpath.startZ == _footpathPlaceZ)
+                && _provisionalFootpath.startZ == placement.baseZ)
             {
                 return;
             }
@@ -1057,7 +1059,7 @@ namespace OpenRCT2::Ui::Windows
             FootpathUpdateProvisional();
 
             // Figure out what slope and height to use
-            auto placement = WindowFootpathGetPlacementFromScreenCoords(screenCoords);
+
             if (!placement.isValid())
             {
                 gMapSelectFlags.unset(MapSelectFlag::enable);


### PR DESCRIPTION
Fixes #25549.

Previously, the footpath paint tool continuously recreated its provisional (ghost) path because the change-detection check compared `_provisionalFootpath.startZ` against `_footpathPlaceZ`, which does not always match the actual placement height.

This change updates the condition to compare `_provisionalFootpath.startZ` against `placement.baseZ`, the same height that is passed into `FootpathProvisionalSet`. As a result, the tool now correctly detects when the cursor position and placement height are unchanged and avoids regenerating the ghost every frame. In the "dirty visuals" debug view, ghost updates now occur only when the placement actually changes; minor redraws from normal selection/hover invalidation remain and are expected.
