### PR TITLE
Remove redundant namespace qualifiers from /paint directory

### DIFF
--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -106,7 +106,7 @@ static bool ShouldShowFPS()
     if (gLegacyScene == LegacyScene::titleSequence)
         return true;
 
-    auto* windowMgr = Ui::GetWindowManager();
+    auto* windowMgr = GetWindowManager();
     return windowMgr->FindByClass(WindowClass::topToolbar);
 }
 
@@ -188,7 +188,7 @@ PaintSession* Painter::CreateSession(RenderTarget& rt, uint32_t viewFlags, uint8
     session->CurrentlyDrawnEntity = nullptr;
     session->CurrentlyDrawnTileElement = nullptr;
     session->Surface = nullptr;
-    session->SelectedElement = OpenRCT2::TileInspector::GetSelectedElement();
+    session->SelectedElement = TileInspector::GetSelectedElement();
     session->InteractionType = ViewportInteractionItem::none;
     session->PathElementOnSameHeight = nullptr;
     session->TrackElementOnSameHeight = nullptr;

--- a/src/openrct2/paint/support/WoodenSupports.cpp
+++ b/src/openrct2/paint/support/WoodenSupports.cpp
@@ -655,10 +655,10 @@ bool PathBoxSupportsPaintSetup(
 }
 
 bool DrawSupportForSequenceA(
-    PaintSession& session, const WoodenSupportType supportType, const OpenRCT2::TrackElemType trackType, const uint8_t sequence,
+    PaintSession& session, const WoodenSupportType supportType, const TrackElemType trackType, const uint8_t sequence,
     const Direction direction, const int32_t height, const ImageId imageTemplate)
 {
-    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackType);
+    const auto& ted = TrackMetaData::GetTrackElementDescriptor(trackType);
     const auto& sequenceDesc = ted.sequences[sequence];
     const auto& desc = sequenceDesc.woodenSupports;
 
@@ -672,10 +672,10 @@ bool DrawSupportForSequenceA(
 }
 
 bool DrawSupportForSequenceB(
-    PaintSession& session, const WoodenSupportType supportType, const OpenRCT2::TrackElemType trackType, const uint8_t sequence,
+    PaintSession& session, const WoodenSupportType supportType, const TrackElemType trackType, const uint8_t sequence,
     const Direction direction, const int32_t height, const ImageId imageTemplate)
 {
-    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackType);
+    const auto& ted = TrackMetaData::GetTrackElementDescriptor(trackType);
     const auto& sequenceDesc = ted.sequences[sequence];
     const auto& desc = sequenceDesc.woodenSupports;
 

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -51,7 +51,7 @@ static void PaintBannerScrollingText(
         return;
 
     auto scrollingMode = bannerEntry.scrolling_mode + (direction & 3);
-    if (scrollingMode >= Drawing::ScrollingText::kMaxModes)
+    if (scrollingMode >= ScrollingText::kMaxModes)
     {
         return;
     }
@@ -66,12 +66,12 @@ static void PaintBannerScrollingText(
     }
     else
     {
-        OpenRCT2::FormatStringLegacy(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        FormatStringLegacy(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::tiny);
     auto scroll = stringWidth > 0 ? (getGameState().currentTicks / 2) % stringWidth : 0;
-    auto imageId = Drawing::ScrollingText::setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, PaletteIndex::pi0);
+    auto imageId = ScrollingText::setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, PaletteIndex::pi0);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 22 }, { bbOffset, { 1, 1, 21 } });
 }
 

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -80,8 +80,7 @@ static void PaintRideEntranceExitScrollingText(
     auto scroll = stringWidth > 0 ? (getGameState().currentTicks / 2) % stringWidth : 0;
 
     PaintAddImageAsChild(
-        session,
-        Drawing::ScrollingText::setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, stationObj.ScrollingMode, PaletteIndex::pi0),
+        session, ScrollingText::setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, stationObj.ScrollingMode, PaletteIndex::pi0),
         { 0, 0, height + stationObj.Height }, { { 2, 2, height + stationObj.Height }, { 28, 28, 51 } });
 }
 
