### PR TITLE
Rework drawing header includes

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -28,6 +28,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/Console.hpp>
 #include <openrct2/core/Guard.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/interface/Viewport.h>
 #include <openrct2/rct2/T6Exporter.h>

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
@@ -11,7 +11,7 @@
 
 #include "OpenGLAPI.h"
 
-#include <openrct2/drawing/Drawing.h>
+#include <openrct2/drawing/RenderTarget.h>
 #include <vector>
 
 struct SDL_Window;

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -15,7 +15,6 @@
 #include <array>
 #include <cassert>
 #include <openrct2/SpriteIds.h>
-#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/DrawingLock.hpp>
 #include <unordered_map>
 #include <vector>

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -30,6 +30,7 @@
 #include <openrct2/audio/Audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/EnumUtils.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Chat.h>
 #include <openrct2/interface/Screenshot.h>
 #include <openrct2/network/Network.h>

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -19,6 +19,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Window.h>
 #include <openrct2/localisation/StringIds.h>
 #include <openrct2/platform/Platform.h>

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -11,6 +11,7 @@
 
 #include <openrct2-ui/interface/Graph.h>
 #include <openrct2/Date.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/localisation/Formatter.h>

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -11,7 +11,7 @@
 
 #include <openrct2/Context.h>
 #include <openrct2/core/Money.hpp>
-#include <openrct2/drawing/Drawing.h>
+#include <openrct2/drawing/RenderTarget.h>
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/world/Location.hpp>
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -19,6 +19,7 @@
 #include <openrct2/Input.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/drawing/Text.h>
 #include <openrct2/interface/ColourWithFlags.h>

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -12,7 +12,7 @@
 #include "Window.h"
 
 #include <openrct2-ui/UiStringIds.h>
-#include <openrct2/drawing/Drawing.h>
+#include <openrct2/drawing/FilterPaletteIds.h>
 #include <openrct2/interface/Widget.h>
 
 namespace OpenRCT2::Ui

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -18,6 +18,7 @@
     #include <numeric>
     #include <openrct2/Context.h>
     #include <openrct2/core/String.hpp>
+    #include <openrct2/drawing/Drawing.h>
     #include <openrct2/drawing/Rectangle.h>
     #include <openrct2/localisation/Formatter.h>
     #include <openrct2/localisation/Formatting.h>

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -13,8 +13,8 @@
 
     #include "CustomImages.h"
 
+    #include <openrct2/drawing/Drawing.h>
     #include <openrct2/drawing/Rectangle.h>
-    #include <openrct2/drawing/Text.h>
     #include <openrct2/scripting/Duktape.hpp>
 
 using namespace OpenRCT2::Drawing;

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/core/Guard.hpp>
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/interface/Viewport.h>
 #include <openrct2/localisation/StringIds.h>

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/Version.h>
 #include <openrct2/core/FileSystem.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Text.h>
 #include <openrct2/localisation/Formatting.h>
 #include <openrct2/platform/Platform.h>

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/actions/CheatSetAction.h>
 #include <openrct2/actions/ParkSetDateAction.h>
 #include <openrct2/core/EnumUtils.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Currency.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.Date.h>

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/Input.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/actions/ClearAction.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/world/MapSelection.h>

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/core/Guard.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/localisation/Language.h>
 #include <openrct2/localisation/LocalisationService.h>

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -20,6 +20,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/audio/Audio.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/management/Research.h>
 #include <openrct2/scenario/Scenario.h>

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/Input.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/SpriteIds.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/interface/Cursors.h>

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -27,8 +27,8 @@
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
-#include <openrct2/drawing/Text.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/object/ClimateObject.h>
 #include <openrct2/object/MusicObject.h>

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/SpriteIds.h>
 #include <openrct2/actions/ParkEntrancePlaceAction.h>
 #include <openrct2/audio/Audio.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/object/EntranceObject.h>
 #include <openrct2/object/ObjectLimits.h>

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -14,6 +14,7 @@
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/actions/ParkSetLoanAction.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Formatting.h>

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -28,6 +28,7 @@
 #include <openrct2/actions/FootpathRemoveAction.h>
 #include <openrct2/audio/Audio.h>
 #include <openrct2/core/FlagHolder.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/NetworkAction.h>
 #include <openrct2/object/FootpathObject.h>

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -18,6 +18,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/Guest.h>

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/entity/Guest.h>
 #include <openrct2/entity/Staff.h>

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -20,6 +20,7 @@
 #include <openrct2/core/File.h>
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/UnitConversion.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/object/ObjectManager.h>

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/actions/PeepSpawnPlaceAction.h>
 #include <openrct2/actions/SurfaceSetStyleAction.h>
 #include <openrct2/audio/Audio.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/entity/EntityList.h>
 #include <openrct2/entity/EntityRegistry.h>

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -17,8 +17,8 @@
 #include <openrct2/actions/NetworkModifyGroupAction.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
