### PR TITLE
Remove redundant namespace qualifiers from Vehicle.cpp

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -63,7 +63,6 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 using namespace OpenRCT2::TrackMetaData;
-using namespace OpenRCT2::Math::Trigonometry;
 using namespace OpenRCT2::RideVehicle;
 static bool vehicle_boat_is_location_accessible(const CoordsXYZ& location);
 
@@ -89,18 +88,15 @@ uint8_t _vehicleF64E2C;
 Vehicle* _vehicleFrontVehicle;
 CoordsXYZ _vehicleCurPosition;
 
-static constexpr OpenRCT2::Audio::SoundId _screamSetMisc[] = {
-    OpenRCT2::Audio::SoundId::scream8,
-    OpenRCT2::Audio::SoundId::scream1,
+static constexpr SoundId _screamSetMisc[] = {
+    SoundId::scream8, SoundId::scream1,
 };
-static constexpr OpenRCT2::Audio::SoundId _screamSetWooden[] = {
-    OpenRCT2::Audio::SoundId::scream3, OpenRCT2::Audio::SoundId::scream1, OpenRCT2::Audio::SoundId::scream5,
-    OpenRCT2::Audio::SoundId::scream6, OpenRCT2::Audio::SoundId::scream7, OpenRCT2::Audio::SoundId::scream2,
-    OpenRCT2::Audio::SoundId::scream4,
+static constexpr SoundId _screamSetWooden[] = {
+    SoundId::scream3, SoundId::scream1, SoundId::scream5, SoundId::scream6, SoundId::scream7, SoundId::scream2,
+    SoundId::scream4,
 };
-static constexpr OpenRCT2::Audio::SoundId _screamSetSteel[] = {
-    OpenRCT2::Audio::SoundId::scream1,
-    OpenRCT2::Audio::SoundId::scream6,
+static constexpr SoundId _screamSetSteel[] = {
+    SoundId::scream1, SoundId::scream6,
 };
 
 /** rct2: 0x009A37C4 */
@@ -116,19 +112,19 @@ static constexpr CoordsXY kSurroundingTiles[] = {
     { 0, +kCoordsXYStep },
 };
 
-static constexpr OpenRCT2::Audio::SoundId kDoorOpenSoundIds[] = {
-    OpenRCT2::Audio::SoundId::null,       // DoorSoundType::none
-    OpenRCT2::Audio::SoundId::doorOpen,   // DoorSoundType::door
-    OpenRCT2::Audio::SoundId::portcullis, // DoorSoundType::portcullis
+static constexpr SoundId kDoorOpenSoundIds[] = {
+    SoundId::null,       // DoorSoundType::none
+    SoundId::doorOpen,   // DoorSoundType::door
+    SoundId::portcullis, // DoorSoundType::portcullis
 };
-static_assert(std::size(kDoorOpenSoundIds) == OpenRCT2::Audio::kDoorSoundTypeCount);
+static_assert(std::size(kDoorOpenSoundIds) == kDoorSoundTypeCount);
 
-static constexpr OpenRCT2::Audio::SoundId kDoorCloseSoundIds[] = {
-    OpenRCT2::Audio::SoundId::null,       // DoorSoundType::none
-    OpenRCT2::Audio::SoundId::doorClose,  // DoorSoundType::door
-    OpenRCT2::Audio::SoundId::portcullis, // DoorSoundType::portcullis
+static constexpr SoundId kDoorCloseSoundIds[] = {
+    SoundId::null,       // DoorSoundType::none
+    SoundId::doorClose,  // DoorSoundType::door
+    SoundId::portcullis, // DoorSoundType::portcullis
 };
-static_assert(std::size(kDoorCloseSoundIds) == OpenRCT2::Audio::kDoorSoundTypeCount);
+static_assert(std::size(kDoorCloseSoundIds) == kDoorSoundTypeCount);
 
 template<>
 bool EntityBase::Is<Vehicle>() const
@@ -144,25 +140,25 @@ bool EntityBase::Is<Vehicle>() const
  */
 static void InvokeVehicleCrashHook(const EntityId vehicleId, const std::string_view crashId)
 {
-    auto& hookEngine = OpenRCT2::GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(OpenRCT2::Scripting::HookType::vehicleCrash))
+    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+    if (hookEngine.HasSubscriptions(Scripting::HookType::vehicleCrash))
     {
-        auto ctx = OpenRCT2::GetContext()->GetScriptEngine().GetContext();
+        auto ctx = GetContext()->GetScriptEngine().GetContext();
 
         // Create event args object
-        auto obj = OpenRCT2::Scripting::DukObject(ctx);
+        auto obj = Scripting::DukObject(ctx);
         obj.Set("id", vehicleId.ToUnderlying());
         obj.Set("crashIntoType", crashId);
 
         // Call the subscriptions
         auto e = obj.Take();
-        hookEngine.Call(OpenRCT2::Scripting::HookType::vehicleCrash, e, true);
+        hookEngine.Call(Scripting::HookType::vehicleCrash, e, true);
     }
 }
 #endif
 
 static bool vehicle_move_info_valid(
-    VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction, int32_t offset)
+    VehicleTrackSubposition trackSubposition, TrackElemType type, uint8_t direction, int32_t offset)
 {
     uint16_t typeAndDirection = (EnumValue(type) << 2) | (direction & 3);
 
@@ -219,7 +215,7 @@ static bool vehicle_move_info_valid(
 }
 
 static const VehicleInfo* vehicle_get_move_info(
-    VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction, int32_t offset)
+    VehicleTrackSubposition trackSubposition, TrackElemType type, uint8_t direction, int32_t offset)
 {
     uint16_t typeAndDirection = (EnumValue(type) << 2) | (direction & 3);
 
@@ -236,7 +232,7 @@ const VehicleInfo* Vehicle::GetMoveInfo() const
     return vehicle_get_move_info(TrackSubposition, GetTrackType(), GetTrackDirection(), track_progress);
 }
 
-uint16_t VehicleGetMoveInfoSize(VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction)
+uint16_t VehicleGetMoveInfoSize(VehicleTrackSubposition trackSubposition, TrackElemType type, uint8_t direction)
 {
     uint16_t typeAndDirection = (EnumValue(type) << 2) | (direction & 3);
 
@@ -291,7 +287,7 @@ Vehicle* TryGetVehicle(EntityId spriteIndex)
 
 void VehicleSoundsUpdate()
 {
-    auto windowManager = OpenRCT2::Ui::GetWindowManager();
+    auto windowManager = Ui::GetWindowManager();
     windowManager->BroadcastIntent(Intent(INTENT_ACTION_UPDATE_VEHICLE_SOUNDS));
 }
 
@@ -485,27 +481,27 @@ bool Vehicle::OpenRestraints()
     return restraintsOpen;
 }
 
-void RideUpdateMeasurementsSpecialElements_Default(Ride& ride, const OpenRCT2::TrackElemType trackType)
+void RideUpdateMeasurementsSpecialElements_Default(Ride& ride, const TrackElemType trackType)
 {
     const auto& ted = GetTrackElementDescriptor(trackType);
     if (ted.flags.has(TrackElementFlag::normalToInversion))
     {
-        if (ride.numInversions < OpenRCT2::Limits::kMaxInversions)
+        if (ride.numInversions < Limits::kMaxInversions)
             ride.numInversions++;
     }
 }
 
-void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const OpenRCT2::TrackElemType trackType)
+void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const TrackElemType trackType)
 {
     const auto& ted = GetTrackElementDescriptor(trackType);
     if (ted.flags.has(TrackElementFlag::isGolfHole))
     {
-        if (ride.numHoles < OpenRCT2::Limits::kMaxGolfHoles)
+        if (ride.numHoles < Limits::kMaxGolfHoles)
             ride.numHoles++;
     }
 }
 
-void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const OpenRCT2::TrackElemType trackType)
+void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const TrackElemType trackType)
 {
     if (trackType >= TrackElemType::flatCovered && trackType <= TrackElemType::rightQuarterTurn3TilesCovered)
     {
@@ -523,7 +519,7 @@ void Vehicle::UpdateMeasurements()
     if (curRide == nullptr)
         return;
 
-    if (status == Vehicle::Status::travellingBoat)
+    if (status == Status::travellingBoat)
     {
         curRide->lifecycleFlags |= RIDE_LIFECYCLE_TESTED;
         curRide->lifecycleFlags |= RIDE_LIFECYCLE_NO_RAW_STATS;
@@ -608,7 +604,7 @@ void Vehicle::UpdateMeasurements()
             if (!curRide->testingFlags.has(RideTestingFlag::poweredLift))
             {
                 curRide->testingFlags.set(RideTestingFlag::poweredLift);
-                if (curRide->numPoweredLifts < OpenRCT2::Limits::kRideMaxNumPoweredLiftsCount)
+                if (curRide->numPoweredLifts < Limits::kRideMaxNumPoweredLiftsCount)
                     curRide->numPoweredLifts++;
             }
         }
@@ -745,7 +741,7 @@ void Vehicle::UpdateMeasurements()
             curRide->testingFlags.unset(RideTestingFlag::dropUp);
             curRide->testingFlags.set(RideTestingFlag::dropDown);
 
-            if (curRide->numDrops < OpenRCT2::Limits::kRideMaxDropsCount)
+            if (curRide->numDrops < Limits::kRideMaxDropsCount)
                 curRide->numDrops++;
 
             curRide->startDropHeight = z / kCoordsZStep;
@@ -774,7 +770,7 @@ void Vehicle::UpdateMeasurements()
             curRide->testingFlags.unset(RideTestingFlag::dropDown);
             curRide->testingFlags.set(RideTestingFlag::dropUp);
 
-            if (curRide->numDrops < OpenRCT2::Limits::kRideMaxDropsCount)
+            if (curRide->numDrops < Limits::kRideMaxDropsCount)
                 curRide->numDrops++;
 
             curRide->startDropHeight = z / kCoordsZStep;
@@ -782,7 +778,7 @@ void Vehicle::UpdateMeasurements()
 
         if (ted.flags.has(TrackElementFlag::helix))
         {
-            if (curRide->numHelices < OpenRCT2::Limits::kMaxHelices)
+            if (curRide->numHelices < Limits::kMaxHelices)
                 curRide->numHelices++;
         }
     }
@@ -873,7 +869,7 @@ void Vehicle::UpdateMeasurements()
 
 struct SoundIdVolume
 {
-    OpenRCT2::Audio::SoundId id;
+    SoundId id;
     uint8_t volume;
 };
 
@@ -882,10 +878,10 @@ struct SoundIdVolume
  *  rct2: 0x006D7AC0
  */
 static SoundIdVolume VehicleSoundFadeInOut(
-    OpenRCT2::Audio::SoundId currentSoundId, uint8_t currentVolume, OpenRCT2::Audio::SoundId targetSoundId,
+    SoundId currentSoundId, uint8_t currentVolume, SoundId targetSoundId,
     uint8_t targetVolume)
 {
-    if (currentSoundId != OpenRCT2::Audio::SoundId::null)
+    if (currentSoundId != SoundId::null)
     {
         if (currentSoundId == targetSoundId)
         {
@@ -907,14 +903,14 @@ static SoundIdVolume VehicleSoundFadeInOut(
 
 void Vehicle::GetLiftHillSound(const Ride& curRide, SoundIdVolume& curSound)
 {
-    scream_sound_id = OpenRCT2::Audio::SoundId::null;
+    scream_sound_id = SoundId::null;
     if (curRide.type < std::size(kRideTypeDescriptors))
     {
         // Get lift hill sound
         curSound.id = GetRideTypeDescriptor(curRide.type).LiftData.sound_id;
         curSound.volume = 243;
         if (!(sound2_flags & VEHICLE_SOUND2_FLAGS_LIFT_HILL))
-            curSound.id = OpenRCT2::Audio::SoundId::null;
+            curSound.id = SoundId::null;
     }
 }
 
@@ -960,71 +956,71 @@ void Vehicle::Update()
 
     switch (status)
     {
-        case Vehicle::Status::movingToEndOfStation:
+        case Status::movingToEndOfStation:
             UpdateMovingToEndOfStation();
             break;
-        case Vehicle::Status::waitingForPassengers:
+        case Status::waitingForPassengers:
             UpdateWaitingForPassengers();
             break;
-        case Vehicle::Status::waitingToDepart:
+        case Status::waitingToDepart:
             UpdateWaitingToDepart();
             break;
-        case Vehicle::Status::crashing:
-        case Vehicle::Status::crashed:
+        case Status::crashing:
+        case Status::crashed:
             UpdateCrash();
             break;
-        case Vehicle::Status::travellingDodgems:
+        case Status::travellingDodgems:
             UpdateDodgemsMode();
             break;
-        case Vehicle::Status::swinging:
+        case Status::swinging:
             UpdateSwinging();
             break;
-        case Vehicle::Status::simulatorOperating:
+        case Status::simulatorOperating:
             UpdateSimulatorOperating();
             break;
-        case Vehicle::Status::topSpinOperating:
+        case Status::topSpinOperating:
             UpdateTopSpinOperating();
             break;
-        case Vehicle::Status::ferrisWheelRotating:
+        case Status::ferrisWheelRotating:
             UpdateFerrisWheelRotating();
             break;
-        case Vehicle::Status::spaceRingsOperating:
+        case Status::spaceRingsOperating:
             UpdateSpaceRingsOperating();
             break;
-        case Vehicle::Status::hauntedHouseOperating:
+        case Status::hauntedHouseOperating:
             UpdateHauntedHouseOperating();
             break;
-        case Vehicle::Status::crookedHouseOperating:
+        case Status::crookedHouseOperating:
             UpdateCrookedHouseOperating();
             break;
-        case Vehicle::Status::rotating:
+        case Status::rotating:
             UpdateRotating();
             break;
-        case Vehicle::Status::departing:
+        case Status::departing:
             UpdateDeparting();
             break;
-        case Vehicle::Status::travelling:
+        case Status::travelling:
             UpdateTravelling();
             break;
-        case Vehicle::Status::travellingCableLift:
+        case Status::travellingCableLift:
             UpdateTravellingCableLift();
             break;
-        case Vehicle::Status::travellingBoat:
+        case Status::travellingBoat:
             UpdateTravellingBoat();
             break;
-        case Vehicle::Status::arriving:
+        case Status::arriving:
             UpdateArriving();
             break;
-        case Vehicle::Status::unloadingPassengers:
+        case Status::unloadingPassengers:
             UpdateUnloadingPassengers();
             break;
-        case Vehicle::Status::waitingForCableLift:
+        case Status::waitingForCableLift:
             UpdateWaitingForCableLift();
             break;
-        case Vehicle::Status::showingFilm:
+        case Status::showingFilm:
             UpdateShowingFilm();
             break;
-        case Vehicle::Status::doingCircusShow:
+        case Status::doingCircusShow:
             UpdateDoingCircusShow();
             break;
         default:
@@ -1086,7 +1082,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             current_station = StationIndex::FromUnderlying(0);
             velocity = 0;
             acceleration = 0;
-            SetState(Vehicle::Status::waitingForPassengers);
+            SetState(Status::waitingForPassengers);
             break;
         default:
         {
@@ -1121,7 +1117,7 @@ void Vehicle::UpdateMovingToEndOfStation()
 
                 if (curRide->mode == RideMode::race && sub_state >= 40)
                 {
-                    SetState(Vehicle::Status::waitingForPassengers);
+                    SetState(Status::waitingForPassengers);
                     break;
                 }
             }
@@ -1139,7 +1135,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             current_station = StationIndex::FromUnderlying(station);
             velocity = 0;
             acceleration = 0;
-            SetState(Vehicle::Status::waitingForPassengers);
+            SetState(Status::waitingForPassengers);
             break;
         }
     }
@@ -1183,7 +1179,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         if (!peep[seat].IsNull())
         {
             curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
-            SetState(Vehicle::Status::unloadingPassengers);
+            SetState(Status::unloadingPassengers);
             return;
         }
 
@@ -1199,7 +1195,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         return;
 
     curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
-    SetState(Vehicle::Status::waitingForPassengers);
+    SetState(Status::waitingForPassengers);
 }
 
 static std::optional<uint32_t> ride_get_train_index_from_vehicle(const Ride& ride, EntityId spriteIndex)
@@ -1333,8 +1329,7 @@ void Vehicle::UpdateWaitingForPassengers()
                 if (train == nullptr)
                     continue;
 
-                if (train->status == Vehicle::Status::unloadingPassengers
-                    || train->status == Vehicle::Status::movingToEndOfStation)
+                if (train->status == Status::unloadingPassengers || train->status == Status::movingToEndOfStation)
                 {
                     if (train->current_station == current_station)
                     {
@@ -1390,7 +1385,7 @@ void Vehicle::UpdateWaitingForPassengers()
         SetFlag(VehicleFlags::WaitingOnAdjacentStation);
     }
 
-    SetState(Vehicle::Status::waitingToDepart);
+    SetState(Status::waitingToDepart);
 }
 
 /**
@@ -1433,7 +1428,7 @@ void Vehicle::UpdateDodgemsMode()
     Invalidate();
     velocity = 0;
     acceleration = 0;
-    SetState(Vehicle::Status::unloadingPassengers);
+    SetState(Status::unloadingPassengers);
 }
 
 /**
@@ -1481,7 +1476,7 @@ void Vehicle::UpdateWaitingToDepart()
             {
                 if (!currentStation.Exit.IsNull())
                 {
-                    SetState(Vehicle::Status::unloadingPassengers);
+                    SetState(Status::unloadingPassengers);
                     return;
                 }
             }
@@ -1495,7 +1490,7 @@ void Vehicle::UpdateWaitingToDepart()
                 {
                     if (!currentStation.Exit.IsNull())
                     {
-                        SetState(Vehicle::Status::unloadingPassengers);
+                        SetState(Status::unloadingPassengers);
                         return;
                     }
                     break;
@@ -1524,7 +1519,7 @@ void Vehicle::UpdateWaitingToDepart()
         }
     }
 
-    SetState(Vehicle::Status::departing);
+    SetState(Status::departing);
 
     if (curRide->lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT)
     {
@@ -1537,7 +1532,7 @@ void Vehicle::UpdateWaitingToDepart()
         {
             if (track.element->AsTrack()->HasCableLift())
             {
-                SetState(Vehicle::Status::waitingForCableLift, sub_state);
+                SetState(Status::waitingForCableLift, sub_state);
             }
         }
     }
@@ -1547,36 +1542,36 @@ void Vehicle::UpdateWaitingToDepart()
         case RideMode::dodgems:
             // Dodgems mode uses sub_state and TimeActive to tell how long
             // the vehicle has been ridden.
-            SetState(Vehicle::Status::travellingDodgems);
+            SetState(Status::travellingDodgems);
             TimeActive = 0;
             UpdateDodgemsMode();
             break;
         case RideMode::swing:
-            SetState(Vehicle::Status::swinging);
+            SetState(Status::swinging);
             NumSwings = 0;
             current_time = -1;
             UpdateSwinging();
             break;
         case RideMode::rotation:
-            SetState(Vehicle::Status::rotating);
+            SetState(Status::rotating);
             NumRotations = 0;
             current_time = -1;
             UpdateRotating();
             break;
         case RideMode::filmAvengingAviators:
-            SetState(Vehicle::Status::simulatorOperating);
+            SetState(Status::simulatorOperating);
             current_time = -1;
             UpdateSimulatorOperating();
             break;
         case RideMode::filmThrillRiders:
-            SetState(Vehicle::Status::simulatorOperating, 1);
+            SetState(Status::simulatorOperating, 1);
             current_time = -1;
             UpdateSimulatorOperating();
             break;
         case RideMode::beginners:
         case RideMode::intense:
         case RideMode::berserk:
-            SetState(Vehicle::Status::topSpinOperating, sub_state);
+            SetState(Status::topSpinOperating, sub_state);
             switch (curRide->mode)
             {
                 case RideMode::beginners:
@@ -1601,7 +1596,7 @@ void Vehicle::UpdateWaitingToDepart()
             break;
         case RideMode::forwardRotation:
         case RideMode::backwardRotation:
-            SetState(Vehicle::Status::ferrisWheelRotating, flatRideAnimationFrame);
+            SetState(Status::ferrisWheelRotating, flatRideAnimationFrame);
             NumRotations = 0;
             ferris_wheel_var_0 = 8;
             ferris_wheel_var_1 = 8;
@@ -1610,7 +1605,7 @@ void Vehicle::UpdateWaitingToDepart()
         case RideMode::mouseTails3DFilm:
         case RideMode::stormChasers3DFilm:
         case RideMode::spaceRaiders3DFilm:
-            SetState(Vehicle::Status::showingFilm, sub_state);
+            SetState(Status::showingFilm, sub_state);
             switch (curRide->mode)
             {
                 case RideMode::mouseTails3DFilm:
@@ -1632,24 +1627,24 @@ void Vehicle::UpdateWaitingToDepart()
             UpdateShowingFilm();
             break;
         case RideMode::circus:
-            SetState(Vehicle::Status::doingCircusShow);
+            SetState(Status::doingCircusShow);
             current_time = -1;
             UpdateDoingCircusShow();
             break;
         case RideMode::spaceRings:
-            SetState(Vehicle::Status::spaceRingsOperating);
+            SetState(Status::spaceRingsOperating);
             flatRideAnimationFrame = 0;
             current_time = -1;
             UpdateSpaceRingsOperating();
             break;
         case RideMode::hauntedHouse:
-            SetState(Vehicle::Status::hauntedHouseOperating);
+            SetState(Status::hauntedHouseOperating);
             flatRideAnimationFrame = 0;
             current_time = -1;
             UpdateHauntedHouseOperating();
             break;
         case RideMode::crookedHouse:
-            SetState(Vehicle::Status::crookedHouseOperating);
+            SetState(Status::crookedHouseOperating);
             flatRideAnimationFrame = 0;
             current_time = -1;
             UpdateCrookedHouseOperating();
@@ -2143,7 +2138,7 @@ void Vehicle::UpdateTravellingBoatHireSetup()
     // No longer on a track so reset to 0 for import/export
     SetTrackDirection(0);
     SetTrackType(TrackElemType::flat);
-    SetState(Vehicle::Status::travellingBoat);
+    SetState(Status::travellingBoat);
     remaining_distance += 27924;
 
     UpdateTravellingBoat();
@@ -2207,15 +2202,13 @@ void Vehicle::UpdateDeparting()
 
         if (rideEntry->flags & RIDE_ENTRY_FLAG_PLAY_DEPART_SOUND)
         {
-            auto soundId = (rideEntry->Cars[0].soundRange == SoundRange::tramBell) ? OpenRCT2::Audio::SoundId::tram
-                                                                                   : OpenRCT2::Audio::SoundId::trainDeparting;
-
-            OpenRCT2::Audio::Play3D(soundId, GetLocation());
+            auto soundId = (rideEntry->Cars[0].soundRange == SoundRange::tramBell) ? SoundId::tram : SoundId::trainDeparting;
+            Play3D(soundId, GetLocation());
         }
 
         if (curRide->mode == RideMode::upwardLaunch || (curRide->mode == RideMode::downwardLaunch && NumLaunches > 1))
         {
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch2, GetLocation());
+            Play3D(SoundId::rideLaunch2, GetLocation());
         }
 
         if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TESTED))
@@ -2421,7 +2414,7 @@ void Vehicle::FinishDeparting()
         if (NumLaunches >= 1 && (14 << 16) > velocity)
             return;
 
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch1, GetLocation());
+        Play3D(SoundId::rideLaunch1, GetLocation());
     }
 
     if (curRide->mode == RideMode::upwardLaunch)
@@ -2429,7 +2422,7 @@ void Vehicle::FinishDeparting()
         if ((curRide->launchSpeed << 16) > velocity)
             return;
 
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch1, GetLocation());
+        Play3D(SoundId::rideLaunch1, GetLocation());
     }
 
     if (curRide->mode != RideMode::race && !curRide->isBlockSectioned())
@@ -2446,7 +2439,7 @@ void Vehicle::FinishDeparting()
         currentStation.Depart |= waitingTime;
     }
     lost_time_out = 0;
-    SetState(Vehicle::Status::travelling, 1);
+    SetState(Status::travelling, 1);
     if (velocity < 0)
         sub_state = 0;
 }
@@ -2527,7 +2520,7 @@ void Vehicle::UpdateCollisionSetup()
         return;
     }
 
-    SetState(Vehicle::Status::crashed, sub_state);
+    SetState(Status::crashed, sub_state);
 
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
@@ -2565,7 +2558,7 @@ void Vehicle::UpdateCollisionSetup()
 #endif
         const auto trainLoc = train->GetLocation();
 
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::crash, trainLoc);
+        Play3D(SoundId::crash, trainLoc);
 
         ExplosionCloud::Create(trainLoc);
 
@@ -2615,11 +2608,11 @@ void Vehicle::UpdateCrashSetup()
         SimulateCrash();
         return;
     }
-    SetState(Vehicle::Status::crashing, sub_state);
+    SetState(Status::crashing, sub_state);
 
     if (NumPeepsUntilTrainTail() != 0)
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScream2, GetLocation());
+        Play3D(SoundId::hauntedHouseScream2, GetLocation());
     }
 
     int32_t edx = velocity >> 10;
@@ -2741,7 +2734,7 @@ void Vehicle::UpdateTravelling()
             {
                 if (sub_state <= 1)
                 {
-                    SetState(Vehicle::Status::arriving, 1);
+                    SetState(Status::arriving, 1);
                     var_C0 = 0;
                     return;
                 }
@@ -2851,7 +2844,7 @@ void Vehicle::UpdateTravelling()
     if (curRide->mode == RideMode::poweredLaunchPasstrough && velocity < 0)
         return;
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     current_station = _vehicleStationIndex;
     var_C0 = 0;
     if (velocity < 0)
@@ -2976,7 +2969,7 @@ void Vehicle::UpdateArriving()
             ClearFlag(VehicleFlags::ReverseInclineCompletedLap);
             velocity = 0;
             acceleration = 0;
-            SetState(Vehicle::Status::unloadingPassengers);
+            SetState(Status::unloadingPassengers);
             return;
         default:
         {
@@ -3007,7 +3000,7 @@ void Vehicle::UpdateArriving()
 
     if (curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_STATION && !stationBrakesWork)
     {
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
@@ -3040,42 +3033,42 @@ void Vehicle::UpdateArriving()
     {
         if (NumLaps < curRide->numCircuits)
         {
-            SetState(Vehicle::Status::departing, 1);
+            SetState(Status::departing, 1);
             return;
         }
 
         if (NumLaps == curRide->numCircuits && HasFlag(VehicleFlags::ReverseInclineCompletedLap))
         {
-            SetState(Vehicle::Status::departing, 1);
+            SetState(Status::departing, 1);
             return;
         }
     }
 
     if (curRide->numCircuits != 1 && NumLaps < curRide->numCircuits)
     {
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
     if ((curRide->mode == RideMode::upwardLaunch || curRide->mode == RideMode::downwardLaunch) && NumLaunches < 2)
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch2, GetLocation());
+        Play3D(SoundId::rideLaunch2, GetLocation());
         velocity = 0;
         acceleration = 0;
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
     if (curRide->mode == RideMode::race && curRide->lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
     {
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
     ClearFlag(VehicleFlags::ReverseInclineCompletedLap);
     velocity = 0;
     acceleration = 0;
-    SetState(Vehicle::Status::unloadingPassengers);
+    SetState(Status::unloadingPassengers);
 }
 
 /**
@@ -3136,7 +3129,7 @@ void Vehicle::UpdateUnloadingPassengers()
             {
                 UpdateTestFinish();
             }
-            SetState(Vehicle::Status::movingToEndOfStation);
+            SetState(Status::movingToEndOfStation);
             return;
         }
 
@@ -3177,7 +3170,7 @@ void Vehicle::UpdateUnloadingPassengers()
     {
         UpdateTestFinish();
     }
-    SetState(Vehicle::Status::movingToEndOfStation);
+    SetState(Status::movingToEndOfStation);
 }
 
 /**
@@ -3194,10 +3187,10 @@ void Vehicle::UpdateWaitingForCableLift()
     if (cableLift == nullptr)
         return;
 
-    if (cableLift->status != Vehicle::Status::waitingForPassengers)
+    if (cableLift->status != Status::waitingForPassengers)
         return;
 
-    cableLift->SetState(Vehicle::Status::waitingToDepart, sub_state);
+    cableLift->SetState(Status::waitingToDepart, sub_state);
     cableLift->cable_lift_target = Id;
 }
 
@@ -3261,7 +3254,7 @@ void Vehicle::UpdateTravellingCableLift()
 
     if (curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_11)
     {
-        SetState(Vehicle::Status::travelling, 1);
+        SetState(Status::travelling, 1);
         lost_time_out = 0;
         return;
     }
@@ -3320,7 +3313,7 @@ void Vehicle::TryReconnectBoatToTrack(const CoordsXY& currentBoatLocation, const
         }
 
         track_progress = 0;
-        SetState(Vehicle::Status::travelling, sub_state);
+        SetState(Status::travelling, sub_state);
         _vehicleCurPosition.x = currentBoatLocation.x;
         _vehicleCurPosition.y = currentBoatLocation.y;
     }
@@ -3781,7 +3774,7 @@ void Vehicle::UpdateSwinging()
     // swing has to be in slowing down phase
     if (sub_state == 0)
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
         return;
     }
@@ -3878,7 +3871,7 @@ void Vehicle::UpdateFerrisWheelRotating()
     if (subState != flatRideAnimationFrame)
         return;
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     var_C0 = 0;
 }
 
@@ -3904,7 +3897,7 @@ void Vehicle::UpdateSimulatorOperating()
         return;
     }
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     var_C0 = 0;
 }
 
@@ -3996,7 +3989,7 @@ void Vehicle::UpdateRotating()
         {
             if (sub_state == 2)
             {
-                SetState(Vehicle::Status::arriving);
+                SetState(Status::arriving);
                 var_C0 = 0;
                 return;
             }
@@ -4031,7 +4024,7 @@ void Vehicle::UpdateSpaceRingsOperating()
     }
     else
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
     }
 }
@@ -4059,7 +4052,7 @@ void Vehicle::UpdateHauntedHouseOperating()
 
     if (current_time + 1 > 1500)
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
         return;
     }
@@ -4068,24 +4061,24 @@ void Vehicle::UpdateHauntedHouseOperating()
     switch (current_time)
     {
         case 45:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScare, GetLocation());
+            Play3D(SoundId::hauntedHouseScare, GetLocation());
             break;
         case 75:
             flatRideAnimationFrame = 1;
             Invalidate();
             break;
         case 400:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScream1, GetLocation());
+            Play3D(SoundId::hauntedHouseScream1, GetLocation());
             break;
         case 745:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScare, GetLocation());
+            Play3D(SoundId::hauntedHouseScare, GetLocation());
             break;
         case 775:
             flatRideAnimationFrame = 1;
             Invalidate();
             break;
         case 1100:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScream2, GetLocation());
+            Play3D(SoundId::hauntedHouseScream2, GetLocation());
             break;
     }
 }
@@ -4102,7 +4095,7 @@ void Vehicle::UpdateCrookedHouseOperating()
     // Originally used an array of size 1 at 0x009A0AC4 and passed the sub state into it.
     if (static_cast<uint16_t>(current_time + 1) > 600)
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
         return;
     }
@@ -4138,7 +4131,7 @@ void Vehicle::UpdateTopSpinOperating()
         return;
     }
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     var_C0 = 0;
 }
 
@@ -4161,7 +4154,7 @@ void Vehicle::UpdateShowingFilm()
     }
     else
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
     }
 }
@@ -4182,7 +4175,7 @@ void Vehicle::UpdateDoingCircusShow()
     }
     else
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
     }
 }
@@ -4314,7 +4307,7 @@ void Vehicle::CrashOnLand()
         SimulateCrash();
         return;
     }
-    SetState(Vehicle::Status::crashed, sub_state);
+    SetState(Status::crashed, sub_state);
 
 #ifdef ENABLE_SCRIPTING
     InvokeVehicleCrashHook(Id, "land");
@@ -4349,7 +4342,7 @@ void Vehicle::CrashOnLand()
     sub_state = 2;
 
     const auto curLoc = GetLocation();
-    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::crash, curLoc);
+    Play3D(SoundId::crash, curLoc);
 
     ExplosionCloud::Create(curLoc);
     ExplosionFlare::Create(curLoc);
@@ -4382,7 +4375,7 @@ void Vehicle::CrashOnWater()
         SimulateCrash();
         return;
     }
-    SetState(Vehicle::Status::crashed, sub_state);
+    SetState(Status::crashed, sub_state);
 
 #ifdef ENABLE_SCRIPTING
     InvokeVehicleCrashHook(Id, "water");
@@ -4417,7 +4410,7 @@ void Vehicle::CrashOnWater()
     sub_state = 2;
 
     const auto curLoc = GetLocation();
-    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::water1, curLoc);
+    Play3D(SoundId::water1, curLoc);
 
     CrashSplashParticle::Create(curLoc);
     CrashSplashParticle::Create(curLoc + CoordsXYZ{ -8, -9, 0 });
@@ -4538,9 +4531,9 @@ void Vehicle::UpdateCrash()
 void Vehicle::UpdateSound()
 {
     // frictionVolume (bl) should be set before hand
-    SoundIdVolume frictionSound = { OpenRCT2::Audio::SoundId::null, 255 };
+    SoundIdVolume frictionSound = { SoundId::null, 255 };
     // bh screamVolume should be set before hand
-    SoundIdVolume screamSound = { OpenRCT2::Audio::SoundId::null, 255 };
+    SoundIdVolume screamSound = { SoundId::null, 255 };
 
     auto curRide = GetRide();
     if (curRide == nullptr)
@@ -4569,7 +4562,7 @@ void Vehicle::UpdateSound()
             screamSound.id = scream_sound_id;
             if (!(currentTicks & 0x7F))
             {
-                if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::null)
+                if (velocity < 4.0_mph || scream_sound_id != SoundId::null)
                 {
                     GetLiftHillSound(*curRide, screamSound);
                     break;
@@ -4577,13 +4570,13 @@ void Vehicle::UpdateSound()
 
                 if ((ScenarioRand() & 0xFFFF) <= 0x5555)
                 {
-                    scream_sound_id = OpenRCT2::Audio::SoundId::trainWhistle;
+                    scream_sound_id = SoundId::trainWhistle;
                     screamSound.volume = 255;
                     break;
                 }
             }
-            if (screamSound.id == OpenRCT2::Audio::SoundId::noScream)
-                screamSound.id = OpenRCT2::Audio::SoundId::null;
+            if (screamSound.id == SoundId::noScream)
+                screamSound.id = SoundId::null;
             screamSound.volume = 255;
             break;
 
@@ -4591,7 +4584,7 @@ void Vehicle::UpdateSound()
             screamSound.id = scream_sound_id;
             if (!(currentTicks & 0x7F))
             {
-                if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::null)
+                if (velocity < 4.0_mph || scream_sound_id != SoundId::null)
                 {
                     GetLiftHillSound(*curRide, screamSound);
                     break;
@@ -4599,13 +4592,13 @@ void Vehicle::UpdateSound()
 
                 if ((ScenarioRand() & 0xFFFF) <= 0x5555)
                 {
-                    scream_sound_id = OpenRCT2::Audio::SoundId::tram;
+                    scream_sound_id = SoundId::tram;
                     screamSound.volume = 255;
                     break;
                 }
             }
-            if (screamSound.id == OpenRCT2::Audio::SoundId::noScream)
-                screamSound.id = OpenRCT2::Audio::SoundId::null;
+            if (screamSound.id == SoundId::noScream)
+                screamSound.id = SoundId::null;
             screamSound.volume = 255;
             break;
 
@@ -4613,12 +4606,12 @@ void Vehicle::UpdateSound()
             if ((carEntry.flags & CAR_ENTRY_FLAG_RIDERS_SCREAM))
             {
                 screamSound.id = UpdateScreamSound();
-                if (screamSound.id == OpenRCT2::Audio::SoundId::noScream)
+                if (screamSound.id == SoundId::noScream)
                 {
-                    screamSound.id = OpenRCT2::Audio::SoundId::null;
+                    screamSound.id = SoundId::null;
                     break;
                 }
-                if (screamSound.id != OpenRCT2::Audio::SoundId::null)
+                if (screamSound.id != SoundId::null)
                 {
                     break;
                 }
@@ -4648,16 +4641,16 @@ void Vehicle::UpdateSound()
  *
  *  rct2: 0x006D796B
  */
-OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
+SoundId Vehicle::UpdateScreamSound()
 {
     int32_t totalNumPeeps = NumPeepsUntilTrainTail();
     if (totalNumPeeps == 0)
-        return OpenRCT2::Audio::SoundId::null;
+        return SoundId::null;
 
     if (velocity < 0)
     {
         if (velocity > -2.75_mph)
-            return OpenRCT2::Audio::SoundId::null;
+            return SoundId::null;
 
         for (Vehicle* vehicle2 = getGameState().entities.GetEntity<Vehicle>(Id); vehicle2 != nullptr;
              vehicle2 = getGameState().entities.GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
@@ -4675,11 +4668,11 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
             if (vehicle2->pitch == VehiclePitch::up50)
                 return ProduceScreamSound(totalNumPeeps);
         }
-        return OpenRCT2::Audio::SoundId::null;
+        return SoundId::null;
     }
 
     if (velocity < 2.75_mph)
-        return OpenRCT2::Audio::SoundId::null;
+        return SoundId::null;
 
     for (Vehicle* vehicle2 = getGameState().entities.GetEntity<Vehicle>(Id); vehicle2 != nullptr;
          vehicle2 = getGameState().entities.GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
@@ -4697,16 +4690,16 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
         if (vehicle2->pitch == VehiclePitch::down50)
             return ProduceScreamSound(totalNumPeeps);
     }
-    return OpenRCT2::Audio::SoundId::null;
+    return SoundId::null;
 }
 
-OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps)
+SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps)
 {
     const auto* rideEntry = GetRideEntry();
 
     const auto& carEntry = rideEntry->Cars[vehicle_type];
 
-    if (scream_sound_id == OpenRCT2::Audio::SoundId::null)
+    if (scream_sound_id == SoundId::null)
     {
         auto r = ScenarioRand();
         if (totalNumPeeps >= static_cast<int32_t>(r % 16))
@@ -4723,13 +4716,13 @@ OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps
                     scream_sound_id = _screamSetSteel[r % std::size(_screamSetSteel)];
                     break;
                 default:
-                    scream_sound_id = OpenRCT2::Audio::SoundId::noScream;
+                    scream_sound_id = SoundId::noScream;
                     break;
             }
         }
         else
         {
-            scream_sound_id = OpenRCT2::Audio::SoundId::noScream;
+            scream_sound_id = SoundId::noScream;
         }
     }
     return scream_sound_id;