@@ -261,7 +260,7 @@ static void PaintParkEntranceScrollingText(
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::tiny);
     auto scroll = stringWidth > 0 ? (gameState.currentTicks / 2) % stringWidth : 0;
-    auto imageIndex = Drawing::ScrollingText::setup(
+    auto imageIndex = ScrollingText::setup(
         session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode + direction / 2, PaletteIndex::pi0);
     auto textHeight = height + entrance.GetTextHeight();
     PaintAddImageAsChild(session, imageIndex, { 0, 0, textHeight }, { { 2, 2, textHeight }, { 28, 28, 47 } });

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -36,7 +36,6 @@
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
-using namespace OpenRCT2::Numerics;
 
 // clang-format off
 static constexpr BoundBoxXY LargeSceneryBoundBoxes[] = {
@@ -80,7 +79,7 @@ static void PaintLargeScenerySupports(
     WoodenBSupportsPaintSetupRotated(
         session, WoodenSupportType::truss, WoodenSupportSubType::neSw, direction, supportHeight, imageTemplate, transitionType);
 
-    int32_t clearanceHeight = ceil2(tileElement.GetClearanceZ() + 15, 16);
+    int32_t clearanceHeight = Numerics::ceil2(tileElement.GetClearanceZ() + 15, 16);
     if (tile.allowSupportsAbove)
     {
         PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, clearanceHeight, 0x20);
@@ -221,7 +220,7 @@ static void PaintLargeScenery3DText(
     char signString[256];
     auto ft = Formatter();
     banner->formatTextTo(ft);
-    OpenRCT2::FormatStringLegacy(signString, sizeof(signString), STR_STRINGID, ft.Data());
+    FormatStringLegacy(signString, sizeof(signString), STR_STRINGID, ft.Data());
 
     auto offsetY = text->offset[(direction & 1)].y * 2;
     if (text->flags & LARGE_SCENERY_TEXT_FLAG_VERTICAL)
@@ -326,13 +325,13 @@ static void PaintLargeSceneryScrollingText(
     }
     else
     {
-        OpenRCT2::FormatStringLegacy(text, sizeof(text), STR_SCROLLING_SIGN_TEXT, ft.Data());
+        FormatStringLegacy(text, sizeof(text), STR_SCROLLING_SIGN_TEXT, ft.Data());
     }
 
     auto scrollMode = sceneryEntry.scrolling_mode + ((direction + 1) & 3);
     auto stringWidth = GfxGetStringWidth(text, FontStyle::tiny);
     auto scroll = stringWidth > 0 ? (getGameState().currentTicks / 2) % stringWidth : 0;
-    auto imageId = Drawing::ScrollingText::setup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollMode, textPaletteIndex);
+    auto imageId = ScrollingText::setup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollMode, textPaletteIndex);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 25 }, { bbOffset, { 1, 1, 21 } });
 }
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -181,8 +181,7 @@ static void PathPaintQueueBanner(
         uint16_t scroll = stringWidth > 0 ? (getGameState().currentTicks / 2) % stringWidth : 0;
 
         PaintAddImageAsChild(
-            session,
-            Drawing::ScrollingText::setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, PaletteIndex::pi0),
+            session, ScrollingText::setup(session, STR_BANNER_TEXT_FORMAT, ft, scroll, scrollingMode, PaletteIndex::pi0),
             { 0, 0, height + 7 }, { boundBoxOffsets, { 1, 1, 21 } });
     }
 

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -164,7 +164,7 @@ static void PaintWallScrollingText(
         return;
 
     scrollingMode = wallEntry.scrolling_mode + ((direction + 1) & 3);
-    if (scrollingMode >= Drawing::ScrollingText::kMaxModes)
+    if (scrollingMode >= ScrollingText::kMaxModes)
         return;
 
     auto banner = wallElement.GetBanner();
@@ -183,12 +183,12 @@ static void PaintWallScrollingText(
     }
     else
     {
-        OpenRCT2::FormatStringLegacy(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
+        FormatStringLegacy(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
     }
 
     auto stringWidth = GfxGetStringWidth(signString, FontStyle::tiny);
     auto scroll = stringWidth > 0 ? (getGameState().currentTicks / 2) % stringWidth : 0;
-    auto imageId = Drawing::ScrollingText::setup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollingMode, textPaletteIndex);
+    auto imageId = ScrollingText::setup(session, STR_SCROLLING_SIGN_TEXT, ft, scroll, scrollingMode, textPaletteIndex);
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 8 }, { boundsOffset, { 1, 1, 13 } });
 }
 

