### PR TITLE
Prevent _preloaderScene nullptr deref

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1239,7 +1239,7 @@ namespace OpenRCT2
 
             if (!gOpenRCT2Headless)
             {
-                _preloaderScene->SetOnComplete([&]() { SwitchToStartUpScene(); });
+                GetPreloaderScene()->SetOnComplete([&]() { SwitchToStartUpScene(); });
             }
             else
             {


### PR DESCRIPTION
This was discovered while working on an experimental onboarding scene. In the case where that scene was active, instead of the preloader, the line in this PR would deref a nullptr. Using the `GetPreloaderScene` function call prevents this by implicitly instantiating the scene if needed.

As it stands, I don't think there is a way to trigger this in the codebase; it's just added rigour. As such, I've not added a changelog entry.

Split off from #25681