### PR TITLE
Remove top-level const qualifiers from function declarations

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -122,11 +122,10 @@ public:
     void FilterRect(
         RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
     void DrawLine(RenderTarget& rt, PaletteIndex colour, const ScreenLine& line) override;
-    void DrawSprite(RenderTarget& rt, const ImageId imageId, int32_t x, int32_t y) override;
-    void DrawSpriteRawMasked(
-        RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-    void DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, PaletteIndex colour) override;
-    void DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
+    void DrawSprite(RenderTarget& rt, ImageId imageId, int32_t x, int32_t y) override;
+    void DrawSpriteRawMasked(RenderTarget& rt, int32_t x, int32_t y, ImageId maskImage, ImageId colourImage) override;
+    void DrawSpriteSolid(RenderTarget& rt, ImageId image, int32_t x, int32_t y, PaletteIndex colour) override;
+    void DrawGlyph(RenderTarget& rt, ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawTTFBitmap(
         RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold) override;
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -39,7 +39,7 @@ namespace OpenRCT2::Ui
             size_t operator()(const GlyphId& k) const
             {
                 size_t hash = k.Image * 7;
-                hash += (k.Palette & 0xFFFFFFFFUL) * 13;
+                hash += (k.Palette & 0xFFFFFFFFuL) * 13;
                 hash += (k.Palette >> 32uL) * 23;
                 return hash;
             }
@@ -207,8 +207,8 @@ namespace OpenRCT2::Ui
         TextureCache();
         ~TextureCache();
         void InvalidateImage(ImageIndex image);
-        BasicTextureInfo GetOrLoadImageTexture(const ImageId imageId);
-        BasicTextureInfo GetOrLoadGlyphTexture(const ImageId imageId, const PaletteMap& paletteMap);
+        BasicTextureInfo GetOrLoadImageTexture(ImageId imageId);
+        BasicTextureInfo GetOrLoadGlyphTexture(ImageId imageId, const PaletteMap& paletteMap);
         BasicTextureInfo GetOrLoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
 
         GLuint GetAtlasesTexture();
@@ -220,12 +220,12 @@ namespace OpenRCT2::Ui
         void CreateTextures();
         void GeneratePaletteTexture();
         void EnlargeAtlasesTexture(GLuint newEntries);
-        AtlasTextureInfo LoadImageTexture(const ImageId image);
-        AtlasTextureInfo LoadGlyphTexture(const ImageId image, const PaletteMap& paletteMap);
+        AtlasTextureInfo LoadImageTexture(ImageId image);
+        AtlasTextureInfo LoadGlyphTexture(ImageId image, const PaletteMap& paletteMap);
         AtlasTextureInfo AllocateImage(int32_t imageWidth, int32_t imageHeight);
         AtlasTextureInfo LoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
-        static Drawing::RenderTarget GetImageAsRT(const ImageId imageId);
-        static Drawing::RenderTarget GetGlyphAsRT(const ImageId imageId, const PaletteMap& paletteMap);
+        static Drawing::RenderTarget GetImageAsRT(ImageId imageId);
+        static Drawing::RenderTarget GetGlyphAsRT(ImageId imageId, const PaletteMap& paletteMap);
         void FreeTextures();
 
         static Drawing::RenderTarget CreateRT(int32_t width, int32_t height);

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -54,10 +54,10 @@ namespace OpenRCT2::Ui::FileBrowser
     void SetAndSaveConfigPath(u8string& config_str, u8string_view path);
     bool IsValidPath(const char* path);
     u8string GetLastDirectoryByType(LoadSaveType type);
-    u8string GetInitialDirectoryByType(const LoadSaveType type);
-    const char* GetFilterPatternByType(const LoadSaveType type, const bool isSave);
+    u8string GetInitialDirectoryByType(LoadSaveType type);
+    const char* GetFilterPatternByType(LoadSaveType type, bool isSave);
     u8string RemovePatternWildcard(u8string_view pattern);
-    u8string GetDir(const LoadSaveType type);
+    u8string GetDir(LoadSaveType type);
     void RegisterCallback(LoadSaveCallback callback);
     void InvokeCallback(ModalResult result, const utf8* path);
     void Select(const char* path, LoadSaveAction action, LoadSaveType type, TrackDesign* trackDesignPtr);

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -66,7 +66,7 @@ namespace OpenRCT2::Ui::Windows
 
     static money64 FootpathProvisionalSet(
         ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXY& footpathLocA, const CoordsXY& footpathLocB,
-        int32_t startZ, const std::span<const ProvisionalTile> tiles, PathConstructFlags constructFlags);
+        int32_t startZ, std::span<const ProvisionalTile> tiles, PathConstructFlags constructFlags);
 
     enum class PathConstructionMode : uint8_t
     {

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -189,8 +189,7 @@ namespace OpenRCT2::Ui::Windows
 
     // OverwritePrompt
     WindowBase* WindowOverwritePromptOpen(
-        const std::string_view name, const std::string_view path, LoadSaveAction action, LoadSaveType type,
-        TrackDesign* trackDesignPtr);
+        std::string_view name, std::string_view path, LoadSaveAction action, LoadSaveType type, TrackDesign* trackDesignPtr);
     void WindowLoadSaveOverwritePromptInputKey(WindowBase* w, uint32_t keycode);
 
     // Park
@@ -271,9 +270,9 @@ namespace OpenRCT2::Ui::Windows
     // Scenery
     WindowBase* SceneryOpen();
     void WindowScenerySetSelectedItem(
-        const ScenerySelection& sceneryconst, std::optional<colour_t> primary, const std::optional<colour_t> secondary,
-        const std::optional<colour_t> tertiary, const std::optional<colour_t> rotation);
-    void WindowScenerySetSelectedTab(const ObjectEntryIndex sceneryGroupIndex);
+        const ScenerySelection& sceneryconst, std::optional<colour_t> primary, std::optional<colour_t> secondary,
+        std::optional<colour_t> tertiary, std::optional<colour_t> rotation);
+    void WindowScenerySetSelectedTab(ObjectEntryIndex sceneryGroupIndex);
     void WindowScenerySetDefaultPlacementConfiguration();
     void WindowSceneryInit();
     void WindowSceneryResetSelectedSceneryItems();

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -92,7 +92,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* EditorScenarioOptionsOpen();
 
     // Error