--- a/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
@@ -20,8 +20,6 @@
 #include "../../track/Segment.h"
 #include "../../track/Support.h"
 
-using namespace OpenRCT2;
-
 static constexpr TunnelGroup kTunnelGroup = TunnelGroup::Standard;
 
 namespace OpenRCT2::AlpineRC

--- a/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
@@ -20,8 +20,6 @@
 #include "../../track/Segment.h"
 #include "../../track/Support.h"
 
-using namespace OpenRCT2;
-
 static constexpr TunnelGroup kTunnelGroup = TunnelGroup::Standard;
 
 namespace OpenRCT2::SingleRailRC

--- a/src/openrct2/paint/track/transport/Chairlift.cpp
+++ b/src/openrct2/paint/track/transport/Chairlift.cpp
@@ -150,7 +150,7 @@ static const TrackElement* ChairliftPaintUtilMapGetTrackElementAtFromRideFuzzy(
 };
 
 static bool ChairliftPaintUtilIsFirstTrack(
-    const Ride& ride, const TrackElement& trackElement, const CoordsXY& pos, OpenRCT2::TrackElemType trackType)
+    const Ride& ride, const TrackElement& trackElement, const CoordsXY& pos, TrackElemType trackType)
 {
     if (trackElement.GetTrackType() != TrackElemType::beginStation)
     {
@@ -170,7 +170,7 @@ static bool ChairliftPaintUtilIsFirstTrack(
 }
 
 static bool ChairliftPaintUtilIsLastTrack(
-    const Ride& ride, const TrackElement& trackElement, const CoordsXY& pos, OpenRCT2::TrackElemType trackType)
+    const Ride& ride, const TrackElement& trackElement, const CoordsXY& pos, TrackElemType trackType)
 {
     if (trackElement.GetTrackType() != TrackElemType::endStation)
     {
@@ -662,7 +662,7 @@ static void ChairliftPaintRightQuarterTurn1Tile(
 }
 
 /* 0x008AAA0C */
-TrackPaintFunction GetTrackPaintFunctionChairlift(OpenRCT2::TrackElemType trackType)
+TrackPaintFunction GetTrackPaintFunctionChairlift(TrackElemType trackType)
 {
     switch (trackType)
     {

--- a/src/openrct2/paint/vehicle/Vehicle.LaunchedFreefall.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.LaunchedFreefall.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2
             {
                 baseImage_id += 2; // Draw peeps sitting without transparent area between them for restraints
             }
-            auto directionOffset = OpenRCT2::Entity::Yaw::YawTo4(imageDirection);
+            auto directionOffset = Entity::Yaw::YawTo4(imageDirection);
             image_id = ImageId(
                 baseImage_id + (((directionOffset + 0) & 3) * 3), vehicle->peep_tshirt_colours[0],
                 vehicle->peep_tshirt_colours[1]);

--- a/src/openrct2/paint/vehicle/Vehicle.MiniGolf.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.MiniGolf.cpp
@@ -123,7 +123,7 @@ namespace OpenRCT2
             return;
 
         uint8_t frame = MiniGolfPeepAnimationFrames[EnumValue(vehicle->mini_golf_current_animation)][vehicle->animation_frame];
-        uint32_t ebx = (frame << 2) + OpenRCT2::Entity::Yaw::YawTo4(imageDirection);
+        uint32_t ebx = (frame << 2) + Entity::Yaw::YawTo4(imageDirection);
 
         ImageIndex index = rideEntry->Cars[0].base_image_id + 1 + ebx;
         auto image = ImageId(index, peep->TshirtColour, peep->TrousersColour);

--- a/src/openrct2/paint/vehicle/Vehicle.RiverRapids.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.RiverRapids.cpp
@@ -32,7 +32,7 @@ namespace OpenRCT2
         PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
         const CarEntry* carEntry)
     {
-        imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
+        imageDirection = Entity::Yaw::YawTo32(imageDirection);
 
         ImageId image_id;
         int32_t baseImage_id = imageDirection;

--- a/src/openrct2/paint/vehicle/Vehicle.RotoDrop.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.RotoDrop.cpp
@@ -25,7 +25,7 @@ namespace OpenRCT2
         PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
         const CarEntry* carEntry)
     {
-        imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
+        imageDirection = Entity::Yaw::YawTo32(imageDirection);
 
         auto imageFlags = ImageId(0, vehicle->colours.Body, vehicle->colours.Trim);
         if (vehicle->IsGhost())

--- a/src/openrct2/paint/vehicle/Vehicle.SplashBoats.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.SplashBoats.cpp
@@ -38,8 +38,7 @@ namespace OpenRCT2
         }
 
         session.CurrentlyDrawnEntity = vehicleToPaint;
-        imageDirection = OpenRCT2::Entity::Yaw::Add(
-            OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->Orientation);
+        imageDirection = Entity::Yaw::Add(Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->Orientation);
         session.SpritePosition.x = vehicleToPaint->x;
         session.SpritePosition.y = vehicleToPaint->y;
         vehicleToPaint->Paint(session, imageDirection);

--- a/src/openrct2/paint/vehicle/Vehicle.Submarine.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.Submarine.cpp
@@ -55,7 +55,7 @@ namespace OpenRCT2
             imageId1 = ImageId(baseImageId + 1).WithRemap(Drawing::FilterPaletteID::paletteGhost);
         }
 
-        const auto& bb = VehicleBoundboxes[carEntry->draw_order][OpenRCT2::Entity::Yaw::YawTo16(imageDirection)];
+        const auto& bb = VehicleBoundboxes[carEntry->draw_order][Entity::Yaw::YawTo16(imageDirection)];
         PaintAddImageAsParent(
             session, imageId0, { 0, 0, z },
             { { bb.offset_x, bb.offset_y, bb.offset_z + z }, { bb.length_x, bb.length_y, bb.length_z } });

--- a/src/openrct2/paint/vehicle/Vehicle.VirginiaReel.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.VirginiaReel.cpp
@@ -32,7 +32,7 @@ namespace OpenRCT2
         PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
         const CarEntry* carEntry)
     {
-        imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
+        imageDirection = Entity::Yaw::YawTo32(imageDirection);
         const uint8_t rotation = session.CurrentRotation;
         int32_t ecx = ((vehicle->spin_sprite / 8) + (rotation * 8)) & 31;
         int32_t baseImage_id = [&] {

--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -4700,8 +4700,7 @@ void VehicleVisualDefault(
         if (vehicle->HasFlag(VehicleFlags::CarIsReversed))
         {
             auto imagePitch = PitchInvertTable[EnumValue(vehicle->pitch)];
-            auto imageYaw = (imageDirection + (OpenRCT2::Entity::Yaw::kBaseRotation / 2))
-                & (OpenRCT2::Entity::Yaw::kBaseRotation - 1);
+            auto imageYaw = (imageDirection + (kBaseRotation / 2)) & (kBaseRotation - 1);
             PaintFunctionsByPitch[EnumValue(imagePitch)](session, vehicle, imageYaw, z, carEntry, kBoundBoxIndexUndefined);
         }
         else


### PR DESCRIPTION
Some notes:
- The files in the `/vehicle` subdirectory are already in the OpenRCT2 namespace so the qualifier is redundant.
- The files in the `/tile_element` subdirectory have `using namespace OpenRCT2` and `using namespace OpenRCT2::Drawing`, so those qualifiers become redundant (there was one stand out file that also had `using namespace OpenRCT2::Numerics` for a single function so I removed that).
- This also cleans up `Chairlift.cpp`, `AlpineCoaster.cpp` and `SingleRailRollerCoaster.cpp` which I forgot to do in a previous PR.