@@ -5192,7 +5185,7 @@ void Vehicle::ApplyStopBlockBrake()
 void Vehicle::ApplyCableLiftBlockBrake(bool brakeClosed)
 {
     // If we are already on the cable lift, ignore the brake
-    if (status == Vehicle::Status::travellingCableLift)
+    if (status == Status::travellingCableLift)
         return;
 
     // Slow down if travelling faster than 4mph
@@ -5213,7 +5206,7 @@ void Vehicle::ApplyCableLiftBlockBrake(bool brakeClosed)
         velocity = 0;
         acceleration = 0;
         if (!brakeClosed)
-            SetState(Vehicle::Status::waitingForCableLift, sub_state);
+            SetState(Status::waitingForCableLift, sub_state);
         else
             _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_BLOCK_BRAKE;
     }
@@ -5338,11 +5331,11 @@ static void BlockBrakesOpenPreviousSection(const Ride& ride, const CoordsXYZ& ve
     auto trackType = trackElement->GetTrackType();
     if (trackType == TrackElemType::endStation)
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::blockBrakeClose, location);
+        Play3D(SoundId::blockBrakeClose, location);
     }
     else if (TrackTypeIsBlockBrakes(trackType))
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::blockBrakeClose, location);
+        Play3D(SoundId::blockBrakeClose, location);
         BlockBrakeSetLinkedBrakesClosed(location, *trackElement, false);
     }
 }