-    WindowBase* ErrorOpen(StringId title, StringId message, class Formatter& formatter, bool autoClose = false);
+    WindowBase* ErrorOpen(StringId title, StringId message, const class Formatter& formatter, bool autoClose = false);
     WindowBase* ErrorOpen(std::string_view title, std::string_view message, bool autoClose = false);
 
     // Finances
@@ -352,7 +352,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* TopToolbarOpen();
 
     // TrackDesignPlace
-    WindowBase* TrackPlaceOpen(struct TrackDesignFileRef* tdFileRef);
+    WindowBase* TrackPlaceOpen(const struct TrackDesignFileRef* tdFileRef);
     void TrackPlaceClearProvisionalTemporarily();
     void TrackPlaceRestoreProvisional();
 

--- a/src/openrct2-ui/windows/Windows.h
+++ b/src/openrct2-ui/windows/Windows.h
@@ -92,7 +92,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* EditorScenarioOptionsOpen();
 
     // Error
-    WindowBase* ErrorOpen(StringId title, StringId message, const class Formatter& formatter, bool autoClose = false);
+    WindowBase* ErrorOpen(StringId title, StringId message, class Formatter& formatter, bool autoClose = false);
     WindowBase* ErrorOpen(std::string_view title, std::string_view message, bool autoClose = false);
 
     // Finances
@@ -352,7 +352,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* TopToolbarOpen();
 
     // TrackDesignPlace
-    WindowBase* TrackPlaceOpen(const struct TrackDesignFileRef* tdFileRef);
+    WindowBase* TrackPlaceOpen(struct TrackDesignFileRef* tdFileRef);
     void TrackPlaceClearProvisionalTemporarily();
     void TrackPlaceRestoreProvisional();
 

--- a/src/openrct2/actions/NetworkModifyGroupAction.h
+++ b/src/openrct2/actions/NetworkModifyGroupAction.h
@@ -43,7 +43,7 @@ namespace OpenRCT2::GameActions
     public:
         NetworkModifyGroupAction() = default;
         NetworkModifyGroupAction(
-            ModifyGroupType type, uint8_t groupId = std::numeric_limits<uint8_t>::max(), const std::string name = "",
+            ModifyGroupType type, uint8_t groupId = std::numeric_limits<uint8_t>::max(), std::string name = "",
             uint32_t permissionIndex = 0, PermissionState permissionState = PermissionState::Count);
 
         void AcceptParameters(GameActionParameterVisitor&) final;

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.h
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.h
@@ -36,6 +36,6 @@ namespace OpenRCT2::GameActions
         Result Query(GameState_t& gameState) const override;
         Result Execute(GameState_t& gameState) const override;
 
-        static Result TrackPlaceQuery(GameState_t& gameState, const CoordsXYZ& loc, const bool isExit);
+        static Result TrackPlaceQuery(GameState_t& gameState, const CoordsXYZ& loc, bool isExit);
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/StaffSetPatrolAreaAction.h
+++ b/src/openrct2/actions/StaffSetPatrolAreaAction.h
@@ -31,7 +31,7 @@ namespace OpenRCT2::GameActions
 
     public:
         StaffSetPatrolAreaAction() = default;
-        StaffSetPatrolAreaAction(EntityId spriteId, const MapRange& range, const StaffSetPatrolAreaMode mode);
+        StaffSetPatrolAreaAction(EntityId spriteId, const MapRange& range, StaffSetPatrolAreaMode mode);
 
         uint16_t GetActionFlags() const override;
 

--- a/src/openrct2/command_line/UriHandler.cpp
+++ b/src/openrct2/command_line/UriHandler.cpp
@@ -20,7 +20,7 @@ namespace OpenRCT2
 #ifndef DISABLE_NETWORK
     static exitcode_t HandleUriJoin(const std::vector<std::string_view>& args);
     static bool TryParseHostnamePort(
-        const std::string_view hostnamePort, std::string* outHostname, int32_t* outPort, int32_t defaultPort);
+        std::string_view hostnamePort, std::string* outHostname, int32_t* outPort, int32_t defaultPort);
 #endif
 
     exitcode_t CommandLine::HandleCommandUri(CommandLineArgEnumerator* enumerator)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -259,7 +259,7 @@ void GfxDrawPickedUpPeep(OpenRCT2::Drawing::RenderTarget& rt);
 void GfxDrawLine(OpenRCT2::Drawing::RenderTarget& rt, const ScreenLine& line, OpenRCT2::Drawing::PaletteIndex colour);
 void GfxDrawLineSoftware(OpenRCT2::Drawing::RenderTarget& rt, const ScreenLine& line, OpenRCT2::Drawing::PaletteIndex colour);
 void GfxDrawDashedLine(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength,
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenLine& screenLine, int32_t dashedLineSegmentLength,
     OpenRCT2::Drawing::PaletteIndex colour);
 
 // sprite
@@ -269,7 +269,7 @@ bool GfxLoadCsg();
 void GfxUnloadG1();
 void GfxUnloadG2AndFonts();
 void GfxUnloadCsg();
-const OpenRCT2::G1Element* GfxGetG1Element(const ImageId imageId);
+const OpenRCT2::G1Element* GfxGetG1Element(ImageId imageId);
 const OpenRCT2::G1Element* GfxGetG1Element(ImageIndex image_id);
 const OpenRCT2::G1Palette* GfxGetG1Palette(ImageIndex imageId);
 void GfxSetG1Element(ImageIndex imageId, const OpenRCT2::G1Element* g1);
@@ -278,20 +278,18 @@ bool IsCsgLoaded();
 void FASTCALL GfxSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
 void FASTCALL GfxBmpSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
 void FASTCALL GfxRleSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
