### PR TITLE
Remove redundant OpenRCT2 namespace qualifiers from paint code

### DIFF
--- a/src/openrct2/paint/track/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AirPoweredVerticalCoaster.cpp
@@ -1007,7 +1007,7 @@ static void AirPoweredVerticalRCTrackOnridePhoto(
     TrackPaintUtilOnridePhotoPaint2(session, direction, trackElement, height);
 }
 
-TrackPaintFunction GetTrackPaintFunctionAirPoweredVerticalRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionAirPoweredVerticalRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
@@ -7180,7 +7180,7 @@ namespace OpenRCT2::AlpineRC
         }
     }
 
-    TrackPaintFunction GetTrackPaintFunction(OpenRCT2::TrackElemType trackType)
+    TrackPaintFunction GetTrackPaintFunction(TrackElemType trackType)
     {
         switch (trackType)
         {

--- a/src/openrct2/paint/track/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/BobsleighCoaster.cpp
@@ -4079,7 +4079,7 @@ static void BobsleighRCTrackOnRidePhoto(
     TrackPaintUtilOnridePhotoPaint2(session, direction, trackElement, height);
 }
 
-TrackPaintFunction GetTrackPaintFunctionBobsleighRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionBobsleighRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/ClassicStandUpRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicStandUpRollerCoaster.cpp
@@ -1364,7 +1364,7 @@ static void classicStandUpRCTrackDiagRightBankTo25DegDown(
     classicStandUpRCTrackDiag25DegUpToLeftBank(session, ride, trackSequence, direction, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionClassicStandUpRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionClassicStandUpRC(TrackElemType trackType)
 {
     if (!IsCsgLoaded())
     {

--- a/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
@@ -1178,7 +1178,7 @@ static void ClassicWoodenRCTrackDiagRightBank(
 // Stylistically, this coaster is _very_ similar to the regular Wooden Roller Coaster.
 // The only difference is to which parts the colours are applied, and the degree of the banking.
 // As such, all non-banked pieces are simply drawn as regular wooden roller coaster pieces with a different paint scheme.
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionClassicWoodenRC(TrackElemType trackType)
 {
     if (!IsCsgLoaded())
     {

--- a/src/openrct2/paint/track/coaster/ClassicWoodenTwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicWoodenTwisterRollerCoaster.cpp
@@ -2086,7 +2086,7 @@ static void ClassicWoodenTwisterRCTrackRightEighthBankToOrthogonal(
 // Stylistically, this coaster is _very_ similar to the regular Wooden Roller Coaster.
 // The only difference is the degree of the banking.
 // As such, all non-banked pieces are simply drawn as regular wooden roller coaster pieces.
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenTwisterRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionClassicWoodenTwisterRC(TrackElemType trackType)
 {
     if (!IsCsgLoaded())
     {

--- a/src/openrct2/paint/track/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CompactInvertedCoaster.cpp
@@ -9611,7 +9611,7 @@ static void CompactInvertedRCTrackBlockBrakes(
     PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
-TrackPaintFunction GetTrackPaintFunctionCompactInvertedRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionCompactInvertedRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/CorkscrewRollerCoaster.cpp
@@ -20416,7 +20416,7 @@ static void CorkscrewRCTrackRightEighthDiveLoopToDownOrthogonal(
         session, ride, 5 - trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionCorkscrewRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionCorkscrewRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoaster.cpp
@@ -847,7 +847,7 @@ static void FlyingRCTrackRightFlyingLargeHalfLoopUninvertedDown(
         session, ride, 6 - trackSequence, direction, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionFlyingRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionFlyingRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.cpp
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoasterInverted.cpp
@@ -8912,7 +8912,7 @@ static void FlyingRCTrackFlyerHalfLoopDown(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionFlyingRCInverted(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionFlyingRCInverted(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HeartlineTwisterCoaster.cpp
@@ -1678,7 +1678,7 @@ static void HeartlineTwisterRCTrackRightHeartlineRoll(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionHeartlineTwisterRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionHeartlineTwisterRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -14545,7 +14545,7 @@ namespace OpenRCT2::HybridRC
         }
     }
 
-    TrackPaintFunction GetTrackPaintFunction(OpenRCT2::TrackElemType trackType)
+    TrackPaintFunction GetTrackPaintFunction(TrackElemType trackType)
     {
         switch (trackType)
         {

--- a/src/openrct2/paint/track/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/InvertedHairpinCoaster.cpp
@@ -1382,7 +1382,7 @@ static void InvertedHairpinRCTrackBlockBrakes(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionInvertedHairpinRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionInvertedHairpinRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/InvertedImpulseCoaster.cpp
@@ -758,7 +758,7 @@ static void InvertedImpulseRCTrackRightQuarterTurn190DegDown(
         session, ride, trackSequence, (direction - 1) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionInvertedImpulseRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionInvertedImpulseRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/InvertedRollerCoaster.cpp
@@ -11330,7 +11330,7 @@ static void InvertedRCTrackBooster(
     PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
-TrackPaintFunction GetTrackPaintFunctionInvertedRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionInvertedRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/JuniorRollerCoaster.cpp
@@ -5767,7 +5767,7 @@ static void JuniorRCTrackOnRidePhoto(
 
 /* 0x008AAA0C */
 template<JuniorRCSubType TSubType>
-TrackPaintFunction GetTrackPaintFunctionJuniorRCTemplate(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionJuniorRCTemplate(TrackElemType trackType)
 {
     switch (trackType)
     {
@@ -5996,12 +5996,12 @@ TrackPaintFunction GetTrackPaintFunctionJuniorRCTemplate(OpenRCT2::TrackElemType
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionJuniorRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionJuniorRC(TrackElemType trackType)
 {
     return GetTrackPaintFunctionJuniorRCTemplate<JuniorRCSubType::Junior>(trackType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionWaterRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionWaterRC(TrackElemType trackType)
 {
     return GetTrackPaintFunctionJuniorRCTemplate<JuniorRCSubType::WaterCoaster>(trackType);
 }

--- a/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
+++ b/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp
@@ -19556,7 +19556,7 @@ static void LatticeTriangleTrackRightEighthDiveLoopToDownOrthogonal(
         session, ride, 5 - trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionLatticeTriangleTrack(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLatticeTriangleTrack(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/LayDownRollerCoasterInverted.cpp
+++ b/src/openrct2/paint/track/coaster/LayDownRollerCoasterInverted.cpp
@@ -8165,7 +8165,7 @@ static void LayDownRCTrackHalfLoopInvertedUp(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionLayDownRCInverted(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLayDownRCInverted(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LimLaunchedRollerCoaster.cpp
@@ -5772,7 +5772,7 @@ static void LimLaunchedRCTrackBooster(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionLimLaunchedRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLimLaunchedRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/LoopingRollerCoaster.cpp
@@ -10307,7 +10307,7 @@ static void LoopingRCTrackBooster(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionLoopingRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLoopingRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/MineRide.cpp
+++ b/src/openrct2/paint/track/coaster/MineRide.cpp
@@ -5423,7 +5423,7 @@ static void MineRideTrackDiagRightBank(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionMineRide(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMineRide(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MineTrainCoaster.cpp
@@ -7224,7 +7224,7 @@ static void MineTrainRCTrack60DegDownToFlatLongBase(
         session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionMineTrainRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMineTrainRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MiniRollerCoaster.cpp
@@ -8985,7 +8985,7 @@ static void MiniRCTrackBooster(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionMiniRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMiniRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MiniSuspendedCoaster.cpp
@@ -2189,7 +2189,7 @@ static void MiniSuspendedRCTrackDiag25DegDownToFlat(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionMiniSuspendedRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMiniSuspendedRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/MultiDimensionRollerCoaster.cpp
@@ -14516,7 +14516,7 @@ static void MultiDimensionRCTrackMultidimInverted90DegUpToFlatQuarterLoop(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionMultiDimensionRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMultiDimensionRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ReverseFreefallCoaster.cpp
@@ -401,7 +401,7 @@ static void PaintReverseFreefallRCOnridePhoto(
     TrackPaintUtilOnridePhotoPaint2(session, direction, trackElement, height);
 }
 
-TrackPaintFunction GetTrackPaintFunctionReverseFreefallRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionReverseFreefallRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ReverserRollerCoaster.cpp
@@ -1370,7 +1370,7 @@ static void ReverserRCTrackRightReverser(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionReverserRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionReverserRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SideFrictionRollerCoaster.cpp
@@ -2909,7 +2909,7 @@ static void SideFrictionRCTrackDiag60DegDownTo25DegDown(
         session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 };
 
-TrackPaintFunction GetTrackPaintFunctionSideFrictionRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSideFrictionRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
@@ -19883,7 +19883,7 @@ namespace OpenRCT2::SingleRailRC
         }
     }
 
-    TrackPaintFunction GetTrackPaintFunction(OpenRCT2::TrackElemType trackType)
+    TrackPaintFunction GetTrackPaintFunction(TrackElemType trackType)
     {
         switch (trackType)
         {

--- a/src/openrct2/paint/track/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/StandUpRollerCoaster.cpp
@@ -18361,7 +18361,7 @@ static void StandUpRCTrackRightLargeZeroGRollDown(
         session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionStandUpRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionStandUpRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/Steeplechase.cpp
+++ b/src/openrct2/paint/track/coaster/Steeplechase.cpp
@@ -2181,7 +2181,7 @@ static void SteeplechaseTrackBlockBrakes(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionSteeplechase(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSteeplechase(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SuspendedSwingingCoaster.cpp
@@ -4689,7 +4689,7 @@ static void SuspendedSwingingRCTrackBlockBrakes(
     PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
-TrackPaintFunction GetTrackPaintFunctionSuspendedSwingingRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSuspendedSwingingRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/TwisterRollerCoaster.cpp
@@ -20051,7 +20051,7 @@ static void TwisterRCTrackRightEighthDiveLoopToDownOrthogonal(
         session, ride, 5 - trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionTwisterRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionTwisterRC(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/VirginiaReel.cpp
+++ b/src/openrct2/paint/track/coaster/VirginiaReel.cpp
@@ -472,7 +472,7 @@ static void PaintVirginiaReelTrackRightQuarterTurn1Tile(
 /**
  * rct2: 0x00811184
  */
-TrackPaintFunction GetTrackPaintFunctionVirginiaReel(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionVirginiaReel(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/WildMouse.cpp
+++ b/src/openrct2/paint/track/coaster/WildMouse.cpp
@@ -941,7 +941,7 @@ static void WildMouseTrackBlockBrakes(
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionWildMouse(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionWildMouse(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -13359,7 +13359,7 @@ static void WoodenRCTrackRightLargeHalfLoopDown(
 }
 
 template<bool isClassic>
-TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType trackType)
 {
     switch (trackType)
     {
@@ -13678,12 +13678,12 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(OpenRCT2::Track
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionWoodenRC(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionWoodenRC(TrackElemType trackType)
 {
     return GetTrackPaintFunctionWoodenAndClassicWoodenRC<false>(trackType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(TrackElemType trackType)
 {
     return GetTrackPaintFunctionWoodenAndClassicWoodenRC<true>(trackType);
 }

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
@@ -303,7 +303,7 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
         kSegmentsAll,
     };
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftBankedQuarterTurn3Tiles>(
+    DrawSupportForSequenceA<TrackElemType::leftBankedQuarterTurn3Tiles>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -521,7 +521,7 @@ static void WoodenRCTrackBankedRightQuarterTurn5(
         kSegmentsAll,
     };
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::bankedRightQuarterTurn5Tiles>(
+    DrawSupportForSequenceA<TrackElemType::bankedRightQuarterTurn5Tiles>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2964,7 +2964,7 @@ static void WoodenRCTrackDiagFlatToBank(
             break;
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlat>(
+    DrawSupportForSequenceA<TrackElemType::diagFlat>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -3032,7 +3032,7 @@ static void WoodenRCTrackDiagBankTo25DegUp(
             break;
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlatToUp25>(
+    DrawSupportForSequenceA<TrackElemType::diagFlatToUp25>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48);
@@ -3100,7 +3100,7 @@ static void WoodenRCTrackDiagUp25ToBank(
             break;
     }
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp25ToFlat>(
+    DrawSupportForSequenceB<TrackElemType::diagUp25ToFlat>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56);
@@ -3168,7 +3168,7 @@ static void WoodenRCTrackDiagLeftBank(
             break;
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagLeftBank>(
+    DrawSupportForSequenceA<TrackElemType::diagLeftBank>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -3336,7 +3336,7 @@ static void WoodenRCTrackLeftEighthBankToDiag(
             break;
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftEighthBankToDiag>(
+    DrawSupportForSequenceA<TrackElemType::leftEighthBankToDiag>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -3504,10 +3504,10 @@ static void WoodenRCTrackRightEighthBankToDiag(
             break;
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::rightEighthBankToDiag>(
+    DrawSupportForSequenceA<TrackElemType::rightEighthBankToDiag>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(OpenRCT2::TrackElemType trackType);
+TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(TrackElemType trackType);

--- a/src/openrct2/paint/track/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenWildMouse.cpp
@@ -716,7 +716,7 @@ static void WoodenWildMouseTrack60DegDownToFlat(
     WoodenWildMouseTrackFlatTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionWoodenWildMouse(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionWoodenWildMouse(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/CarRide.cpp
+++ b/src/openrct2/paint/track/gentle/CarRide.cpp
@@ -723,7 +723,7 @@ static void PaintCarRideTrackLogBumps(
 /**
  * rct2: 0x006F7000
  */
-TrackPaintFunction GetTrackPaintFunctionCarRide(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionCarRide(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/Circus.cpp
+++ b/src/openrct2/paint/track/gentle/Circus.cpp
@@ -121,7 +121,7 @@ static void PaintCircus(
     PaintUtilSetGeneralSupportHeight(session, height + 128);
 }
 
-TrackPaintFunction GetTrackPaintFunctionCircus(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionCircus(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/gentle/CrookedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/CrookedHouse.cpp
@@ -147,7 +147,7 @@ static void PaintCrookedHouse(
     PaintUtilSetGeneralSupportHeight(session, height + 128);
 }
 
-TrackPaintFunction GetTrackPaintFunctionCrookedHouse(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionCrookedHouse(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/gentle/Dodgems.cpp
+++ b/src/openrct2/paint/track/gentle/Dodgems.cpp
@@ -109,7 +109,7 @@ static void PaintDodgems(
 /**
  * rct2:
  */
-TrackPaintFunction GetTrackPaintFunctionDodgems(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionDodgems(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack4x4)
     {

--- a/src/openrct2/paint/track/gentle/FerrisWheel.cpp
+++ b/src/openrct2/paint/track/gentle/FerrisWheel.cpp
@@ -174,7 +174,7 @@ static void PaintFerrisWheel(
     PaintUtilSetGeneralSupportHeight(session, height + 176);
 }
 
-TrackPaintFunction GetTrackPaintFunctionFerrisWheel(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionFerrisWheel(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack1x4C)
     {

--- a/src/openrct2/paint/track/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/paint/track/gentle/FlyingSaucers.cpp
@@ -69,7 +69,7 @@ static void PaintFlyingSaucers(
 /**
  * rct2: 0x00887208
  */
-TrackPaintFunction GetTrackPaintFunctionFlyingSaucers(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionFlyingSaucers(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack4x4)
     {

--- a/src/openrct2/paint/track/gentle/GhostTrain.cpp
+++ b/src/openrct2/paint/track/gentle/GhostTrain.cpp
@@ -559,7 +559,7 @@ static void PaintGhostTrainTrackBrakes(
 /**
  * rct2: 0x00770924
  */
-TrackPaintFunction GetTrackPaintFunctionGhostTrain(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionGhostTrain(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/HauntedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/HauntedHouse.cpp
@@ -125,7 +125,7 @@ static void PaintHauntedHouse(
     PaintUtilSetGeneralSupportHeight(session, height + 128);
 }
 
-TrackPaintFunction GetTrackPaintFunctionHauntedHouse(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionHauntedHouse(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/gentle/Maze.cpp
+++ b/src/openrct2/paint/track/gentle/Maze.cpp
@@ -187,7 +187,7 @@ static void MazePaintSetup(
 /**
  * rct2: 0x008A81E8
  */
-TrackPaintFunction GetTrackPaintFunctionMaze(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMaze(TrackElemType trackType)
 {
     if (trackType != TrackElemType::maze)
     {

--- a/src/openrct2/paint/track/gentle/MerryGoRound.cpp
+++ b/src/openrct2/paint/track/gentle/MerryGoRound.cpp
@@ -175,7 +175,7 @@ static void PaintMerryGoRound(
     PaintUtilSetGeneralSupportHeight(session, height + 64);
 }
 
-TrackPaintFunction GetTrackPaintFunctionMerryGoRound(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMerryGoRound(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/gentle/MiniGolf.cpp
+++ b/src/openrct2/paint/track/gentle/MiniGolf.cpp
@@ -1086,7 +1086,7 @@ static void PaintMiniGolfHoleE(
 /**
  * rct2: 0x0087EDC4
  */
-TrackPaintFunction GetTrackPaintFunctionMiniGolf(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMiniGolf(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/paint/track/gentle/MiniHelicopters.cpp
@@ -365,7 +365,7 @@ static void PaintMiniHelicoptersTrackSpinningTunnel(
 /**
  * rct2: 0x0081F268
  */
-TrackPaintFunction GetTrackPaintFunctionMiniHelicopters(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMiniHelicopters(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/MonorailCycles.cpp
+++ b/src/openrct2/paint/track/gentle/MonorailCycles.cpp
@@ -591,7 +591,7 @@ static void PaintMonorailCyclesTrackSBendRight(
 /**
  * rct2: 0x0088ac88
  */
-TrackPaintFunction GetTrackPaintFunctionMonorailCycles(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMonorailCycles(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/ObservationTower.cpp
+++ b/src/openrct2/paint/track/gentle/ObservationTower.cpp
@@ -140,7 +140,7 @@ static void PaintObservationTowerSection(
 /**
  * rct2: 0x0070DC5C
  */
-TrackPaintFunction GetTrackPaintFunctionObservationTower(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionObservationTower(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/gentle/SpaceRings.cpp
+++ b/src/openrct2/paint/track/gentle/SpaceRings.cpp
@@ -190,7 +190,7 @@ static void PaintSpaceRings(
 /**
  * rct2: 0x0x00767A40
  */
-TrackPaintFunction GetTrackPaintFunctionSpaceRings(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSpaceRings(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/gentle/SpiralSlide.cpp
+++ b/src/openrct2/paint/track/gentle/SpiralSlide.cpp
@@ -253,7 +253,7 @@ static void PaintSpiralSlide(
 /**
  * rct2: 0x0074840C
  */
-TrackPaintFunction GetTrackPaintFunctionSpiralSlide(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSpiralSlide(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack2x2)
     {

--- a/src/openrct2/paint/track/shops/Facility.cpp
+++ b/src/openrct2/paint/track/shops/Facility.cpp
@@ -80,7 +80,7 @@ static void PaintFacility(
 }
 
 /* 0x00762D44 */
-TrackPaintFunction GetTrackPaintFunctionFacility(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionFacility(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/shops/Shop.cpp
+++ b/src/openrct2/paint/track/shops/Shop.cpp
@@ -65,7 +65,7 @@ static void PaintShop(
         PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
 }
 
-TrackPaintFunction GetTrackPaintFunctionShop(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionShop(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/thrill/3dCinema.cpp
+++ b/src/openrct2/paint/track/thrill/3dCinema.cpp
@@ -121,7 +121,7 @@ static void Paint3dCinema(
     PaintUtilSetGeneralSupportHeight(session, height + 128);
 }
 
-TrackPaintFunction GetTrackPaintFunction3dCinema(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunction3dCinema(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/thrill/Enterprise.cpp
+++ b/src/openrct2/paint/track/thrill/Enterprise.cpp
@@ -175,7 +175,7 @@ static void PaintEnterprise(
     PaintUtilSetGeneralSupportHeight(session, height + 160);
 }
 
-TrackPaintFunction GetTrackPaintFunctionEnterprise(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionEnterprise(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack4x4)
     {

--- a/src/openrct2/paint/track/thrill/GoKarts.cpp
+++ b/src/openrct2/paint/track/thrill/GoKarts.cpp
@@ -1971,7 +1971,7 @@ static void TrackLeftQuarterTurn5Tiles(
         session, session.TrackColours.WithIndex(kGoKartsLeftQuarterTurn5TilesSprites[direction][trackSequence][2]), height,
         { 0, 0, 0 }, kGoKartsLeftQuarterTurn5TilesBoundBoxes[direction][trackSequence][2]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftQuarterTurn5Tiles>(
+    DrawSupportForSequenceA<TrackElemType::leftQuarterTurn5Tiles>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     if (trackSequence == 0 && (direction == 0 || direction == 3))
     {
@@ -2023,7 +2023,7 @@ static void TrackLeftEighthToDiag(
         session, session.TrackColours.WithIndex(kGoKartsLeftEighthToDiagSprites[direction][trackSequence][2]), height,
         { 0, 0, 0 }, kGoKartsLeftEighthToDiagBoundBoxes[direction][trackSequence][2]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftEighthToDiag>(
+    DrawSupportForSequenceA<TrackElemType::leftEighthToDiag>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     if (trackSequence == 0 && (direction == 0 || direction == 3))
     {
@@ -2047,7 +2047,7 @@ static void TrackRightEighthToDiag(
         session, session.TrackColours.WithIndex(kGoKartsRightEighthToDiagSprites[direction][trackSequence][2]), height,
         { 0, 0, 0 }, kGoKartsRightEighthToDiagBoundBoxes[direction][trackSequence][2]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::rightEighthToDiag>(
+    DrawSupportForSequenceA<TrackElemType::rightEighthToDiag>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     if (trackSequence == 0 && (direction == 0 || direction == 3))
     {
@@ -2086,7 +2086,7 @@ static void TrackDiagFlat(
         session, session.TrackColours.WithIndex(kGoKartsDiagFlatSprites[direction][trackSequence][1]), height, { 0, 0, 0 },
         kGoKartsDiagFlatBoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlat>(
+    DrawSupportForSequenceA<TrackElemType::diagFlat>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2103,7 +2103,7 @@ static void TrackDiagFlatToUp25(
         session, session.TrackColours.WithIndex(kGoKartsDiagFlatToUp25Sprites[direction][trackSequence][1]), height,
         { 0, 0, 0 }, kGoKartsDiagFlatToUp25BoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlatToUp25>(
+    DrawSupportForSequenceA<TrackElemType::diagFlatToUp25>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48);
@@ -2120,7 +2120,7 @@ static void TrackDiagUp25ToFlat(
         session, session.TrackColours.WithIndex(kGoKartsDiagUp25ToFlatSprites[direction][trackSequence][1]), height,
         { 0, 0, 0 }, kGoKartsDiagUp25ToFlatBoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp25ToFlat>(
+    DrawSupportForSequenceB<TrackElemType::diagUp25ToFlat>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56);
@@ -2137,7 +2137,7 @@ static void TrackDiagUp25(
         session, session.TrackColours.WithIndex(kGoKartsDiagUp25Sprites[direction][trackSequence][1]), height, { 0, 0, 0 },
         kGoKartsDiagUp25BoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp25>(
+    DrawSupportForSequenceB<TrackElemType::diagUp25>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56);
@@ -2181,7 +2181,7 @@ static void TrackDiagUp25ToUp60(
         session, session.TrackColours.WithIndex(kGoKartsDiagUp25ToUp60Sprites[direction][trackSequence][1]), height,
         { 0, 0, 0 }, kGoKartsDiagUp25ToUp60BoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp25ToUp60>(
+    DrawSupportForSequenceB<TrackElemType::diagUp25ToUp60>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 72);
@@ -2198,7 +2198,7 @@ static void TrackDiagUp60ToUp25(
         session, session.TrackColours.WithIndex(kGoKartsDiagUp60ToUp25Sprites[direction][trackSequence][1]), height,
         { 0, 0, 0 }, kGoKartsDiagUp60ToUp25BoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp60ToUp25>(
+    DrawSupportForSequenceB<TrackElemType::diagUp60ToUp25>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 72);
@@ -2215,7 +2215,7 @@ static void TrackDiagUp60(
         session, session.TrackColours.WithIndex(kGoKartsDiagUp60Sprites[direction][trackSequence][1]), height, { 0, 0, 0 },
         kGoKartsDiagUp60BoundBoxes[direction][trackSequence][1]);
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp60>(
+    DrawSupportForSequenceB<TrackElemType::diagUp60>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 104);
@@ -2708,7 +2708,7 @@ static void TrackSBendLeft(
         session, session.TrackColours.WithIndex(kGoKartsSBendLeftSprites[direction][trackSequence][2]), height, { 0, 0, 0 },
         kGoKartsSBendLeftBoundBoxes[direction][trackSequence][2]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::sBendLeft>(
+    DrawSupportForSequenceA<TrackElemType::sBendLeft>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     if ((trackSequence == 0 && (direction == 0 || direction == 3))
         || (trackSequence == 3 && (direction == 1 || direction == 2)))
@@ -2743,7 +2743,7 @@ static void TrackSBendRight(
         session, session.TrackColours.WithIndex(kGoKartsSBendRightSprites[direction][trackSequence][2]), height, { 0, 0, 0 },
         kGoKartsSBendRightBoundBoxes[direction][trackSequence][2]);
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::sBendRight>(
+    DrawSupportForSequenceA<TrackElemType::sBendRight>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     if ((trackSequence == 0 && (direction == 0 || direction == 3))
         || (trackSequence == 3 && (direction == 1 || direction == 2)))
@@ -2767,7 +2767,7 @@ static void TrackSBendRight(
 /**
  * rct2: 0x0074A668
  */
-TrackPaintFunction GetTrackPaintFunctionGoKarts(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionGoKarts(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/paint/track/thrill/LaunchedFreefall.cpp
@@ -141,7 +141,7 @@ static void PaintLaunchedFreefallTowerSection(
 /**
  * rct2: 0x006FD0E8
  */
-TrackPaintFunction GetTrackPaintFunctionLaunchedFreefall(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLaunchedFreefall(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/thrill/MagicCarpet.cpp
+++ b/src/openrct2/paint/track/thrill/MagicCarpet.cpp
@@ -256,7 +256,7 @@ static void PaintMagicCarpet(
     PaintUtilSetGeneralSupportHeight(session, height + 176);
 }
 
-TrackPaintFunction GetTrackPaintFunctionMagicCarpet(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMagicCarpet(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/thrill/MotionSimulator.cpp
+++ b/src/openrct2/paint/track/thrill/MotionSimulator.cpp
@@ -146,7 +146,7 @@ static void PaintMotionSimulator(
  *
  *  rct2: 0x00763520
  */
-TrackPaintFunction GetTrackPaintFunctionMotionsimulator(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMotionsimulator(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/thrill/RotoDrop.cpp
+++ b/src/openrct2/paint/track/thrill/RotoDrop.cpp
@@ -154,7 +154,7 @@ static void PaintRotoDropTowerSection(
 /**
  * rct2: 0x00886074
  */
-TrackPaintFunction GetTrackPaintFunctionRotoDrop(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionRotoDrop(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
@@ -189,7 +189,7 @@ static void PaintSwingingInverterShip(
     PaintUtilSetGeneralSupportHeight(session, height + 176);
 }
 
-TrackPaintFunction GetTrackPaintFunctionSwingingInverterShip(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSwingingInverterShip(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack1x4B)
     {

--- a/src/openrct2/paint/track/thrill/SwingingShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingShip.cpp
@@ -299,7 +299,7 @@ static void PaintSwingingShip(
     PaintUtilSetGeneralSupportHeight(session, height + 112);
 }
 
-TrackPaintFunction GetTrackPaintFunctionSwingingShip(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSwingingShip(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack1x5)
     {

--- a/src/openrct2/paint/track/thrill/TopSpin.cpp
+++ b/src/openrct2/paint/track/thrill/TopSpin.cpp
@@ -249,7 +249,7 @@ static void PaintTopSpin(
     PaintUtilSetGeneralSupportHeight(session, height + 112);
 }
 
-TrackPaintFunction GetTrackPaintFunctionTopspin(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionTopspin(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/thrill/Twist.cpp
+++ b/src/openrct2/paint/track/thrill/Twist.cpp
@@ -170,7 +170,7 @@ static void PaintTwist(
 /**
  * rct2: 0x0076D658
  */
-TrackPaintFunction GetTrackPaintFunctionTwist(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionTwist(TrackElemType trackType)
 {
     if (trackType != TrackElemType::flatTrack3x3)
     {

--- a/src/openrct2/paint/track/transport/Lift.cpp
+++ b/src/openrct2/paint/track/transport/Lift.cpp
@@ -141,7 +141,7 @@ static void PaintLiftTowerSection(
 /**
  * rct2: 0x0076C5BC
  */
-TrackPaintFunction GetTrackPaintFunctionLift(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLift(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/transport/MiniatureRailway.cpp
+++ b/src/openrct2/paint/track/transport/MiniatureRailway.cpp
@@ -2306,7 +2306,7 @@ static void MiniatureRailwayTrackDiag25DegDownToFlat(
 /**
  * rct2: 0x008ACE48
  */
-TrackPaintFunction GetTrackPaintFunctionMiniatureRailway(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMiniatureRailway(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/transport/Monorail.cpp
+++ b/src/openrct2/paint/track/transport/Monorail.cpp
@@ -1212,7 +1212,7 @@ static void PaintMonorailTrackDiag25DegDownToFlat(
 /**
  * rct2: 0x008ADF34
  */
-TrackPaintFunction GetTrackPaintFunctionMonorail(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionMonorail(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/paint/track/transport/SuspendedMonorail.cpp
@@ -1971,7 +1971,7 @@ static void SuspendedMonorailTrackDiag25DegDownToFlat(
     }
 }
 
-TrackPaintFunction GetTrackPaintFunctionSuspendedMonorail(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSuspendedMonorail(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/BoatHire.cpp
+++ b/src/openrct2/paint/track/water/BoatHire.cpp
@@ -1231,7 +1231,7 @@ static void PaintBoatHireTrackSBendRight(
 /**
  * rct2: 0x008B0D60
  */
-TrackPaintFunction GetTrackPaintFunctionBoatHire(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionBoatHire(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/DinghySlide.cpp
+++ b/src/openrct2/paint/track/water/DinghySlide.cpp
@@ -1058,7 +1058,7 @@ static void DinghySlideTrackLeftQuarterTurn3(
     DinghySlideTrackRightQuarterTurn3(session, ride, trackSequence, (direction + 1) % 4, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionDinghySlide(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionDinghySlide(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/DinghySlideCovered.cpp
+++ b/src/openrct2/paint/track/water/DinghySlideCovered.cpp
@@ -951,7 +951,7 @@ static void DinghySlideTrackCovered60DegDownTo25DegDown(
         session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionDinghySlideCovered(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionDinghySlideCovered(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/LogFlume.cpp
+++ b/src/openrct2/paint/track/water/LogFlume.cpp
@@ -985,7 +985,7 @@ static void LogFlumeTrack60Down25(
     PaintUtilSetGeneralSupportHeight(session, height + 72);
 }
 
-TrackPaintFunction GetTrackPaintFunctionLogFlume(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionLogFlume(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/RiverRapids.cpp
+++ b/src/openrct2/paint/track/water/RiverRapids.cpp
@@ -705,7 +705,7 @@ static void PaintRiverRapidsTrackWhirlpool(
 /**
  * rct2: 0x0075745C
  **/
-TrackPaintFunction GetTrackPaintFunctionRiverRapids(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionRiverRapids(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/SplashBoats.cpp
+++ b/src/openrct2/paint/track/water/SplashBoats.cpp
@@ -1188,7 +1188,7 @@ static void PaintSplashBoatsTrackOnRidePhoto(
     TrackPaintUtilOnridePhotoPaint2(session, direction, trackElement, height);
 }
 
-TrackPaintFunction GetTrackPaintFunctionSplashBoats(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSplashBoats(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/track/water/SubmarineRide.cpp
+++ b/src/openrct2/paint/track/water/SubmarineRide.cpp
@@ -172,7 +172,7 @@ static void SubmarineRidePaintTrackRightQuarterTurn1Tile(
 /**
  * rct2: 0x008995D4
  */
-TrackPaintFunction GetTrackPaintFunctionSubmarineRide(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionSubmarineRide(TrackElemType trackType)
 {
     switch (trackType)
     {


### PR DESCRIPTION
All of these files have `using namespace OpenRCT2` at the top, so it's unnecessary to specify the OpenRCT2 namespace again in the code.