### PR TITLE
Remove redundant const qualifier in constexpr assignments

### DIFF
--- a/src/openrct2/rct12/Limits.h
+++ b/src/openrct2/rct12/Limits.h
@@ -40,9 +40,9 @@ namespace OpenRCT2::RCT12::Limits
 
     constexpr uint16_t kRideMeasurementMaxItems = 4800;
 
-    constexpr uint16_t const kMaxInversions = 31;
-    constexpr uint16_t const kMaxGolfHoles = 31;
-    constexpr uint16_t const kMaxHelices = 31;
+    constexpr uint16_t kMaxInversions = 31;
+    constexpr uint16_t kMaxGolfHoles = 31;
+    constexpr uint16_t kMaxHelices = 31;
     constexpr uint8_t kMaxElementHeight = 255;
     constexpr uint8_t kCustomerHistorySize = 10;
 

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -352,7 +352,7 @@ constexpr uint16_t kRCT12TileElementLargeTypeMask = 0x3FF;
 constexpr uint8_t kRCT12TrackElementTypeFlagChainLift = 1 << 7;
 constexpr uint8_t kRCT12TrackElementSequenceGreenLight = 1 << 7;
 
-constexpr uint16_t const kRCT12xy8Undefined = 0xFFFF;
+constexpr uint16_t kRCT12xy8Undefined = 0xFFFF;
 
 using RCT12ObjectEntryIndex = uint8_t;
 constexpr RCT12ObjectEntryIndex kRCT12ObjectEntryIndexNull = 255;

--- a/src/openrct2/rct2/Limits.h
+++ b/src/openrct2/rct2/Limits.h
@@ -27,9 +27,7 @@ namespace OpenRCT2::RCT2::Limits
     constexpr uint8_t kMaxResearchedRideEntryQuads = 8; // With 32 bits per uint32_t, this means there is room for
                                                         // 256 entries.
     constexpr uint8_t kMaxResearchedSceneryItemQuads = 56;
-    constexpr const uint16_t kMaxResearchedSceneryItems = (kMaxResearchedSceneryItemQuads * 32); // There are 32
-                                                                                                 // bits per
-                                                                                                 // quad.
+    constexpr uint16_t kMaxResearchedSceneryItems = (kMaxResearchedSceneryItemQuads * 32); // There are 32 bits per quad.
     constexpr uint16_t kMaxResearchItems = 500;
 
     constexpr uint16_t kTD6MaxTrackElements = 8192;

--- a/src/openrct2/scripting/Plugin.h
+++ b/src/openrct2/scripting/Plugin.h
@@ -67,7 +67,7 @@ namespace OpenRCT2::Scripting
         std::string_view GetPath() const
         {
             return _path;
-        };
+        }
 
         bool HasPath() const
         {

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -653,8 +653,8 @@ static void InvalidateAll(const ViewportList& viewports)
 
         // Code adapted from PaintSessionGenerateRotate.
         // Ideally this would iterate over tiles in memory order.
-        constexpr const int32_t maxTileHeightModifier = 88; // from magic value in PaintSessionGenerateRotate
-        constexpr const int32_t maxTileHeight = (kMaxTileElementHeight * kCoordsZStep) + maxTileHeightModifier;
+        constexpr int32_t maxTileHeightModifier = 88; // from magic value in PaintSessionGenerateRotate
+        constexpr int32_t maxTileHeight = (kMaxTileElementHeight * kCoordsZStep) + maxTileHeightModifier;
 
         const auto direction = DirectionFlipXAxis(viewport->rotation);
         const int32_t numVerticalTiles = (viewport->ViewHeight() + maxTileHeight) / kScreenCoordsTileHeight;

--- a/src/openrct2/world/tile_element/TrackElement.h
+++ b/src/openrct2/world/tile_element/TrackElement.h
@@ -40,13 +40,12 @@ namespace OpenRCT2
         TRACK_ELEMENT_COLOUR_SEAT_ROTATION_MASK = 0b11110000,
     };
 
-    constexpr const int32_t kLandEdgeDoorFrameClosed = 0;
-    constexpr const int32_t kLandEdgeDoorFrameOpening = 1;
-    constexpr const int32_t kLandEdgeDoorFrameOpen = 3;
-    constexpr const int32_t kLandEdgeDoorFrameClosing = 4;
-    constexpr const int32_t kLandEdgeDoorFrameEnd = 6;
-
-    constexpr const int32_t kLandEdgeDoorFrameCount = 8;
+    constexpr int32_t kLandEdgeDoorFrameClosed = 0;
+    constexpr int32_t kLandEdgeDoorFrameOpening = 1;
+    constexpr int32_t kLandEdgeDoorFrameOpen = 3;
+    constexpr int32_t kLandEdgeDoorFrameClosing = 4;
+    constexpr int32_t kLandEdgeDoorFrameEnd = 6;
+    constexpr int32_t kLandEdgeDoorFrameCount = 8;
 
 #pragma pack(push, 1)
 


### PR DESCRIPTION
`constexpr` is always `const` so the qualifier is unnecessary. Also removes a stray semicolon in a file that was also triggering a warning.