### PR TITLE
Move ZoomLevel::min implementation to ZoomLevel.cpp

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -2030,8 +2030,3 @@ namespace OpenRCT2
         return viewports;
     }
 } // namespace OpenRCT2
-
-ZoomLevel ZoomLevel::min()
-{
-    return ZoomLevel{ -2 };
-}

--- a/src/openrct2/interface/ZoomLevel.cpp
+++ b/src/openrct2/interface/ZoomLevel.cpp
@@ -9,6 +9,11 @@
 
 #include "ZoomLevel.h"
 
+ZoomLevel ZoomLevel::min()
+{
+    return ZoomLevel{ -2 };
+}
+
 ZoomLevel ZoomLevel::operator++(int)
 {
     ZoomLevel tmp(*this);


### PR DESCRIPTION
Found a stray function in the Viewport.cpp unit.