### PR TITLE
Untangle metal support repositioning

### DIFF
--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -115,75 +115,75 @@ using RepositionAttempt = std::array<RepositionRow, kNumMetalSupportPlaces>;
 
 static constexpr RepositionAttempt kMetalSupportSegmentOffsets0 = {
     {
-        { { MetalSupportPlace::topLeftSide, 2 } },
-        { { MetalSupportPlace::bottomLeftSide, 1 } },
-        { { MetalSupportPlace::topRightSide, 3 } },
-        { { MetalSupportPlace::bottomRightSide, 0 } },
-        { 
-            { MetalSupportPlace::topLeftSide, 3 }, 
-            { MetalSupportPlace::topRightSide, 0 }, 
-            { MetalSupportPlace::bottomRightSide, 1 }, 
-            { MetalSupportPlace::bottomLeftSide, 2 } 
-        },
-        { { MetalSupportPlace::leftCorner, 2 } },
-        { { MetalSupportPlace::topCorner, 3 } },
-        { { MetalSupportPlace::bottomCorner, 1 } },
-        { { MetalSupportPlace::rightCorner, 0 } },
+         { { MetalSupportPlace::topLeftSide, 2 } },     /* topCorner          */
+         { { MetalSupportPlace::bottomLeftSide, 1 } },  /* leftCorner         */
+         { { MetalSupportPlace::topRightSide, 3 } },    /* rightCorner        */
+         { { MetalSupportPlace::bottomRightSide, 0 } }, /* bottomCorner       */
+         {                                               
+             { MetalSupportPlace::topLeftSide, 3 },            /* centre, rotation 0 */
+             { MetalSupportPlace::topRightSide, 0 },           /* centre, rotation 1 */
+             { MetalSupportPlace::bottomRightSide, 1 },        /* centre, rotation 2 */
+             { MetalSupportPlace::bottomLeftSide, 2 }          /* centre, rotation 3 */
+         },                                             
+         { { MetalSupportPlace::leftCorner, 2 } },      /* topLeftSide        */
+         { { MetalSupportPlace::topCorner, 3 } },       /* topRightSide       */
+         { { MetalSupportPlace::bottomCorner, 1 } },    /* bottomLeftSide     */
+         { { MetalSupportPlace::rightCorner, 0 } },     /* bottomRightSide    */
     }
 };
 
 static constexpr RepositionAttempt kMetalSupportSegmentOffsets1 = {
 {
-        { { MetalSupportPlace::topRightSide, 1 } },
-        { { MetalSupportPlace::topLeftSide, 0 } },
-        { { MetalSupportPlace::bottomRightSide, 2 } },
-        { { MetalSupportPlace::bottomLeftSide, 3 } },
-        { 
-            { MetalSupportPlace::topRightSide, 0 }, 
-            { MetalSupportPlace::bottomRightSide, 1}, 
-            { MetalSupportPlace::bottomLeftSide, 2}, 
-            { MetalSupportPlace::topLeftSide, 3 } 
-        },
-        { { MetalSupportPlace::topCorner, 0 } },
-        { { MetalSupportPlace::rightCorner, 1 } },
-        { { MetalSupportPlace::leftCorner, 3 } },
-        { { MetalSupportPlace::bottomCorner, 2 } },
+         { { MetalSupportPlace::topRightSide, 1 } },    /* topCorner          */
+         { { MetalSupportPlace::topLeftSide, 0 } },     /* leftCorner         */
+         { { MetalSupportPlace::bottomRightSide, 2 } }, /* rightCorner        */
+         { { MetalSupportPlace::bottomLeftSide, 3 } },  /* bottomCorner       */
+         { 
+             { MetalSupportPlace::topRightSide, 0 },           /* centre, rotation 0 */
+             { MetalSupportPlace::bottomRightSide, 1},         /* centre, rotation 1 */
+             { MetalSupportPlace::bottomLeftSide, 2},          /* centre, rotation 2 */
+             { MetalSupportPlace::topLeftSide, 3 }             /* centre, rotation 3 */
+         },
+         { { MetalSupportPlace::topCorner, 0 } },       /* topLeftSide        */
+         { { MetalSupportPlace::rightCorner, 1 } },     /* topRightSide       */
+         { { MetalSupportPlace::leftCorner, 3 } },      /* bottomLeftSide     */
+         { { MetalSupportPlace::bottomCorner, 2 } },    /* bottomRightSide    */
     }
 };
 static constexpr RepositionAttempt kMetalSupportSegmentOffsets2 = {
     {
-        { { MetalSupportPlace::leftCorner, 6 } },
-        { { MetalSupportPlace::bottomCorner, 5 } },
-        { { MetalSupportPlace::topCorner, 7 } },
-        { { MetalSupportPlace::rightCorner, 4 } },
-        { 
-            { MetalSupportPlace::bottomRightSide, 1 }, 
-            { MetalSupportPlace::bottomLeftSide, 2 }, 
-            { MetalSupportPlace::topLeftSide, 3 }, 
-            { MetalSupportPlace::topRightSide, 0 } 
-        },
-        { { MetalSupportPlace::centre, 1 } }, 
-        { { MetalSupportPlace::centre, 2 } }, 
-        { { MetalSupportPlace::centre, 0 } }, 
-        { { MetalSupportPlace::centre, 3 } }, 
+         { { MetalSupportPlace::leftCorner, 6 } },      /* topCorner          */ 
+         { { MetalSupportPlace::bottomCorner, 5 } },    /* leftCorner         */
+         { { MetalSupportPlace::topCorner, 7 } },       /* rightCorner        */
+         { { MetalSupportPlace::rightCorner, 4 } },     /* bottomCorner       */
+         {                                               
+             { MetalSupportPlace::bottomRightSide, 1 },        /* centre, rotation 0 */ 
+             { MetalSupportPlace::bottomLeftSide, 2 },         /* centre, rotation 1 */
+             { MetalSupportPlace::topLeftSide, 3 },            /* centre, rotation 2 */
+             { MetalSupportPlace::topRightSide, 0 }            /* centre, rotation 3 */
+         },                                             
+         { { MetalSupportPlace::centre, 1 } },          /* topLeftSide        */
+         { { MetalSupportPlace::centre, 2 } },          /* topRightSide       */
+         { { MetalSupportPlace::centre, 0 } },          /* bottomLeftSide     */
+         { { MetalSupportPlace::centre, 3 } },          /* bottomRightSide    */
     }
 };
 static constexpr RepositionAttempt kMetalSupportSegmentOffsets3 = {
     {
-        { { MetalSupportPlace::rightCorner, 5 } }, 
-        { { MetalSupportPlace::topCorner, 4 } }, 
-        { { MetalSupportPlace::bottomCorner, 6 } }, 
-        { { MetalSupportPlace::leftCorner, 7 } }, 
-        { 
-            { MetalSupportPlace::bottomLeftSide, 2 },
-            { MetalSupportPlace::topLeftSide, 3 }, 
-            { MetalSupportPlace::topRightSide, 0 }, 
-            { MetalSupportPlace::bottomRightSide, 1 } 
-        },
-        { { MetalSupportPlace::bottomRightSide, 5 } },
-        { { MetalSupportPlace::bottomLeftSide, 6 } },
-        { { MetalSupportPlace::topRightSide, 4 } },
-        { { MetalSupportPlace::topLeftSide, 7 } },
+         { { MetalSupportPlace::rightCorner, 5 } },     /* topCorner          */
+         { { MetalSupportPlace::topCorner, 4 } },       /* leftCorner         */
+         { { MetalSupportPlace::bottomCorner, 6 } },    /* rightCorner        */
+         { { MetalSupportPlace::leftCorner, 7 } },      /* bottomCorner       */
+         {                                               
+             { MetalSupportPlace::bottomLeftSide, 2 },         /* centre, rotation 0 */
+             { MetalSupportPlace::topLeftSide, 3 },            /* centre, rotation 1 */
+             { MetalSupportPlace::topRightSide, 0 },           /* centre, rotation 2 */
+             { MetalSupportPlace::bottomRightSide, 1 }         /* centre, rotation 3 */
+         },                                             
+         { { MetalSupportPlace::bottomRightSide, 5 } }, /* topLeftSide        */
+         { { MetalSupportPlace::bottomLeftSide, 6 } },  /* topRightSide       */
+         { { MetalSupportPlace::topRightSide, 4 } },    /* bottomLeftSide     */
+         { { MetalSupportPlace::topLeftSide, 7 } },     /* bottomRightSide    */
     }
 };
 

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -87,8 +87,7 @@ static constexpr CoordsXY kMetalSupportBoundBoxOffsets[] = {
     { 16, 28 },
 };
 