-void FASTCALL GfxDrawSprite(OpenRCT2::Drawing::RenderTarget& rt, const ImageId image_id, const ScreenCoordsXY& coords);
+void FASTCALL GfxDrawSprite(OpenRCT2::Drawing::RenderTarget& rt, ImageId image_id, const ScreenCoordsXY& coords);
 void FASTCALL GfxDrawGlyph(
-    OpenRCT2::Drawing::RenderTarget& rt, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    OpenRCT2::Drawing::RenderTarget& rt, ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteSolid(
-    OpenRCT2::Drawing::RenderTarget& rt, const ImageId image, const ScreenCoordsXY& coords,
-    OpenRCT2::Drawing::PaletteIndex colour);
+    OpenRCT2::Drawing::RenderTarget& rt, ImageId image, const ScreenCoordsXY& coords, OpenRCT2::Drawing::PaletteIndex colour);
 void FASTCALL GfxDrawSpriteRawMasked(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
-void FASTCALL
-    GfxDrawSpriteSoftware(OpenRCT2::Drawing::RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, ImageId maskImage, ImageId colourImage);
+void FASTCALL GfxDrawSpriteSoftware(OpenRCT2::Drawing::RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    OpenRCT2::Drawing::RenderTarget& rt, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    OpenRCT2::Drawing::RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& scrCoords, ImageId maskImage, ImageId colourImage);
 
 // string
 void GfxDrawStringLeftCentred(

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -35,12 +35,10 @@ namespace OpenRCT2::Drawing
             RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
             = 0;
         virtual void DrawLine(RenderTarget& rt, PaletteIndex colour, const ScreenLine& line) = 0;
-        virtual void DrawSprite(RenderTarget& rt, const ImageId image, int32_t x, int32_t y) = 0;
-        virtual void DrawSpriteRawMasked(
-            RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
-            = 0;
-        virtual void DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, PaletteIndex colour) = 0;
-        virtual void DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) = 0;
+        virtual void DrawSprite(RenderTarget& rt, ImageId image, int32_t x, int32_t y) = 0;
+        virtual void DrawSpriteRawMasked(RenderTarget& rt, int32_t x, int32_t y, ImageId maskImage, ImageId colourImage) = 0;
+        virtual void DrawSpriteSolid(RenderTarget& rt, ImageId image, int32_t x, int32_t y, PaletteIndex colour) = 0;
+        virtual void DrawGlyph(RenderTarget& rt, ImageId image, int32_t x, int32_t y, const PaletteMap& palette) = 0;
         virtual void DrawTTFBitmap(
             RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y, uint8_t hintingThreshold)
             = 0;

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -54,7 +54,7 @@ namespace OpenRCT2::Drawing::LightFx
     void UpdateBuffers(RenderTarget&);
     const GamePalette& GetPalette();
 
-    void Add3DLight(const EntityBase& entity, const uint8_t id, const CoordsXYZ& loc, const LightType lightType);
+    void Add3DLight(const EntityBase& entity, uint8_t id, const CoordsXYZ& loc, LightType lightType);
 
     void Add3DLightMagicFromDrawingTile(
         const CoordsXY& mapPosition, int16_t offsetX, int16_t offsetY, int16_t offsetZ, LightType lightType);
@@ -67,8 +67,8 @@ namespace OpenRCT2::Drawing::LightFx
     void AddLightsMagicVehicle_Monorail(const Vehicle* vehicle);
     void AddLightsMagicVehicle_MiniatureRailway(const Vehicle* vehicle);
 
-    void AddKioskLights(const CoordsXY& mapPosition, const int32_t height, const uint8_t zOffset);
-    void AddShopLights(const CoordsXY& mapPosition, const uint8_t direction, const int32_t height, const uint8_t zOffset);
+    void AddKioskLights(const CoordsXY& mapPosition, int32_t height, uint8_t zOffset);
+    void AddShopLights(const CoordsXY& mapPosition, uint8_t direction, int32_t height, uint8_t zOffset);
 
     void ApplyPaletteFilter(uint8_t i, uint8_t* r, uint8_t* g, uint8_t* b);
     void RenderToTexture(

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -142,11 +142,10 @@ namespace OpenRCT2
             void FilterRect(
                 RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
             void DrawLine(RenderTarget& rt, PaletteIndex colour, const ScreenLine& line) override;
-            void DrawSprite(RenderTarget& rt, const ImageId imageId, int32_t x, int32_t y) override;
-            void DrawSpriteRawMasked(
-                RenderTarget& rt, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-            void DrawSpriteSolid(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, PaletteIndex colour) override;
-            void DrawGlyph(RenderTarget& rt, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+            void DrawSprite(RenderTarget& rt, ImageId imageId, int32_t x, int32_t y) override;
+            void DrawSpriteRawMasked(RenderTarget& rt, int32_t x, int32_t y, ImageId maskImage, ImageId colourImage) override;
+            void DrawSpriteSolid(RenderTarget& rt, ImageId image, int32_t x, int32_t y, PaletteIndex colour) override;
+            void DrawGlyph(RenderTarget& rt, ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawTTFBitmap(
                 RenderTarget& rt, TextDrawInfo* info, TTFSurface* surface, int32_t x, int32_t y,
                 uint8_t hintingThreshold) override;

--- a/src/openrct2/entity/EntityRegistry.h
+++ b/src/openrct2/entity/EntityRegistry.h
@@ -117,15 +117,15 @@ namespace OpenRCT2
         }
 
         // Use only with imports that must happen at a specified index
-        EntityBase* CreateEntityAt(const EntityId index, const EntityType type);
+        EntityBase* CreateEntityAt(EntityId index, EntityType type);
         // Use only with imports that must happen at a specified index
         template<typename T>
-        T* CreateEntityAt(const EntityId index)
+        T* CreateEntityAt(EntityId index)
         {
             return static_cast<T*>(CreateEntityAt(index, T::cEntityType));
         }
 
-        const std::list<EntityId>& GetEntityList(const EntityType id);
+        const std::list<EntityId>& GetEntityList(EntityType id);
         uint16_t GetMiscEntityCount();
 
         void ResetAllEntities();
@@ -184,7 +184,7 @@ namespace OpenRCT2
         void AddToEntityList(EntityBase& entity);
         void AddToFreeList(EntityId index);
         void RemoveFromEntityList(EntityBase& entity);
-        void PrepareNewEntity(EntityBase& base, const EntityType type);
+        void PrepareNewEntity(EntityBase& base, EntityType type);
         void EntitySpatialInsert(EntityBase& entity, const CoordsXY& newLoc);
         void EntitySpatialRemove(EntityBase& entity);
         void FreeEntity(EntityBase& entity);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -450,7 +450,7 @@ static void GuestRideIsTooIntense(Guest& guest, Ride& ride, bool peepAtRide);
 static void GuestResetRideHeading(Guest& guest);
 static void GuestTriedToEnterFullQueue(Guest& guest, Ride& ride);
 static int16_t GuestCalculateRideSatisfaction(Guest& guest, const Ride& ride);
-static void GuestUpdateFavouriteRide(Guest& guest, const Ride& ride, const uint8_t satisfaction);
+static void GuestUpdateFavouriteRide(Guest& guest, const Ride& ride, uint8_t satisfaction);
 static int16_t GuestCalculateRideValueSatisfaction(Guest& guest, const Ride& ride);
 static int16_t GuestCalculateRideIntensityNauseaSatisfaction(Guest& guest, const Ride& ride);
 static void GuestUpdateRideNauseaGrowth(Guest& guest, const Ride& ride);

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -461,7 +461,7 @@ void PeepWindowStateUpdate(Peep* peep);
 void PeepDecrementNumRiders(Peep* peep);
 
 void PeepSetMapTooltip(Peep* peep);
-int32_t PeepCompare(const EntityId sprite_index_a, const EntityId sprite_index_b);
+int32_t PeepCompare(EntityId sprite_index_a, EntityId sprite_index_b);
 
 void PeepUpdateNames();
 

--- a/src/openrct2/entity/Staff.h
+++ b/src/openrct2/entity/Staff.h
@@ -168,4 +168,4 @@ OpenRCT2::GameActions::Result StaffSetColour(StaffType staffType, colour_t value
 
 money64 GetStaffWage(StaffType type);
 
-const PatrolArea& GetMergedPatrolArea(const StaffType type);
+const PatrolArea& GetMergedPatrolArea(StaffType type);

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -152,7 +152,7 @@ namespace OpenRCT2::Colour
 
 #ifndef DISABLE_TTF
 OpenRCT2::Drawing::PaletteIndex BlendColours(
-    const OpenRCT2::Drawing::PaletteIndex paletteIndex1, const OpenRCT2::Drawing::PaletteIndex paletteIndex2);
+    OpenRCT2::Drawing::PaletteIndex paletteIndex1, OpenRCT2::Drawing::PaletteIndex paletteIndex2);
 #endif
 
 typedef OpenRCT2::Drawing::PaletteIndex BlendColourMapType[kPaletteCount][kPaletteCount];

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -70,13 +70,13 @@ namespace OpenRCT2
             return (sPos.x >= pos.x && sPos.x < pos.x + width && sPos.y >= pos.y && sPos.y < pos.y + height);
         }
 
-        [[nodiscard]] bool ContainsTile(const TileCoordsXY coords) const noexcept;
+        [[nodiscard]] bool ContainsTile(TileCoordsXY coords) const noexcept;
 
         [[nodiscard]] ScreenCoordsXY ScreenToViewportCoord(const ScreenCoordsXY& screenCoord) const;
 
         void Invalidate() const;
 
-        void Invalidate(const int32_t x, const int32_t y, const int32_t z0, const int32_t z1, const ZoomLevel maxZoom) const;
+        void Invalidate(int32_t x, int32_t y, int32_t z0, int32_t z1, ZoomLevel maxZoom) const;
     };
 
     struct Focus;

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -119,7 +119,7 @@ namespace OpenRCT2
         void setViewportLocation(const CoordsXYZ& coords);
         void invalidate();
         void removeViewport();
-        void setWidgets(const std::span<const Widget> newWidgets);
+        void setWidgets(std::span<const Widget> newWidgets);
         void resizeFrame();
 
         int16_t getTitleBarTargetHeight() const;

--- a/src/openrct2/management/Marketing.h
+++ b/src/openrct2/management/Marketing.h
@@ -73,4 +73,4 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaign);
 bool MarketingIsCampaignTypeApplicable(int32_t campaignType);
 MarketingCampaign* MarketingGetCampaign(int32_t campaignType);
 void MarketingNewCampaign(const MarketingCampaign& campaign);
-void MarketingCancelCampaignsForRide(const RideId rideId);
+void MarketingCancelCampaignsForRide(RideId rideId);

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -322,5 +322,5 @@ namespace OpenRCT2::News
     void AddItemToQueue(Item* newNewsItem);
     void RemoveItem(int32_t index);
 
-    void importNewsItems(GameState_t& gameState, const std::span<const Item> recent, const std::span<const Item> archived);
+    void importNewsItems(GameState_t& gameState, std::span<const Item> recent, std::span<const Item> archived);
 } // namespace OpenRCT2::News

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -63,7 +63,7 @@ namespace OpenRCT2::Network
 
         const utf8* GetLastDisconnectReason() const noexcept;
         void SetLastDisconnectReason(std::string_view src);
-        void SetLastDisconnectReason(const StringId string_id, void* args = nullptr);
+        void SetLastDisconnectReason(StringId string_id, void* args = nullptr);
 
     private:
         std::vector<uint8_t> _inboundBuffer;

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -41,8 +41,8 @@ namespace OpenRCT2::Network
         std::string PublicKeyString();
         std::string PublicKeyHash();
         void Unload();
-        bool Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const;
-        bool Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const;
+        bool Sign(const uint8_t* md, size_t len, std::vector<uint8_t>& signature) const;
+        bool Verify(const uint8_t* md, size_t len, const std::vector<uint8_t>& signature) const;
 
     private:
         Key(const Key&) = delete;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -303,7 +303,7 @@ namespace OpenRCT2
         }
 
         bool IsCompatibilityObject() const;
