### PR TITLE
Fix #25628: AVX2 and SSE4 availability not detected correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#25571] Potential crash due to drawing a Crooked House ride.
 - Fix: [#25588] When the master server becomes unreachable the server would not register again until a restart.
 - Fix: [#25592] Log flume, river rapids, & splash boats can get control failure breakdown instead of brakes failure.
+- Fix: [#25628] Availability of AVX2 and SSE4.1 is not detected correctly. 
 
 0.4.29 (2025-11-22)
 ------------------------------------------------------------------------

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -27,6 +27,7 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../core/CallingConventions.h"
 #include "../core/File.h"
 #include "../core/Path.hpp"
 #include "../core/String.hpp"


### PR DESCRIPTION
I could reproduce the issue in a debugger, and verified the fix as well.