-/** rct2: 0x0097AF32 */
-static constexpr uint8_t kMetalSupportSegmentOffsets[] = {
+static constexpr std::array<uint8_t, kMetalSupportSkip> kMetalSupportSegmentOffsets0 = {
     5, 2, 5, 2, 5, 2, 5, 2,
     7, 1, 7, 1, 7, 1, 7, 1,
     6, 3, 6, 3, 6, 3, 6, 3,
@@ -98,7 +97,8 @@ static constexpr uint8_t kMetalSupportSegmentOffsets[] = {
     0, 3, 0, 3, 0, 3, 0, 3,
     3, 1, 3, 1, 3, 1, 3, 1,
     2, 0, 2, 0, 2, 0, 2, 0,
-
+};
+static constexpr std::array<uint8_t, kMetalSupportSkip> kMetalSupportSegmentOffsets1 = {
     6, 1, 6, 1, 6, 1, 6, 1,
     5, 0, 5, 0, 5, 0, 5, 0,
     8, 2, 8, 2, 8, 2, 8, 2,
@@ -108,7 +108,8 @@ static constexpr uint8_t kMetalSupportSegmentOffsets[] = {
     2, 1, 2, 1, 2, 1, 2, 1,
     1, 3, 1, 3, 1, 3, 1, 3,
     3, 2, 3, 2, 3, 2, 3, 2,
-
+};
+static constexpr std::array<uint8_t, kMetalSupportSkip> kMetalSupportSegmentOffsets2 = {
     1, 6, 1, 6, 1, 6, 1, 6,
     3, 5, 3, 5, 3, 5, 3, 5,
     0, 7, 0, 7, 0, 7, 0, 7,
@@ -118,7 +119,8 @@ static constexpr uint8_t kMetalSupportSegmentOffsets[] = {
     4, 2, 4, 2, 4, 2, 4, 2,
     4, 0, 4, 0, 4, 0, 4, 0,
     4, 3, 4, 3, 4, 3, 4, 3,
-
+};
+static constexpr std::array<uint8_t, kMetalSupportSkip> kMetalSupportSegmentOffsets3 = {
     2, 5, 2, 5, 2, 5, 2, 5,
     0, 4, 0, 4, 0, 4, 0, 4,
     3, 6, 3, 6, 3, 6, 3, 6,
@@ -128,6 +130,14 @@ static constexpr uint8_t kMetalSupportSegmentOffsets[] = {
     7, 6, 7, 6, 7, 6, 7, 6,
     6, 4, 6, 4, 6, 4, 6, 4,
     5, 7, 5, 7, 5, 7, 5, 7,
+};
+
+/** rct2: 0x0097AF32 */
+static constexpr std::array<std::array<uint8_t, kMetalSupportSkip>, 4> kMetalSupportSegmentOffsets = {
+    kMetalSupportSegmentOffsets0,
+    kMetalSupportSegmentOffsets1,
+    kMetalSupportSegmentOffsets2,
+    kMetalSupportSegmentOffsets3,
 };
 
 /** rct2: 0x0097B052, 0x0097B053 */
@@ -325,28 +335,18 @@ static bool MetalSupportsPaintSetupCommon(
             return false;
 
         uint16_t baseIndex = session.CurrentRotation * 2;
-        uint8_t newSegment = kMetalSupportSegmentOffsets[baseIndex + segment * 8];
-        if (currentHeight <= supportSegments[newSegment].height)
+        uint8_t attempt = 0;
+        uint8_t newSegment = 0;
+        for (; attempt < kMetalSupportSegmentOffsets.size(); attempt++)
         {
-            baseIndex += kMetalSupportSkip;
-            newSegment = kMetalSupportSegmentOffsets[baseIndex + segment * 8];
-            if (currentHeight <= supportSegments[newSegment].height)
-            {
-                baseIndex += kMetalSupportSkip;
-                newSegment = kMetalSupportSegmentOffsets[baseIndex + segment * 8];
-                if (currentHeight <= supportSegments[newSegment].height)
-                {
-                    baseIndex += kMetalSupportSkip;
-                    newSegment = kMetalSupportSegmentOffsets[baseIndex + segment * 8];
-                    if (currentHeight <= supportSegments[newSegment].height)
-                    {
-                        return false;
-                    }
-                }
-            }
-        }
+            newSegment = kMetalSupportSegmentOffsets[attempt][baseIndex + segment * 8];
+            if (currentHeight > supportSegments[newSegment].height)
+                break;
 
-        const uint8_t crossBeamIndex = kMetalSupportSegmentOffsets[baseIndex + segment * 8 + 1];
+            if (attempt == kMetalSupportSegmentOffsets.size() - 1)
+                return false;
+        }
+        const uint8_t crossBeamIndex = kMetalSupportSegmentOffsets[attempt][baseIndex + segment * 8 + 1];
         if constexpr (typeB)
         {
             if (crossBeamIndex >= kMetalSupportCrossbeamTwoSegmentOffsetIndex)


### PR DESCRIPTION
The old table was enormous, as it contained data for both the placement and the crossbeam index, per direction, per preferred placement, per attempt.

@mixiate or @spacek531 Could one of you verify this branch renders exactly the same as `develop` does?