-#include <openrct2/drawing/Text.h>
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/network/Network.h>
 #include <openrct2/ui/WindowManager.h>

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -10,7 +10,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
-#include <openrct2/drawing/Text.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/network/Network.h>
 #include <openrct2/ui/WindowManager.h>
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/audio/Audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/LocalisationService.h>

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -15,8 +15,8 @@
 #include <openrct2/core/Http.h>
 #include <openrct2/core/Json.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
-#include <openrct2/drawing/Text.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/StringIds.h>

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -30,6 +30,7 @@
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/core/File.h>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/IDrawingEngine.h>
 #include <openrct2/drawing/ScrollingText.h>
 #include <openrct2/localisation/Currency.h>

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/interface/FileBrowser.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Windows.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/StringIds.h>
 #include <openrct2/ui/WindowManager.h>
 #include <string>

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -24,6 +24,7 @@
 #include <openrct2/actions/ParkSetNameAction.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/UnitConversion.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Currency.h>
 #include <openrct2/localisation/Formatting.h>

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -17,7 +17,7 @@
 #include <openrct2/SpriteIds.h>
 #include <openrct2/actions/PlayerKickAction.h>
 #include <openrct2/actions/PlayerSetGroupAction.h>
-#include <openrct2/drawing/Text.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/Network.h>
 #include <openrct2/network/NetworkAction.h>

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -15,6 +15,7 @@
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/actions/ParkSetResearchFundingAction.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.Date.h>
 #include <openrct2/management/Finance.h>

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -40,6 +40,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/String.hpp>
 #include <openrct2/core/UnitConversion.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/entity/EntityList.h>
 #include <openrct2/entity/Staff.h>

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -34,6 +34,7 @@
 #include <openrct2/audio/Audio.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/core/Numerics.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/Viewport.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/Network.h>

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -35,6 +35,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/Guard.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/management/Research.h>

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/world/Scenery.h>

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -19,8 +19,8 @@
     #include <openrct2/SpriteIds.h>
     #include <openrct2/config/Config.h>
     #include <openrct2/core/Json.hpp>
+    #include <openrct2/drawing/Drawing.h>
     #include <openrct2/drawing/Rectangle.h>
-    #include <openrct2/drawing/Text.h>
     #include <openrct2/interface/Colour.h>
     #include <openrct2/localisation/Formatter.h>
     #include <openrct2/network/Network.h>

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -17,6 +17,7 @@
     #include <openrct2/ParkImporter.h>
     #include <openrct2/config/Config.h>
     #include <openrct2/core/String.hpp>
+    #include <openrct2/drawing/Drawing.h>
     #include <openrct2/interface/Chat.h>
     #include <openrct2/network/Network.h>
     #include <openrct2/ui/WindowManager.h>

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -24,6 +24,7 @@
 #include <openrct2/actions/StaffSetOrdersAction.h>
 #include <openrct2/actions/StaffSetPatrolAreaAction.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/PatrolArea.h>
 #include <openrct2/entity/Staff.h>

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -16,8 +16,8 @@
 #include <openrct2/Game.h>
 #include <openrct2/Input.h>
 #include <openrct2/SpriteIds.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
-#include <openrct2/drawing/Text.h>
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Formatting.h>

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/SpriteIds.h>
 #include <openrct2/actions/TileModifyAction.h>
 #include <openrct2/core/Guard.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/object/FootpathObject.h>

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -35,6 +35,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/Numerics.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/Staff.h>
 #include <openrct2/interface/Chat.h>
 #include <openrct2/interface/ColourWithFlags.h>

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -22,6 +22,7 @@
 #include <openrct2/actions/TrackDesignAction.h>
 #include <openrct2/audio/Audio.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/paint/VirtualFloor.h>
 #include <openrct2/ride/RideConstruction.h>

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -18,6 +18,7 @@
 #include <openrct2/config/Config.h>
 #include <openrct2/core/String.hpp>
 #include <openrct2/core/UnitConversion.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/IDrawingEngine.h>
 #include <openrct2/drawing/Rectangle.h>
 #include <openrct2/localisation/Formatting.h>

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -20,6 +20,7 @@
 #include <openrct2/actions/CheatSetAction.h>
 #include <openrct2/actions/ParkSetDateAction.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/Staff.h>
 #include <openrct2/localisation/Localisation.Date.h>
 #include <openrct2/network/Network.h>

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -23,6 +23,7 @@
 #include "core/EnumUtils.hpp"
 #include "core/Path.hpp"
 #include "core/String.hpp"
+#include "drawing/Drawing.h"
 #include "entity/EntityList.h"
 #include "entity/EntityRegistry.h"
 #include "entity/Guest.h"

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -31,6 +31,7 @@
 #include "core/Money.hpp"
 #include "core/Path.hpp"
 #include "core/String.hpp"
+#include "drawing/Drawing.h"
 #include "entity/EntityList.h"
 #include "entity/EntityRegistry.h"
 #include "entity/PatrolArea.h"

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -16,6 +16,7 @@
 #include "ReplayManager.h"
 #include "actions/GameAction.h"
 #include "config/Config.h"
