### PR TITLE
A few strong enum conversions

### DIFF
--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -15,26 +15,18 @@
 
 namespace OpenRCT2
 {
-    enum InputFlag
+    enum class InputFlag : uint8_t
     {
         widgetPressed,
-
         // The dropdown can stay open if the mouse is released, set on flag Dropdown::Flag::StayOpen.
         dropdownStayOpen,
-
-        // The mouse has been released and the dropdown is still open.
-        // InputFlag::dropdownStayOpen is already set if this happens.
+        // The mouse has been released and the dropdown is still open. dropdownStayOpen is already set if this happens.
         dropdownMouseUp,
-
         toolActive,
-
         // Left click on a viewport
         leftMousePressed,
-
         rightMousePressed,
-
         allowRightMouseRemoval,
-
         viewportScrolling,
     };
     using InputFlags = FlagHolder<uint8_t, InputFlag>;

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -132,7 +132,7 @@ namespace OpenRCT2
         }
     }
 
-    enum CarSpriteFlag : uint8_t
+    enum class CarSpriteFlag : uint8_t
     {
         flat,
         gentleSlopes,

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -25,7 +25,7 @@ namespace OpenRCT2
         GetStringTable().Sort();
         NameStringId = LanguageAllocateObjectString(GetName());
         IconImageId = LoadImages();
-        if ((Flags & TerrainSurfaceFlags::smoothWithSelf) || (Flags & TerrainSurfaceFlags::smoothWithOther))
+        if (Flags.hasAny(TerrainSurfaceFlag::smoothWithSelf, TerrainSurfaceFlag::smoothWithOther))
         {
             PatternBaseImageId = IconImageId + 1;
             EntryBaseImageId = PatternBaseImageId + 6;
@@ -87,11 +87,11 @@ namespace OpenRCT2
             Colour = Colour::FromString(Json::GetString(properties["colour"]), kNoValue);
             Rotations = Json::GetNumber<int8_t>(properties["rotations"], 1);
             Price = Json::GetNumber<money64>(properties["price"]);
-            Flags = Json::GetFlags<TerrainSurfaceFlags>(
+            Flags = Json::GetFlagHolder<TerrainSurfaceFlags, TerrainSurfaceFlag>(
                 properties,
-                { { "smoothWithSelf", TerrainSurfaceFlags::smoothWithSelf },
-                  { "smoothWithOther", TerrainSurfaceFlags::smoothWithOther },
-                  { "canGrow", TerrainSurfaceFlags::canGrow } });
+                { { "smoothWithSelf", TerrainSurfaceFlag::smoothWithSelf },
+                  { "smoothWithOther", TerrainSurfaceFlag::smoothWithOther },
+                  { "canGrow", TerrainSurfaceFlag::canGrow } });
 
             const auto mapColours = properties["mapColours"];
             const bool mapColoursAreValid = mapColours.is_array() && mapColours.size() == std::size(MapColours);

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -17,12 +17,13 @@ struct CoordsXY;
 
 namespace OpenRCT2
 {
-    enum TerrainSurfaceFlags
+    enum class TerrainSurfaceFlag : uint8_t
     {
-        smoothWithSelf = 1 << 0,
-        smoothWithOther = 1 << 1,
-        canGrow = 1 << 2,
+        smoothWithSelf,
+        smoothWithOther,
+        canGrow,
     };
+    using TerrainSurfaceFlags = FlagHolder<uint8_t, TerrainSurfaceFlag>;
 
     class TerrainSurfaceObject final : public Object
     {

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -256,7 +256,7 @@ static bool SurfaceShouldSmoothSelf(const TerrainSurfaceObject* surfaceObject)
     if (surfaceObject == nullptr)
         return false;
 
-    return surfaceObject->Flags & TerrainSurfaceFlags::smoothWithSelf;
+    return surfaceObject->Flags.has(TerrainSurfaceFlag::smoothWithSelf);
 }
 
 static bool SurfaceShouldSmooth(const TerrainSurfaceObject* surfaceObject)
@@ -264,7 +264,7 @@ static bool SurfaceShouldSmooth(const TerrainSurfaceObject* surfaceObject)
     if (surfaceObject == nullptr)
         return false;
 
-    return surfaceObject->Flags & TerrainSurfaceFlags::smoothWithOther;
+    return surfaceObject->Flags.has(TerrainSurfaceFlag::smoothWithOther);
 }
 
 static ImageId GetEdgeImageWithOffset(const TerrainEdgeObject* edgeObject, uint32_t offset)

--- a/src/openrct2/world/tile_element/SurfaceElement.cpp
+++ b/src/openrct2/world/tile_element/SurfaceElement.cpp
@@ -69,7 +69,7 @@ namespace OpenRCT2
         const auto* surfaceObject = objMgr.GetLoadedObject<TerrainSurfaceObject>(surfaceStyle);
         if (surfaceObject != nullptr)
         {
-            if (surfaceObject->Flags & TerrainSurfaceFlags::canGrow)
+            if (surfaceObject->Flags.has(TerrainSurfaceFlag::canGrow))
             {
                 return true;
             }


### PR DESCRIPTION
`CarSpriteFlag`, `TerrainSurfaceFlag` and `InputFlag` were being used as if they were strong enums, but they were not. While I was at it I converted `TerrainSurfaceFlag` into a FlagHolder as well.