### PR TITLE
Remove sketchy casino link from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,6 @@ Some Linux distributions offer native packages:
 
 Some \*BSD operating systems offer native packages:
 * FreeBSD: [games/openrct2](https://www.freshports.org/games/openrct2)
-* OpenBSD: [games/openrct2](https://openports.se/games/openrct2)
 
 ---
 


### PR DESCRIPTION
The link to the OpenBSD ports of OpenRCT2 now points to an unrelated, unlicensed swedish casino website.

The original website seems to have shut down about 2 years ago