-        void SetIsCompatibilityObject(const bool on);
+        void SetIsCompatibilityObject(bool on);
 
         const ImageTable& GetImageTable() const
         {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -219,7 +219,7 @@ namespace OpenRCT2::ObjectFactory
      * @note jRoot is deliberately left non-const: json_t behaviour changes when const
      */
     static std::unique_ptr<Object> CreateObjectFromJson(
-        json_t& jRoot, const IFileDataRetriever* fileRetriever, bool loadImageTable, const std::string_view path);
+        json_t& jRoot, const IFileDataRetriever* fileRetriever, bool loadImageTable, std::string_view path);
 
     static ObjectSourceGame ParseSourceGame(const std::string_view s)
     {

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -51,7 +51,7 @@ namespace OpenRCT2
         virtual Object* LoadObject(const ObjectEntryDescriptor& descriptor) = 0;
         virtual Object* LoadObject(const ObjectEntryDescriptor& descriptor, ObjectEntryIndex slot) = 0;
         virtual Object* LoadRepositoryItem(const ObjectRepositoryItem& ori) = 0;
-        virtual void LoadObjects(const ObjectList& entries, const bool reportProgress = false) = 0;
+        virtual void LoadObjects(const ObjectList& entries, bool reportProgress = false) = 0;
         virtual void UnloadObjects(const std::vector<ObjectEntryDescriptor>& entries) = 0;
         virtual void UnloadAllTransient() = 0;
         virtual void UnloadAll() = 0;
@@ -70,5 +70,5 @@ namespace OpenRCT2
     Object* ObjectManagerLoadObject(const RCTObjectEntry* entry);
     void ObjectManagerUnloadObjects(const std::vector<ObjectEntryDescriptor>& entries);
     void ObjectManagerUnloadAllObjects();
-    [[nodiscard]] StringId ObjectManagerGetSourceGameString(const ObjectSourceGame sourceGame);
+    [[nodiscard]] StringId ObjectManagerGetSourceGameString(ObjectSourceGame sourceGame);
 } // namespace OpenRCT2

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -253,7 +253,7 @@ extern bool gPaintWidePathsAsGhost;
 extern bool gPaintStableSort;
 
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 /**
  *  rct2: 0x006861AC, 0x00686337, 0x006864D0, 0x0068666B, 0x0098196C
  *
@@ -267,23 +267,21 @@ PaintStruct* PaintAddImageAsParent(
  * @return (ebp) PaintStruct on success (CF == 0), nullptr on failure (CF == 1)
  */
 inline PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize)