@@ -5762,11 +5755,11 @@ static uint8_t GetTargetFrame(const CarEntry& carEntry, uint32_t animationState)
  */
 static constexpr CoordsXYZ ComputeSteamOffset(int32_t height, int32_t length, VehiclePitch pitch, uint8_t yaw)
 {
-    uint8_t trueYaw = OpenRCT2::Entity::Yaw::YawTo64(yaw);
-    auto offsets = PitchToDirectionVectorFromGeometry[EnumValue(pitch)];
+    uint8_t trueYaw = Entity::Yaw::YawTo64(yaw);
+    auto offsets = Math::Trigonometry::PitchToDirectionVectorFromGeometry[EnumValue(pitch)];
     int32_t projectedRun = (offsets.x * length - offsets.y * height) / 256;
     int32_t projectedHeight = (offsets.x * height + offsets.y * length) / 256;
-    return { ComputeXYVector(projectedRun, trueYaw), projectedHeight };
+    return { Math::Trigonometry::ComputeXYVector(projectedRun, trueYaw), projectedHeight };
 }
 
 /**
@@ -5963,7 +5956,7 @@ static void play_scenery_door_open_sound(const CoordsXYZ& loc, WallElement* tile
         return;
 
     auto soundId = kDoorOpenSoundIds[EnumValue(doorSoundType)];
-    OpenRCT2::Audio::Play3D(soundId, loc);
+    Play3D(soundId, loc);
 }
 
 /**
@@ -6033,7 +6026,7 @@ void Vehicle::UpdateSceneryDoor() const
 template<bool isBackwards>
 static void AnimateLandscapeDoor(
     const CoordsXYZ& doorLocation, TrackElement& trackElement, const bool isLastVehicle,
-    const OpenRCT2::Audio::DoorSoundType doorSound, const CoordsXYZ& soundLocation)
+    const DoorSoundType doorSound, const CoordsXYZ& soundLocation)
 {
     const auto doorState = isBackwards ? trackElement.GetDoorAState() : trackElement.GetDoorBState();
     if (!isLastVehicle && doorState == kLandEdgeDoorFrameClosed)
@@ -6044,7 +6037,7 @@ static void AnimateLandscapeDoor(
             trackElement.SetDoorBState(kLandEdgeDoorFrameOpening);
 
         MapAnimations::CreateTemporary(doorLocation, MapAnimations::TemporaryType::landEdgeDoor);
-        OpenRCT2::Audio::Play3D(kDoorOpenSoundIds[EnumValue(doorSound)], soundLocation);
+        Play3D(kDoorOpenSoundIds[EnumValue(doorSound)], soundLocation);
     }
 
     if (isLastVehicle)
@@ -6055,7 +6048,7 @@ static void AnimateLandscapeDoor(
             trackElement.SetDoorBState(kLandEdgeDoorFrameClosing);
 
         MapAnimations::CreateTemporary(doorLocation, MapAnimations::TemporaryType::landEdgeDoor);
-        OpenRCT2::Audio::Play3D(kDoorCloseSoundIds[EnumValue(doorSound)], soundLocation);
+        Play3D(kDoorCloseSoundIds[EnumValue(doorSound)], soundLocation);
     }
 }
 
@@ -6163,8 +6156,7 @@ static void vehicle_update_play_water_splash_sound()
         return;
     }
 
-    OpenRCT2::Audio::Play3D(
-        OpenRCT2::Audio::SoundId::waterSplash, { _vehicleCurPosition.x, _vehicleCurPosition.y, _vehicleCurPosition.z });
+    Play3D(SoundId::waterSplash, { _vehicleCurPosition.x, _vehicleCurPosition.y, _vehicleCurPosition.z });
 }
 
 /**
@@ -6394,7 +6386,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         return false;
     }
 
-    if (collideVehicle->status == Vehicle::Status::travellingBoat && sub_state == BoatHireSubState::EnteringReturnPosition)
+    if (collideVehicle->status == Status::travellingBoat && sub_state == BoatHireSubState::EnteringReturnPosition)
     {
         return false;
     }
@@ -6408,7 +6400,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         return true;
     }
 
-    if (status == Vehicle::Status::movingToEndOfStation)
+    if (status == Status::movingToEndOfStation)
     {
         if (Orientation == 0)
         {
@@ -6440,8 +6432,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         }
     }
 
-    if (collideVehicle->status == Vehicle::Status::travellingBoat && status != Vehicle::Status::arriving
-        && status != Vehicle::Status::travelling)
+    if ((collideVehicle->status == Status::travellingBoat) && (status != Status::arriving) && (status != Status::travelling))
     {
         return false;
     }
@@ -6654,7 +6645,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
             {
                 if (!(rideEntry.Cars[0].flags & CAR_ENTRY_FLAG_POWERED))
                 {
-                    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::blockBrakeRelease, TrackLocation);
+                    Play3D(SoundId::blockBrakeRelease, TrackLocation);
                 }
             }
             MapInvalidateElement(TrackLocation, tileElement);
@@ -6866,7 +6857,7 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
                     if (_vehicleF64E2C == 0)
                     {
                         _vehicleF64E2C++;
-                        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::brakeRelease, { x, y, z });
+                        Play3D(SoundId::brakeRelease, { x, y, z });
                     }
                 }
             }
@@ -7354,11 +7345,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         if (remaining_distance < 0x368A)
         {
             Loc6DCDE4(curRide);
-            return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+            return UpdateMiniGolfSubroutineStatus::stop;
         }
         acceleration = Geometry::getAccelerationFromPitch(pitch);
         _vehicleUnkF64E10++;
-        return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+        return UpdateMiniGolfSubroutineStatus::restart;
     }
 
     if (mini_golf_flags & MiniGolfFlag::Flag2)
@@ -7376,11 +7367,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         mini_golf_flags &= ~MiniGolfFlag::Flag2;
     }
@@ -7391,7 +7382,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         Vehicle* vEDI = getGameState().entities.GetEntity<Vehicle>(vehicleIdx);
         if (vEDI == nullptr)
         {
-            return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+            return UpdateMiniGolfSubroutineStatus::stop;
         }
         if (!(vEDI->mini_golf_flags & MiniGolfFlag::Flag0) || (vEDI->mini_golf_flags & MiniGolfFlag::Flag2))
         {
@@ -7404,11 +7395,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         if (vEDI->var_D3 != 0)
         {
@@ -7421,11 +7412,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         vEDI->mini_golf_flags &= ~MiniGolfFlag::Flag0;
         mini_golf_flags &= ~MiniGolfFlag::Flag0;
@@ -7437,7 +7428,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         Vehicle* vEDI = getGameState().entities.GetEntity<Vehicle>(vehicleIdx);
         if (vEDI == nullptr)
         {
-            return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+            return UpdateMiniGolfSubroutineStatus::stop;
         }
         if (!(vEDI->mini_golf_flags & MiniGolfFlag::Flag1) || (vEDI->mini_golf_flags & MiniGolfFlag::Flag2))
         {
@@ -7450,11 +7441,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         if (vEDI->var_D3 != 0)
         {
@@ -7467,11 +7458,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         vEDI->mini_golf_flags &= ~MiniGolfFlag::Flag1;
         mini_golf_flags &= ~MiniGolfFlag::Flag1;
@@ -7503,26 +7494,26 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
 
         mini_golf_flags |= MiniGolfFlag::Flag4;
         mini_golf_flags &= ~MiniGolfFlag::Flag3;
     }
 
-    return Vehicle::UpdateMiniGolfSubroutineStatus::carryOn;
+    return UpdateMiniGolfSubroutineStatus::carryOn;
 }
 
 [[nodiscard]] Vehicle::UpdateMiniGolfSubroutineStatus Vehicle::Loc6DC462(const Ride& curRide)
 {
     while (true)
     {
-        Vehicle::UpdateMiniGolfSubroutineStatus flagsStatus = Vehicle::UpdateMiniGolfSubroutineStatus::restart;
-        while (flagsStatus == Vehicle::UpdateMiniGolfSubroutineStatus::restart)
+        UpdateMiniGolfSubroutineStatus flagsStatus = UpdateMiniGolfSubroutineStatus::restart;
+        while (flagsStatus == UpdateMiniGolfSubroutineStatus::restart)
         {
             flagsStatus = UpdateTrackMotionMiniGolfFlagsStatus(curRide);
         }
@@ -7752,7 +7743,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 remaining_distance = 0x368A;
                 acceleration = Geometry::getAccelerationFromPitch(pitch);
                 _vehicleUnkF64E10++;
-                return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+                return UpdateMiniGolfSubroutineStatus::restart;
             }
 
             TrackLocation = trackPos;
@@ -8470,7 +8461,7 @@ void Vehicle::UpdateCrossings() const
                             MapGetTrackElementAtOfTypeSeq(frontVehicle->TrackLocation, frontVehicle->GetTrackType(), 0) };
     int32_t curZ = frontVehicle->TrackLocation.z;
 
-    if (xyElement.element != nullptr && status != Vehicle::Status::arriving)
+    if (xyElement.element != nullptr && status != Status::arriving)
     {
         int16_t autoReserveAhead = 4 + abs(velocity) / 150000;
         int16_t crossingBonus = 0;
@@ -8528,7 +8519,7 @@ void Vehicle::UpdateCrossings() const
 
             // Ensure trains near a station don't block possible crossings after the stop,
             // except when they are departing
-            if (xyElement.element->AsTrack()->IsStation() && status != Vehicle::Status::departing)
+            if (xyElement.element->AsTrack()->IsStation() && status != Status::departing)
             {
                 break;
             }
@@ -8543,7 +8534,7 @@ void Vehicle::UpdateCrossings() const
     }
 
     // Ensure departing trains don't clear blocked crossings behind them that might already be blocked by another incoming train
-    uint8_t freeCount = travellingForwards && status != Vehicle::Status::departing ? 3 : 1;
+    uint8_t freeCount = travellingForwards && status != Status::departing ? 3 : 1;
     while (freeCount-- > 0)
     {
         if (travellingForwards)
@@ -8570,10 +8561,10 @@ void Vehicle::Claxon() const
     switch (rideEntry->Cars[vehicle_type].soundRange)
     {
         case SoundRange::steamWhistle:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::trainWhistle, { x, y, z });
+            Play3D(SoundId::trainWhistle, { x, y, z });
             break;
         case SoundRange::tramBell:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::tram, { x, y, z });
+            Play3D(SoundId::tram, { x, y, z });
             break;
         default:
             break;
@@ -8610,7 +8601,7 @@ Vehicle* Vehicle::GetCar(size_t carIndex) const
     return car;
 }
 
-void Vehicle::SetState(Vehicle::Status vehicleStatus, uint8_t subState)
+void Vehicle::SetState(Status vehicleStatus, uint8_t subState)
 {
     status = vehicleStatus;
     sub_state = subState;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -63,7 +63,6 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Audio;
 using namespace OpenRCT2::TrackMetaData;
-using namespace OpenRCT2::Math::Trigonometry;
 using namespace OpenRCT2::RideVehicle;
 static bool vehicle_boat_is_location_accessible(const CoordsXYZ& location);
 
@@ -89,18 +88,17 @@ uint8_t _vehicleF64E2C;
 Vehicle* _vehicleFrontVehicle;
 CoordsXYZ _vehicleCurPosition;
 
-static constexpr OpenRCT2::Audio::SoundId _screamSetMisc[] = {
-    OpenRCT2::Audio::SoundId::scream8,
-    OpenRCT2::Audio::SoundId::scream1,
+static constexpr SoundId _screamSetMisc[] = {
+    SoundId::scream8,
+    SoundId::scream1,
 };
-static constexpr OpenRCT2::Audio::SoundId _screamSetWooden[] = {
-    OpenRCT2::Audio::SoundId::scream3, OpenRCT2::Audio::SoundId::scream1, OpenRCT2::Audio::SoundId::scream5,
-    OpenRCT2::Audio::SoundId::scream6, OpenRCT2::Audio::SoundId::scream7, OpenRCT2::Audio::SoundId::scream2,
-    OpenRCT2::Audio::SoundId::scream4,
+static constexpr SoundId _screamSetWooden[] = {
+    SoundId::scream3, SoundId::scream1, SoundId::scream5, SoundId::scream6,
+    SoundId::scream7, SoundId::scream2, SoundId::scream4,
 };
-static constexpr OpenRCT2::Audio::SoundId _screamSetSteel[] = {
-    OpenRCT2::Audio::SoundId::scream1,
-    OpenRCT2::Audio::SoundId::scream6,
+static constexpr SoundId _screamSetSteel[] = {
+    SoundId::scream1,
+    SoundId::scream6,
 };
 
 /** rct2: 0x009A37C4 */
