### PR TITLE
Fix #25745: Crash when a player connection is aborted early

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
+- Fix: [#25745] Crash when a player connection is aborted early.
 - Fix: [#25799] The animated options tab icon of the news window does not always redraw.
 
 0.4.30 (2026-01-04)

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -547,7 +547,10 @@ namespace OpenRCT2::Network
 
             if (!ProcessConnection(*connection))
             {
-                LOG_INFO("Disconnecting player %s", connection->player->Name.c_str());
+                if (connection->player != nullptr)
+                    LOG_INFO("Disconnecting player %s", connection->player->Name.c_str());
+                else
+                    LOG_INFO("Disconnecting unknown player");
                 connection->Disconnect();
             }
             else


### PR DESCRIPTION
Note: there are 5-6 additional issues that should be linked, but GitHub only allows linking 10.