### PR TITLE
Include string_view in ObjectManager.h

### DIFF
--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -15,6 +15,7 @@
 #include "ObjectTypes.h"
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 namespace OpenRCT2


### PR DESCRIPTION
`c:\Files\OpenRCT2\src\openrct2\object\ObjectManager.h(42,65): error C2039: 'string_view': is not a member of 'std' [c:\Files\OpenRCT2\src\openrct2\libopenrct2.vcxproj]`

MSVC needs this one.