### PR TITLE
Remove Drawing.h include from a few more places

### DIFF
--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -15,6 +15,7 @@
 
     #include <openrct2/drawing/Drawing.h>
     #include <openrct2/drawing/Rectangle.h>
+    #include <openrct2/drawing/RenderTarget.h>
     #include <openrct2/scripting/Duktape.hpp>
 
 using namespace OpenRCT2::Drawing;

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -39,6 +39,7 @@
 #include "core/Path.hpp"
 #include "core/String.hpp"
 #include "core/Timer.hpp"
+#include "drawing/Drawing.h"
 #include "drawing/IDrawingEngine.h"
 #include "drawing/Image.h"
 #include "drawing/LightFX.h"

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -16,6 +16,7 @@
 #include "../core/String.hpp"
 #include "../core/UTF8.h"
 #include "../core/UnicodeChar.h"
+#include "../drawing/Drawing.h"
 #include "../drawing/IDrawingContext.h"
 #include "../drawing/IDrawingEngine.h"
 #include "../drawing/Text.h"

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -9,14 +9,18 @@
 
 #pragma once
 
-#include "Drawing.h"
+#include "../world/Location.hpp"
+#include "FilterPaletteIds.h"
+#include "PaletteIndex.h"
 #include "TTF.h"
 
+struct PaletteMap;
 struct TextDrawInfo;
 
 namespace OpenRCT2::Drawing
 {
     struct IDrawingEngine;
+    struct RenderTarget;
 
     struct IDrawingContext
     {

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -12,6 +12,7 @@
 #include "IDrawingContext.h"
 #include "IDrawingEngine.h"
 #include "InvalidationGrid.h"
+#include "RenderTarget.h"
 
 #include <memory>
 

--- a/src/openrct2/scenes/preloader/PreloaderScene.h
+++ b/src/openrct2/scenes/preloader/PreloaderScene.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "../../core/JobPool.h"
-#include "../../drawing/Drawing.h"
 #include "../Scene.h"
 
 namespace OpenRCT2


### PR DESCRIPTION
This remove `Drawing.h` includes from a few more places, notably `IDrawingContext.h`. Not that impactful this time, but still.