@@ -116,19 +114,19 @@ static constexpr CoordsXY kSurroundingTiles[] = {
     { 0, +kCoordsXYStep },
 };
 
-static constexpr OpenRCT2::Audio::SoundId kDoorOpenSoundIds[] = {
-    OpenRCT2::Audio::SoundId::null,       // DoorSoundType::none
-    OpenRCT2::Audio::SoundId::doorOpen,   // DoorSoundType::door
-    OpenRCT2::Audio::SoundId::portcullis, // DoorSoundType::portcullis
+static constexpr SoundId kDoorOpenSoundIds[] = {
+    SoundId::null,       // DoorSoundType::none
+    SoundId::doorOpen,   // DoorSoundType::door
+    SoundId::portcullis, // DoorSoundType::portcullis
 };
-static_assert(std::size(kDoorOpenSoundIds) == OpenRCT2::Audio::kDoorSoundTypeCount);
+static_assert(std::size(kDoorOpenSoundIds) == kDoorSoundTypeCount);
 
-static constexpr OpenRCT2::Audio::SoundId kDoorCloseSoundIds[] = {
-    OpenRCT2::Audio::SoundId::null,       // DoorSoundType::none
-    OpenRCT2::Audio::SoundId::doorClose,  // DoorSoundType::door
-    OpenRCT2::Audio::SoundId::portcullis, // DoorSoundType::portcullis
+static constexpr SoundId kDoorCloseSoundIds[] = {
+    SoundId::null,       // DoorSoundType::none
+    SoundId::doorClose,  // DoorSoundType::door
+    SoundId::portcullis, // DoorSoundType::portcullis
 };
-static_assert(std::size(kDoorCloseSoundIds) == OpenRCT2::Audio::kDoorSoundTypeCount);
+static_assert(std::size(kDoorCloseSoundIds) == kDoorSoundTypeCount);
 
 template<>
 bool EntityBase::Is<Vehicle>() const
@@ -144,25 +142,25 @@ bool EntityBase::Is<Vehicle>() const
  */
 static void InvokeVehicleCrashHook(const EntityId vehicleId, const std::string_view crashId)
 {
-    auto& hookEngine = OpenRCT2::GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(OpenRCT2::Scripting::HookType::vehicleCrash))
+    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+    if (hookEngine.HasSubscriptions(Scripting::HookType::vehicleCrash))
     {
-        auto ctx = OpenRCT2::GetContext()->GetScriptEngine().GetContext();
+        auto ctx = GetContext()->GetScriptEngine().GetContext();
 
         // Create event args object
-        auto obj = OpenRCT2::Scripting::DukObject(ctx);
+        auto obj = Scripting::DukObject(ctx);
         obj.Set("id", vehicleId.ToUnderlying());
         obj.Set("crashIntoType", crashId);
 
         // Call the subscriptions
         auto e = obj.Take();
-        hookEngine.Call(OpenRCT2::Scripting::HookType::vehicleCrash, e, true);
+        hookEngine.Call(Scripting::HookType::vehicleCrash, e, true);
     }
 }
 #endif
 
 static bool vehicle_move_info_valid(
-    VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction, int32_t offset)
+    VehicleTrackSubposition trackSubposition, TrackElemType type, uint8_t direction, int32_t offset)
 {
     uint16_t typeAndDirection = (EnumValue(type) << 2) | (direction & 3);
 
@@ -219,7 +217,7 @@ static bool vehicle_move_info_valid(
 }
 
 static const VehicleInfo* vehicle_get_move_info(
-    VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction, int32_t offset)
+    VehicleTrackSubposition trackSubposition, TrackElemType type, uint8_t direction, int32_t offset)
 {
     uint16_t typeAndDirection = (EnumValue(type) << 2) | (direction & 3);
 
@@ -236,7 +234,7 @@ const VehicleInfo* Vehicle::GetMoveInfo() const
     return vehicle_get_move_info(TrackSubposition, GetTrackType(), GetTrackDirection(), track_progress);
 }
 