+#include "drawing/Drawing.h"
 #include "entity/EntityTweener.h"
 #include "entity/PatrolArea.h"
 #include "interface/Screenshot.h"

--- a/src/openrct2/actions/BannerSetNameAction.cpp
+++ b/src/openrct2/actions/BannerSetNameAction.cpp
@@ -12,6 +12,7 @@
 #include "../Context.h"
 #include "../Diagnostic.h"
 #include "../core/String.hpp"
+#include "../drawing/Drawing.h"
 #include "../drawing/ScrollingText.h"
 #include "../localisation/StringIds.h"
 #include "../windows/Intent.h"

--- a/src/openrct2/actions/BannerSetStyleAction.cpp
+++ b/src/openrct2/actions/BannerSetStyleAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Diagnostic.h"
+#include "../drawing/Drawing.h"
 #include "../drawing/ScrollingText.h"
 #include "../localisation/StringIdType.h"
 #include "../management/Finance.h"

--- a/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
@@ -20,6 +20,7 @@
 #include "../world/Footpath.h"
 #include "../world/Location.hpp"
 #include "../world/Map.h"
+#include "../world/MapLimits.h"
 #include "../world/Park.h"
 #include "../world/QuarterTile.h"
 #include "../world/tile_element/EntranceElement.h"

--- a/src/openrct2/actions/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/MapChangeSizeAction.cpp
@@ -11,7 +11,7 @@
 
 #include "../Context.h"
 #include "../GameState.h"
-#include "../drawing/IDrawingEngine.h"
+#include "../drawing/Drawing.h"
 #include "../ui/UiContext.h"
 #include "../ui/WindowManager.h"
 #include "../windows/Intent.h"

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -14,6 +14,7 @@
 #include "../Diagnostic.h"
 #include "../GameState.h"
 #include "../core/MemoryStream.h"
+#include "../drawing/Drawing.h"
 #include "../drawing/ScrollingText.h"
 #include "../entity/EntityList.h"
 #include "../management/NewsItem.h"

--- a/src/openrct2/actions/RideSetNameAction.cpp
+++ b/src/openrct2/actions/RideSetNameAction.cpp
@@ -13,6 +13,7 @@
 #include "../Context.h"
 #include "../Diagnostic.h"
 #include "../core/MemoryStream.h"
+#include "../drawing/Drawing.h"
 #include "../drawing/ScrollingText.h"
 #include "../localisation/StringIds.h"
 #include "../ride/Ride.h"

--- a/src/openrct2/actions/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/RideSetSettingAction.cpp
@@ -12,6 +12,7 @@
 #include "../Context.h"
 #include "../Diagnostic.h"
 #include "../GameState.h"
+#include "../drawing/Drawing.h"
 #include "../object/ObjectManager.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"

--- a/src/openrct2/actions/SignSetNameAction.cpp
+++ b/src/openrct2/actions/SignSetNameAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../Context.h"
 #include "../Diagnostic.h"
+#include "../drawing/Drawing.h"
 #include "../drawing/ScrollingText.h"
 #include "../localisation/StringIds.h"
 #include "../ride/Ride.h"

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../Diagnostic.h"
 #include "../GameState.h"
+#include "../drawing/Drawing.h"
 #include "../entity/EntityRegistry.h"
 #include "../entity/Staff.h"
 #include "../ui/WindowManager.h"

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../Diagnostic.h"
 #include "../GameState.h"
+#include "../drawing/Drawing.h"
 #include "../entity/EntityRegistry.h"
 #include "../entity/PatrolArea.h"
 #include "../entity/Peep.h"

--- a/src/openrct2/command_line/sprite/SpriteCommands.cpp
+++ b/src/openrct2/command_line/sprite/SpriteCommands.cpp
@@ -13,6 +13,7 @@
 #include "../../OpenRCT2.h"
 #include "../../core/Memory.hpp"
 #include "../../core/String.hpp"
+#include "../../drawing/Drawing.h"
 #include "../../object/ObjectFactory.h"
 #include "../CommandLine.hpp"
 

--- a/src/openrct2/command_line/sprite/SpriteCommands.h
+++ b/src/openrct2/command_line/sprite/SpriteCommands.h
@@ -9,15 +9,16 @@
 
 #pragma once
 
+#include "../../core/StringTypes.h"
 #include "../../drawing/ImageImporter.h"
 
 #include <cstdint>
 #include <optional>
-#include <string_view>
 
