### PR TITLE
Fix #25469: Assertion when drawing in ui.imageManager.draw callback

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#24952] Duplicate track designs when running via Steam without having RCT1 linked.
 - Fix: [#25187] On-ride photo platform does not render as ghost when placing track design.
 - Fix: [#25229] Excessive logging of game actions, reduced to top-level game actions and filters ghost related ones.
+- Fix: [#25469] Drawing in the ui.imageManager.draw callback causes an assertion.
 - Fix: [#25524] The track construction arrow does not immediately change position when deleting track pieces.
 - Fix: [#25552] Clear Scenery does not show an error message about insufficient money if cash is negative.
 - Fix: [#25565] Chairlift station ends are missing tunnels at certain rotations.

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -465,7 +465,9 @@ namespace OpenRCT2::Scripting
         }
 
         auto dukG = GetObjectAsDukValue(ctx, std::make_shared<ScGraphicsContext>(ctx, rt));
+        drawingEngine->BeginDraw();
         scriptEngine.ExecutePluginCall(plugin, callback, { dukG }, false);
+        drawingEngine->EndDraw();
 
         if (createNewImage)
         {


### PR DESCRIPTION
Fixes #25469

Drawing in the callback here causes an assertion as the drawing context is not active. This begins and ends it around the callback.

There are scripts in #16872 and #25469 to test with.