-uint16_t VehicleGetMoveInfoSize(VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction)
+uint16_t VehicleGetMoveInfoSize(VehicleTrackSubposition trackSubposition, TrackElemType type, uint8_t direction)
 {
     uint16_t typeAndDirection = (EnumValue(type) << 2) | (direction & 3);
 
@@ -291,7 +289,7 @@ Vehicle* TryGetVehicle(EntityId spriteIndex)
 
 void VehicleSoundsUpdate()
 {
-    auto windowManager = OpenRCT2::Ui::GetWindowManager();
+    auto windowManager = Ui::GetWindowManager();
     windowManager->BroadcastIntent(Intent(INTENT_ACTION_UPDATE_VEHICLE_SOUNDS));
 }
 
@@ -485,27 +483,27 @@ bool Vehicle::OpenRestraints()
     return restraintsOpen;
 }
 
-void RideUpdateMeasurementsSpecialElements_Default(Ride& ride, const OpenRCT2::TrackElemType trackType)
+void RideUpdateMeasurementsSpecialElements_Default(Ride& ride, const TrackElemType trackType)
 {
     const auto& ted = GetTrackElementDescriptor(trackType);
     if (ted.flags.has(TrackElementFlag::normalToInversion))
     {
-        if (ride.numInversions < OpenRCT2::Limits::kMaxInversions)
+        if (ride.numInversions < Limits::kMaxInversions)
             ride.numInversions++;
     }
 }
 
-void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const OpenRCT2::TrackElemType trackType)
+void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const TrackElemType trackType)
 {
     const auto& ted = GetTrackElementDescriptor(trackType);
     if (ted.flags.has(TrackElementFlag::isGolfHole))
     {
-        if (ride.numHoles < OpenRCT2::Limits::kMaxGolfHoles)
+        if (ride.numHoles < Limits::kMaxGolfHoles)
             ride.numHoles++;
     }
 }
 
