### PR TITLE
Fix #23636: Mismatched entity count in save file

### DIFF
--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2639,10 +2639,19 @@ namespace OpenRCT2
     template<typename T>
     void ParkFile::WriteEntitiesOfType(GameState_t& gameState, OrcaStream& os, OrcaStream::ChunkStream& cs)
     {
-        uint16_t count = gameState.entities.GetEntityListCount(T::cEntityType);
+        const auto entityList = EntityList<T>();
+        // We do not rely on GetEntityListCount as there is a potential issue (#23636) that needs investigating.
+        const auto count = [&]() -> uint16_t {
+            uint16_t res = 0;
+            for ([[maybe_unused]] auto* _ : entityList)
+            {
+                res++;
+            }
+            return res;
+        }();
         cs.write(T::cEntityType);
         cs.write(count);
-        for (auto* ent : EntityList<T>())
+        for (auto* ent : entityList)
         {
             cs.write(ent->Id);
             ReadWriteEntity(os, cs, *ent);


### PR DESCRIPTION
This is based on #24552, with two changes:
1. The entity list is copied and used for both the count and the actual writes
2. It no longer asserts if the count mismatches (which is why #24552 was not merged).