### PR TITLE
Remove redundant static_casts in miscellaneous files

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -515,7 +515,7 @@ namespace OpenRCT2
 
     static void InputWindowResizeContinue(WindowBase& w, const ScreenCoordsXY& screenCoords)
     {
-        if (screenCoords.y < static_cast<int32_t>(ContextGetHeight()) - 2)
+        if (screenCoords.y < (ContextGetHeight() - 2))
         {
             auto differentialCoords = screenCoords - gInputDragLast;
             int32_t targetWidth = _originalWindowWidth + differentialCoords.x - w.width;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -883,29 +883,25 @@ static StringId window_cheats_page_titles[] = {
                 case WIDX_MONTH_UP:
                     _monthSpinnerValue++;
                     _monthSpinnerValue = std::clamp(_monthSpinnerValue, 1, static_cast<int32_t>(MONTH_COUNT));
-                    _daySpinnerValue = std::clamp(
-                        _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
+                    _daySpinnerValue = std::clamp(_daySpinnerValue, 1, Date::GetDaysInMonth(_monthSpinnerValue - 1));
                     invalidateWidget(WIDX_MONTH_BOX);
                     invalidateWidget(WIDX_DAY_BOX);
                     break;
                 case WIDX_MONTH_DOWN:
                     _monthSpinnerValue--;
                     _monthSpinnerValue = std::clamp(_monthSpinnerValue, 1, static_cast<int32_t>(MONTH_COUNT));
-                    _daySpinnerValue = std::clamp(
-                        _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
+                    _daySpinnerValue = std::clamp(_daySpinnerValue, 1, Date::GetDaysInMonth(_monthSpinnerValue - 1));
                     invalidateWidget(WIDX_MONTH_BOX);
                     invalidateWidget(WIDX_DAY_BOX);
                     break;
                 case WIDX_DAY_UP:
                     _daySpinnerValue++;
-                    _daySpinnerValue = std::clamp(
-                        _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
+                    _daySpinnerValue = std::clamp(_daySpinnerValue, 1, Date::GetDaysInMonth(_monthSpinnerValue - 1));
                     invalidateWidget(WIDX_DAY_BOX);
                     break;
                 case WIDX_DAY_DOWN:
                     _daySpinnerValue--;
-                    _daySpinnerValue = std::clamp(
-                        _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
+                    _daySpinnerValue = std::clamp(_daySpinnerValue, 1, Date::GetDaysInMonth(_monthSpinnerValue - 1));
                     invalidateWidget(WIDX_DAY_BOX);
                     break;
                 case WIDX_DATE_SET:

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -564,7 +564,7 @@ namespace OpenRCT2::Ui::Windows
                         auto newLoan = gameState.park.bankLoan - 1000.00_GBP;
                         if (gameState.park.bankLoan > 0)
                         {
-                            newLoan = std::max(static_cast<money64>(0LL), newLoan);
+                            newLoan = std::max(0.00_GBP, newLoan);
                         }
                         auto gameAction = GameActions::ParkSetLoanAction(newLoan);
                         GameActions::Execute(&gameAction, gameState);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2228,7 +2228,7 @@ namespace OpenRCT2::Ui::Windows
         void AdvancedDraw(Drawing::RenderTarget& rt)
         {
             auto ft = Formatter();
-            ft.Add<int32_t>(static_cast<int32_t>(Config::Get().general.autosaveAmount));
+            ft.Add<int32_t>(Config::Get().general.autosaveAmount);
             DrawTextBasic(
                 rt, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
                 STR_WINDOW_COLOUR_2_COMMA32, ft, { colours[1] });

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4174,8 +4174,7 @@ namespace OpenRCT2::Ui::Windows
             auto z = info.Element->GetBaseZ();
             auto direction = info.Element->GetDirection();
             auto gameAction = GameActions::RideSetColourSchemeAction(
-                CoordsXYZD{ info.Loc, z, static_cast<Direction>(direction) }, info.Element->AsTrack()->GetTrackType(),
-                newColourScheme);
+                CoordsXYZD{ info.Loc, z, direction }, info.Element->AsTrack()->GetTrackType(), newColourScheme);
             GameActions::Execute(&gameAction, getGameState());
         }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -331,7 +331,7 @@ namespace OpenRCT2::Ui::Windows
             auto i = static_cast<size_t>(screenCoords.y / kScrollableRowHeight);
             if (i != _highlightedIndex)
             {
-                _highlightedIndex = static_cast<size_t>(i);
+                _highlightedIndex = i;
                 invalidate();
             }
         }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -142,12 +142,12 @@ void SetupInUseSelectionFlags()
     {
         for (auto i = 0u; i < getObjectEntryGroupCount(objectType); i++)
         {
-            Editor::ClearSelectedObject(static_cast<ObjectType>(objectType), i, ObjectSelectionFlags::AllFlags);
+            Editor::ClearSelectedObject(objectType, i, ObjectSelectionFlags::AllFlags);
 
-            auto loadedObj = objectMgr.GetLoadedObject(static_cast<ObjectType>(objectType), i);
+            auto loadedObj = objectMgr.GetLoadedObject(objectType, i);
             if (loadedObj != nullptr)
             {
-                Editor::SetSelectedObject(static_cast<ObjectType>(objectType), i, ObjectSelectionFlags::Selected);
+                Editor::SetSelectedObject(objectType, i, ObjectSelectionFlags::Selected);
             }
         }
     }

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -55,8 +55,7 @@ namespace OpenRCT2::GameActions
         auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
         if (_surfaceStyle != kObjectEntryIndexNull)
         {
-            const auto surfaceObj = static_cast<TerrainSurfaceObject*>(
-                objManager.GetLoadedObject<TerrainSurfaceObject>(_surfaceStyle));
+            const auto surfaceObj = objManager.GetLoadedObject<TerrainSurfaceObject>(_surfaceStyle);
 
             if (surfaceObj == nullptr)
             {

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2348,7 +2348,7 @@ void Guest::SpendMoney(money64& peep_expend_type, money64 amount, ExpenditureTyp
 {
     assert(!(getGameState().park.flags & PARK_FLAGS_NO_MONEY));
 
-    CashInPocket = std::max(0.00_GBP, static_cast<money64>(CashInPocket) - amount);
+    CashInPocket = std::max(0.00_GBP, CashInPocket - amount);
     CashSpent += amount;
 
     peep_expend_type += amount;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1724,8 +1724,7 @@ namespace OpenRCT2
         Viewport* viewport = window->viewport;
         auto viewLoc = screenCoords;
         viewLoc -= viewport->pos;
-        if (viewLoc.x >= 0 && viewLoc.x < static_cast<int32_t>(viewport->width) && viewLoc.y >= 0
-            && viewLoc.y < static_cast<int32_t>(viewport->height))
+        if ((viewLoc.x >= 0) && (viewLoc.x < viewport->width) && (viewLoc.y >= 0) && (viewLoc.y < viewport->height))
         {
             viewLoc.x = viewport->zoom.ApplyTo(viewLoc.x);
             viewLoc.y = viewport->zoom.ApplyTo(viewLoc.y);

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -773,9 +773,7 @@ namespace OpenRCT2::Network
             {
                 const char* bufferStart = static_cast<const char*>(buffer) + totalSent;
                 size_t remainingSize = size - totalSent;
-                int32_t sentBytes = sendto(
-                    _socket, bufferStart, static_cast<int32_t>(remainingSize), FLAG_NO_PIPE, static_cast<const sockaddr*>(ss),
-                    ss_len);
+                int32_t sentBytes = sendto(_socket, bufferStart, static_cast<int32_t>(remainingSize), FLAG_NO_PIPE, ss, ss_len);
                 if (sentBytes == SOCKET_ERROR)
                 {
                     return totalSent;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -592,7 +592,7 @@ namespace OpenRCT2::RCT1
                                 RCT12::EntryList* entries = GetEntryList(objectType);
 
                                 // Check if there are spare entries available
-                                size_t maxEntries = static_cast<size_t>(getObjectEntryGroupCount(objectType));
+                                size_t maxEntries = getObjectEntryGroupCount(objectType);
                                 if (entries != nullptr && entries->GetCount() < maxEntries)
                                 {
                                     entries->GetOrAddEntry(objectName);

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -639,12 +639,12 @@ struct RCT12TileElement : public RCT12TileElementBase
     template<typename TType, RCT12TileElementType TClass>
     const TType* as() const
     {
-        return static_cast<RCT12TileElementType>(GetType()) == TClass ? reinterpret_cast<const TType*>(this) : nullptr;
+        return GetType() == TClass ? reinterpret_cast<const TType*>(this) : nullptr;
     }
     template<typename TType, RCT12TileElementType TClass>
     TType* as()
     {
-        return static_cast<RCT12TileElementType>(GetType()) == TClass ? reinterpret_cast<TType*>(this) : nullptr;
+        return GetType() == TClass ? reinterpret_cast<TType*>(this) : nullptr;
     }
 
     const RCT12SurfaceElement* AsSurface() const

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5641,7 +5641,7 @@ void DetermineRideEntranceAndExitLocations()
                 }
                 else
                 {
-                    station.Entrance.direction = static_cast<uint8_t>(entranceElement->GetDirection());
+                    station.Entrance.direction = entranceElement->GetDirection();
                 }
             }
 
@@ -5656,7 +5656,7 @@ void DetermineRideEntranceAndExitLocations()
                 }
                 else
                 {
-                    station.Exit.direction = static_cast<uint8_t>(entranceElement->GetDirection());
+                    station.Exit.direction = entranceElement->GetDirection();
                 }
             }
 
@@ -5707,8 +5707,7 @@ void DetermineRideEntranceAndExitLocations()
                                 }
 
                                 // Found our entrance
-                                station.Entrance = { x, y, entranceElement->BaseHeight,
-                                                     static_cast<uint8_t>(entranceElement->GetDirection()) };
+                                station.Entrance = { x, y, entranceElement->BaseHeight, entranceElement->GetDirection() };
                                 alreadyFoundEntrance = true;
 
                                 LOG_VERBOSE(
@@ -5726,8 +5725,7 @@ void DetermineRideEntranceAndExitLocations()
                                 }
 
                                 // Found our exit
-                                station.Exit = { x, y, entranceElement->BaseHeight,
-                                                 static_cast<uint8_t>(entranceElement->GetDirection()) };
+                                station.Exit = { x, y, entranceElement->BaseHeight, entranceElement->GetDirection() };
                                 alreadyFoundExit = true;
 
                                 LOG_VERBOSE(

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1641,8 +1641,8 @@ static GameActions::Result TrackDesignPlaceRide(
                 }
 
                 auto trackPlaceAction = GameActions::TrackPlaceAction(
-                    ride.id, trackType, ride.type, { newCoords, tempZ, static_cast<uint8_t>(rotation) },
-                    track.brakeBoosterSpeed, track.colourScheme, track.seatRotation, liftHillAndAlternativeState, true);
+                    ride.id, trackType, ride.type, { newCoords, tempZ, rotation }, track.brakeBoosterSpeed, track.colourScheme,
+                    track.seatRotation, liftHillAndAlternativeState, true);
                 trackPlaceAction.SetFlags(flags);
 
                 auto res = flags.has(CommandFlag::apply) ? GameActions::ExecuteNested(&trackPlaceAction, gameState)

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -283,8 +283,7 @@ static TrackDesignAddStatus TrackDesignSaveAddLargeScenery(const CoordsXY& loc, 
         auto direction = tileElement->GetDirection();
         auto sequence = tileElement->GetSequenceIndex();
 
-        auto sceneryOrigin = MapLargeSceneryGetOrigin(
-            { loc.x, loc.y, z << 3, static_cast<Direction>(direction) }, sequence, nullptr);
+        auto sceneryOrigin = MapLargeSceneryGetOrigin({ loc.x, loc.y, z << 3, direction }, sequence, nullptr);
         if (!sceneryOrigin.has_value())
         {
             return TrackDesignAddStatus::Success();
@@ -298,7 +297,7 @@ static TrackDesignAddStatus TrackDesignSaveAddLargeScenery(const CoordsXY& loc, 
 
             CoordsXYZ tileLoc = { sceneryOrigin->x + rotatedOffsetPos.x, sceneryOrigin->y + rotatedOffsetPos.y,
                                   sceneryOrigin->z + tile.offset.z };
-            auto largeElement = MapGetLargeScenerySegment({ tileLoc, static_cast<Direction>(direction) }, tile.index);
+            auto largeElement = MapGetLargeScenerySegment({ tileLoc, direction }, tile.index);
             if (largeElement != nullptr)
             {
                 if (tile.index == 0)
@@ -499,8 +498,7 @@ static void TrackDesignSaveRemoveLargeScenery(const CoordsXY& loc, LargeSceneryE
         auto direction = tileElement->GetDirection();
         auto sequence = tileElement->GetSequenceIndex();
 
-        auto sceneryOrigin = MapLargeSceneryGetOrigin(
-            { loc.x, loc.y, z << 3, static_cast<Direction>(direction) }, sequence, nullptr);
+        auto sceneryOrigin = MapLargeSceneryGetOrigin({ loc.x, loc.y, z << 3, direction }, sequence, nullptr);
         if (!sceneryOrigin)
         {
             return;
@@ -514,7 +512,7 @@ static void TrackDesignSaveRemoveLargeScenery(const CoordsXY& loc, LargeSceneryE
 
             CoordsXYZ tileLoc = { sceneryOrigin->x + rotatedOffsetPos.x, sceneryOrigin->y + rotatedOffsetPos.y,
                                   sceneryOrigin->z + tile.offset.z };
-            auto largeElement = MapGetLargeScenerySegment({ tileLoc, static_cast<Direction>(direction) }, tile.index);
+            auto largeElement = MapGetLargeScenerySegment({ tileLoc, direction }, tile.index);
             if (largeElement != nullptr)
             {
                 if (tile.index == 0)


### PR DESCRIPTION
This removes a few `static_cast`s where the types already matched.

(Yes these were verified manually, I am aware it could cause a lot of false positives and did not just blindly apply it to the whole solution)