-void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const OpenRCT2::TrackElemType trackType)
+void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const TrackElemType trackType)
 {
     if (trackType >= TrackElemType::flatCovered && trackType <= TrackElemType::rightQuarterTurn3TilesCovered)
     {
@@ -523,7 +521,7 @@ void Vehicle::UpdateMeasurements()
     if (curRide == nullptr)
         return;
 
-    if (status == Vehicle::Status::travellingBoat)
+    if (status == Status::travellingBoat)
     {
         curRide->lifecycleFlags |= RIDE_LIFECYCLE_TESTED;
         curRide->lifecycleFlags |= RIDE_LIFECYCLE_NO_RAW_STATS;
@@ -608,7 +606,7 @@ void Vehicle::UpdateMeasurements()
             if (!curRide->testingFlags.has(RideTestingFlag::poweredLift))
             {
                 curRide->testingFlags.set(RideTestingFlag::poweredLift);
-                if (curRide->numPoweredLifts < OpenRCT2::Limits::kRideMaxNumPoweredLiftsCount)
+                if (curRide->numPoweredLifts < Limits::kRideMaxNumPoweredLiftsCount)
                     curRide->numPoweredLifts++;
             }
         }
@@ -745,7 +743,7 @@ void Vehicle::UpdateMeasurements()
             curRide->testingFlags.unset(RideTestingFlag::dropUp);
             curRide->testingFlags.set(RideTestingFlag::dropDown);
 
-            if (curRide->numDrops < OpenRCT2::Limits::kRideMaxDropsCount)
+            if (curRide->numDrops < Limits::kRideMaxDropsCount)
                 curRide->numDrops++;
 
             curRide->startDropHeight = z / kCoordsZStep;
@@ -774,7 +772,7 @@ void Vehicle::UpdateMeasurements()
             curRide->testingFlags.unset(RideTestingFlag::dropDown);
             curRide->testingFlags.set(RideTestingFlag::dropUp);
 
-            if (curRide->numDrops < OpenRCT2::Limits::kRideMaxDropsCount)
+            if (curRide->numDrops < Limits::kRideMaxDropsCount)
                 curRide->numDrops++;
 
             curRide->startDropHeight = z / kCoordsZStep;
@@ -782,7 +780,7 @@ void Vehicle::UpdateMeasurements()
 
         if (ted.flags.has(TrackElementFlag::helix))
         {
-            if (curRide->numHelices < OpenRCT2::Limits::kMaxHelices)
+            if (curRide->numHelices < Limits::kMaxHelices)
                 curRide->numHelices++;
         }
     }
@@ -873,7 +871,7 @@ void Vehicle::UpdateMeasurements()
 
 struct SoundIdVolume
 {
-    OpenRCT2::Audio::SoundId id;
+    SoundId id;
     uint8_t volume;
 };
 
@@ -882,10 +880,9 @@ struct SoundIdVolume
  *  rct2: 0x006D7AC0
  */
 static SoundIdVolume VehicleSoundFadeInOut(
-    OpenRCT2::Audio::SoundId currentSoundId, uint8_t currentVolume, OpenRCT2::Audio::SoundId targetSoundId,
-    uint8_t targetVolume)
+    SoundId currentSoundId, uint8_t currentVolume, SoundId targetSoundId, uint8_t targetVolume)
 {
-    if (currentSoundId != OpenRCT2::Audio::SoundId::null)
+    if (currentSoundId != SoundId::null)
     {
         if (currentSoundId == targetSoundId)
         {
@@ -907,14 +904,14 @@ static SoundIdVolume VehicleSoundFadeInOut(
 
 void Vehicle::GetLiftHillSound(const Ride& curRide, SoundIdVolume& curSound)
 {
-    scream_sound_id = OpenRCT2::Audio::SoundId::null;
+    scream_sound_id = SoundId::null;
     if (curRide.type < std::size(kRideTypeDescriptors))
     {
         // Get lift hill sound
         curSound.id = GetRideTypeDescriptor(curRide.type).LiftData.sound_id;
         curSound.volume = 243;
         if (!(sound2_flags & VEHICLE_SOUND2_FLAGS_LIFT_HILL))
-            curSound.id = OpenRCT2::Audio::SoundId::null;
+            curSound.id = SoundId::null;
     }
 }
 
@@ -960,71 +957,71 @@ void Vehicle::Update()
 
     switch (status)
     {
-        case Vehicle::Status::movingToEndOfStation:
+        case Status::movingToEndOfStation:
             UpdateMovingToEndOfStation();
             break;
-        case Vehicle::Status::waitingForPassengers:
+        case Status::waitingForPassengers:
             UpdateWaitingForPassengers();
             break;
-        case Vehicle::Status::waitingToDepart:
+        case Status::waitingToDepart:
             UpdateWaitingToDepart();
             break;
-        case Vehicle::Status::crashing:
-        case Vehicle::Status::crashed:
+        case Status::crashing:
+        case Status::crashed:
             UpdateCrash();
             break;
-        case Vehicle::Status::travellingDodgems:
+        case Status::travellingDodgems:
             UpdateDodgemsMode();
             break;
-        case Vehicle::Status::swinging:
+        case Status::swinging:
             UpdateSwinging();
             break;
-        case Vehicle::Status::simulatorOperating:
+        case Status::simulatorOperating:
             UpdateSimulatorOperating();
             break;
-        case Vehicle::Status::topSpinOperating:
+        case Status::topSpinOperating:
             UpdateTopSpinOperating();
             break;
-        case Vehicle::Status::ferrisWheelRotating:
+        case Status::ferrisWheelRotating:
             UpdateFerrisWheelRotating();
             break;
-        case Vehicle::Status::spaceRingsOperating:
+        case Status::spaceRingsOperating:
             UpdateSpaceRingsOperating();
             break;
-        case Vehicle::Status::hauntedHouseOperating:
+        case Status::hauntedHouseOperating:
             UpdateHauntedHouseOperating();
             break;
-        case Vehicle::Status::crookedHouseOperating:
+        case Status::crookedHouseOperating:
             UpdateCrookedHouseOperating();
             break;
-        case Vehicle::Status::rotating:
+        case Status::rotating:
             UpdateRotating();
             break;
-        case Vehicle::Status::departing:
+        case Status::departing:
             UpdateDeparting();
             break;
-        case Vehicle::Status::travelling:
+        case Status::travelling:
             UpdateTravelling();
             break;
-        case Vehicle::Status::travellingCableLift:
+        case Status::travellingCableLift:
             UpdateTravellingCableLift();
             break;
-        case Vehicle::Status::travellingBoat:
+        case Status::travellingBoat:
             UpdateTravellingBoat();
             break;
-        case Vehicle::Status::arriving:
+        case Status::arriving:
             UpdateArriving();
             break;
-        case Vehicle::Status::unloadingPassengers:
+        case Status::unloadingPassengers:
             UpdateUnloadingPassengers();
             break;
-        case Vehicle::Status::waitingForCableLift:
+        case Status::waitingForCableLift:
             UpdateWaitingForCableLift();
             break;
-        case Vehicle::Status::showingFilm:
+        case Status::showingFilm:
             UpdateShowingFilm();
             break;
-        case Vehicle::Status::doingCircusShow:
+        case Status::doingCircusShow:
             UpdateDoingCircusShow();
             break;
         default:
@@ -1086,7 +1083,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             current_station = StationIndex::FromUnderlying(0);
             velocity = 0;
             acceleration = 0;
-            SetState(Vehicle::Status::waitingForPassengers);
+            SetState(Status::waitingForPassengers);
             break;
         default:
         {
@@ -1121,7 +1118,7 @@ void Vehicle::UpdateMovingToEndOfStation()
 
                 if (curRide->mode == RideMode::race && sub_state >= 40)
                 {
-                    SetState(Vehicle::Status::waitingForPassengers);
+                    SetState(Status::waitingForPassengers);
                     break;
                 }
             }
@@ -1139,7 +1136,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             current_station = StationIndex::FromUnderlying(station);
             velocity = 0;
             acceleration = 0;
-            SetState(Vehicle::Status::waitingForPassengers);
+            SetState(Status::waitingForPassengers);
             break;
         }
     }
@@ -1183,7 +1180,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         if (!peep[seat].IsNull())
         {
             curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
-            SetState(Vehicle::Status::unloadingPassengers);
+            SetState(Status::unloadingPassengers);
             return;
         }
 
@@ -1199,7 +1196,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         return;
 
     curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
-    SetState(Vehicle::Status::waitingForPassengers);
+    SetState(Status::waitingForPassengers);
 }
 
 static std::optional<uint32_t> ride_get_train_index_from_vehicle(const Ride& ride, EntityId spriteIndex)
@@ -1333,8 +1330,7 @@ void Vehicle::UpdateWaitingForPassengers()
                 if (train == nullptr)
                     continue;
 
-                if (train->status == Vehicle::Status::unloadingPassengers
-                    || train->status == Vehicle::Status::movingToEndOfStation)
+                if (train->status == Status::unloadingPassengers || train->status == Status::movingToEndOfStation)
                 {
                     if (train->current_station == current_station)
                     {
@@ -1390,7 +1386,7 @@ void Vehicle::UpdateWaitingForPassengers()
         SetFlag(VehicleFlags::WaitingOnAdjacentStation);
     }
 
-    SetState(Vehicle::Status::waitingToDepart);
+    SetState(Status::waitingToDepart);
 }
 
 /**
@@ -1433,7 +1429,7 @@ void Vehicle::UpdateDodgemsMode()
     Invalidate();
     velocity = 0;
     acceleration = 0;
-    SetState(Vehicle::Status::unloadingPassengers);
+    SetState(Status::unloadingPassengers);
 }
 
 /**
@@ -1481,7 +1477,7 @@ void Vehicle::UpdateWaitingToDepart()
             {
                 if (!currentStation.Exit.IsNull())
                 {
-                    SetState(Vehicle::Status::unloadingPassengers);
+                    SetState(Status::unloadingPassengers);
                     return;
                 }
             }
@@ -1495,7 +1491,7 @@ void Vehicle::UpdateWaitingToDepart()
                 {
                     if (!currentStation.Exit.IsNull())
                     {
-                        SetState(Vehicle::Status::unloadingPassengers);
+                        SetState(Status::unloadingPassengers);
                         return;
                     }
                     break;
@@ -1524,7 +1520,7 @@ void Vehicle::UpdateWaitingToDepart()
         }
     }
 
-    SetState(Vehicle::Status::departing);
+    SetState(Status::departing);
 
     if (curRide->lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT)
     {
@@ -1537,7 +1533,7 @@ void Vehicle::UpdateWaitingToDepart()
         {
             if (track.element->AsTrack()->HasCableLift())
             {
-                SetState(Vehicle::Status::waitingForCableLift, sub_state);
+                SetState(Status::waitingForCableLift, sub_state);
             }
         }
     }
@@ -1547,36 +1543,36 @@ void Vehicle::UpdateWaitingToDepart()
         case RideMode::dodgems:
             // Dodgems mode uses sub_state and TimeActive to tell how long
             // the vehicle has been ridden.
-            SetState(Vehicle::Status::travellingDodgems);
+            SetState(Status::travellingDodgems);
             TimeActive = 0;
             UpdateDodgemsMode();
             break;
         case RideMode::swing:
-            SetState(Vehicle::Status::swinging);
+            SetState(Status::swinging);
             NumSwings = 0;
             current_time = -1;
             UpdateSwinging();
             break;
         case RideMode::rotation:
-            SetState(Vehicle::Status::rotating);
+            SetState(Status::rotating);
             NumRotations = 0;
             current_time = -1;
             UpdateRotating();
             break;
         case RideMode::filmAvengingAviators:
-            SetState(Vehicle::Status::simulatorOperating);
+            SetState(Status::simulatorOperating);
             current_time = -1;
             UpdateSimulatorOperating();
             break;
         case RideMode::filmThrillRiders:
-            SetState(Vehicle::Status::simulatorOperating, 1);
+            SetState(Status::simulatorOperating, 1);
             current_time = -1;
             UpdateSimulatorOperating();
             break;
         case RideMode::beginners:
         case RideMode::intense:
         case RideMode::berserk:
-            SetState(Vehicle::Status::topSpinOperating, sub_state);
+            SetState(Status::topSpinOperating, sub_state);
             switch (curRide->mode)
             {
                 case RideMode::beginners:
@@ -1601,7 +1597,7 @@ void Vehicle::UpdateWaitingToDepart()
             break;
         case RideMode::forwardRotation:
         case RideMode::backwardRotation:
-            SetState(Vehicle::Status::ferrisWheelRotating, flatRideAnimationFrame);
+            SetState(Status::ferrisWheelRotating, flatRideAnimationFrame);
             NumRotations = 0;
             ferris_wheel_var_0 = 8;
             ferris_wheel_var_1 = 8;
@@ -1610,7 +1606,7 @@ void Vehicle::UpdateWaitingToDepart()
         case RideMode::mouseTails3DFilm:
         case RideMode::stormChasers3DFilm:
         case RideMode::spaceRaiders3DFilm:
-            SetState(Vehicle::Status::showingFilm, sub_state);
+            SetState(Status::showingFilm, sub_state);
             switch (curRide->mode)
             {
                 case RideMode::mouseTails3DFilm:
@@ -1632,24 +1628,24 @@ void Vehicle::UpdateWaitingToDepart()
             UpdateShowingFilm();
             break;
         case RideMode::circus:
-            SetState(Vehicle::Status::doingCircusShow);
+            SetState(Status::doingCircusShow);
             current_time = -1;
             UpdateDoingCircusShow();
             break;
         case RideMode::spaceRings:
-            SetState(Vehicle::Status::spaceRingsOperating);
+            SetState(Status::spaceRingsOperating);
             flatRideAnimationFrame = 0;
             current_time = -1;
             UpdateSpaceRingsOperating();
             break;
         case RideMode::hauntedHouse:
-            SetState(Vehicle::Status::hauntedHouseOperating);
+            SetState(Status::hauntedHouseOperating);
             flatRideAnimationFrame = 0;
             current_time = -1;
             UpdateHauntedHouseOperating();
             break;
         case RideMode::crookedHouse:
-            SetState(Vehicle::Status::crookedHouseOperating);
+            SetState(Status::crookedHouseOperating);
             flatRideAnimationFrame = 0;
             current_time = -1;
             UpdateCrookedHouseOperating();
@@ -2143,7 +2139,7 @@ void Vehicle::UpdateTravellingBoatHireSetup()
     // No longer on a track so reset to 0 for import/export
     SetTrackDirection(0);
     SetTrackType(TrackElemType::flat);
-    SetState(Vehicle::Status::travellingBoat);
+    SetState(Status::travellingBoat);
     remaining_distance += 27924;
 
     UpdateTravellingBoat();
@@ -2207,15 +2203,13 @@ void Vehicle::UpdateDeparting()
 
         if (rideEntry->flags & RIDE_ENTRY_FLAG_PLAY_DEPART_SOUND)
         {
-            auto soundId = (rideEntry->Cars[0].soundRange == SoundRange::tramBell) ? OpenRCT2::Audio::SoundId::tram
-                                                                                   : OpenRCT2::Audio::SoundId::trainDeparting;
-
-            OpenRCT2::Audio::Play3D(soundId, GetLocation());
+            auto soundId = (rideEntry->Cars[0].soundRange == SoundRange::tramBell) ? SoundId::tram : SoundId::trainDeparting;
+            Play3D(soundId, GetLocation());
         }
 
         if (curRide->mode == RideMode::upwardLaunch || (curRide->mode == RideMode::downwardLaunch && NumLaunches > 1))
         {
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch2, GetLocation());
+            Play3D(SoundId::rideLaunch2, GetLocation());
         }
 
         if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TESTED))
@@ -2421,7 +2415,7 @@ void Vehicle::FinishDeparting()
         if (NumLaunches >= 1 && (14 << 16) > velocity)
             return;
 
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch1, GetLocation());
+        Play3D(SoundId::rideLaunch1, GetLocation());
     }
 
     if (curRide->mode == RideMode::upwardLaunch)
@@ -2429,7 +2423,7 @@ void Vehicle::FinishDeparting()
         if ((curRide->launchSpeed << 16) > velocity)
             return;
 
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch1, GetLocation());
+        Play3D(SoundId::rideLaunch1, GetLocation());
     }
 
     if (curRide->mode != RideMode::race && !curRide->isBlockSectioned())
@@ -2446,7 +2440,7 @@ void Vehicle::FinishDeparting()
         currentStation.Depart |= waitingTime;
     }
     lost_time_out = 0;
-    SetState(Vehicle::Status::travelling, 1);
+    SetState(Status::travelling, 1);
     if (velocity < 0)
         sub_state = 0;
 }
@@ -2527,7 +2521,7 @@ void Vehicle::UpdateCollisionSetup()
         return;
     }
 
-    SetState(Vehicle::Status::crashed, sub_state);
+    SetState(Status::crashed, sub_state);
 
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
@@ -2565,7 +2559,7 @@ void Vehicle::UpdateCollisionSetup()
 #endif
         const auto trainLoc = train->GetLocation();
 
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::crash, trainLoc);
+        Play3D(SoundId::crash, trainLoc);
 
         ExplosionCloud::Create(trainLoc);
 
@@ -2615,11 +2609,11 @@ void Vehicle::UpdateCrashSetup()
         SimulateCrash();
         return;
     }
-    SetState(Vehicle::Status::crashing, sub_state);
+    SetState(Status::crashing, sub_state);
 
     if (NumPeepsUntilTrainTail() != 0)
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScream2, GetLocation());
+        Play3D(SoundId::hauntedHouseScream2, GetLocation());
     }
 
     int32_t edx = velocity >> 10;
@@ -2741,7 +2735,7 @@ void Vehicle::UpdateTravelling()
             {
                 if (sub_state <= 1)
                 {
-                    SetState(Vehicle::Status::arriving, 1);
+                    SetState(Status::arriving, 1);
                     var_C0 = 0;
                     return;
                 }
@@ -2851,7 +2845,7 @@ void Vehicle::UpdateTravelling()
     if (curRide->mode == RideMode::poweredLaunchPasstrough && velocity < 0)
         return;
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     current_station = _vehicleStationIndex;
     var_C0 = 0;
     if (velocity < 0)
@@ -2976,7 +2970,7 @@ void Vehicle::UpdateArriving()
             ClearFlag(VehicleFlags::ReverseInclineCompletedLap);
             velocity = 0;
             acceleration = 0;
-            SetState(Vehicle::Status::unloadingPassengers);
+            SetState(Status::unloadingPassengers);
             return;
         default:
         {
@@ -3007,7 +3001,7 @@ void Vehicle::UpdateArriving()
 
     if (curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_STATION && !stationBrakesWork)
     {
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
@@ -3040,42 +3034,42 @@ void Vehicle::UpdateArriving()
     {
         if (NumLaps < curRide->numCircuits)
         {
-            SetState(Vehicle::Status::departing, 1);
+            SetState(Status::departing, 1);
             return;
         }
 
         if (NumLaps == curRide->numCircuits && HasFlag(VehicleFlags::ReverseInclineCompletedLap))
         {
-            SetState(Vehicle::Status::departing, 1);
+            SetState(Status::departing, 1);
             return;
         }
     }
 
     if (curRide->numCircuits != 1 && NumLaps < curRide->numCircuits)
     {
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
     if ((curRide->mode == RideMode::upwardLaunch || curRide->mode == RideMode::downwardLaunch) && NumLaunches < 2)
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::rideLaunch2, GetLocation());
+        Play3D(SoundId::rideLaunch2, GetLocation());
         velocity = 0;
         acceleration = 0;
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
     if (curRide->mode == RideMode::race && curRide->lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
     {
-        SetState(Vehicle::Status::departing, 1);
+        SetState(Status::departing, 1);
         return;
     }
 
     ClearFlag(VehicleFlags::ReverseInclineCompletedLap);
     velocity = 0;
     acceleration = 0;
-    SetState(Vehicle::Status::unloadingPassengers);
+    SetState(Status::unloadingPassengers);
 }
 
 /**
@@ -3136,7 +3130,7 @@ void Vehicle::UpdateUnloadingPassengers()
             {
                 UpdateTestFinish();
             }
-            SetState(Vehicle::Status::movingToEndOfStation);
+            SetState(Status::movingToEndOfStation);
             return;
         }
 
@@ -3177,7 +3171,7 @@ void Vehicle::UpdateUnloadingPassengers()
     {
         UpdateTestFinish();
     }
-    SetState(Vehicle::Status::movingToEndOfStation);
+    SetState(Status::movingToEndOfStation);
 }
 
 /**
@@ -3194,10 +3188,10 @@ void Vehicle::UpdateWaitingForCableLift()
     if (cableLift == nullptr)
         return;
 
-    if (cableLift->status != Vehicle::Status::waitingForPassengers)
+    if (cableLift->status != Status::waitingForPassengers)
         return;
 
-    cableLift->SetState(Vehicle::Status::waitingToDepart, sub_state);
+    cableLift->SetState(Status::waitingToDepart, sub_state);
     cableLift->cable_lift_target = Id;
 }
 
@@ -3261,7 +3255,7 @@ void Vehicle::UpdateTravellingCableLift()
 
     if (curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_11)
     {
-        SetState(Vehicle::Status::travelling, 1);
+        SetState(Status::travelling, 1);
         lost_time_out = 0;
         return;
     }
@@ -3320,7 +3314,7 @@ void Vehicle::TryReconnectBoatToTrack(const CoordsXY& currentBoatLocation, const
         }
 
         track_progress = 0;
-        SetState(Vehicle::Status::travelling, sub_state);
+        SetState(Status::travelling, sub_state);
         _vehicleCurPosition.x = currentBoatLocation.x;
         _vehicleCurPosition.y = currentBoatLocation.y;
     }
@@ -3781,7 +3775,7 @@ void Vehicle::UpdateSwinging()
     // swing has to be in slowing down phase
     if (sub_state == 0)
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
         return;
     }
@@ -3878,7 +3872,7 @@ void Vehicle::UpdateFerrisWheelRotating()
     if (subState != flatRideAnimationFrame)
         return;
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     var_C0 = 0;
 }
 
@@ -3904,7 +3898,7 @@ void Vehicle::UpdateSimulatorOperating()
         return;
     }
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     var_C0 = 0;
 }
 
@@ -3996,7 +3990,7 @@ void Vehicle::UpdateRotating()
         {
             if (sub_state == 2)
             {
-                SetState(Vehicle::Status::arriving);
+                SetState(Status::arriving);
                 var_C0 = 0;
                 return;
             }
@@ -4031,7 +4025,7 @@ void Vehicle::UpdateSpaceRingsOperating()
     }
     else
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
     }
 }
@@ -4059,7 +4053,7 @@ void Vehicle::UpdateHauntedHouseOperating()
 
     if (current_time + 1 > 1500)
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
         return;
     }
@@ -4068,24 +4062,24 @@ void Vehicle::UpdateHauntedHouseOperating()
     switch (current_time)
     {
         case 45:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScare, GetLocation());
+            Play3D(SoundId::hauntedHouseScare, GetLocation());
             break;
         case 75:
             flatRideAnimationFrame = 1;
             Invalidate();
             break;
         case 400:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScream1, GetLocation());
+            Play3D(SoundId::hauntedHouseScream1, GetLocation());
             break;
         case 745:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScare, GetLocation());
+            Play3D(SoundId::hauntedHouseScare, GetLocation());
             break;
         case 775:
             flatRideAnimationFrame = 1;
             Invalidate();
             break;
         case 1100:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::hauntedHouseScream2, GetLocation());
+            Play3D(SoundId::hauntedHouseScream2, GetLocation());
             break;
     }
 }
@@ -4102,7 +4096,7 @@ void Vehicle::UpdateCrookedHouseOperating()
     // Originally used an array of size 1 at 0x009A0AC4 and passed the sub state into it.
     if (static_cast<uint16_t>(current_time + 1) > 600)
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
         return;
     }
@@ -4138,7 +4132,7 @@ void Vehicle::UpdateTopSpinOperating()
         return;
     }
 
-    SetState(Vehicle::Status::arriving);
+    SetState(Status::arriving);
     var_C0 = 0;
 }
 
@@ -4161,7 +4155,7 @@ void Vehicle::UpdateShowingFilm()
     }
     else
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
     }
 }
@@ -4182,7 +4176,7 @@ void Vehicle::UpdateDoingCircusShow()
     }
     else
     {
-        SetState(Vehicle::Status::arriving);
+        SetState(Status::arriving);
         var_C0 = 0;
     }
 }
@@ -4314,7 +4308,7 @@ void Vehicle::CrashOnLand()
         SimulateCrash();
         return;
     }
-    SetState(Vehicle::Status::crashed, sub_state);
+    SetState(Status::crashed, sub_state);
 
 #ifdef ENABLE_SCRIPTING
     InvokeVehicleCrashHook(Id, "land");
@@ -4349,7 +4343,7 @@ void Vehicle::CrashOnLand()
     sub_state = 2;
 
     const auto curLoc = GetLocation();
-    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::crash, curLoc);
+    Play3D(SoundId::crash, curLoc);
 
     ExplosionCloud::Create(curLoc);
     ExplosionFlare::Create(curLoc);
@@ -4382,7 +4376,7 @@ void Vehicle::CrashOnWater()
         SimulateCrash();
         return;
     }
-    SetState(Vehicle::Status::crashed, sub_state);
+    SetState(Status::crashed, sub_state);
 
 #ifdef ENABLE_SCRIPTING
     InvokeVehicleCrashHook(Id, "water");
@@ -4417,7 +4411,7 @@ void Vehicle::CrashOnWater()
     sub_state = 2;
 
     const auto curLoc = GetLocation();
-    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::water1, curLoc);
+    Play3D(SoundId::water1, curLoc);
 
     CrashSplashParticle::Create(curLoc);
     CrashSplashParticle::Create(curLoc + CoordsXYZ{ -8, -9, 0 });
@@ -4538,9 +4532,9 @@ void Vehicle::UpdateCrash()
 void Vehicle::UpdateSound()
 {
     // frictionVolume (bl) should be set before hand
-    SoundIdVolume frictionSound = { OpenRCT2::Audio::SoundId::null, 255 };
+    SoundIdVolume frictionSound = { SoundId::null, 255 };
     // bh screamVolume should be set before hand
-    SoundIdVolume screamSound = { OpenRCT2::Audio::SoundId::null, 255 };
+    SoundIdVolume screamSound = { SoundId::null, 255 };
 
     auto curRide = GetRide();
     if (curRide == nullptr)
@@ -4569,7 +4563,7 @@ void Vehicle::UpdateSound()
             screamSound.id = scream_sound_id;
             if (!(currentTicks & 0x7F))
             {
-                if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::null)
+                if (velocity < 4.0_mph || scream_sound_id != SoundId::null)
                 {
                     GetLiftHillSound(*curRide, screamSound);
                     break;
@@ -4577,13 +4571,13 @@ void Vehicle::UpdateSound()
 
                 if ((ScenarioRand() & 0xFFFF) <= 0x5555)
                 {
-                    scream_sound_id = OpenRCT2::Audio::SoundId::trainWhistle;
+                    scream_sound_id = SoundId::trainWhistle;
                     screamSound.volume = 255;
                     break;
                 }
             }
-            if (screamSound.id == OpenRCT2::Audio::SoundId::noScream)
-                screamSound.id = OpenRCT2::Audio::SoundId::null;
+            if (screamSound.id == SoundId::noScream)
+                screamSound.id = SoundId::null;
             screamSound.volume = 255;
             break;
 
@@ -4591,7 +4585,7 @@ void Vehicle::UpdateSound()
             screamSound.id = scream_sound_id;
             if (!(currentTicks & 0x7F))
             {
-                if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::null)
+                if (velocity < 4.0_mph || scream_sound_id != SoundId::null)
                 {
                     GetLiftHillSound(*curRide, screamSound);
                     break;
@@ -4599,13 +4593,13 @@ void Vehicle::UpdateSound()
 
                 if ((ScenarioRand() & 0xFFFF) <= 0x5555)
                 {
-                    scream_sound_id = OpenRCT2::Audio::SoundId::tram;
+                    scream_sound_id = SoundId::tram;
                     screamSound.volume = 255;
                     break;
                 }
             }
-            if (screamSound.id == OpenRCT2::Audio::SoundId::noScream)
-                screamSound.id = OpenRCT2::Audio::SoundId::null;
+            if (screamSound.id == SoundId::noScream)
+                screamSound.id = SoundId::null;
             screamSound.volume = 255;
             break;
 
@@ -4613,12 +4607,12 @@ void Vehicle::UpdateSound()
             if ((carEntry.flags & CAR_ENTRY_FLAG_RIDERS_SCREAM))
             {
                 screamSound.id = UpdateScreamSound();
-                if (screamSound.id == OpenRCT2::Audio::SoundId::noScream)
+                if (screamSound.id == SoundId::noScream)
                 {
-                    screamSound.id = OpenRCT2::Audio::SoundId::null;
+                    screamSound.id = SoundId::null;
                     break;
                 }
-                if (screamSound.id != OpenRCT2::Audio::SoundId::null)
+                if (screamSound.id != SoundId::null)
                 {
                     break;
                 }
@@ -4648,16 +4642,16 @@ void Vehicle::UpdateSound()
  *
  *  rct2: 0x006D796B
  */
-OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
+SoundId Vehicle::UpdateScreamSound()
 {
     int32_t totalNumPeeps = NumPeepsUntilTrainTail();
     if (totalNumPeeps == 0)
-        return OpenRCT2::Audio::SoundId::null;
+        return SoundId::null;
 
     if (velocity < 0)
     {
         if (velocity > -2.75_mph)
-            return OpenRCT2::Audio::SoundId::null;
+            return SoundId::null;
 
         for (Vehicle* vehicle2 = getGameState().entities.GetEntity<Vehicle>(Id); vehicle2 != nullptr;
              vehicle2 = getGameState().entities.GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
@@ -4675,11 +4669,11 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
             if (vehicle2->pitch == VehiclePitch::up50)
                 return ProduceScreamSound(totalNumPeeps);
         }
-        return OpenRCT2::Audio::SoundId::null;
+        return SoundId::null;
     }
 
     if (velocity < 2.75_mph)
-        return OpenRCT2::Audio::SoundId::null;
+        return SoundId::null;
 
     for (Vehicle* vehicle2 = getGameState().entities.GetEntity<Vehicle>(Id); vehicle2 != nullptr;
          vehicle2 = getGameState().entities.GetEntity<Vehicle>(vehicle2->next_vehicle_on_train))
@@ -4697,16 +4691,16 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
         if (vehicle2->pitch == VehiclePitch::down50)
             return ProduceScreamSound(totalNumPeeps);
     }
-    return OpenRCT2::Audio::SoundId::null;
+    return SoundId::null;
 }
 
-OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps)
+SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps)
 {
     const auto* rideEntry = GetRideEntry();
 
     const auto& carEntry = rideEntry->Cars[vehicle_type];
 
-    if (scream_sound_id == OpenRCT2::Audio::SoundId::null)
+    if (scream_sound_id == SoundId::null)
     {
         auto r = ScenarioRand();
         if (totalNumPeeps >= static_cast<int32_t>(r % 16))
@@ -4723,13 +4717,13 @@ OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps
                     scream_sound_id = _screamSetSteel[r % std::size(_screamSetSteel)];
                     break;
                 default:
-                    scream_sound_id = OpenRCT2::Audio::SoundId::noScream;
+                    scream_sound_id = SoundId::noScream;
                     break;
             }
         }
         else
         {
-            scream_sound_id = OpenRCT2::Audio::SoundId::noScream;
+            scream_sound_id = SoundId::noScream;
         }
     }
     return scream_sound_id;
