### PR TITLE
Remove unused includes from openrct2-cli and openrct2-win projects

### DIFF
--- a/src/openrct2-cli/Cli.cpp
+++ b/src/openrct2-cli/Cli.cpp
@@ -10,7 +10,6 @@
 #include <openrct2/Context.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/command_line/CommandLine.hpp>
-#include <openrct2/platform/Platform.h>
 
 using namespace OpenRCT2;
 

--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -23,8 +23,6 @@
 #include <iterator>
 #include <openrct2-ui/Ui.h>
 #include <openrct2/core/String.hpp>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This removes unused includes from the `openrct2-cli` and `openrct2-win` projects (or folders in non-Visual Studio terms).