### PR TITLE
Fix #25167: Type A metal supports draw with cap if heightExtra is positive

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.4.31 (in development)
 ------------------------------------------------------------------------
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
-- Fix: [#25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
+- Fix: [#4643, #25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
 - Fix: [#25799] The animated options tab icon of the news window does not always redraw.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.31 (in development)
 ------------------------------------------------------------------------
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
+- Fix: [#25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
 - Fix: [#25799] The animated options tab icon of the news window does not always redraw.
 

--- a/src/openrct2/paint/support/MetalSupports.cpp
+++ b/src/openrct2/paint/support/MetalSupports.cpp
@@ -484,8 +484,8 @@ static bool MetalSupportsPaintSetupCommon(
 
     // Draw extra support segments above height with a zero height bounding box
     currentHeight = heightExtra < 0 ? height - 1 : height;
-    const auto extraSupportBeamImageIndex = typeB ? kSupportBasesAndBeams[supportType].beamUncapped
-                                                  : kSupportBasesAndBeams[supportType].beamCapped;
+    const auto extraSupportBeamImageIndex = heightExtra >= 0 ? kSupportBasesAndBeams[supportType].beamUncapped
+                                                             : kSupportBasesAndBeams[supportType].beamCapped;
     const auto totalHeightExtra = heightExtra < 0 ? currentHeight + (-heightExtra) : currentHeight + heightExtra;
     const CoordsXYZ boundBoxOffset = CoordsXYZ(kMetalSupportBoundBoxOffsets[originalSegment], currentHeight);
     while (true)


### PR DESCRIPTION
This fixes #25167 type a metal supports drawing with the top cap sprite when they did not in the original games.
This causes some general support height misalignment and some slight glitches/bugs on these barrel roll and loop supports for example:

RCT2 - Current ORCT2
<img width="313" height="781" alt="rct2" src="https://github.com/user-attachments/assets/706535cc-5b4f-4df1-b2f4-767f050aa539" /><img width="313" height="781" alt="orct2" src="https://github.com/user-attachments/assets/959b0060-1b8e-451b-8cb0-e2ffc0260114" />

RCT1 - Current ORCT2 - This fix
<img width="410" height="316" alt="extraheightbugandbarrelrollsrct1" src="https://github.com/user-attachments/assets/24445ae8-d5b2-4825-b253-2197e53fde29" />
<img width="410" height="316" alt="extraheightbugandbarrelrollsorct2" src="https://github.com/user-attachments/assets/49123d50-c00e-46af-b140-bdbd0f47e17d" />
<img width="410" height="316" alt="extraheightbugandbarrelrolls" src="https://github.com/user-attachments/assets/d87e3a0c-9f53-4261-8647-4df6c236c9f3" />

Save:
[support cap bug.zip](https://github.com/user-attachments/files/24637214/support.cap.bug.zip)

---

In the metal support paint code, it checks if `heightExtra` is negative and if so it turns it positive and negates 1 from the current support height, so that a value of -1 draws the top on a support without it being 1 pixel higher.
Negative `heightExtra` values are used by the steel wild mouse as the tops of the supports are visible through the track.
This system was effectively doing nothing though because all type a supports were being drawn with the top by mistake.
As far as I can tell, this is the intended way that they were supposed to work, and this restores the original behavior of RCT1 and 2.

---

Affects these track types:
```
Diff in bobsleigh.park
Diff in classicstandup.park
Diff in corkscrew.park
Diff in flyingrollercoaster.park
Diff in flyingrollercoasterinverted.park
Diff in giga.park
Diff in hypercoaster.park
Diff in hypertwister.park
Diff in laydown.park
Diff in laydowninverted.park
Diff in limlaunched.park
Diff in looping.park
Diff in lsmlaunched.park
Diff in multidimension.park
Diff in multidimensioninverted.park
Diff in singlerail.park
Diff in spinningwildmouse.park
Diff in standup.park
Diff in steelwildmouse.park
Diff in twister.park
```

The reason why there is a diff in the steel wild mouse is because there is a couple of slightly odd differences between views:
https://github.com/OpenRCT2/OpenRCT2/blob/162977a84bf776874ed7d36ad56b143e74d7c053/src/openrct2/paint/track/coaster/WildMouse.cpp#L850-L859
This is also the case in vanilla though:
RCT2 - Current ORCT2
<img width="196" height="203" alt="rct2mouse" src="https://github.com/user-attachments/assets/9c8ebc74-94c4-4593-a2e0-b757c75e4b2d" /><img width="196" height="203" alt="orct2mouse" src="https://github.com/user-attachments/assets/35ec3b45-c4a1-4fdc-a307-d4e9986ad675" />

---

I didn't make a PR for this before because it does affect some track PRs, however everything has kind of stalled out and so it seems like an okay time to do it.
The pipeline coaster has a tiny amount of differences, some are actually an improvement.
Does not affect the quarter helices or mini track.
Will affect the spinning track as those supports will need to be negative `heightExtra`

---

After this the only difference between type a and b supports will be this:
https://github.com/OpenRCT2/OpenRCT2/blob/162977a84bf776874ed7d36ad56b143e74d7c053/src/openrct2/paint/support/MetalSupports.cpp#L413-L417
I think we should definitely consider not monomorphizing this big function for the sake of a single if.

---

Also closes #4643

I just noticed that a comment on this issue explained it a long time ago:
https://github.com/OpenRCT2/OpenRCT2/issues/4643#issuecomment-267783444

> The metal supports seem to be because the support drawing incorrectly uses `_97B15C` or `_97B190`. Can you go over `metal_a_supports_paint_setup` again? It seems that you merged the bottom branches of the function, which is picked based on a positive/negative `special` value, and only seem to differ in beam substyle.