@@ -5192,7 +5186,7 @@ void Vehicle::ApplyStopBlockBrake()
 void Vehicle::ApplyCableLiftBlockBrake(bool brakeClosed)
 {
     // If we are already on the cable lift, ignore the brake
-    if (status == Vehicle::Status::travellingCableLift)
+    if (status == Status::travellingCableLift)
         return;
 
     // Slow down if travelling faster than 4mph
@@ -5213,7 +5207,7 @@ void Vehicle::ApplyCableLiftBlockBrake(bool brakeClosed)
         velocity = 0;
         acceleration = 0;
         if (!brakeClosed)
-            SetState(Vehicle::Status::waitingForCableLift, sub_state);
+            SetState(Status::waitingForCableLift, sub_state);
         else
             _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_BLOCK_BRAKE;
     }
@@ -5338,11 +5332,11 @@ static void BlockBrakesOpenPreviousSection(const Ride& ride, const CoordsXYZ& ve
     auto trackType = trackElement->GetTrackType();
     if (trackType == TrackElemType::endStation)
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::blockBrakeClose, location);
+        Play3D(SoundId::blockBrakeClose, location);
     }
     else if (TrackTypeIsBlockBrakes(trackType))
     {
-        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::blockBrakeClose, location);
+        Play3D(SoundId::blockBrakeClose, location);
         BlockBrakeSetLinkedBrakesClosed(location, *trackElement, false);
     }
 }