-struct G1Element;
-using utf8 = char;
-using u8string_view = std::basic_string_view<utf8>;
+namespace OpenRCT2
+{
+    struct G1Element;
+}
 
 namespace OpenRCT2::CommandLine::Sprite
 {

--- a/src/openrct2/command_line/sprite/SpriteFile.cpp
+++ b/src/openrct2/command_line/sprite/SpriteFile.cpp
@@ -10,6 +10,7 @@
 #include "SpriteFile.h"
 
 #include "../../core/FileStream.h"
+#include "../../drawing/ImageImporter.h"
 
 namespace OpenRCT2::CommandLine::Sprite
 {
@@ -73,7 +74,7 @@ namespace OpenRCT2::CommandLine::Sprite
         isAbsolute = false;
     }
 
-    void SpriteFile::AddImage(ImageImporter::ImportResult& image)
+    void SpriteFile::AddImage(Drawing::ImageImportResult& image)
     {
         Header.numEntries++;
         // New image will have its data inserted after previous image

--- a/src/openrct2/command_line/sprite/SpriteFile.h
+++ b/src/openrct2/command_line/sprite/SpriteFile.h
@@ -12,6 +12,8 @@
 #include "../../core/StringTypes.h"
 #include "../../drawing/G1Element.h"
 
+#include <optional>
+
 namespace OpenRCT2::Drawing
 {
     struct ImageImportResult;

--- a/src/openrct2/command_line/sprite/SpriteFile.h
+++ b/src/openrct2/command_line/sprite/SpriteFile.h
@@ -9,20 +9,23 @@
 
 #pragma once
 
-#include "../../drawing/Drawing.h"
-#include "../../drawing/ImageImporter.h"
+#include "../../core/StringTypes.h"
+#include "../../drawing/G1Element.h"
+
+namespace OpenRCT2::Drawing
+{
+    struct ImageImportResult;
+}
 
 namespace OpenRCT2::CommandLine::Sprite
 {
-    using OpenRCT2::Drawing::ImageImporter;
-
     class SpriteFile
     {
     public:
-        G1Header Header{};
-        std::vector<G1Element> Entries;
+        OpenRCT2::G1Header Header{};
+        std::vector<OpenRCT2::G1Element> Entries;
         std::vector<uint8_t> Data;
-        void AddImage(ImageImporter::ImportResult& image);
+        void AddImage(Drawing::ImageImportResult& image);
         bool Save(const utf8* path);
         static std::optional<SpriteFile> Open(const utf8* path);
 

--- a/src/openrct2/core/Imaging.h
+++ b/src/openrct2/core/Imaging.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "../drawing/Drawing.h"
+#include "../drawing/ColourPalette.h"
 
 #include <functional>
 #include <istream>

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -9,6 +9,7 @@
 
 #include "Drawing.h"
 
+using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 
 template<DrawBlendOp TBlendOp>

--- a/src/openrct2/drawing/G1Element.h
+++ b/src/openrct2/drawing/G1Element.h
@@ -1,0 +1,76 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../core/CallingConventions.h"
+#include "../core/FlagHolder.hpp"
+
+#include <vector>
+
+namespace OpenRCT2
+{
+    enum class G1Flag : uint8_t
+    {
+        hasTransparency, // Image data contains transparent pixels (0XFF) which will not be rendered
+        one,
+        hasRLECompression, // Image data is encoded using RCT2's form of run length encoding
+        isPalette,         // Image data is a sequence of palette entries R8G8B8
+        hasZoomSprite,     // Use a different sprite for higher zoom levels
+        noZoomDraw,        // Does not get drawn at higher zoom levels (only zoom 0)
+    };
+    using G1Flags = FlagHolder<uint16_t, G1Flag>;
+
+    struct G1Element
+    {
+        uint8_t* offset = nullptr; // 0x00
+        union
+        {
+            int16_t width = 0;  // 0x04
+            int16_t numColours; // If G1Flag::isPalette is set
+        };
+        int16_t height = 0; // 0x06
+        union
+        {
+            int16_t xOffset = 0; // 0x08
+            int16_t startIndex;  // If G1Flag::isPalette is set
+        };
+        int16_t yOffset = 0;      // 0x0A
+        G1Flags flags = {};       // 0x0C
+        int32_t zoomedOffset = 0; // 0x0E
+    };
+
+#pragma pack(push, 1)
+    struct G1Header
+    {
+        uint32_t numEntries = 0;
+        uint32_t totalSize = 0;
+    };
+    static_assert(sizeof(G1Header) == 8);
+#pragma pack(pop)
+
+    struct Gx
+    {
+        G1Header header;
+        std::vector<G1Element> elements;
+        std::unique_ptr<uint8_t[]> data;
+    };
+
+    struct StoredG1Element
+    {
+        uint32_t offset;       // 0x00 note: uint32_t always!
+        int16_t width;         // 0x04
+        int16_t height;        // 0x06
+        int16_t xOffset;       // 0x08
+        int16_t yOffset;       // 0x0A
+        G1Flags flags;         // 0x0C
+        uint16_t zoomedOffset; // 0x0E
+    };
+    static_assert(sizeof(StoredG1Element) == 0x10);
+} // namespace OpenRCT2

--- a/src/openrct2/drawing/G1Element.h
+++ b/src/openrct2/drawing/G1Element.h
@@ -12,6 +12,7 @@
 #include "../core/CallingConventions.h"
 #include "../core/FlagHolder.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace OpenRCT2

--- a/src/openrct2/drawing/Image.h
+++ b/src/openrct2/drawing/Image.h
@@ -15,7 +15,10 @@
 #include <cstdint>
 #include <list>
 
-struct G1Element;
+namespace OpenRCT2
+{
+    struct G1Element;
+}
 
 struct ImageList
 {
@@ -55,7 +58,7 @@ constexpr bool operator!=(const ImageList& lhs, const ImageList& rhs)
     return !(lhs == rhs);
 }
 
-uint32_t GfxObjectAllocateImages(const G1Element* images, uint32_t count);
+uint32_t GfxObjectAllocateImages(const OpenRCT2::G1Element* images, uint32_t count);
 void GfxObjectFreeImages(uint32_t baseImageId, uint32_t count);
 void GfxObjectCheckAllImagesFreed();
 size_t ImageListGetUsedCount();

--- a/src/openrct2/drawing/ImageImporter.cpp
+++ b/src/openrct2/drawing/ImageImporter.cpp
@@ -20,7 +20,7 @@ namespace OpenRCT2::Drawing
 {
     static constexpr int32_t kPaletteTransparent = -1;
 
-    ImageImporter::ImportResult ImageImporter::Import(const Image& image, ImageImportMeta& meta) const
+    ImageImportResult ImageImporter::Import(const Image& image, ImageImportMeta& meta) const
     {
         if (meta.srcSize.width == 0)
             meta.srcSize.width = image.Width;
@@ -52,7 +52,7 @@ namespace OpenRCT2::Drawing
         if (HasFlag(meta.importFlags, ImportFlags::NoDrawOnZoom))
             outElement.flags.set(G1Flag::noZoomDraw);
 
-        ImageImporter::ImportResult result;
+        ImageImportResult result;
         result.Element = outElement;
         result.Buffer = std::move(buffer);
         result.Element.offset = result.Buffer.data();

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -12,7 +12,8 @@
 #include "../core/EnumUtils.hpp"
 #include "../core/Imaging.h"
 #include "../core/JsonFwd.hpp"
-#include "Drawing.h"
+#include "../drawing/G1Element.h"
+#include "../world/Location.hpp"
 
 #include <string_view>
 #include <tuple>
@@ -51,19 +52,19 @@ namespace OpenRCT2::Drawing
         int32_t zoomedOffset{};
     };
 
+    struct ImageImportResult
+    {
+        G1Element Element{};
+        std::vector<uint8_t> Buffer;
+    };
+
     /**
      * Imports images to the internal RCT G1 format.
      */
     class ImageImporter
     {
     public:
-        struct ImportResult
-        {
-            G1Element Element{};
-            std::vector<uint8_t> Buffer;
-        };
-
-        ImportResult Import(const Image& image, ImageImportMeta& meta) const;
+        ImageImportResult Import(const Image& image, ImageImportMeta& meta) const;
 
     private:
         enum class PaletteIndexType : uint8_t

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -25,6 +25,7 @@
 #include "../core/EnumUtils.hpp"
 #include "../core/Guard.hpp"
 #include "../core/String.hpp"
+#include "../drawing/Drawing.h"
 #include "../drawing/LightFX.h"
 #include "../entity/Balloon.h"
 #include "../entity/EntityList.h"

--- a/src/openrct2/interface/Colour.cpp
+++ b/src/openrct2/interface/Colour.cpp
@@ -43,7 +43,7 @@ void ColoursInitMaps()
     {
         // Get palette index in g1 / g2
         const auto paletteIndex = (i < kColourNumOriginal) ? SPR_PALETTE_2_START : SPR_G2_PALETTE_BEGIN - kColourNumOriginal;
-        const G1Element* g1 = GfxGetG1Element(paletteIndex + i);
+        const auto* g1 = GfxGetG1Element(paletteIndex + i);
         if (g1 != nullptr)
         {
             ColourMapA[i].colour_0 = static_cast<PaletteIndex>(g1->offset[INDEX_COLOUR_0]);

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -1,6 +1,7 @@
 #include "WindowBase.h"
 
 #include "../config/Config.h"
+#include "../drawing/Drawing.h"
 #include "../entity/EntityList.h"
 #include "../entity/EntityRegistry.h"
 #include "Cursors.h"

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -247,6 +247,7 @@
     <ClInclude Include="drawing\Drawing.String.h" />
     <ClInclude Include="drawing\FilterPaletteIds.h" />
     <ClInclude Include="drawing\Font.h" />
+    <ClInclude Include="drawing\G1Element.h" />
     <ClInclude Include="drawing\IDrawingContext.h" />
     <ClInclude Include="drawing\IDrawingEngine.h" />
     <ClInclude Include="drawing\Image.h" />

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -23,6 +23,7 @@
 #include "../core/File.h"
 #include "../core/Guard.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 #include "../entity/EntityRegistry.h"
 #include "../entity/EntityTweener.h"
 #include "../localisation/Formatter.h"

--- a/src/openrct2/object/ClimateObject.cpp
+++ b/src/openrct2/object/ClimateObject.cpp
@@ -13,8 +13,10 @@
 #include "../core/Guard.hpp"
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 #include "../localisation/Formatter.h"
 #include "../localisation/StringIds.h"
+#include "../world/Location.hpp"
 
 #include <algorithm>
 

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -12,6 +12,7 @@
 #include "../core/Guard.hpp"
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 
 namespace OpenRCT2
 {

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -12,6 +12,7 @@
 #include "../core/Guard.hpp"
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 #include "../drawing/Image.h"
 #include "FootpathEntry.h"
 #include "ObjectRepository.h"

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -21,6 +21,7 @@
 #include "../core/Json.hpp"
 #include "../core/Path.hpp"
 #include "../core/String.hpp"
+#include "../drawing/Drawing.h"
 #include "../drawing/ImageImporter.h"
 #include "Object.h"
 #include "ObjectFactory.h"

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "../core/JsonFwd.hpp"
-#include "../drawing/Drawing.h"
+#include "../drawing/G1Element.h"
 
 #include <memory>
 #include <vector>

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -18,6 +18,7 @@
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
 #include "../core/Path.hpp"
+#include "../drawing/Drawing.h"
 #include "../drawing/Image.h"
 #include "../localisation/StringIds.h"
 #include "../ride/Ride.h"

--- a/src/openrct2/object/PeepAnimationsObject.cpp
+++ b/src/openrct2/object/PeepAnimationsObject.cpp
@@ -14,6 +14,7 @@
 #include "../core/EnumMap.hpp"
 #include "../core/Guard.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 #include "../peep/PeepAnimations.h"
 #include "../rct12/RCT12.h"
 #include "ObjectRepository.h"

--- a/src/openrct2/object/ScenarioMetaObject.cpp
+++ b/src/openrct2/object/ScenarioMetaObject.cpp
@@ -13,6 +13,7 @@
 #include "../PlatformEnvironment.h"
 #include "../core/Guard.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 
 namespace OpenRCT2
 {

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../core/Money.hpp"
+#include "../interface/Colour.h"
 #include "Object.h"
 
 struct CoordsXY;

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -14,6 +14,7 @@
 #include "../OpenRCT2.h"
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
+#include "../drawing/Drawing.h"
 #include "../localisation/Formatter.h"
 #include "../localisation/Language.h"
 #include "../localisation/StringIds.h"

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -14,6 +14,7 @@
 #include "../ReplayManager.h"
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
+#include "../drawing/Drawing.h"
 #include "../drawing/IDrawingEngine.h"
 #include "../drawing/Text.h"
 #include "../interface/Viewport.h"

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -12,6 +12,7 @@
 #include "../../Game.h"
 #include "../../GameState.h"
 #include "../../config/Config.h"
+#include "../../drawing/Drawing.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"
 #include "../../localisation/Formatting.h"

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -14,6 +14,7 @@
 #include "../../GameState.h"
 #include "../../SpriteIds.h"
 #include "../../config/Config.h"
+#include "../../drawing/Drawing.h"
 #include "../../drawing/LightFX.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -16,6 +16,7 @@
 #include "../../core/EnumUtils.hpp"
 #include "../../core/Numerics.hpp"
 #include "../../core/UTF8.h"
+#include "../../drawing/Drawing.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatting.h"
 #include "../../localisation/StringIds.h"

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -14,6 +14,7 @@
 #include "../../GameState.h"
 #include "../../config/Config.h"
 #include "../../core/Numerics.hpp"
+#include "../../drawing/Drawing.h"
 #include "../../entity/PatrolArea.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -12,6 +12,7 @@
 #include "../../Game.h"
 #include "../../GameState.h"
 #include "../../config/Config.h"
+#include "../../drawing/Drawing.h"
 #include "../../interface/Colour.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatting.h"

--- a/src/openrct2/paint/track/coaster/ClassicStandUpRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicStandUpRollerCoaster.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include "../../../SpriteIds.h"
+#include "../../../drawing/Drawing.h"
 #include "../../../ride/Ride.h"
 #include "../../../ride/Track.h"
 #include "../../../ride/TrackPaint.h"

--- a/src/openrct2/rct1/Csg.cpp
+++ b/src/openrct2/rct1/Csg.cpp
@@ -14,78 +14,80 @@
 #include "../drawing/Drawing.h"
 #include "../rct1/Limits.h"
 
-using namespace OpenRCT2;
-
-std::string FindCsg1datAtLocation(u8string_view path)
+namespace OpenRCT2
 {
-    auto checkPath1 = Path::Combine(path, u8"Data", u8"CSG1.DAT");
-    auto checkPath2 = Path::Combine(path, u8"Data", u8"CSG1.1");
-
-    // Since Linux is case sensitive (and macOS sometimes too), make sure we handle case properly.
-    std::string path1result = Path::ResolveCasing(checkPath1);
-    if (!path1result.empty())
+    std::string FindCsg1datAtLocation(u8string_view path)
     {
-        return path1result;
+        auto checkPath1 = Path::Combine(path, u8"Data", u8"CSG1.DAT");
+        auto checkPath2 = Path::Combine(path, u8"Data", u8"CSG1.1");
+
+        // Since Linux is case sensitive (and macOS sometimes too), make sure we handle case properly.
+        std::string path1result = Path::ResolveCasing(checkPath1);
+        if (!path1result.empty())
+        {
+            return path1result;
+        }
+
+        std::string path2result = Path::ResolveCasing(checkPath2);
+        return path2result;
     }
 
-    std::string path2result = Path::ResolveCasing(checkPath2);
-    return path2result;
-}
-
-bool Csg1datPresentAtLocation(u8string_view path)
-{
-    auto location = FindCsg1datAtLocation(path);
-    return !location.empty();
-}
-
-u8string FindCsg1idatAtLocation(u8string_view path)
-{
-    auto result1 = Path::ResolveCasing(Path::Combine(path, u8"Data", u8"CSG1I.DAT"));
-    if (!result1.empty())
+    bool Csg1datPresentAtLocation(u8string_view path)
     {
-        return result1;
-    }
-    auto result2 = Path::ResolveCasing(Path::Combine(path, u8"RCTdeluxe_install", u8"Data", u8"CSG1I.DAT"));
-    return result2;
-}
-
-bool Csg1idatPresentAtLocation(u8string_view path)
-{
-    std::string location = FindCsg1idatAtLocation(path);
-    return !location.empty();
-}
-
-bool RCT1DataPresentAtLocation(u8string_view path)
-{
-    return Csg1datPresentAtLocation(path) && Csg1idatPresentAtLocation(path) && CsgAtLocationIsUsable(path);
-}
-
-bool CsgIsUsable(const Gx& csg)
-{
-    return csg.header.totalSize == RCT1::Limits::kLLCsg1DatFileSize && csg.header.numEntries == RCT1::Limits::kNumLLCsgEntries;
-}
-
-bool CsgAtLocationIsUsable(u8string_view path)
-{
-    auto csg1HeaderPath = FindCsg1idatAtLocation(path);
-    if (csg1HeaderPath.empty())
-    {
-        return false;
+        auto location = FindCsg1datAtLocation(path);
+        return !location.empty();
     }
 
-    auto csg1DataPath = FindCsg1datAtLocation(path);
-    if (csg1DataPath.empty())
+    u8string FindCsg1idatAtLocation(u8string_view path)
     {
-        return false;
+        auto result1 = Path::ResolveCasing(Path::Combine(path, u8"Data", u8"CSG1I.DAT"));
+        if (!result1.empty())
+        {
+            return result1;
+        }
+        auto result2 = Path::ResolveCasing(Path::Combine(path, u8"RCTdeluxe_install", u8"Data", u8"CSG1I.DAT"));
+        return result2;
     }
 
-    auto fileHeader = FileStream(csg1HeaderPath, FileMode::open);
-    auto fileData = FileStream(csg1DataPath, FileMode::open);
-    size_t fileHeaderSize = fileHeader.GetLength();
-    size_t fileDataSize = fileData.GetLength();
+    bool Csg1idatPresentAtLocation(u8string_view path)
+    {
+        std::string location = FindCsg1idatAtLocation(path);
+        return !location.empty();
+    }
 
-    Gx csg = {};
-    csg.header.numEntries = static_cast<uint32_t>(fileHeaderSize / sizeof(StoredG1Element));
-    csg.header.totalSize = static_cast<uint32_t>(fileDataSize);
-    return CsgIsUsable(csg);
+    bool RCT1DataPresentAtLocation(u8string_view path)
+    {
+        return Csg1datPresentAtLocation(path) && Csg1idatPresentAtLocation(path) && CsgAtLocationIsUsable(path);
+    }
+
+    bool CsgIsUsable(const Gx& csg)
+    {
+        return csg.header.totalSize == RCT1::Limits::kLLCsg1DatFileSize
+            && csg.header.numEntries == RCT1::Limits::kNumLLCsgEntries;
+    }
+
+    bool CsgAtLocationIsUsable(u8string_view path)
+    {
+        auto csg1HeaderPath = FindCsg1idatAtLocation(path);
+        if (csg1HeaderPath.empty())
+        {
+            return false;
+        }
+
+        auto csg1DataPath = FindCsg1datAtLocation(path);
+        if (csg1DataPath.empty())
+        {
+            return false;
+        }
+
+        auto fileHeader = FileStream(csg1HeaderPath, FileMode::open);
+        auto fileData = FileStream(csg1DataPath, FileMode::open);
+        size_t fileHeaderSize = fileHeader.GetLength();
+        size_t fileDataSize = fileData.GetLength();
+
+        Gx csg = {};
+        csg.header.numEntries = static_cast<uint32_t>(fileHeaderSize / sizeof(StoredG1Element));
+        csg.header.totalSize = static_cast<uint32_t>(fileDataSize);
+        return CsgIsUsable(csg);
+    }
 }

--- a/src/openrct2/rct1/Csg.cpp
+++ b/src/openrct2/rct1/Csg.cpp
@@ -90,4 +90,4 @@ namespace OpenRCT2
         csg.header.totalSize = static_cast<uint32_t>(fileDataSize);
         return CsgIsUsable(csg);
     }
-}
+} // namespace OpenRCT2

--- a/src/openrct2/rct1/Csg.h
+++ b/src/openrct2/rct1/Csg.h
@@ -11,12 +11,15 @@
 
 #include "../core/StringTypes.h"
 
-struct Gx;
+namespace OpenRCT2
+{
+    struct Gx;
 
-bool RCT1DataPresentAtLocation(u8string_view path);
-std::string FindCsg1datAtLocation(u8string_view path);
-bool Csg1datPresentAtLocation(u8string_view path);
-std::string FindCsg1idatAtLocation(u8string_view path);
-bool Csg1idatPresentAtLocation(u8string_view path);
-bool CsgIsUsable(const Gx& csg);
-bool CsgAtLocationIsUsable(u8string_view path);
+    bool RCT1DataPresentAtLocation(u8string_view path);
+    std::string FindCsg1datAtLocation(u8string_view path);
+    bool Csg1datPresentAtLocation(u8string_view path);
+    std::string FindCsg1idatAtLocation(u8string_view path);
+    bool Csg1idatPresentAtLocation(u8string_view path);
+    bool CsgIsUsable(const Gx& csg);
+    bool CsgAtLocationIsUsable(u8string_view path);
+} // namespace OpenRCT2

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -28,6 +28,7 @@
 #include "../core/EnumUtils.hpp"
 #include "../core/Guard.hpp"
 #include "../core/Numerics.hpp"
+#include "../drawing/Drawing.h"
 #include "../entity/EntityList.h"
 #include "../entity/EntityRegistry.h"
 #include "../entity/Peep.h"

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -11,6 +11,7 @@
 #include "../Diagnostic.h"
 #include "../Game.h"
 #include "../audio/Audio.h"
+#include "../drawing/Drawing.h"
 #include "../interface/Viewport.h"
 #include "../localisation/StringIds.h"
 #include "../object/FootpathObject.h"

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -26,6 +26,7 @@
 #include "../core/Path.hpp"
 #include "../core/Random.hpp"
 #include "../core/UnitConversion.h"
+#include "../drawing/Drawing.h"
 #include "../entity/Duck.h"
 #include "../entity/Guest.h"
 #include "../entity/Staff.h"

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -18,6 +18,7 @@
 #include "../../audio/Audio.h"
 #include "../../config/Config.h"
 #include "../../core/Console.hpp"
+#include "../../drawing/Drawing.h"
 #include "../../drawing/Text.h"
 #include "../../interface/Screenshot.h"
 #include "../../network/Network.h"

--- a/src/openrct2/scenes/title/TitleScene.h
+++ b/src/openrct2/scenes/title/TitleScene.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "../../drawing/Drawing.h"
 #include "../Scene.h"
 
 struct ITitleSequencePlayer;

--- a/src/openrct2/scenes/title/TitleScene.h
+++ b/src/openrct2/scenes/title/TitleScene.h
@@ -11,6 +11,8 @@
 
 #include "../Scene.h"
 
+#include <cstdint>
+
 struct ITitleSequencePlayer;
 
 namespace OpenRCT2

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -15,6 +15,7 @@
     #include "../../../Date.h"
     #include "../../../GameState.h"
     #include "../../../core/String.hpp"
+    #include "../../../drawing/Drawing.h"
     #include "../../../entity/Guest.h"
     #include "../../../management/Finance.h"
     #include "../../../management/NewsItem.h"

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -19,6 +19,7 @@
 #include "../audio/AudioMixer.h"
 #include "../config/Config.h"
 #include "../core/EnumUtils.hpp"
+#include "../drawing/Drawing.h"
 #include "../object/ClimateObject.h"
 #include "../object/ObjectManager.h"
 #include "../profiling/Profiling.h"

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -20,6 +20,7 @@
 #include <openrct2/actions/ParkSetParameterAction.h>
 #include <openrct2/actions/RideSetPriceAction.h>
 #include <openrct2/actions/RideSetStatusAction.h>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/EntityTweener.h>
 #include <openrct2/entity/Peep.h>

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -24,6 +24,7 @@
 #include <openrct2/core/MemoryStream.h>
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
+#include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/EntityTweener.h>
 #include <openrct2/network/Network.h>


### PR DESCRIPTION
This moves the `G1Element` struct and associates into their own header file.

This further reworks several header files that previously included `Drawing.h` to not do so. Notably, the files `ImageTable.h` (all objects!), `TitleScene.h`, and `Widget.h` (all windows!) are involved. As a consequence, `Drawing.h` (or a smaller header) is now included explicitly in units that actually use it.

Like #25742, the aim is that this will avoid excessive recompilations when either header is changed. The long-term goal is still to improve compilation times. Baby steps — though this is a big one.