+    PaintSession& session, ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize)
 {
     return PaintAddImageAsParent(session, image_id, offset, { offset, boundBoxSize });
 }
 
 [[nodiscard]] PaintStruct* PaintAddImageAsOrphan(
-    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 PaintStruct* PaintAddImageAsChild(
-    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
 PaintStruct* PaintAddImageAsChildRotated(
-    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
-    const BoundBoxXYZ& boundBox);
+    PaintSession& session, uint8_t direction, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
 PaintStruct* PaintAddImageAsParentRotated(
-    PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
-    const BoundBoxXYZ& boundBox);
+    PaintSession& session, uint8_t direction, ImageId imageId, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
 inline PaintStruct* PaintAddImageAsParentRotated(
     PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
@@ -293,10 +291,10 @@ inline PaintStruct* PaintAddImageAsParentRotated(
 }
 
 PaintStruct* PaintAddImageAsParentHeight(
-    PaintSession& session, const ImageId imageId, const int32_t height, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, ImageId imageId, int32_t height, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
-bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId imageId, int32_t x, int32_t y);
-bool PaintAttachToPreviousPS(PaintSession& session, const ImageId image_id, int32_t x, int32_t y);
+bool PaintAttachToPreviousAttach(PaintSession& session, ImageId imageId, int32_t x, int32_t y);
+bool PaintAttachToPreviousPS(PaintSession& session, ImageId image_id, int32_t x, int32_t y);
 void PaintFloatingMoneyEffect(
     PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);

--- a/src/openrct2/paint/VirtualFloor.h
+++ b/src/openrct2/paint/VirtualFloor.h
@@ -29,7 +29,7 @@ void VirtualFloorSetHeight(int16_t height);
 
 void VirtualFloorEnable();
 void VirtualFloorDisable();
-void VirtualFloorInvalidate(const bool alwaysInvalidate);
+void VirtualFloorInvalidate(bool alwaysInvalidate);
 
 bool VirtualFloorTileIsFloor(const CoordsXY& loc);
 

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -62,4 +62,4 @@ void PaintLargeScenery(
     PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::LargeSceneryElement& tileElement);
 void PaintTrack(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::TrackElement& tileElement);
 
-bool PaintShouldShowHeightMarkers(const PaintSession& session, const uint32_t viewportFlag);
+bool PaintShouldShowHeightMarkers(const PaintSession& session, uint32_t viewportFlag);

--- a/src/openrct2/peep/PeepAnimations.h
+++ b/src/openrct2/peep/PeepAnimations.h
@@ -71,14 +71,13 @@ namespace OpenRCT2
         PeepAnimation animations[37]{};
     };
 
-    ObjectEntryIndex findPeepAnimationsIndexForType(const AnimationPeepType type);
-    PeepAnimationsObject* findPeepAnimationsObjectForType(const AnimationPeepType type);
+    ObjectEntryIndex findPeepAnimationsIndexForType(AnimationPeepType type);
+    PeepAnimationsObject* findPeepAnimationsObjectForType(AnimationPeepType type);
 
-    std::vector<ObjectEntryIndex> findAllPeepAnimationsIndexesForType(const AnimationPeepType type, bool randomOnly = false);
-    std::vector<PeepAnimationsObject*> findAllPeepAnimationsObjectForType(
-        const AnimationPeepType type, bool randomOnly = false);
+    std::vector<ObjectEntryIndex> findAllPeepAnimationsIndexesForType(AnimationPeepType type, bool randomOnly = false);
+    std::vector<PeepAnimationsObject*> findAllPeepAnimationsObjectForType(AnimationPeepType type, bool randomOnly = false);
 
-    ObjectEntryIndex findRandomPeepAnimationsIndexForType(const AnimationPeepType type);
+    ObjectEntryIndex findRandomPeepAnimationsIndexForType(AnimationPeepType type);
 
     struct AnimationGroupResult
     {
@@ -89,7 +88,7 @@ namespace OpenRCT2
         std::string_view scriptName;
     };
 
-    std::vector<AnimationGroupResult> getAnimationGroupsByPeepType(const AnimationPeepType type);
+    std::vector<AnimationGroupResult> getAnimationGroupsByPeepType(AnimationPeepType type);
 
     struct AvailableCostume
     {
@@ -99,7 +98,7 @@ namespace OpenRCT2
         std::string friendlyName;
     };
 
-    std::vector<AvailableCostume> getAvailableCostumeStrings(const AnimationPeepType type);
+    std::vector<AvailableCostume> getAvailableCostumeStrings(AnimationPeepType type);
 
     SpriteBounds inferMaxAnimationDimensions(const PeepAnimation& anim);
 } // namespace OpenRCT2

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -164,7 +164,7 @@ namespace OpenRCT2::Platform
     void SetUpFileAssociations();
     bool SetUpFileAssociation(
         std::string_view extension, std::string_view fileTypeText, std::string_view commandText, std::string_view commandArgs,
-        const uint32_t iconIndex);
+        uint32_t iconIndex);
     void RemoveFileAssociations();
     bool SetupUriProtocol();
 #endif

