### PR TITLE
Include <optional> in Paint.h

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -21,6 +21,7 @@
 #include "tile_element/Paint.Tunnel.h"
 
 #include <mutex>
+#include <optional>
 #include <sfl/segmented_vector.hpp>
 #include <sfl/static_vector.hpp>
 #include <thread>


### PR DESCRIPTION
At least on Windows, `Paint.h` would fail to compile because it was missing `<optional>` if you tried to build OpenRCT2 without pre-compiled headers (which I somehow did today, don't ask). It seems this omission was being masqueraded because `openrct2_pch.h` was including `Object.h`, which itself included `<optional>`. With the library now included, compilation of the `libopenrct2` project works as normal.