### PR TITLE
Add getNextValidSegments(ride) method to TrackSegment plugin API

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2723,6 +2723,15 @@ declare global {
          * pathing of vehicles when moving along the track.
          */
         getSubpositions(subpositionType: number, direction: Direction): TrackSubposition[];
+
+        /**
+         * Gets all track segments that can validly connect after this segment for the given ride.
+         * Takes into account geometric compatibility (slope, banking, direction) and
+         * which track groups are enabled for the ride type.
+         * @param ride The ride to check valid segments for.
+         * @returns Array of track segments that can follow this one.
+         */
+        getNextValidSegments(ride: Ride): TrackSegment[];
     }
 
     enum TrackSlope {

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -198,6 +198,8 @@ namespace OpenRCT2::Scripting
 
         std::string getBreakdown() const;
 
+        friend class ScTrackSegment;
+
     public:
         static void Register(duk_context* ctx);
     };

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -14,10 +14,13 @@
     #include "../../Duktape.hpp"
 
     #include <cstdint>
+    #include <memory>
     #include <string>
+    #include <vector>
 
 namespace OpenRCT2::Scripting
 {
+    class ScRide;
     template<>
     inline DukValue ToDuk(duk_context* ctx, const VehicleInfo& value)
     {
@@ -69,6 +72,8 @@ namespace OpenRCT2::Scripting
         bool getTrackFlag() const;
         std::string getTrackCurvature() const;
         std::string getTrackPitchDirection() const;
+        std::vector<std::shared_ptr<ScTrackSegment>> getNextValidSegments(
+            const std::shared_ptr<ScRide>& scRide) const;
     };
 
 } // namespace OpenRCT2::Scripting


### PR DESCRIPTION
  Adds a new method to the TrackSegment interface that returns all track segments that can validly connect after the current segment for a given ride.

  This enables plugins to programmatically determine which track pieces can follow a given piece, taking into account:
  - Geometric compatibility (matching slope, banking, and direction)
  - Track groups enabled for the ride type

  Previously, plugins that wanted to build rides programmatically had to hardcode all track connection rules. With this method, plugins can query valid transitions directly from the game engine.

  Example usage:
  var segment = context.getTrackSegment(trackType);
  var validNext = segment.getNextValidSegments(ride);
  validNext.forEach(s => console.log(s.description));