--- a/src/openrct2/rct1/Tables.h
+++ b/src/openrct2/rct1/Tables.h
@@ -54,5 +54,5 @@ namespace OpenRCT2::RCT1
 
     const std::vector<const char*> GetSceneryObjects(uint8_t sceneryType);
 
-    bool VehicleTypeIsReversed(const VehicleType vehicleType);
+    bool VehicleTypeIsReversed(VehicleType vehicleType);
 } // namespace OpenRCT2::RCT1

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -1223,8 +1223,8 @@ static_assert(sizeof(RCT12VehicleColour) == 2);
 
 #pragma pack(pop)
 
-OpenRCT2::ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(const RCT12ObjectEntryIndex index);
-RideId RCT12RideIdToOpenRCT2RideId(const RCT12RideId rideId);
+OpenRCT2::ObjectEntryIndex RCTEntryIndexToOpenRCT2EntryIndex(RCT12ObjectEntryIndex index);
+RideId RCT12RideIdToOpenRCT2RideId(RCT12RideId rideId);
 bool IsLikelyUTF8(std::string_view s);
 std::string RCT12RemoveFormattingUTF8(std::string_view s);
 std::string ConvertFormattedStringToOpenRCT2(std::string_view buffer);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -458,8 +458,8 @@ public:
      */
     void updateRideTypeForAllPieces();
 
-    void updateSatisfaction(const uint8_t happiness);
-    void updatePopularity(const uint8_t pop_amount);
+    void updateSatisfaction(uint8_t happiness);
+    void updatePopularity(uint8_t pop_amount);
     void removePeeps();
 
     int32_t getTotalLength() const;

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -275,7 +275,7 @@ using StartRideMusicFunction = void (*)(const OpenRCT2::RideAudio::ViewportRideM
 using LightFXAddLightsMagicVehicleFunction = void (*)(const Vehicle* vehicle);
 using RideLocationFunction = CoordsXY (*)(const Vehicle& vehicle, const Ride& ride, const StationIndex& CurrentRideStation);
 using RideUpdateFunction = void (*)(Ride& ride);
-using RideUpdateMeasurementsSpecialElementsFunc = void (*)(Ride& ride, const OpenRCT2::TrackElemType trackType);
+using RideUpdateMeasurementsSpecialElementsFunc = void (*)(Ride& ride, OpenRCT2::TrackElemType trackType);
 using MusicTrackOffsetLengthFunc = std::pair<size_t, size_t> (*)(const Ride& ride);
 using SpecialElementRatingAdjustmentFunc = void (*)(const Ride& ride, int32_t& excitement, int32_t& intensity, int32_t& nausea);
 
@@ -300,7 +300,7 @@ struct TrackDrawerEntry
     StringId tooltip = kStringIdNone;
 
     void GetAvailableTrackGroups(RideTrackGroups& res) const;
-    bool SupportsTrackGroup(const TrackGroup trackGroup) const;
+    bool SupportsTrackGroup(TrackGroup trackGroup) const;
 };
 
 struct TrackDrawerDescriptor
@@ -545,7 +545,7 @@ struct RideTypeDescriptor
 
     bool HasFlag(RtdFlag flag) const;
     /** @deprecated */
