### PR TITLE
Automatically apply basic pull request labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,12 @@
       - '*.md'
       - '**/*.md'
 
+# Localisation
+'localisation':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'data/language/en-GB.txt'
+
 # Game components
 'actions':
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,41 @@
+# Rules for automatically applying labels to PRs
+# See also: https://github.com/actions/labeler
+
+# General labels
+'build':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/*'
+      - '.github/**/*'
+      - 'cmake/*'
+      - 'cmake/**/*'
+      - 'scripts/*'
+      - 'CMakeLists.txt'
+      - '**/CMakeLists.txt'
+      - '*.sln'
+      - '**/*.vcxproj'
+'documentation':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '*.md'
+      - '**/*.md'
+
+# Game components
+'mapgen':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2/world/map_generator/*'
+'network':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2/network/*'
+
+# Platform code
+'platform':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2/platform/*'
+'android':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2-android/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,7 +31,7 @@
   - changed-files:
     - any-glob-to-any-file:
       - 'src/openrct2/actions/*'
-'mapgen':
+'map generator':
   - changed-files:
     - any-glob-to-any-file:
       - 'src/openrct2/world/map_generator/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,6 +21,10 @@
       - '**/*.md'
 
 # Game components
+'actions':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2/actions/*'
 'mapgen':
   - changed-files:
     - any-glob-to-any-file:
@@ -29,6 +33,10 @@
   - changed-files:
     - any-glob-to-any-file:
       - 'src/openrct2/network/*'
+'paint':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2/paint/*'
 
 # Platform code
 'platform':

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -8,7 +8,8 @@ jobs:
   labeler:
     permissions:
       contents: read
-      pull-requests: write
+      issues: write        # automatically creates labels
+      pull-requests: write # assigning labels to PRs
     runs-on: ubuntu-latest
     if: github.repository == 'OpenRCT2/OpenRCT2'
     steps:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,17 @@
+# This workflow automatically labels new pull requests
+# See labeler.yml for the label rules involved
+
+name: Apply labels to pull request
+on: pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: github.repository == 'OpenRCT2/OpenRCT2'
+    steps:
+    - uses: actions/labeler@v6
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR implements automatic labelling of pull requests based on files changed. The aim here is to triage to get the right people more quickly.

Currently quite a basic set-up; I aim to get this expanded a little bit more before offering it for review.