@@ -5762,11 +5756,11 @@ static uint8_t GetTargetFrame(const CarEntry& carEntry, uint32_t animationState)
  */
 static constexpr CoordsXYZ ComputeSteamOffset(int32_t height, int32_t length, VehiclePitch pitch, uint8_t yaw)
 {
-    uint8_t trueYaw = OpenRCT2::Entity::Yaw::YawTo64(yaw);
-    auto offsets = PitchToDirectionVectorFromGeometry[EnumValue(pitch)];
+    uint8_t trueYaw = Entity::Yaw::YawTo64(yaw);
+    auto offsets = Math::Trigonometry::PitchToDirectionVectorFromGeometry[EnumValue(pitch)];
     int32_t projectedRun = (offsets.x * length - offsets.y * height) / 256;
     int32_t projectedHeight = (offsets.x * height + offsets.y * length) / 256;
-    return { ComputeXYVector(projectedRun, trueYaw), projectedHeight };
+    return { Math::Trigonometry::ComputeXYVector(projectedRun, trueYaw), projectedHeight };
 }
 
 /**
@@ -5963,7 +5957,7 @@ static void play_scenery_door_open_sound(const CoordsXYZ& loc, WallElement* tile
         return;
 
     auto soundId = kDoorOpenSoundIds[EnumValue(doorSoundType)];
-    OpenRCT2::Audio::Play3D(soundId, loc);
+    Play3D(soundId, loc);
 }
 
 /**
@@ -6032,8 +6026,8 @@ void Vehicle::UpdateSceneryDoor() const
 
 template<bool isBackwards>
 static void AnimateLandscapeDoor(
-    const CoordsXYZ& doorLocation, TrackElement& trackElement, const bool isLastVehicle,
-    const OpenRCT2::Audio::DoorSoundType doorSound, const CoordsXYZ& soundLocation)
+    const CoordsXYZ& doorLocation, TrackElement& trackElement, const bool isLastVehicle, const DoorSoundType doorSound,
+    const CoordsXYZ& soundLocation)
 {
     const auto doorState = isBackwards ? trackElement.GetDoorAState() : trackElement.GetDoorBState();
     if (!isLastVehicle && doorState == kLandEdgeDoorFrameClosed)
@@ -6044,7 +6038,7 @@ static void AnimateLandscapeDoor(
             trackElement.SetDoorBState(kLandEdgeDoorFrameOpening);
 
         MapAnimations::CreateTemporary(doorLocation, MapAnimations::TemporaryType::landEdgeDoor);
-        OpenRCT2::Audio::Play3D(kDoorOpenSoundIds[EnumValue(doorSound)], soundLocation);
+        Play3D(kDoorOpenSoundIds[EnumValue(doorSound)], soundLocation);
     }
 
     if (isLastVehicle)
@@ -6055,7 +6049,7 @@ static void AnimateLandscapeDoor(
             trackElement.SetDoorBState(kLandEdgeDoorFrameClosing);
 
         MapAnimations::CreateTemporary(doorLocation, MapAnimations::TemporaryType::landEdgeDoor);
-        OpenRCT2::Audio::Play3D(kDoorCloseSoundIds[EnumValue(doorSound)], soundLocation);
+        Play3D(kDoorCloseSoundIds[EnumValue(doorSound)], soundLocation);
     }
 }
 
@@ -6163,8 +6157,7 @@ static void vehicle_update_play_water_splash_sound()
         return;
     }
 
-    OpenRCT2::Audio::Play3D(
-        OpenRCT2::Audio::SoundId::waterSplash, { _vehicleCurPosition.x, _vehicleCurPosition.y, _vehicleCurPosition.z });
+    Play3D(SoundId::waterSplash, { _vehicleCurPosition.x, _vehicleCurPosition.y, _vehicleCurPosition.z });
 }
 
 /**
@@ -6394,7 +6387,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         return false;
     }
 
-    if (collideVehicle->status == Vehicle::Status::travellingBoat && sub_state == BoatHireSubState::EnteringReturnPosition)
+    if (collideVehicle->status == Status::travellingBoat && sub_state == BoatHireSubState::EnteringReturnPosition)
     {
         return false;
     }
@@ -6408,7 +6401,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         return true;
     }
 
-    if (status == Vehicle::Status::movingToEndOfStation)
+    if (status == Status::movingToEndOfStation)
     {
         if (Orientation == 0)
         {
@@ -6440,8 +6433,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         }
     }
 
-    if (collideVehicle->status == Vehicle::Status::travellingBoat && status != Vehicle::Status::arriving
-        && status != Vehicle::Status::travelling)
+    if ((collideVehicle->status == Status::travellingBoat) && (status != Status::arriving) && (status != Status::travelling))
     {
         return false;
     }
@@ -6654,7 +6646,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
             {
                 if (!(rideEntry.Cars[0].flags & CAR_ENTRY_FLAG_POWERED))
                 {
-                    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::blockBrakeRelease, TrackLocation);
+                    Play3D(SoundId::blockBrakeRelease, TrackLocation);
                 }
             }
             MapInvalidateElement(TrackLocation, tileElement);
@@ -6866,7 +6858,7 @@ bool Vehicle::UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& cu
                     if (_vehicleF64E2C == 0)
                     {
                         _vehicleF64E2C++;
-                        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::brakeRelease, { x, y, z });
+                        Play3D(SoundId::brakeRelease, { x, y, z });
                     }
                 }
             }
@@ -7354,11 +7346,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         if (remaining_distance < 0x368A)
         {
             Loc6DCDE4(curRide);
-            return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+            return UpdateMiniGolfSubroutineStatus::stop;
         }
         acceleration = Geometry::getAccelerationFromPitch(pitch);
         _vehicleUnkF64E10++;
-        return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+        return UpdateMiniGolfSubroutineStatus::restart;
     }
 
     if (mini_golf_flags & MiniGolfFlag::Flag2)
@@ -7376,11 +7368,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         mini_golf_flags &= ~MiniGolfFlag::Flag2;
     }
@@ -7391,7 +7383,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         Vehicle* vEDI = getGameState().entities.GetEntity<Vehicle>(vehicleIdx);
         if (vEDI == nullptr)
         {
-            return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+            return UpdateMiniGolfSubroutineStatus::stop;
         }
         if (!(vEDI->mini_golf_flags & MiniGolfFlag::Flag0) || (vEDI->mini_golf_flags & MiniGolfFlag::Flag2))
         {
@@ -7404,11 +7396,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         if (vEDI->var_D3 != 0)
         {
@@ -7421,11 +7413,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         vEDI->mini_golf_flags &= ~MiniGolfFlag::Flag0;
         mini_golf_flags &= ~MiniGolfFlag::Flag0;
@@ -7437,7 +7429,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
         Vehicle* vEDI = getGameState().entities.GetEntity<Vehicle>(vehicleIdx);
         if (vEDI == nullptr)
         {
-            return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+            return UpdateMiniGolfSubroutineStatus::stop;
         }
         if (!(vEDI->mini_golf_flags & MiniGolfFlag::Flag1) || (vEDI->mini_golf_flags & MiniGolfFlag::Flag2))
         {
@@ -7450,11 +7442,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         if (vEDI->var_D3 != 0)
         {
@@ -7467,11 +7459,11 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
         vEDI->mini_golf_flags &= ~MiniGolfFlag::Flag1;
         mini_golf_flags &= ~MiniGolfFlag::Flag1;
@@ -7503,26 +7495,26 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             if (remaining_distance < 0x368A)
             {
                 Loc6DCDE4(curRide);
-                return Vehicle::UpdateMiniGolfSubroutineStatus::stop;
+                return UpdateMiniGolfSubroutineStatus::stop;
             }
             acceleration = Geometry::getAccelerationFromPitch(pitch);
             _vehicleUnkF64E10++;
-            return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+            return UpdateMiniGolfSubroutineStatus::restart;
         }
 
         mini_golf_flags |= MiniGolfFlag::Flag4;
         mini_golf_flags &= ~MiniGolfFlag::Flag3;
     }
 
-    return Vehicle::UpdateMiniGolfSubroutineStatus::carryOn;
+    return UpdateMiniGolfSubroutineStatus::carryOn;
 }
 
 [[nodiscard]] Vehicle::UpdateMiniGolfSubroutineStatus Vehicle::Loc6DC462(const Ride& curRide)
 {
     while (true)
     {
-        Vehicle::UpdateMiniGolfSubroutineStatus flagsStatus = Vehicle::UpdateMiniGolfSubroutineStatus::restart;
-        while (flagsStatus == Vehicle::UpdateMiniGolfSubroutineStatus::restart)
+        UpdateMiniGolfSubroutineStatus flagsStatus = UpdateMiniGolfSubroutineStatus::restart;
+        while (flagsStatus == UpdateMiniGolfSubroutineStatus::restart)
         {
             flagsStatus = UpdateTrackMotionMiniGolfFlagsStatus(curRide);
         }
@@ -7752,7 +7744,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
                 remaining_distance = 0x368A;
                 acceleration = Geometry::getAccelerationFromPitch(pitch);
                 _vehicleUnkF64E10++;
-                return Vehicle::UpdateMiniGolfSubroutineStatus::restart;
+                return UpdateMiniGolfSubroutineStatus::restart;
             }
 
             TrackLocation = trackPos;
@@ -8470,7 +8462,7 @@ void Vehicle::UpdateCrossings() const
                             MapGetTrackElementAtOfTypeSeq(frontVehicle->TrackLocation, frontVehicle->GetTrackType(), 0) };
     int32_t curZ = frontVehicle->TrackLocation.z;
 
-    if (xyElement.element != nullptr && status != Vehicle::Status::arriving)
+    if (xyElement.element != nullptr && status != Status::arriving)
     {
         int16_t autoReserveAhead = 4 + abs(velocity) / 150000;
         int16_t crossingBonus = 0;
@@ -8528,7 +8520,7 @@ void Vehicle::UpdateCrossings() const
 
             // Ensure trains near a station don't block possible crossings after the stop,
             // except when they are departing
-            if (xyElement.element->AsTrack()->IsStation() && status != Vehicle::Status::departing)
+            if (xyElement.element->AsTrack()->IsStation() && status != Status::departing)
             {
                 break;
             }
@@ -8543,7 +8535,7 @@ void Vehicle::UpdateCrossings() const
     }
 
     // Ensure departing trains don't clear blocked crossings behind them that might already be blocked by another incoming train
-    uint8_t freeCount = travellingForwards && status != Vehicle::Status::departing ? 3 : 1;
+    uint8_t freeCount = travellingForwards && status != Status::departing ? 3 : 1;
     while (freeCount-- > 0)
     {
         if (travellingForwards)
@@ -8570,10 +8562,10 @@ void Vehicle::Claxon() const
     switch (rideEntry->Cars[vehicle_type].soundRange)
     {
         case SoundRange::steamWhistle:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::trainWhistle, { x, y, z });
+            Play3D(SoundId::trainWhistle, { x, y, z });
             break;
         case SoundRange::tramBell:
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::tram, { x, y, z });
+            Play3D(SoundId::tram, { x, y, z });
             break;
         default:
             break;
@@ -8610,7 +8602,7 @@ Vehicle* Vehicle::GetCar(size_t carIndex) const
     return car;
 }
 
-void Vehicle::SetState(Vehicle::Status vehicleStatus, uint8_t subState)
+void Vehicle::SetState(Status vehicleStatus, uint8_t subState)
 {
     status = vehicleStatus;
     sub_state = subState;


### PR DESCRIPTION
This also removes `using namespace OpenRCT2::Math::Trigonometry` since it was only relevant for two lines.