-    bool SupportsTrackGroup(const TrackGroup trackGroup) const;
+    bool SupportsTrackGroup(TrackGroup trackGroup) const;
     ResearchCategory GetResearchCategory() const;
     bool SupportsRideMode(RideMode rideMode) const;
     /**

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -99,4 +99,4 @@ struct RideObjectEntry
     }
 };
 
-RideNaming GetRideNaming(const ride_type_t rideType, const RideObjectEntry* rideEntry);
+RideNaming GetRideNaming(ride_type_t rideType, const RideObjectEntry* rideEntry);

--- a/src/openrct2/ride/ShopItem.h
+++ b/src/openrct2/ride/ShopItem.h
@@ -128,7 +128,7 @@ enum
     SHOP_ITEM_FLAG_IS_RECOLOURABLE = (1 << 5),
 };
 
-money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem);
-bool ShopItemHasCommonPrice(const ShopItem shopItem);
+money64 ShopItemGetCommonPrice(Ride* forRide, ShopItem shopItem);
+bool ShopItemHasCommonPrice(ShopItem shopItem);
 
 const ShopItemDescriptor& GetShopItemDescriptor(ShopItem item);

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -203,7 +203,7 @@ static_assert(std::size(kStationBaseTypeSpriteIndexes) == kStationBaseTypeCount)
 
 static bool TrackPaintUtilDrawStationImpl(
     PaintSession& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
-    const TrackElement& trackElement, const StationBaseType baseType, const int32_t baseOffsetZ, int32_t fenceOffsetA,
+    const TrackElement& trackElement, StationBaseType baseType, int32_t baseOffsetZ, int32_t fenceOffsetA,
     int32_t fenceOffsetB);
 
 bool TrackPaintUtilDrawStation(

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -418,7 +418,7 @@ void TrackPaintUtilPaintFloor(
     const OpenRCT2::StationObject* stationStyle);
 void TrackPaintUtilPaintFences(
     PaintSession& session, uint8_t edges, const CoordsXY& position, const OpenRCT2::TrackElement& trackElement,
-    const Ride& ride, const ImageId colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
+    const Ride& ride, ImageId colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 
 enum class StationBaseType
 {
@@ -437,13 +437,13 @@ bool TrackPaintUtilDrawStationCovers2(
     uint8_t stationVariant, ImageId colour);
 bool TrackPaintUtilDrawNarrowStationPlatform(
     PaintSession& session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
-    const OpenRCT2::TrackElement& trackElement, const StationBaseType baseType, const int32_t baseOffsetZ);
+    const OpenRCT2::TrackElement& trackElement, StationBaseType baseType, int32_t baseOffsetZ);
 bool TrackPaintUtilDrawStation(
     PaintSession& session, const Ride& ride, Direction direction, uint16_t height, const OpenRCT2::TrackElement& trackElement,
-    const StationBaseType baseType, const int32_t baseOffsetZ);
+    StationBaseType baseType, int32_t baseOffsetZ);
 bool TrackPaintUtilDrawStation2(
     PaintSession& session, const Ride& ride, Direction direction, uint16_t height, const OpenRCT2::TrackElement& trackElement,
-    const StationBaseType baseType, const int32_t baseOffsetZ, int32_t fenceOffsetA, int32_t fenceOffsetB);
+    StationBaseType baseType, int32_t baseOffsetZ, int32_t fenceOffsetA, int32_t fenceOffsetB);
 bool TrackPaintUtilDrawStationInverted(
     PaintSession& session, const Ride& ride, Direction direction, int32_t height, const OpenRCT2::TrackElement& trackElement,
     uint8_t stationVariant);
@@ -461,42 +461,42 @@ inline void TrackPaintUtilDrawStationTunnelTall(PaintSession& session, Direction
 }
 
 void TrackPaintUtilRightQuarterTurn5TilesPaint(
-    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
+    const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5]);
 void TrackPaintUtilRightQuarterTurn5TilesPaint2(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
     const SpriteBb sprites[][5]);
 void TrackPaintUtilRightQuarterTurn5TilesPaint3(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
     const SpriteBb sprites[][5]);
 
 void TrackPaintUtilRightQuarterTurn3TilesPaint(
-    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
+    const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3]);
 void TrackPaintUtilRightQuarterTurn3TilesPaint2(
-    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][3]);
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
+    const uint32_t sprites[4][3]);
 void TrackPaintUtilRightQuarterTurn3TilesPaint2WithHeightOffset(
-    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
+    const uint32_t sprites[4][3], int32_t heightOffset);
 void TrackPaintUtilRightQuarterTurn3TilesPaint3(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
     const SpriteBb sprites[4][3]);
 void TrackPaintUtilRightQuarterTurn3TilesPaint4(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
     const SpriteBb sprites[4][3]);
 
 void TrackPaintUtilLeftQuarterTurn3TilesPaint(
-    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][3]);
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
+    const uint32_t sprites[4][3]);
 void TrackPaintUtilLeftQuarterTurn3TilesPaintWithHeightOffset(
-    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence, ImageId colourFlags,
+    const uint32_t sprites[4][3], int32_t heightOffset);
 void TrackPaintUtilLeftQuarterTurn1TilePaint(
-    PaintSession& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
-    const ImageId colourFlags, const uint32_t* sprites);
+    PaintSession& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction, ImageId colourFlags,
+    const uint32_t* sprites);
 void TrackPaintUtilSpinningTunnelPaint(PaintSession& session, int8_t thickness, int16_t height, Direction direction);
 
 void TrackPaintUtilOnridePhotoPlatformPaintBase(PaintSession& session, int32_t height);
@@ -523,20 +523,20 @@ void TrackPaintUtilOnridePhotoPaint2(
     int32_t supportsAboveHeightOffset = kGeneralSupportHeightOnRidePhoto, int32_t trackHeightOffset = 3);
 void TrackPaintUtilRightHelixUpSmallQuarterTilesPaint(
     PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
+    ImageId colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2]);
 void TrackPaintUtilRightHelixUpLargeQuarterTilesPaint(
     PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
+    ImageId colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2]);
 void TrackPaintUtilEighthToDiagTilesPaint(
     PaintSession& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
+    ImageId colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4]);
 void TrackPaintUtilDiagTilesPaint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4], const CoordsXYZ boundsOffsets[4],
-    int8_t additionalBoundsHeight, const ImageId colourFlags);
+    int8_t additionalBoundsHeight, ImageId colourFlags);
 inline void TrackPaintUtilDiagTilesPaint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -332,7 +332,7 @@ private:
     void UpdateSound();
     void GetLiftHillSound(const Ride& curRide, SoundIdVolume& curSound);
     OpenRCT2::Audio::SoundId UpdateScreamSound();
-    OpenRCT2::Audio::SoundId ProduceScreamSound(const int32_t totalNumPeeps);
+    OpenRCT2::Audio::SoundId ProduceScreamSound(int32_t totalNumPeeps);
     void UpdateCrashSetup();
     void UpdateCollisionSetup();
     int32_t UpdateMotionDodgems();
@@ -380,7 +380,7 @@ private:
     void UpdateGoKartAttemptSwitchLanes();
     void UpdateSceneryDoor() const;
     void UpdateSceneryDoorBackwards() const;
-    void UpdateLandscapeDoors(const int32_t previousTrackHeight) const;
+    void UpdateLandscapeDoors(int32_t previousTrackHeight) const;
     int32_t CalculateRiderBraking() const;
     uint8_t ChooseBrakeSpeed() const;
     void PopulateBrakeSpeed(const CoordsXYZ& vehicleTrackLocation, OpenRCT2::TrackElement& brake);
@@ -557,9 +557,9 @@ void VehicleUpdateAll();
 void VehicleSoundsUpdate();
 uint16_t VehicleGetMoveInfoSize(VehicleTrackSubposition trackSubposition, OpenRCT2::TrackElemType type, uint8_t direction);
 
-void RideUpdateMeasurementsSpecialElements_Default(Ride& ride, const OpenRCT2::TrackElemType trackType);
-void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const OpenRCT2::TrackElemType trackType);
-void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, const OpenRCT2::TrackElemType trackType);
+void RideUpdateMeasurementsSpecialElements_Default(Ride& ride, OpenRCT2::TrackElemType trackType);
+void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, OpenRCT2::TrackElemType trackType);
+void RideUpdateMeasurementsSpecialElements_WaterCoaster(Ride& ride, OpenRCT2::TrackElemType trackType);
 
 extern Vehicle* gCurrentVehicle;
 extern StationIndex _vehicleStationIndex;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -341,8 +341,7 @@ private:
     bool CurrentTowerElementIsTop();
     bool UpdateTrackMotionForwards(const CarEntry* carEntry, const Ride& curRide, const RideObjectEntry& rideEntry);
     bool UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& curRide, const RideObjectEntry& rideEntry);
-    int32_t UpdateTrackMotionPoweredRideAcceleration(
-        const CarEntry* carEntry, uint32_t totalMass, const int32_t curAcceleration);
+    int32_t UpdateTrackMotionPoweredRideAcceleration(const CarEntry* carEntry, uint32_t totalMass, int32_t curAcceleration);
     int32_t NumPeepsUntilTrainTail() const;
     void InvalidateWindow();
     void TestReset();

--- a/src/openrct2/scenario/ScenarioObjective.h
+++ b/src/openrct2/scenario/ScenarioObjective.h
@@ -43,7 +43,7 @@ namespace OpenRCT2::Scenario
         count
     };
 
-    bool ObjectiveNeedsMoney(const ObjectiveType objective);
+    bool ObjectiveNeedsMoney(ObjectiveType objective);
 
     enum class ObjectiveStatus : uint8_t
     {

--- a/src/openrct2/scripting/bindings/world/ScTileElement.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.hpp
@@ -213,7 +213,7 @@ namespace OpenRCT2::Scripting
 
     public:
         static const LargeSceneryElement* GetOtherLargeSceneryElement(
-            const CoordsXY& loc, const LargeSceneryElement* const largeScenery);
+            const CoordsXY& loc, const LargeSceneryElement* largeScenery);
         static void Register(duk_context* ctx);
     };
 

--- a/src/openrct2/world/Climate.h
+++ b/src/openrct2/world/Climate.h
@@ -98,4 +98,4 @@ bool ClimateIsPrecipitating();
 bool WeatherIsDry(WeatherType);
 bool ClimateHasWeatherEffect();
 OpenRCT2::Drawing::FilterPaletteID ClimateGetWeatherGloomPaletteId(const WeatherState& state);
-uint32_t ClimateGetWeatherSpriteId(const WeatherType weatherType);
+uint32_t ClimateGetWeatherSpriteId(WeatherType weatherType);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -131,7 +131,7 @@ void TileElementIteratorRestartForTile(TileElementIterator* it);
 void MapUpdateTiles();
 int32_t MapGetHighestZ(const CoordsXY& loc);
 
-bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const OpenRCT2::TileElement* const elementToBeRemoved);
+bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const OpenRCT2::TileElement* elementToBeRemoved);
 
 void MapRemoveOutOfRangeElements();
 void MapExtendBoundarySurfaceX();

--- a/src/openrct2/world/MapAnimation.h
+++ b/src/openrct2/world/MapAnimation.h
@@ -19,11 +19,11 @@ namespace OpenRCT2::MapAnimations
         landEdgeDoor,
     };
 
-    void MarkTileForInvalidation(const TileCoordsXY coords);
-    void MarkTileForUpdate(const TileCoordsXY coords);
-    void CreateTemporary(const CoordsXYZ& coords, const TemporaryType type);
+    void MarkTileForInvalidation(TileCoordsXY coords);
+    void MarkTileForUpdate(TileCoordsXY coords);
+    void CreateTemporary(const CoordsXYZ& coords, TemporaryType type);
     void MarkAllTiles();
     void InvalidateAndUpdateAll();
     void ClearAll();
-    void ShiftAll(const TileCoordsXY amount);
+    void ShiftAll(TileCoordsXY amount);
 } // namespace OpenRCT2::MapAnimations

--- a/src/openrct2/world/MapSelection.h
+++ b/src/openrct2/world/MapSelection.h
@@ -63,7 +63,7 @@ extern uint8_t gMapSelectArrowDirection;
 
 MapRange getMapSelectRange();
 void setMapSelectRange(const MapRange& range);
-void setMapSelectRange(const CoordsXY coords);
+void setMapSelectRange(CoordsXY coords);
 
 namespace OpenRCT2::MapSelection
 {

--- a/src/openrct2/world/QuarterTile.h
+++ b/src/openrct2/world/QuarterTile.h
@@ -33,7 +33,7 @@ public:
     const QuarterTile Rotate(uint8_t amount) const;
     uint8_t GetBaseQuarterOccupied() const;
     uint8_t GetZQuarterOccupied() const;
-    TileCornersZ GetQuarterHeights(const int32_t height) const;
+    TileCornersZ GetQuarterHeights(int32_t height) const;
 };
 
 enum

--- a/src/openrct2/world/tile_element/Slope.h
+++ b/src/openrct2/world/tile_element/Slope.h
@@ -50,6 +50,6 @@ namespace OpenRCT2
         uint8_t left;
     };
 
-    SlopeRelativeCornerHeights GetSlopeRelativeCornerHeights(const uint8_t slope);
-    TileCornersZ GetSlopeCornerHeights(const int32_t height, const uint8_t slope);
+    SlopeRelativeCornerHeights GetSlopeRelativeCornerHeights(uint8_t slope);
+    TileCornersZ GetSlopeCornerHeights(int32_t height, uint8_t slope);
 } // namespace OpenRCT2

--- a/src/openrct2/world/tile_element/TrackElement.h
+++ b/src/openrct2/world/tile_element/TrackElement.h
@@ -87,7 +87,7 @@ namespace OpenRCT2
         void SetTrackType(TrackElemType newEntryIndex);
 
         ride_type_t GetRideType() const;
-        void SetRideType(const ride_type_t rideType);
+        void SetRideType(ride_type_t rideType);
 
         uint8_t GetSequenceIndex() const;
         void SetSequenceIndex(uint8_t newSequenceIndex);

--- a/src/openrct2/world/tile_element/WallElement.h
+++ b/src/openrct2/world/tile_element/WallElement.h
@@ -66,7 +66,7 @@ namespace OpenRCT2
         void SetAnimationFrame(uint8_t frameNum);
 
         bool IsAnimating() const;
-        void SetIsAnimating(const bool isAnimating);
+        void SetIsAnimating(bool isAnimating);
 
         Banner* GetBanner() const;
         BannerIndex GetBannerIndex() const;


### PR DESCRIPTION
This affects declarations like these, where the `const` is noise:

`void foo(const int bar);`

This does **NOT** affect declarations like:

`void foo(const int bar&);`
`void foo(const int bar*);`
`const void foo(int bar);`
`void foo(int bar) const;`
`void foo(std::whatever<const int> bar);`

These were verified manually with the help of clang-tidy's  [readability-avoid-const-params-in-decls](https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html).

The rationale is that since parameters are passed by value (that is, they are copied over to the function) then it doesn't make sense to specify const in the function's signature, only in its implementation. This of it like this: in `void foo(const int bar);` you are not forced to pass a `const int` as a parameter, an `int` will suffice - the `const` is indicating that the value will not be changed in the actual function's implementation, but it's misplaced to put it in the signature as well.