### PR TITLE
Add label configuration for plug-ins

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,6 +46,7 @@
 'plug-in':
   - changed-files:
     - any-glob-to-any-file:
+      - 'distribution/openrct2.d.ts'
       - 'src/openrct2/scripting/*'
       - 'src/openrct2-ui/scripting/*'
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -43,6 +43,11 @@
   - changed-files:
     - any-glob-to-any-file:
       - 'src/openrct2/paint/*'
+'plug-in':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/openrct2/scripting/*'
+      - 'src/openrct2-ui/scripting/*'
 
 # Platform code
 'platform':


### PR DESCRIPTION
As discussed on Discord, this PR adds configuration for the `plug-in` label to be added to all PRs with changes under either of these files/folders:
- `distribution/openrct2.d.ts`
- `src/openrct2/scripting/*`
- `src/openrct2-ui/scripting/*`

Not sure how to "test" this before merging, so please let me know if that's possible. 🙂