### PR TITLE
Fix PaletteIndex asserts

### DIFF
--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -62,8 +62,8 @@ PaletteIndex PaletteMap::Blend(PaletteIndex src, PaletteIndex dst) const
 {
 #ifdef _DEBUG
     // src = 0 would be transparent so there is no blend palette for that, hence (src - 1)
-    assert(src != 0 && (src - 1) < _numMaps);
-    assert(dst < _mapLength);
+    assert(EnumValue(src) != 0 && (EnumValue(src) - 1) < _numMaps);
+    assert(EnumValue(dst) < _mapLength);
 #endif
     auto idx = ((EnumValue(src) - 1) * 256) + EnumValue(dst);
     return _data[idx];

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -62,7 +62,7 @@ PaletteIndex PaletteMap::Blend(PaletteIndex src, PaletteIndex dst) const
 {
 #ifdef _DEBUG
     // src = 0 would be transparent so there is no blend palette for that, hence (src - 1)
-    assert(EnumValue(src) != 0 && (EnumValue(src) - 1) < _numMaps);
+    assert(src != PaletteIndex::pi0 && (EnumValue(src) - 1) < _numMaps);
     assert(EnumValue(dst) < _mapLength);
 #endif
     auto idx = ((EnumValue(src) - 1) * 256) + EnumValue(dst);


### PR DESCRIPTION
Since it is now an enum class, I was getting compilation errors for the use of operators like `!=` and `-`