### PR TITLE
Remove redundant namespace qualifiers from "tests" project

### DIFF
--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -26,8 +26,6 @@
 #include <string>
 #include <vector>
 
-using namespace OpenRCT2;
-
 static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW);
 
 /**
@@ -55,7 +53,7 @@ static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW)
     std::vector<std::string> argv;
     for (int i = 0; i < argc; i++)
     {
-        argv.push_back(String::toUtf8(argvW[i]));
+        argv.push_back(OpenRCT2::String::toUtf8(argvW[i]));
     }
     return argv;
 }

--- a/test/tests/IniWriterTest.cpp
+++ b/test/tests/IniWriterTest.cpp
@@ -28,7 +28,7 @@ static auto Enum_Currency = ConfigEnum<int32_t>({
 
 TEST_F(IniWriterTest, create_empty)
 {
-    OpenRCT2::MemoryStream ms(0);
+    MemoryStream ms(0);
     ASSERT_EQ(ms.CanRead(), true);
     ASSERT_EQ(ms.CanWrite(), true);
     auto iw = CreateIniWriter(&ms);
@@ -37,7 +37,7 @@ TEST_F(IniWriterTest, create_empty)
 
 TEST_F(IniWriterTest, create_one_section)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("OpenRCT2");
@@ -53,7 +53,7 @@ TEST_F(IniWriterTest, create_one_section)
 
 TEST_F(IniWriterTest, create_multiple_sections)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("OpenRCT1");
@@ -75,7 +75,7 @@ TEST_F(IniWriterTest, create_multiple_sections)
 
 TEST_F(IniWriterTest, create_loose_bool_entry)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteBoolean("boolval", true);
@@ -91,7 +91,7 @@ TEST_F(IniWriterTest, create_loose_bool_entry)
 
 TEST_F(IniWriterTest, create_loose_enum_entry)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteEnum("by_string", "stringval");
@@ -108,7 +108,7 @@ TEST_F(IniWriterTest, create_loose_enum_entry)
 
 TEST_F(IniWriterTest, create_loose_float_entry)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteFloat("one", 1.);
@@ -125,7 +125,7 @@ TEST_F(IniWriterTest, create_loose_float_entry)
 
 TEST_F(IniWriterTest, create_loose_int32_t_entry)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteInt32("one", 1);
@@ -148,7 +148,7 @@ TEST_F(IniWriterTest, create_loose_int32_t_entry)
 
 TEST_F(IniWriterTest, create_loose_string_entry)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteString("path", u8"C:'\\some/dir\\here/神鷹暢遊");
@@ -165,7 +165,7 @@ TEST_F(IniWriterTest, create_loose_string_entry)
 
 TEST_F(IniWriterTest, create_multiple_section_with_values)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("bool");
@@ -191,7 +191,7 @@ TEST_F(IniWriterTest, create_multiple_section_with_values)
 
 TEST_F(IniWriterTest, create_duplicate_sections)
 {
-    OpenRCT2::MemoryStream ms(1000);
+    MemoryStream ms(1000);
     auto iw = CreateIniWriter(&ms);
     ASSERT_NE(iw, nullptr);
     iw->WriteSection("section");

--- a/test/tests/RideRatings.cpp
+++ b/test/tests/RideRatings.cpp
@@ -32,7 +32,7 @@ protected:
         auto& gameState = getGameState();
         for (const auto& ride : RideManager(gameState))
         {
-            OpenRCT2::RideRating::UpdateRide(ride);
+            RideRating::UpdateRide(ride);
         }
     }
 
@@ -48,7 +48,7 @@ protected:
 
     std::string FormatRatings(const Ride& ride)
     {
-        OpenRCT2::RideRating::Tuple ratings = ride.ratings;
+        RideRating::Tuple ratings = ride.ratings;
         auto name = std::string(ride.getRideTypeDescriptor().Name);
         std::string line = String::stdFormat(
             "%s: (%d, %d, %d)", name.c_str(), static_cast<int>(ratings.excitement), static_cast<int>(ratings.intensity),

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -116,7 +116,7 @@ static bool ExportSave(MemoryStream& stream, std::unique_ptr<IContext>& context)
     exporter->ExportObjectsList = objManager.GetPackableObjects();
 
     auto& gameState = getGameState();
-    exporter->Export(gameState, stream, OpenRCT2::kParkFileSaveCompressionLevel);
+    exporter->Export(gameState, stream, kParkFileSaveCompressionLevel);
 
     return true;
 }

--- a/test/tests/SawyerCodingTest.cpp
+++ b/test/tests/SawyerCodingTest.cpp
@@ -37,16 +37,15 @@ protected:
     void TestEncodeDecode(ChunkEncoding encoding_type)
     {
         // Encode
-        SawyerCoding::ChunkHeader chdr_in;
+        ChunkHeader chdr_in;
         chdr_in.encoding = encoding_type;
         chdr_in.length = sizeof(randomdata);
         uint8_t* encodedDataBuffer = new uint8_t[BUFFER_SIZE];
-        size_t encodedDataSize = SawyerCoding::WriteChunkBuffer(
-            encodedDataBuffer, reinterpret_cast<const uint8_t*>(randomdata), chdr_in);
+        size_t encodedDataSize = WriteChunkBuffer(encodedDataBuffer, reinterpret_cast<const uint8_t*>(randomdata), chdr_in);
         ASSERT_GT(encodedDataSize, sizeof(SawyerCoding::ChunkHeader));
 
         // Decode
-        OpenRCT2::MemoryStream ms(encodedDataBuffer, encodedDataSize);
+        MemoryStream ms(encodedDataBuffer, encodedDataSize);
         SawyerChunkReader reader(&ms);
         auto chunk = reader.ReadChunk();
         ASSERT_EQ(chunk->GetEncoding(), chdr_in.encoding);
@@ -59,11 +58,11 @@ protected:
 
     void TestDecode(const uint8_t* data, size_t size)
     {
-        auto expectedLength = size - sizeof(SawyerCoding::ChunkHeader);
-        auto chdr_in = reinterpret_cast<const SawyerCoding::ChunkHeader*>(data);
+        auto expectedLength = size - sizeof(ChunkHeader);
+        auto chdr_in = reinterpret_cast<const ChunkHeader*>(data);
         ASSERT_EQ(chdr_in->length, expectedLength);
 
-        OpenRCT2::MemoryStream ms(data, size);
+        MemoryStream ms(data, size);
         SawyerChunkReader reader(&ms);
         auto chunk = reader.ReadChunk();
         ASSERT_EQ(chunk->GetEncoding(), chdr_in->encoding);
@@ -120,7 +119,7 @@ TEST_F(SawyerCodingTest, decode_chunk_rotate)
 
 TEST_F(SawyerCodingTest, invalid1)
 {
-    OpenRCT2::MemoryStream ms(invalid1, sizeof(invalid1));
+    MemoryStream ms(invalid1, sizeof(invalid1));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -128,7 +127,7 @@ TEST_F(SawyerCodingTest, invalid1)
 
 TEST_F(SawyerCodingTest, invalid2)
 {
-    OpenRCT2::MemoryStream ms(invalid2, sizeof(invalid2));
+    MemoryStream ms(invalid2, sizeof(invalid2));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -136,7 +135,7 @@ TEST_F(SawyerCodingTest, invalid2)
 
 TEST_F(SawyerCodingTest, invalid3)
 {
-    OpenRCT2::MemoryStream ms(invalid3, sizeof(invalid3));
+    MemoryStream ms(invalid3, sizeof(invalid3));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -144,7 +143,7 @@ TEST_F(SawyerCodingTest, invalid3)
 
 TEST_F(SawyerCodingTest, invalid4)
 {
-    OpenRCT2::MemoryStream ms(invalid4, sizeof(invalid4));
+    MemoryStream ms(invalid4, sizeof(invalid4));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -152,7 +151,7 @@ TEST_F(SawyerCodingTest, invalid4)
 
 TEST_F(SawyerCodingTest, invalid5)
 {
-    OpenRCT2::MemoryStream ms(invalid5, sizeof(invalid5));
+    MemoryStream ms(invalid5, sizeof(invalid5));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -160,7 +159,7 @@ TEST_F(SawyerCodingTest, invalid5)
 
 TEST_F(SawyerCodingTest, invalid6)
 {
-    OpenRCT2::MemoryStream ms(invalid6, sizeof(invalid6));
+    MemoryStream ms(invalid6, sizeof(invalid6));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -168,7 +167,7 @@ TEST_F(SawyerCodingTest, invalid6)
 
 TEST_F(SawyerCodingTest, invalid7)
 {
-    OpenRCT2::MemoryStream ms(invalid7, sizeof(invalid7));
+    MemoryStream ms(invalid7, sizeof(invalid7));
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), SawyerChunkException);
@@ -176,7 +175,7 @@ TEST_F(SawyerCodingTest, invalid7)
 
 TEST_F(SawyerCodingTest, empty)
 {
-    OpenRCT2::MemoryStream ms(empty, 0);
+    MemoryStream ms(empty, 0);
     SawyerChunkReader reader(&ms);
     std::shared_ptr<SawyerChunk> ptr;
     EXPECT_THROW(ptr = reader.ReadChunk(), IOException);

--- a/test/tests/StringTest.cpp
+++ b/test/tests/StringTest.cpp
@@ -91,7 +91,7 @@ TEST_F(StringTest, Convert_950_to_UTF8)
 {
     auto input = StringFromHex("a7d6b374aabab4c4a6e2aab0af57");
     auto expected = u8"快速的棕色狐狸";
-    auto actual = String::convertToUtf8(input, OpenRCT2::CodePage::CP_950);
+    auto actual = String::convertToUtf8(input, CP_950);
     ASSERT_EQ(expected, actual);
 }
 
@@ -99,7 +99,7 @@ TEST_F(StringTest, Convert_UTF8_to_UTF8)
 {
     auto input = u8"سريع|brown|ثعلب";
     auto expected = input;
-    auto actual = String::convertToUtf8(input, OpenRCT2::CodePage::UTF8);
+    auto actual = String::convertToUtf8(input, UTF8);
     ASSERT_EQ(expected, actual);
 }
 
@@ -107,7 +107,7 @@ TEST_F(StringTest, Convert_Empty)
 {
     auto input = "";
     auto expected = input;
-    auto actual = String::convertToUtf8(input, OpenRCT2::CodePage::CP_1252);
+    auto actual = String::convertToUtf8(input, CP_1252);
     ASSERT_EQ(expected, actual);
 }
 


### PR DESCRIPTION
This removes redundant namespace qualifiers from the `tests` project. It also touches a file in `openrct2-win` by making the qualifier explicit which was better than outright removing the redundant ones.