### PR TITLE
Fix news window option tab not invalidating

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
+- Fix: [#25799] The animated options tab icon of the news window does not always redraw.
 
 0.4.30 (2026-01-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -347,13 +347,8 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onUpdate() override
+        void onUpdateNews()
         {
-            currentFrame++;
-
-            if (page != newsTab)
-                return;
-
             if (_pressedNewsItemIndex == -1 || --_suspendUpdateTicks != 0)
             {
                 return;
@@ -389,6 +384,25 @@ namespace OpenRCT2::Ui::Windows
                 {
                     WindowScrollToLocation(*_mainWindow, subjectLoc.value());
                 }
+            }
+        }
+
+        void onUpdateOptions()
+        {
+            currentFrame++;
+            invalidateWidget(WIDX_TAB_OPTIONS);
+        }
+
+        void onUpdate() override
+        {
+            switch (page)
+            {
+                case newsTab:
+                    onUpdateNews();
+                    break;
+                case optionsTab:
+                    onUpdateOptions();
+                    break;
             }
         }
 


### PR DESCRIPTION
Fixes the news window options tab icon not invalidating.
In order to fix this it separates `onUpdate` in to `onUpdateNews` and `onUpdateOptions`, in line with what other tabbed windows do.


https://github.com/user-attachments/assets/472bb7ae-829f-4580-825f-914f99b3d241


https://github.com/user-attachments/assets/27a9d69d-4012-4769-a73a-391b7a79f6a1