### PR TITLE
Fix land purchase selection grid colour not being white

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#25588] When the master server becomes unreachable the server would not register again until a restart.
 - Fix: [#25592] Log flume, river rapids, & splash boats can get control failure breakdown instead of brakes failure.
 - Fix: [#25628] Availability of AVX2 and SSE4.1 is not detected correctly. 
+- Fix: [#25642] The selection marker for purchasing land rights is not drawn with the correct colours.
 
 0.4.29 (2025-11-22)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1136,7 +1136,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
             {
                 auto [waterHeight, waterSurfaceShape] = SurfaceGetHeightAboveWater(tileElement, height, surfaceShape);
 
-                const auto fpId = FilterPaletteID::paletteGlassLightPurple;
+                const auto fpId = FilterPaletteID::paletteSceneryGroundMarker;
                 const auto imageId1 = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, imageId1, 0, 0);
 


### PR DESCRIPTION
Fairly subtle one. The sprite was being drawn with the wrong filter palette, which doesn't affect the sprite at all and it was being drawn with its original colours. I believe it was mistakenly set to purple as the owned land is purple, however those are a specific purple sprite and are not drawn by this code. This now uses the same palette id that the usual full selected tile uses.

Current - RCT1/2 and this fix
<img width="369" height="351" alt="landpurchaseorct2" src="https://github.com/user-attachments/assets/d87ecdb5-0d0d-4da1-9f1b-b361dadc462d" /><img width="369" height="351" alt="landpurchaserct2" src="https://github.com/user-attachments/assets/57eb7d76-3837-47f1-ad26-b217f7d44b2d" />
