### PR TITLE
Remove more redundant namespace qualifiers

### DIFF
--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -529,7 +529,7 @@ namespace OpenRCT2::Ui
         try
         {
             json = Json::ReadFromFile(path.c_str());
-            result = UITheme::FromJson(json);
+            result = FromJson(json);
         }
         catch (const std::exception&)
         {

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -277,7 +277,7 @@ void CustomListView::SetColumns(const std::vector<ListViewColumn>& columns, bool
     }
 }
 
-const std::vector<ListViewItem>& CustomListView::CustomListView::GetItems() const
+const std::vector<ListViewItem>& CustomListView::GetItems() const
 {
     return Items;
 }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -584,7 +584,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_CLOSE:
                 {
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->Close(*this);
                     break;
                 }
@@ -1208,7 +1208,7 @@ namespace OpenRCT2::Ui::Windows
                 customWidgetInfo->Text = value;
                 w->widgets[widgetIndex].string = customWidgetInfo->Text.data();
 
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
                 windowMgr->InvalidateWidget(*w, widgetIndex);
             }
         }
@@ -1244,7 +1244,7 @@ namespace OpenRCT2::Ui::Windows
                     customWidgetInfo->Colour = colour;
                     widget.image = getColourButtonImage(colour);
 
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->InvalidateWidget(*w, widgetIndex);
 
                     std::vector<DukValue> args;
@@ -1290,7 +1290,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 customWidgetInfo->SelectedIndex = selectedIndex;
 
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
                 windowMgr->InvalidateWidget(*w, widgetIndex);
 
                 if (lastSelectedIndex != selectedIndex)
@@ -1497,7 +1497,7 @@ namespace OpenRCT2::Ui::Windows
 
         for (auto& window : customWindows)
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->Close(*window);
         }
     }

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -35,7 +35,7 @@ namespace OpenRCT2::Scripting
 
 namespace OpenRCT2::Ui::Windows
 {
-    WindowBase* WindowCustomOpen(std::shared_ptr<OpenRCT2::Scripting::Plugin> owner, DukValue dukDesc);
+    WindowBase* WindowCustomOpen(std::shared_ptr<Scripting::Plugin> owner, DukValue dukDesc);
 }
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -51,7 +51,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                return OpenRCT2::Ui::Windows::GetWidgetName(w, _widgetIndex);
+                return Ui::Windows::GetWidgetName(w, _widgetIndex);
             }
             return {};
         }
@@ -61,7 +61,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                OpenRCT2::Ui::Windows::SetWidgetName(w, _widgetIndex, value);
+                Ui::Windows::SetWidgetName(w, _widgetIndex, value);
             }
         }
 
@@ -286,7 +286,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                return OpenRCT2::Ui::Windows::GetWidgetTooltip(w, _widgetIndex);
+                return Ui::Windows::GetWidgetTooltip(w, _widgetIndex);
             }
             return {};
         }
@@ -295,7 +295,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                OpenRCT2::Ui::Windows::SetWidgetTooltip(w, _widgetIndex, value);
+                Ui::Windows::SetWidgetTooltip(w, _widgetIndex, value);
             }
         }
 
@@ -384,7 +384,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                OpenRCT2::Ui::Windows::UpdateWidgetText(w, _widgetIndex, value);
+                Ui::Windows::UpdateWidgetText(w, _widgetIndex, value);
             }
         }
 
@@ -956,7 +956,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                return OpenRCT2::Ui::Windows::GetWidgetMaxLength(w, _widgetIndex);
+                return Ui::Windows::GetWidgetMaxLength(w, _widgetIndex);
             }
             return 0;
         }
@@ -966,7 +966,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr && IsCustomWindow())
             {
-                OpenRCT2::Ui::Windows::SetWidgetMaxLength(w, _widgetIndex, value);
+                Ui::Windows::SetWidgetMaxLength(w, _widgetIndex, value);
             }
         }
 

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -187,12 +187,12 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_APPLY].top = widgets[WIDX_APPLY].bottom - 24;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             Rectangle::fill(
@@ -237,7 +237,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void PaintItem(Drawing::RenderTarget& rt, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
+        void PaintItem(RenderTarget& rt, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
         {
             auto listWidth = widgets[WIDX_LIST].right - widgets[WIDX_LIST].left;
             auto stringId = STR_BLACK_STRING;
@@ -258,7 +258,7 @@ namespace OpenRCT2::Ui::Windows
             PaintCheckbox(rt, { { 2, y + 1 }, { 2 + checkboxSize + 1, y + 1 + checkboxSize } }, isChecked);
         }
 
-        void PaintCheckbox(Drawing::RenderTarget& rt, const ScreenRect& rect, bool checked)
+        void PaintCheckbox(RenderTarget& rt, const ScreenRect& rect, bool checked)
         {
             Rectangle::fillInset(
                 rt, rect, colours[1], Rectangle::BorderStyle::inset, Rectangle::FillBrightness::dark,

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -64,7 +64,7 @@ namespace OpenRCT2::Ui::Windows
         void onMouseDown(WidgetIndex widgetIndex) override
         {
             auto* widget = &widgets[widgetIndex - 1];
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
 
             switch (widgetIndex)
             {
@@ -146,7 +146,7 @@ namespace OpenRCT2::Ui::Windows
                 Config::Get().general.customCurrencyAffix = CurrencyDescriptors[EnumValue(CurrencyType::custom)].affix_unicode;
                 Config::Save();
 
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
                 windowMgr->InvalidateAll();
             }
         }
@@ -156,7 +156,7 @@ namespace OpenRCT2::Ui::Windows
             if (text.empty())
                 return;
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
 
             switch (widgetIndex)
             {

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -111,7 +111,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            const auto& ls = OpenRCT2::GetContext()->GetLocalisationService();
+            const auto& ls = GetContext()->GetLocalisationService();
             const auto currentLanguage = ls.GetCurrentLanguage();
             if (ResizeLanguage != currentLanguage)
             {

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -104,7 +104,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextEllipsised(rt, { screenCoords.x + 2, screenCoords.y + yOffset }, width - 7, format, ft, { colour });
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -451,7 +451,7 @@ namespace OpenRCT2::Ui::Windows
 
     void WindowDropdownClose()
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::dropdown);
     }
 

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -126,7 +126,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             auto drawPreviousButton = widgets[WIDX_PREVIOUS_STEP_BUTTON].type != WidgetType::empty;
             auto drawNextButton = widgets[WIDX_NEXT_STEP_BUTTON].type != WidgetType::empty;
@@ -164,7 +164,7 @@ namespace OpenRCT2::Ui::Windows
     private:
         void JumpBackToObjectSelection() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             getGameState().editorStep = EditorStep::ObjectSelection;
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpBackToLandscapeEditor() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             SetAllSceneryItemsInvented();
@@ -185,7 +185,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpBackToInventionListSetUp() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorInventionList);
@@ -195,7 +195,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpBackToObjectiveSelection() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
@@ -205,7 +205,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpBackToOptionsSelection() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
@@ -218,7 +218,7 @@ namespace OpenRCT2::Ui::Windows
             if (!EditorObjectSelectionWindowCheck())
                 return;
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseByClass(WindowClass::editorObjectSelection);
 
             FinishObjectSelection();
@@ -238,7 +238,7 @@ namespace OpenRCT2::Ui::Windows
             auto [checksPassed, errorString] = Editor::CheckPark();
             if (checksPassed)
             {
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
                 windowMgr->CloseAll();
                 ContextOpenWindow(WindowClass::editorInventionList);
                 getGameState().editorStep = EditorStep::InventionsListSetUp;
@@ -253,7 +253,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpForwardToObjectiveSelection() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
@@ -263,7 +263,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpForwardToOptionsSelection() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
@@ -273,7 +273,7 @@ namespace OpenRCT2::Ui::Windows
 
         void JumpForwardToScenarioDetails() const
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
@@ -312,7 +312,7 @@ namespace OpenRCT2::Ui::Windows
             scriptEngine.ClearParkStorage();
 #endif
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
             auto intent = Intent(WindowClass::loadsave);
@@ -335,7 +335,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_NEXT_IMAGE].type = WidgetType::empty;
         }
 
-        void DrawLeftButtonBack(Drawing::RenderTarget& rt)
+        void DrawLeftButtonBack(RenderTarget& rt)
         {
             const auto& previousWidget = widgets[WIDX_PREVIOUS_IMAGE];
             auto leftTop = windowPos + ScreenCoordsXY{ previousWidget.left, previousWidget.top };
@@ -343,7 +343,7 @@ namespace OpenRCT2::Ui::Windows
             Rectangle::filter(rt, { leftTop, rightBottom }, FilterPaletteID::palette51);
         }
 
-        void DrawLeftButton(Drawing::RenderTarget& rt)
+        void DrawLeftButton(RenderTarget& rt)
         {
             const auto topLeft = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 1, widgets[WIDX_PREVIOUS_IMAGE].top + 1 };
@@ -375,7 +375,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(rt, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::centre });
         }
 
-        void DrawRightButtonBack(Drawing::RenderTarget& rt)
+        void DrawRightButtonBack(RenderTarget& rt)
         {
             auto nextWidget = widgets[WIDX_NEXT_IMAGE];
             auto leftTop = windowPos + ScreenCoordsXY{ nextWidget.left, nextWidget.top };
@@ -383,7 +383,7 @@ namespace OpenRCT2::Ui::Windows
             Rectangle::filter(rt, { leftTop, rightBottom }, FilterPaletteID::palette51);
         }
 
-        void DrawRightButton(Drawing::RenderTarget& rt)
+        void DrawRightButton(RenderTarget& rt)
         {
             const auto topLeft = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].left + 1, widgets[WIDX_NEXT_IMAGE].top + 1 };
@@ -416,7 +416,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(rt, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::centre });
         }
 
-        void DrawStepText(Drawing::RenderTarget& rt)
+        void DrawStepText(RenderTarget& rt)
         {
             int16_t stateX = (widgets[WIDX_PREVIOUS_IMAGE].right + widgets[WIDX_NEXT_IMAGE].left) / 2 + windowPos.x;
             int16_t stateY = height - 0x0C + windowPos.y;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -270,7 +270,7 @@ namespace OpenRCT2::Ui::Windows
             WindowEditorInventionsListDragOpen(researchItem, windowPos, widgets[WIDX_PRE_RESEARCHED_SCROLL].right);
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             const auto& gameState = getGameState();
 
@@ -355,7 +355,7 @@ namespace OpenRCT2::Ui::Windows
             return fallback;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -656,7 +656,7 @@ namespace OpenRCT2::Ui::Windows
             close();
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 0, 2 };
 
@@ -687,7 +687,7 @@ namespace OpenRCT2::Ui::Windows
     static void WindowEditorInventionsListDragOpen(
         ResearchItem* researchItem, const ScreenCoordsXY& editorPos, int objectSelectionScrollWidth)
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::editorInventionListDrag);
         auto* wnd = windowMgr->Create<InventionDragWindow>(
             WindowClass::editorInventionListDrag, { 10, 14 },

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -382,7 +382,7 @@ namespace OpenRCT2::Ui::Windows
                     if (gLegacyScene != LegacyScene::trackDesignsManager && !EditorObjectSelectionWindowCheck())
                         return;
 
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->CloseByClass(WindowClass::editorObjectSelection);
 
                     if (isInEditorMode())
@@ -394,7 +394,7 @@ namespace OpenRCT2::Ui::Windows
                         GameNotifyMapChange();
                         GameUnloadScripts();
 
-                        auto* context = OpenRCT2::GetContext();
+                        auto* context = GetContext();
                         context->SetActiveScene(context->GetTitleScene());
                     }
                     break;
@@ -605,7 +605,7 @@ namespace OpenRCT2::Ui::Windows
         {
             // Used for in-game object selection cheat to prevent crashing the game
             // when windows attempt to draw objects that don't exist any more
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseAllExceptClass(WindowClass::editorObjectSelection);
 
             int32_t selected_object = GetObjectFromObjectSelection(GetSelectedObjectType(), screenCoords.y);
@@ -726,7 +726,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             // ScrollPaint
             ScreenCoordsXY screenCoords;
@@ -1009,7 +1009,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PREVIEW].right = widgets[WIDX_PREVIEW].left + kPreviewSize;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -1249,7 +1249,7 @@ namespace OpenRCT2::Ui::Windows
             _listItems.shrink_to_fit();
         }
 
-        void DrawDescriptions(Drawing::RenderTarget& rt)
+        void DrawDescriptions(RenderTarget& rt)
         {
             auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_PREVIEW].midX(), widgets[WIDX_PREVIEW].bottom + 3 };
             auto descriptionWidth = width - widgets[WIDX_LIST].right - 12;
@@ -1357,7 +1357,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawDebugData(Drawing::RenderTarget& rt)
+        void DrawDebugData(RenderTarget& rt)
         {
             ObjectListItem* listItem = &_listItems[selectedListItem];
             auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (kListRowHeight * 6) };
@@ -1751,7 +1751,7 @@ namespace OpenRCT2::Ui::Windows
 
         ContextShowError(STR_INVALID_SELECTION_OF_OBJECTS, errorString, {});
 
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::editorObjectSelection);
         if (w != nullptr)
         {

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -106,7 +106,7 @@ namespace OpenRCT2::Ui::Windows
             return numRows;
         }
 
-        void PaintPreview(Drawing::RenderTarget& rt, ImageIndex imageStart, ScreenCoordsXY screenCoords, Direction direction)
+        void PaintPreview(RenderTarget& rt, ImageIndex imageStart, ScreenCoordsXY screenCoords, Direction direction)
         {
             imageStart += (direction * 3);
 
@@ -308,7 +308,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_LIST].bottom = height - 5;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             GfxDrawSprite(
@@ -316,7 +316,7 @@ namespace OpenRCT2::Ui::Windows
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB].left, widgets[WIDX_TAB].top });
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             GfxClear(rt, ColourMapA[colours[1].colour].mid_light);
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -347,7 +347,7 @@ namespace OpenRCT2::Ui::Windows
             onPrepareDrawGraph(graphPageWidget, centredGraph);
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabImages(rt);
@@ -396,7 +396,7 @@ namespace OpenRCT2::Ui::Windows
             return {};
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (page != WINDOW_FINANCES_PAGE_SUMMARY)
                 return;
@@ -589,7 +589,7 @@ namespace OpenRCT2::Ui::Windows
                 initialiseScrollPosition(WIDX_SUMMARY_SCROLL, 0);
         }
 
-        void onDrawSummary(Drawing::RenderTarget& rt)
+        void onDrawSummary(RenderTarget& rt)
         {
             auto titleBarBottom = widgets[WIDX_TITLE].bottom;
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, titleBarBottom + 37 };
@@ -707,7 +707,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDrawMarketing(Drawing::RenderTarget& rt)
+        void onDrawMarketing(RenderTarget& rt)
         {
             auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_TAB_1].top + 45 };
             int32_t noCampaignsActive = 1;
@@ -786,7 +786,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Graph Events
 
-        void onDrawGraph(Drawing::RenderTarget& rt, const money64 currentValue, const StringId fmt) const
+        void onDrawGraph(RenderTarget& rt, const money64 currentValue, const StringId fmt) const
         {
             Formatter ft;
             ft.Add<money64>(currentValue);
@@ -853,7 +853,7 @@ namespace OpenRCT2::Ui::Windows
             widgetScrollUpdateThumbs(*this, widgetIndex);
         }
 
-        void DrawTabImage(Drawing::RenderTarget& rt, int32_t tabPage, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, int32_t tabPage, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + tabPage;
 
@@ -871,7 +871,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(Drawing::RenderTarget& rt)
+        void DrawTabImages(RenderTarget& rt)
         {
             DrawTabImage(rt, WINDOW_FINANCES_PAGE_SUMMARY, SPR_TAB_FINANCES_SUMMARY_0);
             DrawTabImage(rt, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);
@@ -884,7 +884,7 @@ namespace OpenRCT2::Ui::Windows
 
     static FinancesWindow* FinancesWindowOpen(uint8_t page)
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         auto* window = windowMgr->FocusOrCreate<FinancesWindow>(
             WindowClass::finances, kWindowSizeSummary, WindowFlag::higherContrastOnPress);
 
@@ -896,7 +896,7 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* FinancesOpen()
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         return windowMgr->FocusOrCreate<FinancesWindow>(
             WindowClass::finances, kWindowSizeSummary, WindowFlag::higherContrastOnPress);
     }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -90,7 +90,7 @@ namespace OpenRCT2::Ui::Windows
                     : colours[0].colour);
         }
 
-        void DrawLeftPanel(Drawing::RenderTarget& rt)
+        void DrawLeftPanel(RenderTarget& rt)
         {
             const auto& leftPanelWidget = widgets[WIDX_LEFT_OUTSET];
 
@@ -155,7 +155,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawParkRating(Drawing::RenderTarget& rt, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
+        void DrawParkRating(RenderTarget& rt, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
         {
             int16_t bar_width = (factor * 114) / 255;
             Rectangle::fillInset(
@@ -176,7 +176,7 @@ namespace OpenRCT2::Ui::Windows
             GfxDrawSprite(rt, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
         }
 
-        void DrawRightPanel(Drawing::RenderTarget& rt)
+        void DrawRightPanel(RenderTarget& rt)
         {
             const auto& rightPanelWidget = widgets[WIDX_RIGHT_OUTSET];
 
@@ -238,7 +238,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawNewsItem(Drawing::RenderTarget& rt)
+        void DrawNewsItem(RenderTarget& rt)
         {
             const auto& middleOutsetWidget = widgets[WIDX_MIDDLE_OUTSET];
             auto* newsItem = News::GetItem(0);
@@ -354,7 +354,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawMiddlePanel(Drawing::RenderTarget& rt)
+        void DrawMiddlePanel(RenderTarget& rt)
         {
             Widget* middleOutsetWidget = &widgets[WIDX_MIDDLE_OUTSET];
 
@@ -621,7 +621,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             const auto& leftWidget = widgets[WIDX_LEFT_OUTSET];
             const auto& rightWidget = widgets[WIDX_RIGHT_OUTSET];
@@ -712,7 +712,7 @@ namespace OpenRCT2::Ui::Windows
     {
         if (gLegacyScene == LegacyScene::playing)
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->InvalidateWidgetByClass(WindowClass::bottomToolbar, WIDX_MIDDLE_OUTSET);
         }
     }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -427,7 +427,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabImages(rt);
@@ -573,7 +573,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             Rectangle::fill(
                 rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);
@@ -618,7 +618,7 @@ namespace OpenRCT2::Ui::Windows
 
                     Formatter ft;
                     peep->FormatNameTo(ft);
-                    OpenRCT2::FormatStringLegacy(item.Name, sizeof(item.Name), STR_STRINGID, ft.Data());
+                    FormatStringLegacy(item.Name, sizeof(item.Name), STR_STRINGID, ft.Data());
                 }
 
                 std::sort(_guestList.begin(), _guestList.end(), GetGuestCompareFunc());
@@ -626,7 +626,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawTabImages(Drawing::RenderTarget& rt)
+        void DrawTabImages(RenderTarget& rt)
         {
             // Tab 1 image
             auto i = (_selectedTab == TabId::Individual ? _tabAnimationIndex & ~3 : 0);
@@ -643,7 +643,7 @@ namespace OpenRCT2::Ui::Windows
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
         }
 
-        void DrawScrollIndividual(Drawing::RenderTarget& rt)
+        void DrawScrollIndividual(RenderTarget& rt)
         {
             size_t index = 0;
             auto y = static_cast<int32_t>(_selectedPage) * -kGuestPageHeight;
@@ -710,7 +710,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawScrollSummarised(Drawing::RenderTarget& rt)
+        void DrawScrollSummarised(RenderTarget& rt)
         {
             size_t index = 0;
             auto y = 0;
@@ -773,7 +773,7 @@ namespace OpenRCT2::Ui::Windows
 
                 Formatter ft;
                 peep.FormatNameTo(ft);
-                OpenRCT2::FormatStringLegacy(name, sizeof(name), STR_STRINGID, ft.Data());
+                FormatStringLegacy(name, sizeof(name), STR_STRINGID, ft.Data());
                 if (!String::contains(name, _filterName.c_str(), true))
                 {
                     return false;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -150,7 +150,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -365,8 +365,8 @@ namespace OpenRCT2::Ui::Windows
 
         void InstallTrackDesign()
         {
-            auto& env = OpenRCT2::GetContext()->GetPlatformEnvironment();
-            auto destPath = env.GetDirectoryPath(OpenRCT2::DirBase::user, OpenRCT2::DirId::trackDesigns);
+            auto& env = GetContext()->GetPlatformEnvironment();
+            auto destPath = env.GetDirectoryPath(DirBase::user, DirId::trackDesigns);
             if (!Path::CreateDirectory(destPath))
             {
                 LOG_ERROR("Unable to create directory '%s'", destPath.c_str());
@@ -419,7 +419,7 @@ namespace OpenRCT2::Ui::Windows
             return nullptr;
         }
 
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->ForceClose(WindowClass::editorObjectSelection);
         windowMgr->CloseConstructionWindows();
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -612,7 +612,7 @@ namespace OpenRCT2::Ui::Windows
         void ToolUpdateLand(const ScreenCoordsXY& screenPos)
         {
             const bool mapCtrlPressed = GetInputManager().isModifierKeyPressed(ModifierKey::ctrl);
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
 
             if (gCurrentToolId == Tool::upDownArrow)
             {

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -468,7 +468,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     _landRightsCost = kMoney64Undefined;
 
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->InvalidateByClass(WindowClass::landRights);
                 }
                 return;

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -404,7 +404,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawPreview(Drawing::RenderTarget& rt)
+        void DrawPreview(RenderTarget& rt)
         {
             // Find preview image to draw
             PreviewImage* image = nullptr;
@@ -540,7 +540,7 @@ namespace OpenRCT2::Ui::Windows
         {
             setWidgets(window_loadsave_widgets);
 
-            const auto& uiContext = OpenRCT2::GetContext()->GetUiContext();
+            const auto& uiContext = GetContext()->GetUiContext();
             if (!uiContext.HasFilePicker())
             {
                 disabledWidgets |= (1uLL << WIDX_SYSTEM_BROWSER);
@@ -592,7 +592,7 @@ namespace OpenRCT2::Ui::Windows
         {
             _listItems.clear();
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseByClass(WindowClass::loadsaveOverwritePrompt);
 
             Config::Save();
@@ -731,7 +731,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -1077,7 +1077,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             Rectangle::fill(
                 rt, { { rt.x, rt.y }, { rt.x + rt.width - 1, rt.y + rt.height - 1 } }, ColourMapA[colours[1].colour].mid_light);

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -573,7 +573,7 @@ namespace OpenRCT2::Ui::Windows
             onScrollMouseDown(scrollIndex, screenCoords);
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             GfxClear(rt, PaletteIndex::pi10);
 
@@ -668,7 +668,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabImages(rt);
@@ -961,7 +961,7 @@ namespace OpenRCT2::Ui::Windows
             return colourB;
         }
 
-        void PaintPeepOverlay(Drawing::RenderTarget& rt, const ScreenCoordsXY& offset)
+        void PaintPeepOverlay(RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             auto flashColour = GetGuestFlashColour();
             for (auto guest : EntityList<Guest>())
@@ -975,8 +975,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawMapPeepPixel(
-            Peep* peep, const PaletteIndex flashColour, Drawing::RenderTarget& rt, const ScreenCoordsXY& offset)
+        void DrawMapPeepPixel(Peep* peep, const PaletteIndex flashColour, RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             if (peep->x == kLocationNull)
                 return;
@@ -1022,7 +1021,7 @@ namespace OpenRCT2::Ui::Windows
             return colour;
         }
 
-        void PaintTrainOverlay(Drawing::RenderTarget& rt, const ScreenCoordsXY& offset)
+        void PaintTrainOverlay(RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             for (auto train : TrainManager::View())
             {
@@ -1044,7 +1043,7 @@ namespace OpenRCT2::Ui::Windows
          * The call to Rectangle::fill was originally wrapped in Sub68DABD which made sure that arguments were ordered
          * correctly, but it doesn't look like it's ever necessary here so the call was removed.
          */
-        void PaintHudRectangle(Drawing::RenderTarget& rt, const ScreenCoordsXY& widgetOffset)
+        void PaintHudRectangle(RenderTarget& rt, const ScreenCoordsXY& widgetOffset)
         {
             WindowBase* mainWindow = WindowGetMain();
             if (mainWindow == nullptr)
@@ -1082,7 +1081,7 @@ namespace OpenRCT2::Ui::Windows
             Rectangle::fill(rt, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PaletteIndex::pi56);
         }
 
-        void DrawTabImages(Drawing::RenderTarget& rt)
+        void DrawTabImages(RenderTarget& rt)
         {
             // Guest tab image (animated)
             uint32_t guestTabImage = SPR_TAB_GUESTS_0;

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -75,7 +75,7 @@ namespace OpenRCT2::Ui::Windows
         if (ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
         {
             // The map tooltip is drawn by the bottom toolbar
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::bottomToolbar);
             return;
         }
@@ -101,7 +101,7 @@ namespace OpenRCT2::Ui::Windows
         if (_cursorHoldDuration < 25 || stringId == kStringIdNone || im.isModifierKeyPressed(ModifierKey::ctrl)
             || im.isModifierKeyPressed(ModifierKey::shift) || wm->FindByClass(WindowClass::error) != nullptr)
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseByClass(WindowClass::mapTooltip);
         }
         else

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -369,9 +369,9 @@ namespace OpenRCT2::Ui::Windows
                 if (result->error != GameActions::Status::ok)
                     return;
 
-                OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::placeItem, result->position);
+                Audio::Play3D(Audio::SoundId::placeItem, result->position);
 
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
 
                 auto currentRide = GetRide(rideIndex);
                 if (currentRide != nullptr && RideAreAllPossibleEntrancesAndExitsBuilt(*currentRide).Successful)

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -183,7 +183,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void informationPaint(Drawing::RenderTarget& rt)
+        void informationPaint(RenderTarget& rt)
         {
             RenderTarget clippedRT;
             if (ClipRenderTarget(clippedRT, rt, windowPos, width, height))
@@ -236,7 +236,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void playersPaint(Drawing::RenderTarget& rt)
+        void playersPaint(RenderTarget& rt)
         {
             // Number of players
             StringId stringId = numListItems == 1 ? STR_MULTIPLAYER_PLAYER_COUNT : STR_MULTIPLAYER_PLAYER_COUNT_PLURAL;
@@ -246,7 +246,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(rt, screenCoords, stringId, ft, { colours[2] });
         }
 
-        void playersScrollPaint(int32_t scrollIndex, Drawing::RenderTarget& rt) const
+        void playersScrollPaint(int32_t scrollIndex, RenderTarget& rt) const
         {
             ScreenCoordsXY screenCoords;
             screenCoords.y = 0;
@@ -346,7 +346,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void groupsPaint(Drawing::RenderTarget& rt)
+        void groupsPaint(RenderTarget& rt)
         {
             thread_local std::string _buffer;
 
@@ -389,7 +389,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void groupsScrollPaint(int32_t scrollIndex, Drawing::RenderTarget& rt) const
+        void groupsScrollPaint(int32_t scrollIndex, RenderTarget& rt) const
         {
             auto screenCoords = ScreenCoordsXY{ 0, 0 };
 
@@ -432,7 +432,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void drawTabImage(Drawing::RenderTarget& rt, int32_t page_number, int32_t spriteIndex)
+        void drawTabImage(RenderTarget& rt, int32_t page_number, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB1 + page_number;
 
@@ -454,7 +454,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void drawTabImages(Drawing::RenderTarget& rt)
+        void drawTabImages(RenderTarget& rt)
         {
             drawTabImage(rt, WINDOW_MULTIPLAYER_PAGE_INFORMATION, SPR_TAB_KIOSKS_AND_FACILITIES_0);
             drawTabImage(rt, WINDOW_MULTIPLAYER_PAGE_PLAYERS, SPR_TAB_GUESTS_0);
@@ -704,7 +704,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             drawTabImages(rt);
@@ -900,7 +900,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             switch (page)
             {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -270,7 +270,7 @@ namespace OpenRCT2::Ui::Windows
                     gameAction.SetCallback([](const GameActions::GameAction* ga, const GameActions::Result* result) {
                         if (result->error == GameActions::Status::ok)
                         {
-                            auto* windowMgr = Ui::GetWindowManager();
+                            auto* windowMgr = GetWindowManager();
                             windowMgr->CloseByClass(WindowClass::newCampaign);
                         }
                     });

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -424,14 +424,14 @@ namespace OpenRCT2::Ui::Windows
                 WindowResearchDevelopmentPrepareDraw(this, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
             }
 
-            const auto& ls = OpenRCT2::GetContext()->GetLocalisationService();
+            const auto& ls = GetContext()->GetLocalisationService();
             auto string = ls.GetString(STR_GROUP_BY_TRACK_TYPE);
             auto strWidth = GfxGetStringWidth(string, FontStyle::medium);
             auto localizedGroupByTrackTypeWidth = strWidth + 14;
             widgets[WIDX_GROUP_BY_TRACK_TYPE].left = width - 8 - localizedGroupByTrackTypeWidth;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabImages(rt);
@@ -484,12 +484,12 @@ namespace OpenRCT2::Ui::Windows
 
             _newRideVars.SelectedRide = item;
 
-            OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::click1, 0, windowPos.x + (width / 2));
+            Audio::Play(Audio::SoundId::click1, 0, windowPos.x + (width / 2));
             _newRideVars.SelectedRideCountdown = 8;
             invalidate();
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             if (_currentTab == RESEARCH_TAB)
             {
@@ -584,7 +584,7 @@ namespace OpenRCT2::Ui::Windows
 
             close();
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseConstructionWindows();
 
             auto count = GetNumTrackDesigns(item);
@@ -618,7 +618,7 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            auto repo = OpenRCT2::GetContext()->GetTrackDesignRepository();
+            auto repo = GetContext()->GetTrackDesignRepository();
             _lastTrackDesignCount = static_cast<int32_t>(repo->GetCountForObjectEntry(item.Type, entryName));
             _lastTrackDesignCountRideType = item;
             return _lastTrackDesignCount;
@@ -632,7 +632,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+            auto& objManager = GetContext()->GetObjectManager();
             auto& rideEntries = objManager.GetAllRideEntries(rideType);
             auto isFirst = true;
             for (auto rideEntryIndex : rideEntries)
@@ -661,7 +661,7 @@ namespace OpenRCT2::Ui::Windows
 
         ImageIndex GetRideImage(RideSelection rideSelection)
         {
-            auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+            auto& objMgr = GetContext()->GetObjectManager();
             auto obj = objMgr.GetLoadedObject<RideObject>(rideSelection.EntryIndex);
             return obj == nullptr ? kImageIndexUndefined : obj->GetPreviewImage(rideSelection.Type);
         }
@@ -697,7 +697,7 @@ namespace OpenRCT2::Ui::Windows
             uint8_t highestVehiclePriority = 0;
 
             // For each ride entry for this ride type
-            auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+            auto& objManager = GetContext()->GetObjectManager();
             auto& rideEntries = objManager.GetAllRideEntries(rideType);
             for (auto rideEntryIndex : rideEntries)
             {
@@ -706,7 +706,7 @@ namespace OpenRCT2::Ui::Windows
                     continue;
 
                 // Ride entries
-                auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+                auto& objMgr = GetContext()->GetObjectManager();
                 auto* rideObj = objMgr.GetLoadedObject<RideObject>(rideEntryIndex);
 
                 // Skip if the vehicle isn't the preferred vehicle for this generic track type
@@ -942,10 +942,9 @@ namespace OpenRCT2::Ui::Windows
             widgetScrollUpdateThumbs(*this, WIDX_RIDE_LIST);
         }
 
-        void DrawRideInformation(
-            Drawing::RenderTarget& rt, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
+        void DrawRideInformation(RenderTarget& rt, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
         {
-            auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+            auto& objMgr = GetContext()->GetObjectManager();
             const auto* rideObj = objMgr.GetLoadedObject<RideObject>(item.EntryIndex);
             const auto& rideEntry = rideObj->GetEntry();
             RideNaming rideNaming = GetRideNaming(item.Type, &rideEntry);
@@ -1029,7 +1028,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImage(Drawing::RenderTarget& rt, NewRideTabId tab, int32_t spriteIndex)
+        void DrawTabImage(RenderTarget& rt, NewRideTabId tab, int32_t spriteIndex)
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(tab);
 
@@ -1047,7 +1046,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(Drawing::RenderTarget& rt)
+        void DrawTabImages(RenderTarget& rt)
         {
             DrawTabImage(rt, TRANSPORT_TAB, SPR_TAB_RIDES_TRANSPORT_0);
             DrawTabImage(rt, GENTLE_TAB, SPR_TAB_RIDES_GENTLE_0);
@@ -1099,7 +1098,7 @@ namespace OpenRCT2::Ui::Windows
      */
     WindowBase* NewRideOpen()
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         auto* window = windowMgr->BringToFrontByClass(WindowClass::constructRide);
         if (window)
         {

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -260,7 +260,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_TAB_OPTIONS, page == optionsTab);
         }
 
-        void DrawTabImages(Drawing::RenderTarget& rt)
+        void DrawTabImages(RenderTarget& rt)
         {
             if (!isWidgetDisabled(WIDX_TAB_NEWS))
             {
@@ -308,7 +308,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabImages(rt);
@@ -455,7 +455,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             int32_t lineHeight = FontGetLineHeight(FontStyle::small);
             int32_t itemHeight = CalculateNewsItemHeight();
@@ -501,7 +501,7 @@ namespace OpenRCT2::Ui::Windows
                         { COLOUR_BRIGHT_GREEN, FontStyle::small });
                 }
                 // Subject button
-                if ((newsItem.typeHasSubject()) && !(newsItem.hasButton()))
+                if (newsItem.typeHasSubject() && !newsItem.hasButton())
                 {
                     auto screenCoords = ScreenCoordsXY{ 328 + scrollbarFill, y + lineHeight + 4 };
 
@@ -583,7 +583,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Location button
-                if ((newsItem.typeHasLocation()) && !(newsItem.hasButton()))
+                if (newsItem.typeHasLocation() && !newsItem.hasButton())
                 {
                     auto screenCoords = ScreenCoordsXY{ 352 + scrollbarFill, y + lineHeight + 4 };
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -130,7 +130,7 @@ namespace OpenRCT2::Ui::Windows
                         ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Count));
                         ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Total));
                         ft.Add<char*>(_downloadStatusInfo.Name.c_str());
-                        OpenRCT2::FormatStringLegacy(
+                        FormatStringLegacy(
                             str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS, ft.Data());
                     }
                     else
@@ -139,7 +139,7 @@ namespace OpenRCT2::Ui::Windows
                         ft.Add<char*>(_downloadStatusInfo.Source.c_str());
                         ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Count));
                         ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Total));
-                        OpenRCT2::FormatStringLegacy(
+                        FormatStringLegacy(
                             str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS_FROM, ft.Data());
                     }
 
@@ -180,7 +180,7 @@ namespace OpenRCT2::Ui::Windows
                             auto data = reinterpret_cast<uint8_t*>(response.body.data());
                             auto dataLen = response.body.size();
 
-                            auto& objRepo = OpenRCT2::GetContext()->GetObjectRepository();
+                            auto& objRepo = GetContext()->GetObjectRepository();
                             objRepo.AddObjectFromFile(ObjectGeneration::DAT, name, data, dataLen);
 
                             std::lock_guard<std::mutex> guard(_downloadedEntriesMutex);
@@ -380,7 +380,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto clip = stream.str();
-            OpenRCT2::GetContext()->GetUiContext().SetClipboardText(clip.c_str());
+            GetContext()->GetUiContext().SetClipboardText(clip.c_str());
         }
 
         void SelectObjectFromList(const int32_t index)
@@ -424,7 +424,7 @@ namespace OpenRCT2::Ui::Windows
                     if (selectedListItem > -1 && selectedListItem < numListItems)
                     {
                         const auto name = std::string(_invalidEntries[selectedListItem].GetName());
-                        OpenRCT2::GetContext()->GetUiContext().SetClipboardText(name.c_str());
+                        GetContext()->GetUiContext().SetClipboardText(name.c_str());
                     }
                     break;
                 case WIDX_COPY_ALL:
@@ -492,7 +492,7 @@ namespace OpenRCT2::Ui::Windows
             invalidateWidget(WIDX_SCROLL);
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             WindowDrawWidgets(*this, rt);
 
@@ -510,7 +510,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextEllipsised(rt, screenPos + ScreenCoordsXY{ 0, 29 }, kWindowSize.width - 5, STR_BLACK_STRING, ft);
         }
 
-        void onScrollDraw(const int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(const int32_t scrollIndex, RenderTarget& rt) override
         {
             auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             Rectangle::fill(
@@ -576,7 +576,7 @@ namespace OpenRCT2::Ui::Windows
     WindowBase* ObjectLoadErrorOpen(utf8* path, size_t numMissingObjects, const ObjectEntryDescriptor* missingObjects)
     {
         // Check if window is already open
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         auto* window = windowMgr->BringToFrontByClass(WindowClass::objectLoadError);
         if (window == nullptr)
         {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -744,7 +744,7 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
 
             disabledWidgets = 0;
-            auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext().HasFilePicker();
+            auto hasFilePicker = GetContext()->GetUiContext().HasFilePicker();
             const bool advancedTabSelected = (WIDX_FIRST_TAB + page) == WIDX_TAB_ADVANCED;
             if (!hasFilePicker && advancedTabSelected)
             {
@@ -818,7 +818,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_RESOLUTION_DROPDOWN:
                 {
-                    const auto& resolutions = OpenRCT2::GetContext()->GetUiContext().GetFullscreenResolutions();
+                    const auto& resolutions = GetContext()->GetUiContext().GetFullscreenResolutions();
 
                     int32_t selectedResolution = -1;
                     for (size_t i = 0; i < resolutions.size(); i++)
@@ -908,7 +908,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_RESOLUTION_DROPDOWN:
                 {
-                    const auto& resolutions = OpenRCT2::GetContext()->GetUiContext().GetFullscreenResolutions();
+                    const auto& resolutions = GetContext()->GetUiContext().GetFullscreenResolutions();
 
                     const Resolution& resolution = resolutions[dropdownIndex];
                     if (resolution.Width != Config::Get().general.fullscreenWidth
@@ -917,9 +917,8 @@ namespace OpenRCT2::Ui::Windows
                         Config::Get().general.fullscreenWidth = resolution.Width;
                         Config::Get().general.fullscreenHeight = resolution.Height;
 
-                        if (Config::Get().general.fullscreenMode
-                            == static_cast<int32_t>(OpenRCT2::Ui::FullscreenMode::fullscreen))
-                            ContextSetFullscreenMode(static_cast<int32_t>(OpenRCT2::Ui::FullscreenMode::fullscreen));
+                        if (Config::Get().general.fullscreenMode == static_cast<int32_t>(FullscreenMode::fullscreen))
+                            ContextSetFullscreenMode(static_cast<int32_t>(FullscreenMode::fullscreen));
 
                         Config::Save();
                         GfxInvalidateScreen();
@@ -983,7 +982,7 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<uint16_t>(static_cast<uint16_t>(Config::Get().general.fullscreenHeight));
 
             // Disable resolution dropdown on "Windowed" and "Fullscreen (desktop)"
-            if (Config::Get().general.fullscreenMode != static_cast<int32_t>(OpenRCT2::Ui::FullscreenMode::fullscreen))
+            if (Config::Get().general.fullscreenMode != static_cast<int32_t>(FullscreenMode::fullscreen))
             {
                 disabledWidgets |= (1uLL << WIDX_RESOLUTION_DROPDOWN);
                 disabledWidgets |= (1uLL << WIDX_RESOLUTION);
@@ -1403,11 +1402,11 @@ namespace OpenRCT2::Ui::Windows
                 {
                     Config::Get().sound.masterSoundEnabled = !Config::Get().sound.masterSoundEnabled;
                     if (!Config::Get().sound.masterSoundEnabled)
-                        OpenRCT2::Audio::Pause();
+                        Pause();
                     else
-                        OpenRCT2::Audio::Resume();
+                        Resume();
 
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->InvalidateByClass(WindowClass::topToolbar);
                     Config::Save();
                     invalidate();
@@ -1418,7 +1417,7 @@ namespace OpenRCT2::Ui::Windows
                     Config::Get().sound.rideMusicEnabled = !Config::Get().sound.rideMusicEnabled;
                     if (!Config::Get().sound.rideMusicEnabled)
                     {
-                        OpenRCT2::RideAudio::StopAllChannels();
+                        RideAudio::StopAllChannels();
                     }
                     Config::Save();
                     invalidate();
@@ -1439,17 +1438,17 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_SOUND_DROPDOWN:
-                    OpenRCT2::Audio::PopulateDevices();
+                    PopulateDevices();
 
                     // populate the list with the sound devices
-                    for (int32_t i = 0; i < OpenRCT2::Audio::GetDeviceCount(); i++)
+                    for (int32_t i = 0; i < GetDeviceCount(); i++)
                     {
-                        gDropdown.items[i] = Dropdown::MenuLabel(OpenRCT2::Audio::GetDeviceName(i).c_str());
+                        gDropdown.items[i] = Dropdown::MenuLabel(GetDeviceName(i).c_str());
                     }
 
-                    ShowDropdown(widget, OpenRCT2::Audio::GetDeviceCount());
+                    ShowDropdown(widget, GetDeviceCount());
 
-                    gDropdown.items[OpenRCT2::Audio::GetCurrentDeviceIndex()].setChecked(true);
+                    gDropdown.items[GetCurrentDeviceIndex()].setChecked(true);
                     break;
                 case WIDX_TITLE_MUSIC_DROPDOWN:
                 {
@@ -1478,8 +1477,8 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_SOUND_DROPDOWN:
-                    OpenRCT2::Audio::InitRideSounds(dropdownIndex);
-                    if (dropdownIndex < OpenRCT2::Audio::GetDeviceCount())
+                    InitRideSounds(dropdownIndex);
+                    if (dropdownIndex < GetDeviceCount())
                     {
                         auto& audioContext = GetContext()->GetAudioContext();
                         if (dropdownIndex == 0)
@@ -1494,7 +1493,7 @@ namespace OpenRCT2::Ui::Windows
                             Config::Get().sound.device = deviceName;
                         }
                         Config::Save();
-                        OpenRCT2::Audio::PlayTitleMusic();
+                        PlayTitleMusic();
                     }
                     invalidate();
                     break;
@@ -1513,10 +1512,10 @@ namespace OpenRCT2::Ui::Windows
                     Config::Save();
                     invalidate();
 
-                    OpenRCT2::Audio::StopTitleMusic();
+                    StopTitleMusic();
                     if (Config::Get().sound.titleMusic != TitleMusicKind::None)
                     {
-                        OpenRCT2::Audio::PlayTitleMusic();
+                        PlayTitleMusic();
                     }
                     break;
                 }
@@ -1612,8 +1611,8 @@ namespace OpenRCT2::Ui::Windows
             // Sound device
             StringId audioDeviceStringId = STR_OPTIONS_SOUND_VALUE_DEFAULT;
             const char* audioDeviceName = nullptr;
-            const int32_t currentDeviceIndex = OpenRCT2::Audio::GetCurrentDeviceIndex();
-            if (currentDeviceIndex == -1 || OpenRCT2::Audio::GetDeviceCount() == 0)
+            const int32_t currentDeviceIndex = GetCurrentDeviceIndex();
+            if (currentDeviceIndex == -1 || GetDeviceCount() == 0)
             {
                 audioDeviceStringId = STR_SOUND_NONE;
             }
@@ -1628,7 +1627,7 @@ namespace OpenRCT2::Ui::Windows
 #endif // __linux__
                 if (audioDeviceStringId == STR_STRING)
                 {
-                    audioDeviceName = OpenRCT2::Audio::GetDeviceName(currentDeviceIndex).c_str();
+                    audioDeviceName = GetDeviceName(currentDeviceIndex).c_str();
                 }
             }
 
@@ -1659,7 +1658,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Controls tab events
         void ControlsMouseUp(WidgetIndex widgetIndex)
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
 
             switch (widgetIndex)
             {
@@ -1747,7 +1746,7 @@ namespace OpenRCT2::Ui::Windows
             Config::Save();
             invalidate();
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::topToolbar);
         }
 
@@ -1873,7 +1872,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     Config::Get().general.scenarioUnlockingEnabled ^= 1;
                     Config::Save();
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->InvalidateByClass(WindowClass::scenarioSelect);
                     break;
                 }
@@ -1990,7 +1989,7 @@ namespace OpenRCT2::Ui::Windows
                         Config::Get().interface.scenarioPreviewScreenshots = dropdownIndex;
                         Config::Save();
                         invalidate();
-                        auto* windowMgr = Ui::GetWindowManager();
+                        auto* windowMgr = GetWindowManager();
                         windowMgr->InvalidateByClass(WindowClass::scenarioSelect);
                     }
                     break;
@@ -2075,7 +2074,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WIDX_PATH_TO_RCT1_BROWSE:
                 {
-                    auto rct1path = OpenRCT2::GetContext()->GetUiContext().ShowDirectoryDialog(
+                    auto rct1path = GetContext()->GetUiContext().ShowDirectoryDialog(
                         LanguageGetString(STR_PATH_TO_RCT1_BROWSER));
                     if (!rct1path.empty())
                     {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -78,12 +78,12 @@ namespace OpenRCT2::Ui::Windows
     static RideConstructionState _rideConstructionState2;
 
     static bool WindowRideConstructionUpdateState(
-        OpenRCT2::TrackElemType* trackType, int32_t* trackDirection, RideId* rideIndex,
+        TrackElemType* trackType, int32_t* trackDirection, RideId* rideIndex,
         SelectedLiftAndInverted* _liftHillAndAlternativeState, CoordsXYZ* trackPos, int32_t* properties);
     money64 PlaceProvisionalTrackPiece(
-        RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
-        SelectedLiftAndInverted liftHillAndAlternativeState, const CoordsXYZ& trackPos);
-    static std::pair<bool, OpenRCT2::TrackElemType> WindowRideConstructionUpdateStateGetTrackElement();
+        RideId rideIndex, TrackElemType trackType, int32_t trackDirection, SelectedLiftAndInverted liftHillAndAlternativeState,
+        const CoordsXYZ& trackPos);
+    static std::pair<bool, TrackElemType> WindowRideConstructionUpdateStateGetTrackElement();
 
     static constexpr StringId kWindowTitle = STR_RIDE_CONSTRUCTION_WINDOW_TITLE;
     static constexpr ScreenSize kWindowSize = { 210, 394 };
@@ -216,7 +216,7 @@ namespace OpenRCT2::Ui::Windows
         STR_RIDE_CONSTRUCTION_SEAT_ROTATION_ANGLE_450,     STR_RIDE_CONSTRUCTION_SEAT_ROTATION_ANGLE_495,
     };
 
-    static void WindowRideConstructionMouseUpDemolishNextPiece(const CoordsXYZD& piecePos, OpenRCT2::TrackElemType type);
+    static void WindowRideConstructionMouseUpDemolishNextPiece(const CoordsXYZD& piecePos, TrackElemType type);
     static void WindowRideConstructionUpdateActiveElements();
 
     /* move to ride.c */
@@ -1547,7 +1547,7 @@ namespace OpenRCT2::Ui::Windows
 
             RideConstructionInvalidateCurrentTrack();
             _currentTrackPrice = kMoney64Undefined;
-            OpenRCT2::TrackElemType trackPiece = _specialElementDropdownState.Elements[selectedIndex].TrackType;
+            TrackElemType trackPiece = _specialElementDropdownState.Elements[selectedIndex].TrackType;
             switch (trackPiece)
             {
                 case TrackElemType::endStation:
@@ -1699,7 +1699,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             RideId rideIndex;
-            OpenRCT2::TrackElemType trackType;
+            TrackElemType trackType;
             int32_t trackDirection;
             SelectedLiftAndInverted liftHillAndInvertedState{};
             if (WindowRideConstructionUpdateState(
@@ -2241,7 +2241,7 @@ namespace OpenRCT2::Ui::Windows
 
         void updateMapSelection()
         {
-            OpenRCT2::TrackElemType trackType;
+            TrackElemType trackType;
             int32_t trackDirection;
             CoordsXYZ trackPos{};
 
@@ -2267,7 +2267,7 @@ namespace OpenRCT2::Ui::Windows
                     if (WindowRideConstructionUpdateState(&trackType, &trackDirection, nullptr, nullptr, &trackPos, nullptr))
                     {
                         trackDirection = _currentTrackPieceDirection;
-                        trackType = OpenRCT2::TrackElemType::flat;
+                        trackType = TrackElemType::flat;
                         trackPos = _currentTrackBegin;
                     }
                     break;
@@ -2279,7 +2279,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void selectMapTiles(OpenRCT2::TrackElemType trackType, int32_t trackDirection, const CoordsXY& tileCoords)
+        void selectMapTiles(TrackElemType trackType, int32_t trackDirection, const CoordsXY& tileCoords)
         {
             // If the scenery tool is active, we do not display our tiles as it
             // will conflict with larger scenery objects selecting tiles
@@ -2304,7 +2304,7 @@ namespace OpenRCT2::Ui::Windows
         void Construct()
         {
             RideId rideIndex;
-            OpenRCT2::TrackElemType trackType;
+            TrackElemType trackType;
             int32_t trackDirection, properties;
             SelectedLiftAndInverted liftHillAndAlternativeState{};
             CoordsXYZ trackPos{};
@@ -2355,7 +2355,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            Audio::Play3D(OpenRCT2::Audio::SoundId::placeItem, trackPos);
+            Audio::Play3D(Audio::SoundId::placeItem, trackPos);
 
             if (Network::GetMode() != Network::Mode::none)
             {
@@ -2411,7 +2411,7 @@ namespace OpenRCT2::Ui::Windows
             direction = _currentTrackPieceDirection;
             // The direction is reset by ride_initialise_construction_window(), but we need it to remove flat rides properly.
             Direction currentDirection = _currentTrackPieceDirection;
-            OpenRCT2::TrackElemType type = _currentTrackPieceType;
+            TrackElemType type = _currentTrackPieceType;
             auto newCoords = GetTrackElementOriginAndApplyChanges(
                 { _currentTrackBegin, static_cast<Direction>(direction & 3) }, type, 0, &tileElement, {});
             if (!newCoords.has_value())
@@ -2670,7 +2670,7 @@ namespace OpenRCT2::Ui::Windows
                     if (result->error != GameActions::Status::ok)
                         return;
 
-                    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::placeItem, result->position);
+                    Audio::Play3D(Audio::SoundId::placeItem, result->position);
 
                     auto* windowMgr = GetWindowManager();
 
@@ -2700,7 +2700,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawTrackPiece(
-            Drawing::RenderTarget& rt, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
+            Drawing::RenderTarget& rt, RideId rideIndex, TrackElemType trackType, int32_t trackDirection,
             SelectedLiftAndInverted liftHillAndInvertedState, int32_t widgetWidth, int32_t widgetHeight)
         {
             auto currentRide = GetRide(rideIndex);
@@ -2741,7 +2741,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
         void DrawTrackPieceHelper(
-            Drawing::RenderTarget& rt, RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
+            Drawing::RenderTarget& rt, RideId rideIndex, TrackElemType trackType, int32_t trackDirection,
             SelectedLiftAndInverted liftHillAndInvertedState, const CoordsXY& originCoords, int32_t originZ)
         {
             TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
@@ -2843,7 +2843,7 @@ namespace OpenRCT2::Ui::Windows
             // pieces will be re-enabled as soon as a single entry supports it.
             disabledGroups.flip();
 
-            auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+            auto& objManager = GetContext()->GetObjectManager();
             auto& rideEntries = objManager.GetAllRideEntries(rideType);
             // If there are no vehicles for this ride type, enable all the track pieces.
             if (rideEntries.size() == 0)
@@ -2991,7 +2991,7 @@ namespace OpenRCT2::Ui::Windows
             WindowRideConstructionUpdateActiveElements();
         }
 
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::error);
         if (ride != nullptr)
             CloseConstructWindowOnCompletion(*ride);
@@ -3037,7 +3037,7 @@ namespace OpenRCT2::Ui::Windows
             WindowRideConstructionUpdateActiveElements();
         }
 
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::error);
         if (ride != nullptr)
             CloseConstructWindowOnCompletion(*ride);
@@ -3225,7 +3225,7 @@ namespace OpenRCT2::Ui::Windows
     {
         RideId rideIndex;
         int32_t direction;
-        OpenRCT2::TrackElemType type;
+        TrackElemType type;
         SelectedLiftAndInverted liftHillAndAlternativeState{};
         CoordsXYZ trackPos{};
 
@@ -3375,7 +3375,7 @@ namespace OpenRCT2::Ui::Windows
         MapSelection::addSelectedTile(*mapCoords);
 
         RideId rideIndex;
-        OpenRCT2::TrackElemType trackType;
+        TrackElemType trackType;
         int32_t trackDirection;
         SelectedLiftAndInverted liftHillAndAlternativeState{};
         if (WindowRideConstructionUpdateState(
@@ -3611,7 +3611,7 @@ namespace OpenRCT2::Ui::Windows
         RideConstructionInvalidateCurrentTrack();
 
         CoordsXYZ mapCoords{};
-        OpenRCT2::TrackElemType trackType;
+        TrackElemType trackType;
         int32_t z, highestZ;
 
         if (WindowRideConstructionUpdateState(&trackType, nullptr, nullptr, nullptr, nullptr, nullptr))
@@ -3725,7 +3725,7 @@ namespace OpenRCT2::Ui::Windows
                         || errorText == STR_CAN_ONLY_BUILD_THIS_ABOVE_GROUND || errorText == STR_TOO_HIGH_FOR_SUPPORTS
                         || zAttempts == (numAttempts - 1) || z < 0)
                     {
-                        Audio::Play(OpenRCT2::Audio::SoundId::error, 0, state->position.x);
+                        Audio::Play(Audio::SoundId::error, 0, state->position.x);
                         w = windowMgr->FindByClass(WindowClass::rideConstruction);
                         if (w != nullptr)
                         {
@@ -3743,7 +3743,7 @@ namespace OpenRCT2::Ui::Windows
                 else
                 {
                     windowMgr->CloseByClass(WindowClass::error);
-                    OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::placeItem, _currentTrackBegin);
+                    Audio::Play3D(Audio::SoundId::placeItem, _currentTrackBegin);
                     break;
                 }
             }
@@ -3798,7 +3798,7 @@ namespace OpenRCT2::Ui::Windows
                     _currentTrackAlternative = savedCurrentTrackAlternative;
                     _currentTrackHasLiftHill = savedCurrentTrackLiftHill;
 
-                    OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::error, 0, state->position.x);
+                    Audio::Play(Audio::SoundId::error, 0, state->position.x);
                     break;
                 }
 
@@ -4663,7 +4663,7 @@ namespace OpenRCT2::Ui::Windows
         w->onMouseDown(WIDX_DEMOLISH);
     }
 
-    static void WindowRideConstructionMouseUpDemolishNextPiece(const CoordsXYZD& piecePos, OpenRCT2::TrackElemType type)
+    static void WindowRideConstructionMouseUpDemolishNextPiece(const CoordsXYZD& piecePos, TrackElemType type)
     {
         if (_gotoStartPlacementMode)
         {
@@ -4747,8 +4747,8 @@ namespace OpenRCT2::Ui::Windows
      *  rct2: 0x006CA162
      */
     money64 PlaceProvisionalTrackPiece(
-        RideId rideIndex, OpenRCT2::TrackElemType trackType, int32_t trackDirection,
-        SelectedLiftAndInverted liftHillAndAlternativeState, const CoordsXYZ& trackPos)
+        RideId rideIndex, TrackElemType trackType, int32_t trackDirection, SelectedLiftAndInverted liftHillAndAlternativeState,
+        const CoordsXYZ& trackPos)
     {
         auto ride = GetRide(rideIndex);
         if (ride == nullptr)
@@ -4816,7 +4816,7 @@ namespace OpenRCT2::Ui::Windows
         return res.cost;
     }
 
-    static std::pair<bool, OpenRCT2::TrackElemType> WindowRideConstructionUpdateStateGetTrackElement()
+    static std::pair<bool, TrackElemType> WindowRideConstructionUpdateStateGetTrackElement()
     {
         auto startSlope = _previousTrackPitchEnd;
         auto endSlope = _currentTrackPitchEnd;
@@ -4834,7 +4834,7 @@ namespace OpenRCT2::Ui::Windows
         auto selectedTrack = _currentlySelectedTrack;
         if (selectedTrack == TrackElemType::none)
         {
-            return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+            return std::make_pair(false, TrackElemType::flat);
         }
 
         bool startsDiagonal = (_currentTrackPieceDirection & (1 << 2)) != 0;
@@ -4853,7 +4853,7 @@ namespace OpenRCT2::Ui::Windows
             if (trackPiece != TrackElemType::none)
                 return std::make_pair(true, trackPiece);
             else
-                return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+                return std::make_pair(false, TrackElemType::flat);
         }
 
         auto asTrackType = selectedTrack.trackType;
@@ -4864,12 +4864,12 @@ namespace OpenRCT2::Ui::Windows
             case TrackElemType::sBendRight:
                 if (startSlope != TrackPitch::none || endSlope != TrackPitch::none)
                 {
-                    return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+                    return std::make_pair(false, TrackElemType::flat);
                 }
 
                 if (startBank != TrackRoll::none || endBank != TrackRoll::none)
                 {
-                    return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+                    return std::make_pair(false, TrackElemType::flat);
                 }
 
                 return std::make_pair(true, asTrackType);
@@ -4878,21 +4878,21 @@ namespace OpenRCT2::Ui::Windows
             case TrackElemType::rightVerticalLoop:
                 if (startBank != TrackRoll::none || endBank != TrackRoll::none)
                 {
-                    return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+                    return std::make_pair(false, TrackElemType::flat);
                 }
 
                 if (_rideConstructionState == RideConstructionState::Back)
                 {
                     if (endSlope != TrackPitch::down25)
                     {
-                        return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+                        return std::make_pair(false, TrackElemType::flat);
                     }
                 }
                 else
                 {
                     if (startSlope != TrackPitch::up25)
                     {
-                        return std::make_pair(false, OpenRCT2::TrackElemType::flat);
+                        return std::make_pair(false, TrackElemType::flat);
                     }
                 }
 
@@ -4917,7 +4917,7 @@ namespace OpenRCT2::Ui::Windows
      * @return (CF)
      */
     static bool WindowRideConstructionUpdateState(
-        OpenRCT2::TrackElemType* _trackType, int32_t* _trackDirection, RideId* _rideIndex,
+        TrackElemType* _trackType, int32_t* _trackDirection, RideId* _rideIndex,
         SelectedLiftAndInverted* _liftHillAndInvertedState, CoordsXYZ* _trackPos, int32_t* _properties)
     {
         RideId rideIndex;
@@ -4933,7 +4933,7 @@ namespace OpenRCT2::Ui::Windows
             return true;
         }
 
-        OpenRCT2::TrackElemType trackType = std::get<1>(updated_element);
+        TrackElemType trackType = std::get<1>(updated_element);
         rideIndex = _currentRideIndex;
         if (_currentTrackHasLiftHill)
         {
@@ -5105,7 +5105,7 @@ namespace OpenRCT2::Ui::Windows
         {
             RideId rideIndex;
             int32_t direction;
-            OpenRCT2::TrackElemType type;
+            TrackElemType type;
             SelectedLiftAndInverted liftHillAndAlternativeState{};
             CoordsXYZ trackPos;
             if (WindowRideConstructionUpdateState(

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -587,7 +587,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B3235
          */
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             WindowDrawWidgets(*this, rt);
             DrawTabImages(rt);
@@ -624,7 +624,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B3240
          */
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             Rectangle::fill(
@@ -881,7 +881,7 @@ namespace OpenRCT2::Ui::Windows
          *
          *  rct2: 0x006B38EA
          */
-        void DrawTabImages(Drawing::RenderTarget& rt)
+        void DrawTabImages(RenderTarget& rt)
         {
             int32_t sprite_idx;
 

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -108,7 +108,7 @@ namespace OpenRCT2::Ui::Windows
                 Audio::StopAll();
             }
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::topToolbar);
 
             if (canSave)
@@ -136,7 +136,7 @@ namespace OpenRCT2::Ui::Windows
                 Audio::Resume();
             }
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::topToolbar);
         }
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -267,7 +267,7 @@ namespace OpenRCT2::Ui::Windows
             invalidate();
         }
 
-        ScreenCoordsXY DrawPreview(Drawing::RenderTarget& rt, ScreenCoordsXY screenPos)
+        ScreenCoordsXY DrawPreview(RenderTarget& rt, ScreenCoordsXY screenPos)
         {
             auto targetImageType = PreviewImageType::miniMap;
             if (Config::Get().interface.scenarioPreviewScreenshots)
@@ -302,7 +302,7 @@ namespace OpenRCT2::Ui::Windows
             return frameEndPos;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -525,7 +525,7 @@ namespace OpenRCT2::Ui::Windows
                         mutableScreenCoords.y -= scenarioItemHeight;
                         if (mutableScreenCoords.y < 0 && !listItem.scenario.is_locked)
                         {
-                            OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::click1, 0, windowPos.x + (width / 2));
+                            OpenRCT2::Audio::Play(Audio::SoundId::click1, 0, windowPos.x + (width / 2));
                             gFirstTimeSaving = true;
                             // Callback will likely close this window! So should always return after it.
                             _callback(listItem.scenario.scenario->Path);
@@ -540,7 +540,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             auto paletteIndex = ColourMapA[colours[1].colour].mid_light;
             GfxClear(rt, paletteIndex);
@@ -636,7 +636,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void DrawCategoryHeading(Drawing::RenderTarget& rt, int32_t left, int32_t right, int32_t y, StringId stringId) const
+        void DrawCategoryHeading(RenderTarget& rt, int32_t left, int32_t right, int32_t y, StringId stringId) const
         {
             auto baseColour = colours[1];
             auto lightColour = ColourMapA[baseColour.colour].lighter;
@@ -649,7 +649,7 @@ namespace OpenRCT2::Ui::Windows
             // Get string dimensions
             utf8 buffer[512];
             auto bufferPtr = buffer;
-            OpenRCT2::FormatStringLegacy(bufferPtr, sizeof(buffer), stringId, nullptr);
+            FormatStringLegacy(bufferPtr, sizeof(buffer), stringId, nullptr);
             int32_t categoryStringHalfWidth = (GfxGetStringWidth(bufferPtr, FontStyle::medium) / 2) + 4;
             int32_t strLeft = centreX - categoryStringHalfWidth;
             int32_t strRight = centreX + categoryStringHalfWidth;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -282,7 +282,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (gWindowSceneryScatterEnabled)
             {
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
                 windowMgr->CloseByClass(WindowClass::sceneryScatter);
             }
 
@@ -292,7 +292,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onMouseUp(WidgetIndex widgetIndex) override
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
 
             switch (widgetIndex)
             {
@@ -876,7 +876,7 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = canFit ? WidgetType::flatBtn : WidgetType::empty;
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabs(rt, windowPos);
@@ -1081,7 +1081,7 @@ namespace OpenRCT2::Ui::Windows
 
             PrepareWidgets();
 
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::scenery);
         }
 
@@ -1573,7 +1573,7 @@ namespace OpenRCT2::Ui::Windows
             return { name, price };
         }
 
-        void DrawTabs(Drawing::RenderTarget& rt, const ScreenCoordsXY& offset)
+        void DrawTabs(RenderTarget& rt, const ScreenCoordsXY& offset)
         {
             for (size_t tabIndex = 0; tabIndex < _tabEntries.size(); tabIndex++)
             {
@@ -1588,7 +1588,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawSceneryItem(Drawing::RenderTarget& rt, ScenerySelection scenerySelection)
+        void DrawSceneryItem(RenderTarget& rt, ScenerySelection scenerySelection)
         {
             if (scenerySelection.SceneryType == SCENERY_TYPE_BANNER)
             {
@@ -1706,7 +1706,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             GfxClear(rt, ColourMapA[colours[1].colour].mid_light);
 
@@ -3225,7 +3225,7 @@ namespace OpenRCT2::Ui::Windows
 
                 if (_lastProvisionalError.error != GameActions::Status::ok)
                 {
-                    auto windowManager = Ui::GetWindowManager();
+                    auto windowManager = GetWindowManager();
                     windowManager->ShowError(
                         _lastProvisionalError.getErrorTitle(), _lastProvisionalError.getErrorMessage(), true);
                 }

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -305,7 +305,7 @@ namespace OpenRCT2::Ui::Windows
             return { fallback, ft };
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -326,7 +326,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(rt, windowPos + ScreenCoordsXY{ 8, height - 15 }, _statusText, ft, { COLOUR_WHITE });
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             auto paletteIndex = ColourMapA[colours[1].colour].mid_light;
             GfxClear(rt, paletteIndex);

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -121,7 +121,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
 
@@ -192,7 +192,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onClose() override
         {
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
             windowMgr->CloseByClass(WindowClass::resetShortcutKeysPrompt);
         }
 
@@ -251,7 +251,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(static_cast<WidgetIndex>(WIDX_TAB_0 + _currentTabIndex), true);
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             DrawTabImages(rt);
@@ -297,7 +297,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             auto rtCoords = ScreenCoordsXY{ rt.x, rt.y };
             Rectangle::fill(
@@ -472,7 +472,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(Drawing::RenderTarget& rt) const
+        void DrawTabImages(RenderTarget& rt) const
         {
             for (size_t i = 0; i < _tabs.size(); i++)
             {
@@ -480,7 +480,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImage(Drawing::RenderTarget& rt, size_t tabIndex) const
+        void DrawTabImage(RenderTarget& rt, size_t tabIndex) const
         {
             const auto& tabDesc = _tabs[tabIndex];
             auto widgetIndex = static_cast<WidgetIndex>(WIDX_TAB_0 + tabIndex);
@@ -501,15 +501,14 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawSeparator(Drawing::RenderTarget& rt, int32_t y, int32_t scrollWidth)
+        void DrawSeparator(RenderTarget& rt, int32_t y, int32_t scrollWidth)
         {
             const int32_t top = y + (kScrollableRowHeight / 2) - 1;
             Rectangle::fill(rt, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[1].colour].mid_dark);
             Rectangle::fill(rt, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[1].colour].lightest);
         }
 
-        void DrawItem(
-            Drawing::RenderTarget& rt, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
+        void DrawItem(RenderTarget& rt, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
         {
             auto format = STR_BLACK_STRING;
             if (isHighlighted)

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -40,8 +40,6 @@
 #include <openrct2/world/MapSelection.h>
 #include <openrct2/world/Park.h>
 
-using namespace OpenRCT2::Numerics;
-
 namespace OpenRCT2::Ui::Windows
 {
     static constexpr StringId kWindowTitle = STR_STRINGID;
@@ -483,7 +481,7 @@ namespace OpenRCT2::Ui::Windows
                             return;
                         }
 
-                        auto* windowMgr = Ui::GetWindowManager();
+                        auto* windowMgr = GetWindowManager();
                         windowMgr->CloseByClass(WindowClass::patrolArea);
 
                         auto staffSetPatrolAreaAction = GameActions::StaffSetPatrolAreaAction(
@@ -495,7 +493,7 @@ namespace OpenRCT2::Ui::Windows
                         auto staffId = EntityId::FromUnderlying(number);
                         if (WindowPatrolAreaGetCurrentStaffId() == staffId)
                         {
-                            auto* windowMgr = Ui::GetWindowManager();
+                            auto* windowMgr = GetWindowManager();
                             windowMgr->CloseByClass(WindowClass::patrolArea);
                         }
                         else

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -388,7 +388,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             // Widgets
             WindowDrawWidgets(*this, rt);
@@ -417,7 +417,7 @@ namespace OpenRCT2::Ui::Windows
         void onMouseDown(WidgetIndex widgetIndex) override
         {
             auto widget = &widgets[widgetIndex];
-            auto* windowMgr = Ui::GetWindowManager();
+            auto* windowMgr = GetWindowManager();
 
             switch (widgetIndex)
             {
@@ -707,7 +707,7 @@ namespace OpenRCT2::Ui::Windows
                             ThemeSetColour(wc, _buttonIndex, colour);
                             ColourSchemeUpdateAll();
 
-                            auto* windowMgr = Ui::GetWindowManager();
+                            auto* windowMgr = GetWindowManager();
                             windowMgr->InvalidateAll();
                         }
                     }
@@ -715,7 +715,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             ScreenCoordsXY screenCoords;
 
@@ -906,7 +906,7 @@ namespace OpenRCT2::Ui::Windows
             return 0;
         }
 
-        void WindowThemesDrawTabImages(Drawing::RenderTarget& rt)
+        void WindowThemesDrawTabImages(RenderTarget& rt)
         {
             for (int32_t i = 0; i < WINDOW_THEMES_TAB_COUNT; i++)
             {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1045,7 +1045,7 @@ static uint64_t PageDisabledWidgets[] = {
             invalidateWidget(WIDX_LIST);
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             drawWidgets(rt);
             ScreenCoordsXY screenCoords(windowPos.x, windowPos.y);
@@ -1583,7 +1583,7 @@ static uint64_t PageDisabledWidgets[] = {
             }
         }
 
-        void onScrollDraw(int32_t scrollIndex, Drawing::RenderTarget& rt) override
+        void onScrollDraw(int32_t scrollIndex, RenderTarget& rt) override
         {
             const int32_t listWidth = widgets[WIDX_LIST].width() - 1;
             Rectangle::fill(

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -103,7 +103,7 @@ namespace OpenRCT2::Ui::Windows
             UpdatePosition(gTooltipCursor);
         }
 
-        void onDraw(Drawing::RenderTarget& rt) override
+        void onDraw(RenderTarget& rt) override
         {
             int32_t left = windowPos.x;
             int32_t top = windowPos.y;
@@ -214,7 +214,7 @@ namespace OpenRCT2::Ui::Windows
 
     void WindowTooltipClose()
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::tooltip);
 
         gTooltipCloseTimeout = 0;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -430,13 +430,13 @@ namespace OpenRCT2::Ui::Windows
             }
 
 #ifdef ENABLE_SCRIPTING
-            const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
+            const auto& customMenuItems = Scripting::CustomMenuItems;
             if (!customMenuItems.empty())
             {
                 gDropdown.items[i++] = Dropdown::Separator();
                 for (const auto& item : customMenuItems)
                 {
-                    if (item.Kind == OpenRCT2::Scripting::CustomToolbarMenuItemKind::Standard)
+                    if (item.Kind == Scripting::CustomToolbarMenuItemKind::Standard)
                     {
                         gDropdown.items[i] = Dropdown::PlainMenuLabel(item.Text.c_str());
                         i++;
@@ -477,12 +477,12 @@ namespace OpenRCT2::Ui::Windows
             else
             {
 #ifdef ENABLE_SCRIPTING
-                const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
+                const auto& customMenuItems = Scripting::CustomMenuItems;
                 auto customIndex = static_cast<size_t>(dropdownIndex - customStartIndex);
                 size_t i = 0;
                 for (const auto& item : customMenuItems)
                 {
-                    if (item.Kind == OpenRCT2::Scripting::CustomToolbarMenuItemKind::Standard)
+                    if (item.Kind == Scripting::CustomToolbarMenuItemKind::Standard)
                     {
                         if (i == customIndex)
                         {
@@ -568,7 +568,7 @@ namespace OpenRCT2::Ui::Windows
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_ABOUT);
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_FILE_BUG_ON_GITHUB);
 
-                if (OpenRCT2::GetContext()->HasNewVersionInfo())
+                if (GetContext()->HasNewVersionInfo())
                     gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_UPDATE_AVAILABLE);
 
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_OPTIONS);
@@ -593,7 +593,7 @@ namespace OpenRCT2::Ui::Windows
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_ABOUT);
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_FILE_BUG_ON_GITHUB);
 
-                if (OpenRCT2::GetContext()->HasNewVersionInfo())
+                if (GetContext()->HasNewVersionInfo())
                     gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_UPDATE_AVAILABLE);
 
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_OPTIONS);
@@ -615,7 +615,7 @@ namespace OpenRCT2::Ui::Windows
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_ABOUT);
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_FILE_BUG_ON_GITHUB);
 
-                if (OpenRCT2::GetContext()->HasNewVersionInfo())
+                if (GetContext()->HasNewVersionInfo())
                     gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_UPDATE_AVAILABLE);
 
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_OPTIONS);
@@ -696,7 +696,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case DDIDX_OBJECT_SELECTION:
                 {
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->CloseAll();
                     ContextOpenWindow(WindowClass::editorObjectSelection);
                     break;
@@ -863,7 +863,7 @@ namespace OpenRCT2::Ui::Windows
                     ContextOpenWindow(WindowClass::recentNews);
                     break;
                 case WIDX_MUTE:
-                    OpenRCT2::Audio::ToggleAllSounds();
+                    Audio::ToggleAllSounds();
                     break;
                 case WIDX_CHAT:
                     if (ChatAvailable())
@@ -935,7 +935,7 @@ namespace OpenRCT2::Ui::Windows
                         selectedIndex += DDIDX_SCREENSHOT;
 
                     // The "Update available" menu item is only available when there is one
-                    if (selectedIndex >= DDIDX_UPDATE_AVAILABLE && !OpenRCT2::GetContext()->HasNewVersionInfo())
+                    if (selectedIndex >= DDIDX_UPDATE_AVAILABLE && !GetContext()->HasNewVersionInfo())
                         selectedIndex += 1;
 
                     switch (selectedIndex)
@@ -991,7 +991,7 @@ namespace OpenRCT2::Ui::Windows
                             // Automatically fill the "OpenRCT2 build" input
                             auto versionStr = String::urlEncode(gVersionInfoFull);
                             url.append("&f299dd2a20432827d99b648f73eb4649b23f8ec98d158d6f82b81e43196ee36b=" + versionStr);
-                            OpenRCT2::GetContext()->GetUiContext().OpenURL(url);
+                            GetContext()->GetUiContext().OpenURL(url);
                         }
                         break;
                         case DDIDX_UPDATE_AVAILABLE:
@@ -999,7 +999,7 @@ namespace OpenRCT2::Ui::Windows
                             break;
                         case DDIDX_QUIT_TO_MENU:
                         {
-                            auto* windowMgr = Ui::GetWindowManager();
+                            auto* windowMgr = GetWindowManager();
                             windowMgr->CloseByClass(WindowClass::manageTrackDesign);
                             windowMgr->CloseByClass(WindowClass::trackDeletePrompt);
                             auto loadOrQuitAction = GameActions::LoadOrQuitAction(
@@ -1038,7 +1038,7 @@ namespace OpenRCT2::Ui::Windows
         // NB: these can't go into CustomWindow.cpp, as tools may be active without a visible window.
         void onToolUpdate(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            auto& customTool = OpenRCT2::Scripting::ActiveCustomTool;
+            auto& customTool = Scripting::ActiveCustomTool;
             if (customTool)
             {
                 customTool->OnUpdate(screenCoords);
@@ -1047,7 +1047,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            auto& customTool = OpenRCT2::Scripting::ActiveCustomTool;
+            auto& customTool = Scripting::ActiveCustomTool;
             if (customTool)
             {
                 customTool->OnDown(screenCoords);
@@ -1056,7 +1056,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolDrag(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            auto& customTool = OpenRCT2::Scripting::ActiveCustomTool;
+            auto& customTool = Scripting::ActiveCustomTool;
             if (customTool)
             {
                 customTool->OnDrag(screenCoords);
@@ -1065,7 +1065,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolUp(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            auto& customTool = OpenRCT2::Scripting::ActiveCustomTool;
+            auto& customTool = Scripting::ActiveCustomTool;
             if (customTool)
             {
                 customTool->OnUp(screenCoords);
@@ -1074,7 +1074,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolAbort(WidgetIndex widgetIndex) override
         {
-            auto& customTool = OpenRCT2::Scripting::ActiveCustomTool;
+            auto& customTool = Scripting::ActiveCustomTool;
             if (customTool)
             {
                 customTool->OnAbort();
@@ -1268,7 +1268,7 @@ namespace OpenRCT2::Ui::Windows
 
         void ApplyAudioState()
         {
-            if (!OpenRCT2::Audio::gGameSoundsOff)
+            if (!Audio::gGameSoundsOff)
                 widgets[WIDX_MUTE].image = ImageId(SPR_G2_TOOLBAR_MUTE, Drawing::FilterPaletteID::paletteNull);
             else
                 widgets[WIDX_MUTE].image = ImageId(SPR_G2_TOOLBAR_UNMUTE, Drawing::FilterPaletteID::paletteNull);

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -86,7 +86,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_CLOSE:
                 {
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->CloseByClass(WindowClass::trackDeletePrompt);
                     close();
                     break;
@@ -121,7 +121,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (TrackRepositoryRename(_trackDesignFileReference->path, std::string(text)))
             {
-                auto* windowMgr = Ui::GetWindowManager();
+                auto* windowMgr = GetWindowManager();
                 windowMgr->CloseByClass(WindowClass::trackDeletePrompt);
                 close();
                 WindowTrackDesignListReloadTracks();
@@ -171,7 +171,7 @@ namespace OpenRCT2::Ui::Windows
                     close();
                     if (TrackRepositoryDelete(tdPath))
                     {
-                        auto* windowMgr = Ui::GetWindowManager();
+                        auto* windowMgr = GetWindowManager();
                         windowMgr->CloseByClass(WindowClass::manageTrackDesign);
                         WindowTrackDesignListReloadTracks();
                     }
@@ -207,7 +207,7 @@ namespace OpenRCT2::Ui::Windows
      */
     WindowBase* TrackManageOpen(TrackDesignFileRef* tdFileRef)
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::manageTrackDesign);
         auto trackDesignManageWindow = std::make_unique<TrackDesignManageWindow>(tdFileRef);
 
@@ -224,7 +224,7 @@ namespace OpenRCT2::Ui::Windows
      */
     static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef)
     {
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseByClass(WindowClass::trackDeletePrompt);
 
         auto trackDeletePromptWindow = std::make_unique<TrackDeletePromptWindow>(tdFileRef);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -316,7 +316,7 @@ namespace OpenRCT2::Ui::Windows
                 auto getRide = GetRide(rideId);
                 if (getRide != nullptr)
                 {
-                    auto* windowMgr = Ui::GetWindowManager();
+                    auto* windowMgr = GetWindowManager();
                     windowMgr->CloseByClass(WindowClass::error);
 
                     Audio::Play3D(Audio::SoundId::placeItem, trackLoc);
@@ -779,7 +779,7 @@ namespace OpenRCT2::Ui::Windows
             return nullptr;
         }
 
-        auto* windowMgr = Ui::GetWindowManager();
+        auto* windowMgr = GetWindowManager();
         windowMgr->CloseConstructionWindows();
 
         auto* window = windowMgr->FocusOrCreate<TrackDesignPlaceWindow>(WindowClass::trackDesignPlace, kWindowSize, {});

--- a/src/openrct2/command_line/sprite/SpriteExportObject.cpp
+++ b/src/openrct2/command_line/sprite/SpriteExportObject.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2::CommandLine::Sprite
         auto context = CreateContext();
         context->Initialise();
 
-        std::unique_ptr<Object> metaObject = OpenRCT2::ObjectFactory::CreateObjectFromFile(objectPath, true);
+        std::unique_ptr<Object> metaObject = ObjectFactory::CreateObjectFromFile(objectPath, true);
         if (metaObject == nullptr)
         {
             fprintf(stderr, "Could not load the object.\n");

--- a/src/openrct2/command_line/sprite/SpriteFile.h
+++ b/src/openrct2/command_line/sprite/SpriteFile.h
@@ -24,8 +24,8 @@ namespace OpenRCT2::CommandLine::Sprite
     class SpriteFile
     {
     public:
-        OpenRCT2::G1Header Header{};
-        std::vector<OpenRCT2::G1Element> Entries;
+        G1Header Header{};
+        std::vector<G1Element> Entries;
         std::vector<uint8_t> Data;
         void AddImage(Drawing::ImageImportResult& image);
         bool Save(const utf8* path);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -70,7 +70,7 @@ namespace OpenRCT2::Config
 
         // Localisation
         int32_t language;
-        OpenRCT2::MeasurementFormat measurementFormat;
+        MeasurementFormat measurementFormat;
         TemperatureUnit temperatureFormat;
         bool showHeightAsUnits;
         int32_t dateFormat;

--- a/src/openrct2/config/IniReader.cpp
+++ b/src/openrct2/config/IniReader.cpp
@@ -97,7 +97,7 @@ private:
     std::unordered_map<std::string, std::string, StringIHash, StringICmp> _values;
 
 public:
-    explicit IniReader(OpenRCT2::IStream* stream)
+    explicit IniReader(IStream* stream)
     {
         uint64_t length = stream->GetLength() - stream->GetPosition();
         _buffer.resize(length);
@@ -428,7 +428,7 @@ public:
     }
 };
 
-std::unique_ptr<IIniReader> CreateIniReader(OpenRCT2::IStream* stream)
+std::unique_ptr<IIniReader> CreateIniReader(IStream* stream)
 {
     return std::make_unique<IniReader>(stream);
 }

--- a/src/openrct2/config/IniWriter.cpp
+++ b/src/openrct2/config/IniWriter.cpp
@@ -20,11 +20,11 @@ using namespace OpenRCT2;
 class IniWriter final : public IIniWriter
 {
 private:
-    OpenRCT2::IStream* _stream;
+    IStream* _stream;
     bool _firstSection = true;
 
 public:
-    explicit IniWriter(OpenRCT2::IStream* stream)
+    explicit IniWriter(IStream* stream)
         : _stream(stream)
     {
     }
@@ -105,7 +105,7 @@ void IIniWriter::WriteString(const std::string& name, const utf8* value)
     WriteString(name, String::toStd(value));
 }
 
-std::unique_ptr<IIniWriter> CreateIniWriter(OpenRCT2::IStream* stream)
+std::unique_ptr<IIniWriter> CreateIniWriter(IStream* stream)
 {
     return std::make_unique<IniWriter>(stream);
 }

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -127,7 +127,7 @@ namespace OpenRCT2::File
 
     void WriteAllBytes(u8string_view path, const void* buffer, size_t length)
     {
-        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FileMode::write);
+        auto fs = FileStream(path, FileMode::write);
         fs.Write(buffer, length);
     }
 

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -337,7 +337,7 @@ std::unique_ptr<IFileScanner> Path::ScanDirectory(const std::string& pattern, bo
 
 void Path::QueryDirectory(QueryDirectoryResult* result, const std::string& pattern)
 {
-    auto scanner = Path::ScanDirectory(pattern, true);
+    auto scanner = ScanDirectory(pattern, true);
     while (scanner->Next())
     {
         const FileScanner::FileInfo& fileInfo = scanner->GetFileInfo();

--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -18,7 +18,7 @@ namespace OpenRCT2::Json
 {
     json_t ReadFromFile(u8string_view path, size_t maxSize)
     {
-        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FileMode::open);
+        auto fs = FileStream(path, FileMode::open);
 
         size_t fileLength = static_cast<size_t>(fs.GetLength());
         if (fileLength > maxSize)
@@ -51,7 +51,7 @@ namespace OpenRCT2::Json
         std::string jsonOutput = jsonData.dump(indentSize);
 
         // Write to file
-        auto fs = OpenRCT2::FileStream(path, OpenRCT2::FileMode::write);
+        auto fs = FileStream(path, FileMode::write);
         fs.Write(jsonOutput.data(), jsonOutput.size());
     }
 

--- a/src/openrct2/core/StreamBuffer.cpp
+++ b/src/openrct2/core/StreamBuffer.cpp
@@ -16,7 +16,7 @@ namespace OpenRCT2
 {
     StreamReadBuffer::StreamReadBuffer(IStream& stream, uint64_t length, size_t bufferLength)
     {
-        OpenRCT2::Guard::Assert(bufferLength > 0);
+        Guard::Assert(bufferLength > 0);
 
         _remaining = length;
         if (length <= std::numeric_limits<size_t>::max())
@@ -35,7 +35,7 @@ namespace OpenRCT2
     StreamReadBuffer::~StreamReadBuffer()
     {
         if (_bufferLength > 0)
-            OpenRCT2::Memory::Free(_buffer);
+            Memory::Free(_buffer);
 
         _buffer = nullptr;
         _bufferLength = 0;
@@ -87,7 +87,7 @@ namespace OpenRCT2
 
     StreamWriteBuffer::StreamWriteBuffer(IStream& stream, uint64_t length, size_t bufferLength)
     {
-        OpenRCT2::Guard::Assert(bufferLength > 0);
+        Guard::Assert(bufferLength > 0);
 
         _remaining = length;
         if (length <= std::numeric_limits<size_t>::max())
@@ -103,7 +103,7 @@ namespace OpenRCT2
     StreamWriteBuffer::~StreamWriteBuffer()
     {
         if (_bufferLength > 0)
-            OpenRCT2::Memory::Free(_buffer);
+            Memory::Free(_buffer);
 
         _buffer = nullptr;
         _bufferLength = 0;

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -57,9 +57,9 @@ namespace OpenRCT2::String
     {
 #ifdef _WIN32
         int srcLen = static_cast<int>(src.size());
-        int sizeReq = WideCharToMultiByte(OpenRCT2::CodePage::UTF8, 0, src.data(), srcLen, nullptr, 0, nullptr, nullptr);
+        int sizeReq = WideCharToMultiByte(CodePage::UTF8, 0, src.data(), srcLen, nullptr, 0, nullptr, nullptr);
         auto result = std::string(sizeReq, 0);
-        WideCharToMultiByte(OpenRCT2::CodePage::UTF8, 0, src.data(), srcLen, result.data(), sizeReq, nullptr, nullptr);
+        WideCharToMultiByte(CodePage::UTF8, 0, src.data(), srcLen, result.data(), sizeReq, nullptr, nullptr);
         return result;
 #else
     // Which constructor to use depends on the size of wchar_t...
@@ -85,9 +85,9 @@ namespace OpenRCT2::String
     {
 #ifdef _WIN32
         int srcLen = static_cast<int>(src.size());
-        int sizeReq = MultiByteToWideChar(OpenRCT2::CodePage::UTF8, 0, src.data(), srcLen, nullptr, 0);
+        int sizeReq = MultiByteToWideChar(CodePage::UTF8, 0, src.data(), srcLen, nullptr, 0);
         auto result = std::wstring(sizeReq, 0);
-        MultiByteToWideChar(OpenRCT2::CodePage::UTF8, 0, src.data(), srcLen, result.data(), sizeReq);
+        MultiByteToWideChar(CodePage::UTF8, 0, src.data(), srcLen, result.data(), sizeReq);
         return result;
 #else
         icu::UnicodeString str = icu::UnicodeString::fromUTF8(std::string(src));
@@ -609,9 +609,9 @@ namespace OpenRCT2::String
         std::string dst;
         {
             int srcLen = static_cast<int>(u16.size());
-            int sizeReq = WideCharToMultiByte(OpenRCT2::CodePage::UTF8, 0, u16.data(), srcLen, nullptr, 0, nullptr, nullptr);
+            int sizeReq = WideCharToMultiByte(CodePage::UTF8, 0, u16.data(), srcLen, nullptr, 0, nullptr, nullptr);
             dst = std::string(sizeReq, 0);
-            WideCharToMultiByte(OpenRCT2::CodePage::UTF8, 0, u16.data(), srcLen, dst.data(), sizeReq, nullptr, nullptr);
+            WideCharToMultiByte(CodePage::UTF8, 0, u16.data(), srcLen, dst.data(), sizeReq, nullptr, nullptr);
         }
 
         return dst;

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -438,7 +438,7 @@ static Gx _g2 = {};
 static Gx _fonts = {};
 static Gx _tracks = {};
 static Gx _csg = {};
-static G1Element _scrollingText[Drawing::ScrollingText::kMaxEntries]{};
+static G1Element _scrollingText[ScrollingText::kMaxEntries]{};
 static bool _csgLoaded = false;
 
 static G1Element _g1Temp = {};
@@ -672,7 +672,7 @@ std::optional<Gx> GfxLoadGx(const std::vector<uint8_t>& buffer)
 {
     try
     {
-        OpenRCT2::MemoryStream istream(buffer.data(), buffer.size());
+        MemoryStream istream(buffer.data(), buffer.size());
         Gx gx;
 
         gx.header = istream.ReadValue<G1Header>();

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -276,9 +276,9 @@ void GfxDrawStringLeftCentred(
 /**
  * Changes the palette so that the next character changes colour
  */
-static void ColourCharacter(Drawing::TextColour colour, bool withOutline, Drawing::TextColours& textPalette)
+static void ColourCharacter(TextColour colour, bool withOutline, TextColours& textPalette)
 {
-    auto mapping = Drawing::getTextColourMapping(colour);
+    auto mapping = getTextColourMapping(colour);
 
     if (!withOutline)
     {
@@ -293,9 +293,9 @@ static void ColourCharacter(Drawing::TextColour colour, bool withOutline, Drawin
  * Changes the palette so that the next character changes colour
  * This is specific to changing to a predefined window related colour
  */
-static void ColourCharacterWindow(colour_t colour, bool withOutline, Drawing::TextColours& textPalette)
+static void ColourCharacterWindow(colour_t colour, bool withOutline, TextColours& textPalette)
 {
-    Drawing::TextColours mapping = {
+    TextColours mapping = {
         ColourMapA[colour].colour_11,
         PaletteIndex::pi0,
         PaletteIndex::pi0,
@@ -537,7 +537,7 @@ static void TTFDrawStringRawTTF(RenderTarget& rt, std::string_view text, TextDra
         int32_t drawX = info->x + fontDesc->offset_x;
         int32_t drawY = info->y + fontDesc->offset_y;
         uint8_t hintThresh = Config::Get().fonts.enableHinting ? fontDesc->hinting_threshold : 0;
-        OpenRCT2::Drawing::IDrawingContext* dc = drawingEngine->GetDrawingContext();
+        IDrawingContext* dc = drawingEngine->GetDrawingContext();
         dc->DrawTTFBitmap(rt, info, surface, drawX, drawY, hintThresh);
     }
     info->x += surface->w;
@@ -757,7 +757,7 @@ static void TTFProcessInitialColour(ColourWithFlags colour, TextDrawInfo* info)
         }
         else
         {
-            Drawing::TextColours newPalette = {};
+            TextColours newPalette = {};
             switch (info->darkness)
             {
                 case TextDarkness::extraDark:

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -79,8 +79,8 @@ void PaletteMap::Copy(PaletteIndex dstIndex, const PaletteMap& src, PaletteIndex
     std::copy(src._data.begin() + srcOffset, src._data.begin() + srcOffset + copyLength, _data.begin() + dstOffset);
 }
 
-OpenRCT2::Drawing::GamePalette gPalette;
-OpenRCT2::Drawing::GamePalette gGamePalette;
+GamePalette gPalette;
+GamePalette gGamePalette;
 uint32_t gPaletteEffectFrame;
 
 ImageId gPickupPeepImage;
@@ -88,7 +88,7 @@ int32_t gPickupPeepX;
 int32_t gPickupPeepY;
 
 // Originally 0x9ABE04
-OpenRCT2::Drawing::TextColours gTextPalette = {
+TextColours gTextPalette = {
     PaletteIndex::pi0,
     PaletteIndex::pi0,
     PaletteIndex::pi0,
@@ -882,7 +882,7 @@ FilterPaletteID GetGlassPaletteId(colour_t c)
     return kGlassPaletteIds[c];
 }
 
-void UpdatePalette(std::span<const OpenRCT2::Drawing::PaletteBGRA> palette, PaletteIndex startIndex, int32_t numColours)
+void UpdatePalette(std::span<const PaletteBGRA> palette, PaletteIndex startIndex, int32_t numColours)
 {
     for (int32_t i = EnumValue(startIndex); i < numColours + EnumValue(startIndex); i++)
     {

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -81,8 +81,7 @@ namespace OpenRCT2::Drawing
         virtual ~IDrawingEngineFactory()
         {
         }
-        [[nodiscard]] virtual std::unique_ptr<IDrawingEngine> Create(DrawingEngine type, OpenRCT2::Ui::IUiContext& uiContext)
-            = 0;
+        [[nodiscard]] virtual std::unique_ptr<IDrawingEngine> Create(DrawingEngine type, Ui::IUiContext& uiContext) = 0;
     };
 
     struct IWeatherDrawer

--- a/src/openrct2/drawing/ScrollingText.h
+++ b/src/openrct2/drawing/ScrollingText.h
@@ -36,6 +36,5 @@ namespace OpenRCT2::Drawing::ScrollingText
     void initialiseBitmaps();
     void invalidate();
     ImageId setup(
-        PaintSession& session, StringId stringId, OpenRCT2::Formatter& ft, uint16_t scroll, uint16_t scrollingMode,
-        PaletteIndex colour);
+        PaintSession& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, PaletteIndex colour);
 } // namespace OpenRCT2::Drawing::ScrollingText

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -122,7 +122,7 @@ void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId form
 void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
-    OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
+    FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
     DrawText(rt, coords, textPaint, buffer);
 }
 
@@ -137,7 +137,7 @@ void DrawTextEllipsised(
     RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
-    OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
+    FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
     GfxClipString(buffer, width, textPaint.FontStyle);
 
     DrawText(rt, coords, textPaint, buffer);
@@ -155,7 +155,7 @@ int32_t DrawTextWrapped(
 {
     const void* args = ft.Data();
 
-    StaticLayout layout(OpenRCT2::FormatStringIDLegacy(format, args), textPaint, width);
+    StaticLayout layout(FormatStringIDLegacy(format, args), textPaint, width);
 
     if (textPaint.Alignment == TextAlignment::centre)
     {

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -119,7 +119,7 @@ void X8WeatherDrawer::Restore(RenderTarget& rt)
     #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #endif
 
-X8DrawingEngine::X8DrawingEngine([[maybe_unused]] Ui::IUiContext& uiContext)
+X8DrawingEngine::X8DrawingEngine([[maybe_unused]] IUiContext& uiContext)
 {
     _drawingContext = new X8DrawingContext(this);
     _mainRT.DrawingEngine = this;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -117,9 +117,9 @@ namespace OpenRCT2
         return std::visit(
             [](auto&& arg) {
                 using T = std::decay_t<decltype(arg)>;
-                if constexpr (std::is_same_v<T, Focus::CoordinateFocus>)
+                if constexpr (std::is_same_v<T, CoordinateFocus>)
                     return arg;
-                else if constexpr (std::is_same_v<T, Focus::EntityFocus>)
+                else if constexpr (std::is_same_v<T, EntityFocus>)
                 {
                     auto* centreEntity = getGameState().entities.GetEntity(arg);
                     if (centreEntity != nullptr)

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -44,7 +44,7 @@ const News::Item& News::ItemQueues::Current() const
 
 bool News::IsValidIndex(int32_t index)
 {
-    if (index >= News::MaxItems)
+    if (index >= MaxItems)
     {
         LOG_ERROR("Tried to get news item past MAX_NEWS.");
         return false;
@@ -59,7 +59,7 @@ News::Item* News::GetItem(int32_t index)
 
 News::Item& News::ItemQueues::operator[](size_t index)
 {
-    return const_cast<News::Item&>(const_cast<const News::ItemQueues&>(*this)[index]);
+    return const_cast<Item&>(const_cast<const ItemQueues&>(*this)[index]);
 }
 
 const News::Item& News::ItemQueues::operator[](size_t index) const
@@ -72,12 +72,12 @@ const News::Item& News::ItemQueues::operator[](size_t index) const
 
 News::Item* News::ItemQueues::At(int32_t index)
 {
-    return const_cast<News::Item*>(const_cast<const News::ItemQueues&>(*this).At(index));
+    return const_cast<Item*>(const_cast<const ItemQueues&>(*this).At(index));
 }
 
 const News::Item* News::ItemQueues::At(int32_t index) const
 {
-    if (News::IsValidIndex(index))
+    if (IsValidIndex(index))
     {
         return &(*this)[index];
     }
@@ -132,7 +132,7 @@ static void TickCurrent()
     if (ticks == 1 && (gLegacyScene == LegacyScene::playing))
     {
         // Play sound
-        OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::newsItem, 0, ContextGetWidth() / 2);
+        OpenRCT2::Audio::Play(Audio::SoundId::newsItem, 0, ContextGetWidth() / 2);
     }
 }
 
@@ -209,7 +209,7 @@ void News::ItemQueues::ArchiveCurrent()
  *
  *  rct2: 0x0066BA74
  */
-std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t subject)
+std::optional<CoordsXYZ> News::GetSubjectLocation(ItemType type, int32_t subject)
 {
     std::optional<CoordsXYZ> subjectLoc{ std::nullopt };
 
@@ -217,7 +217,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
 
     switch (type)
     {
-        case News::ItemType::ride:
+        case ItemType::ride:
         {
             Ride* ride = GetRide(RideId::FromUnderlying(subject));
             if (ride == nullptr || ride->overallView.IsNull())
@@ -228,7 +228,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
             subjectLoc = CoordsXYZ{ rideViewCentre, TileElementHeight(rideViewCentre) };
             break;
         }
-        case News::ItemType::peepOnRide:
+        case ItemType::peepOnRide:
         {
             auto peep = gameState.entities.TryGetEntity<Peep>(EntityId::FromUnderlying(subject));
             if (peep == nullptr)
@@ -265,7 +265,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
             }
             break;
         }
-        case News::ItemType::peep:
+        case ItemType::peep:
         {
             auto peep = gameState.entities.TryGetEntity<Peep>(EntityId::FromUnderlying(subject));
             if (peep != nullptr)
@@ -274,7 +274,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(News::ItemType type, int32_t s
             }
             break;
         }
-        case News::ItemType::blank:
+        case ItemType::blank:
         {
             auto subjectUnsigned = static_cast<uint32_t>(subject);
             auto subjectXY = CoordsXY{ static_cast<int16_t>(subjectUnsigned & 0xFFFF),
@@ -302,7 +302,7 @@ News::Item* News::ItemQueues::FirstOpenOrNewSlot()
     // The for loop above guarantees there is always an extra element to use
     assert(Recent.capacity() - Recent.size() >= 2);
     auto newsItem = res + 1;
-    newsItem->type = News::ItemType::null;
+    newsItem->type = ItemType::null;
 
     return &*res;
 }
@@ -311,13 +311,13 @@ News::Item* News::ItemQueues::FirstOpenOrNewSlot()
  *
  *  rct2: 0x0066DF55
  */
-News::Item* News::AddItemToQueue(News::ItemType type, StringId string_id, uint32_t assoc, const Formatter& formatter)
+News::Item* News::AddItemToQueue(ItemType type, StringId string_id, uint32_t assoc, const Formatter& formatter)
 {
     utf8 buffer[256];
 
     // overflows possible?
-    OpenRCT2::FormatStringLegacy(buffer, 256, string_id, formatter.Data());
-    return News::AddItemToQueue(type, buffer, assoc);
+    FormatStringLegacy(buffer, 256, string_id, formatter.Data());
+    return AddItemToQueue(type, buffer, assoc);
 }
 
 // TODO: Use variant for assoc, requires strong type for each possible input.
@@ -326,10 +326,10 @@ News::Item* News::AddItemToQueue(ItemType type, StringId string_id, EntityId ass
     return AddItemToQueue(type, string_id, assoc.ToUnderlying(), formatter);
 }
 
-News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t assoc)
+News::Item* News::AddItemToQueue(ItemType type, const utf8* text, uint32_t assoc)
 {
     auto& date = GetDate();
-    News::Item* newsItem = getGameState().newsItems.FirstOpenOrNewSlot();
+    Item* newsItem = getGameState().newsItems.FirstOpenOrNewSlot();
     newsItem->type = type;
     newsItem->flags = 0;
     newsItem->assoc = assoc; // Make optional for Award, Money, Graph and Null
@@ -346,14 +346,14 @@ News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t
  * @return A boolean if assoc is required.
  */
 
-bool News::CheckIfItemRequiresAssoc(News::ItemType type)
+bool News::CheckIfItemRequiresAssoc(ItemType type)
 {
     switch (type)
     {
-        case News::ItemType::null:
-        case News::ItemType::award:
-        case News::ItemType::money:
-        case News::ItemType::graph:
+        case ItemType::null:
+        case ItemType::award:
+        case ItemType::money:
+        case ItemType::graph:
             return false;
         default:
             return true; // Everything else requires assoc
@@ -366,19 +366,19 @@ bool News::CheckIfItemRequiresAssoc(News::ItemType type)
  *  rct2: 0x0066EBE6
  *
  */
-void News::OpenSubject(News::ItemType type, int32_t subject)
+void News::OpenSubject(ItemType type, int32_t subject)
 {
     switch (type)
     {
-        case News::ItemType::ride:
+        case ItemType::ride:
         {
             auto intent = Intent(WindowClass::ride);
             intent.PutExtra(INTENT_EXTRA_RIDE_ID, subject);
             ContextOpenIntent(&intent);
             break;
         }
-        case News::ItemType::peepOnRide:
-        case News::ItemType::peep:
+        case ItemType::peepOnRide:
+        case ItemType::peep:
         {
             auto peep = getGameState().entities.TryGetEntity<Peep>(EntityId::FromUnderlying(subject));
             if (peep != nullptr)
@@ -389,13 +389,13 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             }
             break;
         }
-        case News::ItemType::money:
+        case ItemType::money:
             ContextOpenWindow(WindowClass::finances);
             break;
-        case News::ItemType::campaign:
+        case ItemType::campaign:
             ContextOpenWindowView(WindowView::financeMarketing);
             break;
-        case News::ItemType::research:
+        case ItemType::research:
         {
             auto item = ResearchItem(subject, ResearchCategory::transport, 0);
             if (item.type == Research::EntryType::ride)
@@ -412,7 +412,7 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             ContextOpenIntent(&intent);
             break;
         }
-        case News::ItemType::peeps:
+        case ItemType::peeps:
         {
             auto intent = Intent(WindowClass::guestList);
             intent.PutExtra(INTENT_EXTRA_GUEST_LIST_FILTER, static_cast<int32_t>(GuestListFilterType::guestsThinkingX));
@@ -420,15 +420,15 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
             ContextOpenIntent(&intent);
             break;
         }
-        case News::ItemType::award:
+        case ItemType::award:
             ContextOpenWindowView(WindowView::parkAwards);
             break;
-        case News::ItemType::graph:
+        case ItemType::graph:
             ContextOpenWindowView(WindowView::parkRating);
             break;
-        case News::ItemType::null:
-        case News::ItemType::blank:
-        case News::ItemType::count:
+        case ItemType::null:
+        case ItemType::blank:
+        case ItemType::count:
             break;
     }
 }
@@ -437,14 +437,14 @@ void News::OpenSubject(News::ItemType type, int32_t subject)
  *
  *  rct2: 0x0066E407
  */
-void News::DisableNewsItems(News::ItemType type, uint32_t assoc)
+void News::DisableNewsItems(ItemType type, uint32_t assoc)
 {
     auto& gameState = getGameState();
     // TODO: write test invalidating windows
     gameState.newsItems.ForeachRecentNews([type, assoc, &gameState](auto& newsItem) {
         if (type == newsItem.type && assoc == newsItem.assoc)
         {
-            newsItem.setFlags(News::ItemFlags::hasButton);
+            newsItem.setFlags(ItemFlags::hasButton);
             if (&newsItem == &gameState.newsItems.Current())
             {
                 auto intent = Intent(INTENT_ACTION_INVALIDATE_TICKER_NEWS);
@@ -456,48 +456,47 @@ void News::DisableNewsItems(News::ItemType type, uint32_t assoc)
     gameState.newsItems.ForeachArchivedNews([type, assoc](auto& newsItem) {
         if (type == newsItem.type && assoc == newsItem.assoc)
         {
-            newsItem.setFlags(News::ItemFlags::hasButton);
+            newsItem.setFlags(ItemFlags::hasButton);
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByClass(WindowClass::recentNews);
         }
     });
 }
 
-void News::AddItemToQueue(News::Item* newNewsItem)
+void News::AddItemToQueue(Item* newNewsItem)
 {
-    News::Item* newsItem = getGameState().newsItems.FirstOpenOrNewSlot();
+    Item* newsItem = getGameState().newsItems.FirstOpenOrNewSlot();
     *newsItem = *newNewsItem;
 }
 
 void News::RemoveItem(int32_t index)
 {
-    if (index < 0 || index >= News::MaxItems)
+    if (index < 0 || index >= MaxItems)
         return;
 
     auto& gameState = getGameState();
     // News item is already null, no need to remove it
-    if (gameState.newsItems[index].type == News::ItemType::null)
+    if (gameState.newsItems[index].type == ItemType::null)
         return;
 
-    size_t newsBoundary = index < News::ItemHistoryStart ? News::ItemHistoryStart : News::MaxItems;
+    size_t newsBoundary = index < ItemHistoryStart ? ItemHistoryStart : MaxItems;
     for (size_t i = index; i < newsBoundary - 1; i++)
     {
         gameState.newsItems[i] = gameState.newsItems[i + 1];
     }
-    gameState.newsItems[newsBoundary - 1].type = News::ItemType::null;
+    gameState.newsItems[newsBoundary - 1].type = ItemType::null;
 }
 
-void News::importNewsItems(
-    GameState_t& gameState, const std::span<const News::Item> recent, const std::span<const News::Item> archived)
+void News::importNewsItems(GameState_t& gameState, const std::span<const Item> recent, const std::span<const Item> archived)
 {
     gameState.newsItems.Clear();
 
-    for (size_t i = 0; i < std::min<size_t>(recent.size(), News::ItemHistoryStart); i++)
+    for (size_t i = 0; i < std::min<size_t>(recent.size(), ItemHistoryStart); i++)
     {
         gameState.newsItems[i] = recent[i];
     }
-    for (size_t i = 0; i < std::min<size_t>(archived.size(), News::MaxItemsArchive); i++)
+    for (size_t i = 0; i < std::min<size_t>(archived.size(), MaxItemsArchive); i++)
     {
-        gameState.newsItems[News::ItemHistoryStart + i] = archived[i];
+        gameState.newsItems[ItemHistoryStart + i] = archived[i];
     }
 }

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -196,7 +196,7 @@ namespace OpenRCT2::Network
         std::ofstream _chat_log_fs;
         uint32_t _lastUpdateTime = 0;
         uint32_t _currentDeltaTime = 0;
-        Mode mode = Network::Mode::none;
+        Mode mode = Mode::none;
         uint8_t default_group = 0;
         bool _closeLock = false;
         bool _requireClose = false;
@@ -240,7 +240,7 @@ namespace OpenRCT2::Network
         uint32_t last_ping_sent_time = 0;
         uint32_t server_connect_time = 0;
         uint32_t _actionId;
-        Status status = Network::Status::none;
+        Status status = Status::none;
         uint8_t player_id = 0;
         uint16_t _port = 0;
         SocketStatus _lastConnectStatus = SocketStatus::closed;

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -148,7 +148,7 @@ namespace OpenRCT2::Network
 
         json_t GetBroadcastJson()
         {
-            json_t root = Network::GetServerInfoAsJson();
+            json_t root = GetServerInfoAsJson();
             root["port"] = _port;
             return root;
         }
@@ -319,7 +319,7 @@ namespace OpenRCT2::Network
 
         json_t GetHeartbeatJson()
         {
-            uint32_t numPlayers = Network::GetNumVisiblePlayers();
+            uint32_t numPlayers = GetNumVisiblePlayers();
 
             json_t root = {
                 { "token", _token },

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -20,14 +20,14 @@
 
 namespace OpenRCT2
 {
-    void BannerObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
+    void BannerObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
     {
-        stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
+        stream->Seek(6, STREAM_SEEK_CURRENT);
         _legacyType.scrolling_mode = stream->ReadValue<uint8_t>();
         _legacyType.flags = stream->ReadValue<uint8_t>();
         _legacyType.price = stream->ReadValue<money16>();
         _legacyType.scenery_tab_id = kObjectEntryIndexNull;
-        stream->Seek(2, OpenRCT2::STREAM_SEEK_CURRENT);
+        stream->Seek(2, STREAM_SEEK_CURRENT);
 
         GetStringTable().Read(context, stream, ObjectStringID::name);
 
@@ -47,7 +47,7 @@ namespace OpenRCT2
         auto firstSourceGame = GetFirstSourceGame();
         if (firstSourceGame == ObjectSourceGame::custom)
         {
-            auto scgPathX = Object::GetScgPathXHeader();
+            auto scgPathX = GetScgPathXHeader();
             SetPrimarySceneryGroup(scgPathX);
         }
     }

--- a/src/openrct2/object/BannerObject.h
+++ b/src/openrct2/object/BannerObject.h
@@ -28,7 +28,7 @@ namespace OpenRCT2
             return &_legacyType;
         }
 
-        void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
+        void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
         void ReadJson(IReadObjectContext* context, json_t& root) override;
         void Load() override;
         void Unload() override;

--- a/src/openrct2/object/EntranceObject.h
+++ b/src/openrct2/object/EntranceObject.h
@@ -29,7 +29,7 @@ namespace OpenRCT2
             return &_legacyType;
         }
 
-        void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
+        void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
         void ReadJson(IReadObjectContext* context, json_t& root) override;
         void Load() override;
         void Unload() override;

--- a/src/openrct2/object/FootpathObject.h
+++ b/src/openrct2/object/FootpathObject.h
@@ -51,7 +51,7 @@ namespace OpenRCT2
             return _pathRailingsDescriptor;
         }
 
-        void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
+        void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
         void ReadJson(IReadObjectContext* context, json_t& root) override;
         void Load() override;
         void Unload() override;

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -24,7 +24,7 @@
 
 namespace OpenRCT2
 {
-    static RCTLargeSceneryText ReadLegacy3DFont(OpenRCT2::IStream& stream)
+    static RCTLargeSceneryText ReadLegacy3DFont(IStream& stream)
     {
         RCTLargeSceneryText _3dFontLegacy = {};
         _3dFontLegacy.offset[0].x = stream.ReadValue<int16_t>();
@@ -52,17 +52,17 @@ namespace OpenRCT2
         return _3dFontLegacy;
     }
 
-    void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
+    void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
     {
-        stream->Seek(6, OpenRCT2::STREAM_SEEK_CURRENT);
+        stream->Seek(6, STREAM_SEEK_CURRENT);
         _legacyType.tool_id = static_cast<CursorID>(stream->ReadValue<uint8_t>());
         _legacyType.flags = stream->ReadValue<uint8_t>();
         _legacyType.price = stream->ReadValue<int16_t>() * 10;
         _legacyType.removal_price = stream->ReadValue<int16_t>() * 10;
-        stream->Seek(5, OpenRCT2::STREAM_SEEK_CURRENT);
+        stream->Seek(5, STREAM_SEEK_CURRENT);
         _legacyType.scenery_tab_id = kObjectEntryIndexNull;
         _legacyType.scrolling_mode = stream->ReadValue<uint8_t>();
-        stream->Seek(4, OpenRCT2::STREAM_SEEK_CURRENT);
+        stream->Seek(4, STREAM_SEEK_CURRENT);
 
         GetStringTable().Read(context, stream, ObjectStringID::name);
 
@@ -164,7 +164,7 @@ namespace OpenRCT2
         LARGE_SCENERY_TILE_FLAG_ALLOW_SUPPORTS_ABOVE = 0x40,
     };
 
-    std::vector<LargeSceneryTile> LargeSceneryObject::ReadTiles(OpenRCT2::IStream* stream)
+    std::vector<LargeSceneryTile> LargeSceneryObject::ReadTiles(IStream* stream)
     {
         auto tiles = std::vector<LargeSceneryTile>();
 
@@ -184,7 +184,7 @@ namespace OpenRCT2
 
         while (stream->ReadValue<uint16_t>() != 0xFFFF)
         {
-            stream->Seek(-2, OpenRCT2::STREAM_SEEK_CURRENT);
+            stream->Seek(-2, STREAM_SEEK_CURRENT);
             tiles.push_back(ReadLegacyTile());
         }
         uint8_t index = 0;

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -33,7 +33,7 @@ namespace OpenRCT2
             return &_legacyType;
         }
 
-        void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
+        void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
         void ReadJson(IReadObjectContext* context, json_t& root) override;
         void Load() override;
         void Unload() override;
@@ -41,7 +41,7 @@ namespace OpenRCT2
         void DrawPreview(Drawing::RenderTarget& rt, int32_t width, int32_t height) const override;
 
     private:
-        [[nodiscard]] static std::vector<LargeSceneryTile> ReadTiles(OpenRCT2::IStream* stream);
+        [[nodiscard]] static std::vector<LargeSceneryTile> ReadTiles(IStream* stream);
         [[nodiscard]] static std::vector<LargeSceneryTile> ReadJsonTiles(json_t& jTiles);
         [[nodiscard]] static std::unique_ptr<LargeSceneryText> ReadJson3dFont(json_t& j3dFont);
         [[nodiscard]] static std::vector<CoordsXY> ReadJsonOffsets(json_t& jOffsets);

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -152,7 +152,7 @@ namespace OpenRCT2
         throw std::runtime_error("Not supported.");
     }
 
-    void Object::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream)
+    void Object::ReadLegacy(IReadObjectContext* context, IStream* stream)
     {
         throw std::runtime_error("Not supported.");
     }

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -243,7 +243,7 @@ namespace OpenRCT2
 
     void* ObjectEntryGetChunk(ObjectType objectType, ObjectEntryIndex index)
     {
-        auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objectMgr = GetContext()->GetObjectManager();
         auto* object = objectMgr.GetLoadedObject(objectType, index);
         if (object != nullptr)
         {
@@ -254,7 +254,7 @@ namespace OpenRCT2
 
     const Object* ObjectEntryGetObject(ObjectType objectType, ObjectEntryIndex index)
     {
-        auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objectMgr = GetContext()->GetObjectManager();
         return objectMgr.GetLoadedObject(objectType, index);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -517,12 +517,11 @@ namespace OpenRCT2
 
             // Encode data
             ObjectType objectType = entry->GetType();
-            SawyerCoding::ChunkHeader chunkHeader;
+            ChunkHeader chunkHeader;
             chunkHeader.encoding = kLegacyObjectEntryGroupEncoding[EnumValue(objectType)];
             chunkHeader.length = static_cast<uint32_t>(dataSize);
             uint8_t* encodedDataBuffer = Memory::Allocate<uint8_t>(0x600000);
-            size_t encodedDataSize = SawyerCoding::WriteChunkBuffer(
-                encodedDataBuffer, reinterpret_cast<const uint8_t*>(data), chunkHeader);
+            size_t encodedDataSize = WriteChunkBuffer(encodedDataBuffer, reinterpret_cast<const uint8_t*>(data), chunkHeader);
 
             // Save to file
             try
@@ -611,7 +610,7 @@ namespace OpenRCT2
                 }
 
                 // Convert to UTF-8 filename
-                return String::convertToUtf8(normalisedName, OpenRCT2::CodePage::CP_1252);
+                return String::convertToUtf8(normalisedName, CodePage::CP_1252);
             }
             else
             {
@@ -619,7 +618,7 @@ namespace OpenRCT2
             }
         }
 
-        void WritePackedObject(OpenRCT2::IStream* stream, const RCTObjectEntry* entry)
+        void WritePackedObject(IStream* stream, const RCTObjectEntry* entry)
         {
             const ObjectRepositoryItem* item = FindObject(entry);
             if (item == nullptr)
@@ -628,7 +627,7 @@ namespace OpenRCT2
             }
 
             // Read object data from file
-            auto fs = OpenRCT2::FileStream(item->Path, OpenRCT2::FileMode::open);
+            auto fs = FileStream(item->Path, FileMode::open);
             auto fileEntry = fs.ReadValue<RCTObjectEntry>();
             if (*entry != fileEntry)
             {

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -117,7 +117,7 @@ namespace OpenRCT2
         if (numRotationFrames == 0)
             return SpritePrecision::None;
         else
-            return static_cast<SpritePrecision>(Numerics::bitScanForward(numRotationFrames) + 1);
+            return static_cast<SpritePrecision>(bitScanForward(numRotationFrames) + 1);
     }
 
     static void RideObjectUpdateRideType(RideObjectEntry& rideEntry)
@@ -445,7 +445,7 @@ namespace OpenRCT2
         car.no_seating_rows = stream->ReadValue<uint8_t>();
         car.spinning_inertia = stream->ReadValue<uint8_t>();
         car.spinning_friction = stream->ReadValue<uint8_t>();
-        car.friction_sound_id = stream->ReadValue<OpenRCT2::Audio::SoundId>();
+        car.friction_sound_id = stream->ReadValue<Audio::SoundId>();
         car.ReversedCarIndex = stream->ReadValue<uint8_t>();
         car.soundRange = stream->ReadValue<SoundRange>();
         car.double_sound_frequency = stream->ReadValue<uint8_t>();
@@ -599,7 +599,7 @@ namespace OpenRCT2
                 car.spriteHeightPositive = 1;
                 car.flags = CAR_ENTRY_FLAG_SPINNING;
                 car.PaintStyle = VEHICLE_VISUAL_FLAT_RIDE_OR_CAR_RIDE;
-                car.friction_sound_id = OpenRCT2::Audio::SoundId::null;
+                car.friction_sound_id = Audio::SoundId::null;
                 car.soundRange = SoundRange::none;
                 car.draw_order = 6;
 
@@ -757,8 +757,7 @@ namespace OpenRCT2
         car.no_seating_rows = Json::GetNumber<uint8_t>(jCar["numSeatRows"]);
         car.spinning_inertia = Json::GetNumber<uint8_t>(jCar["spinningInertia"]);
         car.spinning_friction = Json::GetNumber<uint8_t>(jCar["spinningFriction"]);
-        car.friction_sound_id = Json::GetEnum<OpenRCT2::Audio::SoundId>(
-            jCar["frictionSoundId"], OpenRCT2::Audio::SoundId::null);
+        car.friction_sound_id = Json::GetEnum<Audio::SoundId>(jCar["frictionSoundId"], Audio::SoundId::null);
         car.ReversedCarIndex = Json::GetNumber<uint8_t>(jCar["logFlumeReverserVehicleType"]);
         car.soundRange = Json::GetEnum<SoundRange>(jCar["soundRange"], SoundRange::none);
         car.double_sound_frequency = Json::GetNumber<uint8_t>(jCar["doubleSoundFrequency"]);

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -26,8 +26,8 @@ namespace OpenRCT2
     private:
         RideObjectEntry _legacyType = {};
         VehicleColourPresetList _presetColours = {};
-        std::vector<int8_t> _peepLoadingPositions[OpenRCT2::RCT2::ObjectLimits::kMaxCarTypesPerRideEntry];
-        std::vector<std::array<CoordsXY, 3>> _peepLoadingWaypoints[OpenRCT2::RCT2::ObjectLimits::kMaxCarTypesPerRideEntry];
+        std::vector<int8_t> _peepLoadingPositions[RCT2::ObjectLimits::kMaxCarTypesPerRideEntry];
+        std::vector<std::array<CoordsXY, 3>> _peepLoadingWaypoints[RCT2::ObjectLimits::kMaxCarTypesPerRideEntry];
         bool _shouldLoadImages = false;
 
     public:
@@ -43,7 +43,7 @@ namespace OpenRCT2
         }
 
         void ReadJson(IReadObjectContext* context, json_t& root) override;
-        void ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stream) override;
+        void ReadLegacy(IReadObjectContext* context, IStream* stream) override;
         void Load() override;
         void Unload() override;
 
@@ -58,7 +58,7 @@ namespace OpenRCT2
         static ride_type_t ParseRideType(const std::string& s);
 
     private:
-        void ReadLegacyCar(IReadObjectContext* context, OpenRCT2::IStream* stream, CarEntry& car);
+        void ReadLegacyCar(IReadObjectContext* context, IStream* stream, CarEntry& car);
 
         void ReadJsonVehicleInfo(IReadObjectContext* context, json_t& properties);
         std::vector<CarEntry> ReadJsonCars([[maybe_unused]] IReadObjectContext* context, json_t& jCars);

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -100,7 +100,7 @@ namespace OpenRCT2
                 if (mapColoursAreValid)
                     MapColours[i] = mapColours[i];
                 else
-                    MapColours[i] = OpenRCT2::Drawing::PaletteIndex::pi0;
+                    MapColours[i] = Drawing::PaletteIndex::pi0;
             }
 
             for (auto& el : properties["special"])

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -59,7 +59,7 @@ namespace OpenRCT2
         uint8_t Rotations{};
         money64 Price{};
         TerrainSurfaceFlags Flags{};
-        OpenRCT2::Drawing::PaletteIndex MapColours[2]{};
+        Drawing::PaletteIndex MapColours[2]{};
 
         void ReadJson(IReadObjectContext* context, json_t& root) override;
         void Load() override;

--- a/src/openrct2/object/WallSceneryEntry.cpp
+++ b/src/openrct2/object/WallSceneryEntry.cpp
@@ -13,7 +13,6 @@ namespace OpenRCT2
 {
     Audio::DoorSoundType WallSceneryEntry::getDoorSoundType() const
     {
-        return static_cast<OpenRCT2::Audio::DoorSoundType>(
-            (flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT);
+        return static_cast<Audio::DoorSoundType>((flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/park/Legacy.cpp
+++ b/src/openrct2/park/Legacy.cpp
@@ -2352,7 +2352,7 @@ static bool ConvertPeepAnimationType(TPeepType* peep, AnimObjectConversionTable&
     return true;
 }
 
-void ConvertPeepAnimationTypeToObjects(OpenRCT2::GameState_t& gameState)
+void ConvertPeepAnimationTypeToObjects(GameState_t& gameState)
 {
     // First, build a conversion table based on the currently selected objects
     auto table = BuildPeepAnimObjectConversionTable();
@@ -2383,12 +2383,12 @@ static constexpr auto kClimateObjectIdsByLegacyClimateType = std::to_array<std::
     "rct2.climate.cold",
 });
 
-std::string_view GetClimateObjectIdFromLegacyClimateType(OpenRCT2::RCT12::ClimateType climate)
+std::string_view GetClimateObjectIdFromLegacyClimateType(RCT12::ClimateType climate)
 {
     return kClimateObjectIdsByLegacyClimateType[EnumValue(climate)];
 }
 
-bool TrackTypeMustBeMadeInvisible(ride_type_t rideType, OpenRCT2::TrackElemType trackType, int32_t parkFileVersion)
+bool TrackTypeMustBeMadeInvisible(ride_type_t rideType, TrackElemType trackType, int32_t parkFileVersion)
 {
     // Lots of Log Flumes exist where the downward slopes are simulated by using other track
     // types like the Splash Boats, but not actually made invisible, because they never needed

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -263,7 +263,7 @@ namespace OpenRCT2
                     cs.readWrite(image.type);
                     cs.readWrite(image.width);
                     cs.readWrite(image.height);
-                    cs.readWriteArray(image.pixels, [&cs](OpenRCT2::Drawing::PaletteIndex& pixel) {
+                    cs.readWriteArray(image.pixels, [&cs](Drawing::PaletteIndex& pixel) {
                         cs.readWrite(pixel);
                         return true;
                     });
@@ -531,7 +531,7 @@ namespace OpenRCT2
         void ReadWritePreviewChunk(GameState_t& gameState, OrcaStream& os)
         {
             os.readWriteChunk(ParkFileChunkType::PREVIEW, [&gameState](OrcaStream::ChunkStream& cs) {
-                auto preview = OpenRCT2::generatePreviewFromGameState(gameState);
+                auto preview = generatePreviewFromGameState(gameState);
 
                 cs.readWrite(preview.parkName);
                 cs.readWrite(preview.parkRating);
@@ -547,7 +547,7 @@ namespace OpenRCT2
                     cs.readWrite(image.type);
                     cs.readWrite(image.width);
                     cs.readWrite(image.height);
-                    cs.readWriteArray(image.pixels, [&cs](OpenRCT2::Drawing::PaletteIndex& pixel) {
+                    cs.readWriteArray(image.pixels, [&cs](Drawing::PaletteIndex& pixel) {
                         cs.readWrite(pixel);
                         return true;
                     });
@@ -644,7 +644,7 @@ namespace OpenRCT2
                 auto& rideRatings = gameState.rideRatingUpdateStates;
                 if (os.getHeader().targetVersion >= 21)
                 {
-                    cs.readWriteArray(rideRatings, [this, &cs](OpenRCT2::RideRating::UpdateState& calcData) {
+                    cs.readWriteArray(rideRatings, [this, &cs](RideRating::UpdateState& calcData) {
                         ReadWriteRideRatingCalculationData(cs, calcData);
                         return true;
                     });
@@ -655,7 +655,7 @@ namespace OpenRCT2
                     if (os.getMode() == OrcaStream::Mode::reading)
                     {
                         // Since we read only one state ensure the rest is reset.
-                        OpenRCT2::RideRating::ResetUpdateStates();
+                        RideRating::ResetUpdateStates();
                     }
                     auto& rideRatingUpdateState = rideRatings[0];
                     ReadWriteRideRatingCalculationData(cs, rideRatingUpdateState);
@@ -672,7 +672,7 @@ namespace OpenRCT2
             }
         }
 
-        void ReadWriteRideRatingCalculationData(OrcaStream::ChunkStream& cs, OpenRCT2::RideRating::UpdateState& calcData)
+        void ReadWriteRideRatingCalculationData(OrcaStream::ChunkStream& cs, RideRating::UpdateState& calcData)
         {
             cs.readWrite(calcData.AmountOfBrakes);
             cs.readWrite(calcData.Proximity);
@@ -1931,7 +1931,7 @@ namespace OpenRCT2
                         cs.readWrite(rideType);
                         return true;
                     });
-                    OpenRCT2::RideUse::GetTypeHistory().Set(guest->Id, LegacyGetRideTypesBeenOn(rideTypeBeenOn));
+                    RideUse::GetTypeHistory().Set(guest->Id, LegacyGetRideTypesBeenOn(rideTypeBeenOn));
                     cs.readWrite(guest->ItemFlags);
                     cs.readWrite(guest->Photo2RideRef);
                     cs.readWrite(guest->Photo3RideRef);
@@ -1990,7 +1990,7 @@ namespace OpenRCT2
                         cs.readWrite(rideType);
                         return true;
                     });
-                    OpenRCT2::RideUse::GetHistory().Set(guest->Id, LegacyGetRidesBeenOn(ridesBeenOn));
+                    RideUse::GetHistory().Set(guest->Id, LegacyGetRidesBeenOn(ridesBeenOn));
                 }
                 else
                 {
@@ -2383,7 +2383,7 @@ namespace OpenRCT2
                 cs.readWrite(rideType);
                 return true;
             });
-            OpenRCT2::RideUse::GetTypeHistory().Set(guest.Id, LegacyGetRideTypesBeenOn(rideTypeBeenOn));
+            RideUse::GetTypeHistory().Set(guest.Id, LegacyGetRideTypesBeenOn(rideTypeBeenOn));
         }
 
         cs.readWrite(guest.TimeInQueue);
@@ -2394,7 +2394,7 @@ namespace OpenRCT2
                 cs.readWrite(rideType);
                 return true;
             });
-            OpenRCT2::RideUse::GetHistory().Set(guest.Id, LegacyGetRidesBeenOn(ridesBeenOn));
+            RideUse::GetHistory().Set(guest.Id, LegacyGetRidesBeenOn(ridesBeenOn));
         }
         else
         {
@@ -2402,14 +2402,14 @@ namespace OpenRCT2
             {
                 std::vector<RideId> rideUse;
                 cs.readWriteVector(rideUse, [&cs](RideId& rideId) { cs.readWrite(rideId); });
-                OpenRCT2::RideUse::GetHistory().Set(guest.Id, std::move(rideUse));
+                RideUse::GetHistory().Set(guest.Id, std::move(rideUse));
                 std::vector<ObjectEntryIndex> rideTypeUse;
                 cs.readWriteVector(rideTypeUse, [&cs](ObjectEntryIndex& rideType) { cs.readWrite(rideType); });
-                OpenRCT2::RideUse::GetTypeHistory().Set(guest.Id, std::move(rideTypeUse));
+                RideUse::GetTypeHistory().Set(guest.Id, std::move(rideTypeUse));
             }
             else
             {
-                auto* rideUse = OpenRCT2::RideUse::GetHistory().GetAll(guest.Id);
+                auto* rideUse = RideUse::GetHistory().GetAll(guest.Id);
                 if (rideUse == nullptr)
                 {
                     std::vector<RideId> empty;
@@ -2419,7 +2419,7 @@ namespace OpenRCT2
                 {
                     cs.readWriteVector(*rideUse, [&cs](RideId& rideId) { cs.readWrite(rideId); });
                 }
-                auto* rideTypeUse = OpenRCT2::RideUse::GetTypeHistory().GetAll(guest.Id);
+                auto* rideTypeUse = RideUse::GetTypeHistory().GetAll(guest.Id);
                 if (rideTypeUse == nullptr)
                 {
                     std::vector<ObjectEntryIndex> empty;
@@ -2714,13 +2714,13 @@ namespace OpenRCT2
 
     void ParkFileExporter::Export(GameState_t& gameState, std::string_view path, int16_t compressionLevel)
     {
-        auto parkFile = std::make_unique<OpenRCT2::ParkFile>();
+        auto parkFile = std::make_unique<ParkFile>();
         parkFile->Save(gameState, path, compressionLevel);
     }
 
     void ParkFileExporter::Export(GameState_t& gameState, IStream& stream, int16_t compressionLevel)
     {
-        auto parkFile = std::make_unique<OpenRCT2::ParkFile>();
+        auto parkFile = std::make_unique<ParkFile>();
         parkFile->ExportObjectsList = ExportObjectsList;
         parkFile->Save(gameState, stream, compressionLevel);
     }
@@ -2754,12 +2754,12 @@ int32_t ScenarioSave(GameState_t& gameState, u8string_view path, int32_t flags)
     PrepareMapForSave();
 
     bool result = false;
-    auto parkFile = std::make_unique<OpenRCT2::ParkFile>();
+    auto parkFile = std::make_unique<ParkFile>();
     try
     {
         if (flags & S6_SAVE_FLAG_EXPORT)
         {
-            auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+            auto& objManager = GetContext()->GetObjectManager();
             parkFile->ExportObjectsList = objManager.GetPackableObjects();
         }
         parkFile->OmitTracklessRides = true;
@@ -2800,7 +2800,7 @@ private:
     [[maybe_unused]]
 #endif
     const IObjectRepository& _objectRepository;
-    std::unique_ptr<OpenRCT2::ParkFile> _parkFile;
+    std::unique_ptr<ParkFile> _parkFile;
 
 public:
     ParkFileImporter(IObjectRepository& objectRepository)
@@ -2810,7 +2810,7 @@ public:
 
     ParkLoadResult Load(const u8string& path, const bool skipObjectCheck) override
     {
-        _parkFile = std::make_unique<OpenRCT2::ParkFile>();
+        _parkFile = std::make_unique<ParkFile>();
         _parkFile->Load(path, skipObjectCheck);
 
         auto result = ParkLoadResult(std::move(_parkFile->RequiredObjects));
@@ -2829,9 +2829,9 @@ public:
     }
 
     ParkLoadResult LoadFromStream(
-        OpenRCT2::IStream* stream, bool isScenario, bool skipObjectCheck = false, const u8string& path = {}) override
+        IStream* stream, bool isScenario, bool skipObjectCheck = false, const u8string& path = {}) override
     {
-        _parkFile = std::make_unique<OpenRCT2::ParkFile>();
+        _parkFile = std::make_unique<ParkFile>();
         _parkFile->Load(*stream, skipObjectCheck);
 
         auto result = ParkLoadResult(std::move(_parkFile->RequiredObjects));

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -67,7 +67,7 @@ namespace OpenRCT2
     public:
         std::vector<const ObjectRepositoryItem*> ExportObjectsList;
 
-        void Export(OpenRCT2::GameState_t& gameState, std::string_view path, int16_t compressionLevel);
-        void Export(OpenRCT2::GameState_t& gameState, OpenRCT2::IStream& stream, int16_t compressionLevel);
+        void Export(GameState_t& gameState, std::string_view path, int16_t compressionLevel);
+        void Export(GameState_t& gameState, IStream& stream, int16_t compressionLevel);
     };
 } // namespace OpenRCT2

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -98,15 +98,15 @@ namespace OpenRCT2::Platform
         if (File::Exists(combinedPath))
             return std::make_optional<RCT2Variant>(RCT2Variant::rct2Original);
 
-        combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicWindowsDataFolder, u8"g1.dat"));
+        combinedPath = Path::ResolveCasing(Path::Combine(path, kRCTClassicWindowsDataFolder, u8"g1.dat"));
         if (File::Exists(combinedPath))
             return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicWindows);
 
-        combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicMacOSDataFolder, u8"g1.dat"));
+        combinedPath = Path::ResolveCasing(Path::Combine(path, kRCTClassicMacOSDataFolder, u8"g1.dat"));
         if (File::Exists(combinedPath))
             return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicMac);
 
-        combinedPath = Path::ResolveCasing(Path::Combine(path, OpenRCT2::Platform::kRCTClassicPlusMacOSDataFolder, u8"g1.dat"));
+        combinedPath = Path::ResolveCasing(Path::Combine(path, kRCTClassicPlusMacOSDataFolder, u8"g1.dat"));
         if (File::Exists(combinedPath))
             return std::make_optional<RCT2Variant>(RCT2Variant::rctClassicPlusMac);
 

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -630,10 +630,10 @@ namespace OpenRCT2::Platform
         wchar_t currCode[9];
         if (GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT, LOCALE_SINTLSYMBOL, currCode, static_cast<int>(std::size(currCode))) == 0)
         {
-            return Platform::GetCurrencyValue(nullptr);
+            return GetCurrencyValue(nullptr);
         }
 
-        return Platform::GetCurrencyValue(String::toUtf8(currCode).c_str());
+        return GetCurrencyValue(String::toUtf8(currCode).c_str());
     }
 
     MeasurementFormat GetLocaleMeasurementFormat()

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -331,7 +331,7 @@ namespace OpenRCT2::RCT1
         money16 price;                                       // 0x0E8
         RCT12xy8 chairliftBullwheelLocation[2];              // 0x0EA
         uint8_t chairliftBullwheelZ[2];                      // 0x0EE
-        OpenRCT2::RideRating::Tuple ratings;                 // 0x0F0
+        RideRating::Tuple ratings;                           // 0x0F0
         money16 value;                                       // 0x0F6
         uint16_t chairliftBullwheelRotation;                 // 0x0F8
         uint8_t satisfaction;                                // 0x0FA
@@ -504,9 +504,9 @@ namespace OpenRCT2::RCT1
         uint8_t RideSubtype;     // 0xD6
         uint8_t ColoursExtended; // 0xD7
 
-        OpenRCT2::RCT12::TrackElemType GetTrackType() const
+        RCT12::TrackElemType GetTrackType() const
         {
-            return static_cast<OpenRCT2::RCT12::TrackElemType>(TrackTypeAndDirection >> 2);
+            return static_cast<RCT12::TrackElemType>(TrackTypeAndDirection >> 2);
         }
 
         uint8_t GetTrackDirection() const
@@ -1312,5 +1312,5 @@ namespace OpenRCT2::RCT1
         RCT1_PATH_SUPPORT_TYPE_BAMBOO,
     };
 
-    OpenRCT2::TrackElemType RCT1TrackTypeToOpenRCT2(OpenRCT2::RCT12::TrackElemType origTrackType, ride_type_t rideType);
+    TrackElemType RCT1TrackTypeToOpenRCT2(RCT12::TrackElemType origTrackType, ride_type_t rideType);
 } // namespace OpenRCT2::RCT1

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -37,7 +37,7 @@ namespace OpenRCT2::RCT1
     class TD4Importer final : public ITrackImporter
     {
     private:
-        OpenRCT2::MemoryStream _stream;
+        MemoryStream _stream;
         std::string _name;
 
     public:
@@ -51,14 +51,14 @@ namespace OpenRCT2::RCT1
             if (String::iequals(extension, ".td4"))
             {
                 _name = GetNameFromTrackPath(path);
-                auto fs = OpenRCT2::FileStream(path, OpenRCT2::FileMode::open);
+                auto fs = FileStream(path, FileMode::open);
                 return LoadFromStream(&fs);
             }
 
             throw std::runtime_error("Invalid RCT1 track extension.");
         }
 
-        bool LoadFromStream(OpenRCT2::IStream* stream) override
+        bool LoadFromStream(IStream* stream) override
         {
             auto chunkReader = SawyerChunkReader(stream);
             auto data = chunkReader.ReadChunkTrack();
@@ -97,9 +97,9 @@ namespace OpenRCT2::RCT1
 
             for (int32_t i = 0; i < Limits::kNumColourSchemes; i++)
             {
-                td->appearance.trackColours[i].main = RCT1::GetColour(td4aa.TrackSpineColour[i]);
-                td->appearance.trackColours[i].additional = RCT1::GetColour(td4aa.TrackRailColour[i]);
-                td->appearance.trackColours[i].supports = RCT1::GetColour(td4aa.TrackSupportColour[i]);
+                td->appearance.trackColours[i].main = GetColour(td4aa.TrackSpineColour[i]);
+                td->appearance.trackColours[i].additional = GetColour(td4aa.TrackRailColour[i]);
+                td->appearance.trackColours[i].supports = GetColour(td4aa.TrackSupportColour[i]);
             }
             // The maze style is saved in the support colour, but taking it through the conversion function
             // will mess up style 3 (wooden fences).
@@ -118,9 +118,9 @@ namespace OpenRCT2::RCT1
             _stream.Read(&td4, sizeof(TD4));
             for (size_t i = 0; i < std::size(td->appearance.trackColours); i++)
             {
-                td->appearance.trackColours[i].main = RCT1::GetColour(td4.TrackSpineColourV0);
-                td->appearance.trackColours[i].additional = RCT1::GetColour(td4.TrackRailColourV0);
-                td->appearance.trackColours[i].supports = RCT1::GetColour(td4.TrackSupportColourV0);
+                td->appearance.trackColours[i].main = GetColour(td4.TrackSpineColourV0);
+                td->appearance.trackColours[i].additional = GetColour(td4.TrackRailColourV0);
+                td->appearance.trackColours[i].supports = GetColour(td4.TrackSupportColourV0);
 
                 // Mazes were only hedges
                 if (td4.Type == RideType::hedgeMaze)
@@ -139,7 +139,7 @@ namespace OpenRCT2::RCT1
 
         std::unique_ptr<TrackDesign> ImportTD4Base(std::unique_ptr<TrackDesign> td, TD4& td4Base)
         {
-            td->trackAndVehicle.rtdIndex = RCT1::GetRideType(td4Base.Type, td4Base.VehicleType);
+            td->trackAndVehicle.rtdIndex = GetRideType(td4Base.Type, td4Base.VehicleType);
 
             // All TD4s that use powered launch use the type that doesn't pass the station.
             td->operation.rideMode = static_cast<RideMode>(td4Base.Mode);
@@ -151,11 +151,11 @@ namespace OpenRCT2::RCT1
             std::string_view vehicleObject;
             if (td4Base.Type == RideType::hedgeMaze)
             {
-                vehicleObject = RCT1::GetRideTypeObject(td4Base.Type, false);
+                vehicleObject = GetRideTypeObject(td4Base.Type, false);
             }
             else
             {
-                vehicleObject = RCT1::GetVehicleObject(td4Base.VehicleType);
+                vehicleObject = GetVehicleObject(td4Base.VehicleType);
             }
             assert(!vehicleObject.empty());
             td->trackAndVehicle.vehicleObject = ObjectEntryDescriptor(vehicleObject);
@@ -165,15 +165,15 @@ namespace OpenRCT2::RCT1
             for (int32_t i = 0; i < Limits::kMaxTrainsPerRide; i++)
             {
                 // RCT1 had no third colour
-                RCT1::VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = RCT1::GetColourSchemeCopyDescriptor(
+                VehicleColourSchemeCopyDescriptor colourSchemeCopyDescriptor = GetColourSchemeCopyDescriptor(
                     td4Base.VehicleType);
                 if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_1)
                 {
-                    td->appearance.vehicleColours[i].Body = RCT1::GetColour(td4Base.VehicleColours[i].BodyColour);
+                    td->appearance.vehicleColours[i].Body = GetColour(td4Base.VehicleColours[i].BodyColour);
                 }
                 else if (colourSchemeCopyDescriptor.colour1 == COPY_COLOUR_2)
                 {
-                    td->appearance.vehicleColours[i].Body = RCT1::GetColour(td4Base.VehicleColours[i].TrimColour);
+                    td->appearance.vehicleColours[i].Body = GetColour(td4Base.VehicleColours[i].TrimColour);
                 }
                 else
                 {
@@ -182,11 +182,11 @@ namespace OpenRCT2::RCT1
 
                 if (colourSchemeCopyDescriptor.colour2 == COPY_COLOUR_1)
                 {
-                    td->appearance.vehicleColours[i].Trim = RCT1::GetColour(td4Base.VehicleColours[i].BodyColour);
+                    td->appearance.vehicleColours[i].Trim = GetColour(td4Base.VehicleColours[i].BodyColour);
                 }
                 else if (colourSchemeCopyDescriptor.colour2 == COPY_COLOUR_2)
                 {
-                    td->appearance.vehicleColours[i].Trim = RCT1::GetColour(td4Base.VehicleColours[i].TrimColour);
+                    td->appearance.vehicleColours[i].Trim = GetColour(td4Base.VehicleColours[i].TrimColour);
                 }
                 else
                 {
@@ -195,11 +195,11 @@ namespace OpenRCT2::RCT1
 
                 if (colourSchemeCopyDescriptor.colour3 == COPY_COLOUR_1)
                 {
-                    td->appearance.vehicleColours[i].Tertiary = RCT1::GetColour(td4Base.VehicleColours[i].BodyColour);
+                    td->appearance.vehicleColours[i].Tertiary = GetColour(td4Base.VehicleColours[i].BodyColour);
                 }
                 else if (colourSchemeCopyDescriptor.colour3 == COPY_COLOUR_2)
                 {
-                    td->appearance.vehicleColours[i].Tertiary = RCT1::GetColour(td4Base.VehicleColours[i].TrimColour);
+                    td->appearance.vehicleColours[i].Tertiary = GetColour(td4Base.VehicleColours[i].TrimColour);
                 }
                 else
                 {

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -1278,6 +1278,6 @@ namespace OpenRCT2::RCT12
      * Handles single and multi-byte strings.
      */
     size_t GetRCTStringBufferLen(const char* buffer, size_t maxBufferLen);
-    bool TrackTypeHasSpeedSetting(OpenRCT2::RCT12::TrackElemType trackType);
-    bool TrackTypeIsStation(OpenRCT2::RCT12::TrackElemType trackType);
+    bool TrackTypeHasSpeedSetting(TrackElemType trackType);
+    bool TrackTypeIsStation(TrackElemType trackType);
 } // namespace OpenRCT2::RCT12

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -211,7 +211,7 @@ namespace OpenRCT2::RCT2
         money16 price;                                       // 0x138
         RCT12xy8 chairliftBullwheelLocation[2];              // 0x13A
         uint8_t chairliftBullwheelZ[2];                      // 0x13E
-        OpenRCT2::RideRating::Tuple ratings;                 // 0x140
+        RideRating::Tuple ratings;                           // 0x140
         money16 value;                                       // 0x146
         uint16_t chairliftBullwheelRotation;                 // 0x148
         uint8_t satisfaction;                                // 0x14A
@@ -527,15 +527,15 @@ namespace OpenRCT2::RCT2
         uint8_t SeatRotation;       // 0xD8
         uint8_t TargetSeatRotation; // 0xD9
 
-        OpenRCT2::RCT12::TrackElemType GetTrackType() const
+        RCT12::TrackElemType GetTrackType() const
         {
-            return static_cast<OpenRCT2::RCT12::TrackElemType>(TrackTypeAndDirection >> 2);
+            return static_cast<RCT12::TrackElemType>(TrackTypeAndDirection >> 2);
         }
         uint8_t GetTrackDirection() const
         {
             return TrackTypeAndDirection & kRCT12VehicleTrackDirectionMask;
         }
-        void SetTrackType(OpenRCT2::RCT12::TrackElemType trackType)
+        void SetTrackType(RCT12::TrackElemType trackType)
         {
             // set the upper 14 bits to 0
             TrackTypeAndDirection &= ~kRCT12VehicleTrackTypeMask;
@@ -749,7 +749,7 @@ namespace OpenRCT2::RCT2
         uint16_t ProximityStartZ;
         uint8_t CurrentRide;
         uint8_t State;
-        OpenRCT2::RCT12::TrackElemType ProximityTrackType;
+        RCT12::TrackElemType ProximityTrackType;
         uint8_t ProximityBaseHeight;
         uint16_t ProximityTotal;
         uint16_t ProximityScores[26];
@@ -1045,11 +1045,9 @@ namespace OpenRCT2::RCT2
         flatRide,
     };
 
-    OpenRCT2::TrackElemType RCT2TrackTypeToOpenRCT2(
-        OpenRCT2::RCT12::TrackElemType origTrackType, ride_type_t rideType, bool isFlatRide);
-    OpenRCT2::TrackElemType RCT2TrackTypeToOpenRCT2(
-        OpenRCT2::RCT12::TrackElemType origTrackType, OriginalRideClass originalClass);
-    OpenRCT2::RCT12::TrackElemType OpenRCT2TrackTypeToRCT2(OpenRCT2::TrackElemType origTrackType);
+    TrackElemType RCT2TrackTypeToOpenRCT2(RCT12::TrackElemType origTrackType, ride_type_t rideType, bool isFlatRide);
+    TrackElemType RCT2TrackTypeToOpenRCT2(RCT12::TrackElemType origTrackType, OriginalRideClass originalClass);
+    RCT12::TrackElemType OpenRCT2TrackTypeToRCT2(TrackElemType origTrackType);
 
     struct FootpathMapping
     {

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::RCT2
     {
         try
         {
-            auto fs = OpenRCT2::FileStream(path, OpenRCT2::FileMode::write);
+            auto fs = FileStream(path, FileMode::write);
             return SaveTrack(&fs);
         }
         catch (const std::exception& e)
@@ -53,17 +53,17 @@ namespace OpenRCT2::RCT2
         }
     }
 
-    bool T6Exporter::SaveTrack(OpenRCT2::IStream* stream)
+    bool T6Exporter::SaveTrack(IStream* stream)
     {
         auto& rtd = GetRideTypeDescriptor(_trackDesign.trackAndVehicle.rtdIndex);
         auto td6rideType = OpenRCT2RideTypeToRCT2RideType(_trackDesign.trackAndVehicle.rtdIndex);
-        OpenRCT2::MemoryStream tempStream;
+        MemoryStream tempStream;
         tempStream.WriteValue<uint8_t>(td6rideType);
         tempStream.WriteValue<uint8_t>(0);
         tempStream.WriteValue<uint32_t>(0);
         tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign.operation.rideMode));
         tempStream.WriteValue<uint8_t>(EnumValue(_trackDesign.appearance.vehicleColourSettings) | (2 << 2));
-        for (auto i = 0; i < RCT2::Limits::kMaxVehicleColours; i++)
+        for (auto i = 0; i < Limits::kMaxVehicleColours; i++)
         {
             tempStream.WriteValue<uint8_t>(_trackDesign.appearance.vehicleColours[i].Body);
             tempStream.WriteValue<uint8_t>(_trackDesign.appearance.vehicleColours[i].Trim);
@@ -120,7 +120,7 @@ namespace OpenRCT2::RCT2
         tempStream.Write(&_trackDesign.trackAndVehicle.vehicleObject.Entry, sizeof(RCTObjectEntry));
         tempStream.WriteValue<uint8_t>(_trackDesign.statistics.spaceRequired.x);
         tempStream.WriteValue<uint8_t>(_trackDesign.statistics.spaceRequired.y);
-        for (auto i = 0; i < RCT2::Limits::kMaxVehicleColours; i++)
+        for (auto i = 0; i < Limits::kMaxVehicleColours; i++)
         {
             tempStream.WriteValue<uint8_t>(_trackDesign.appearance.vehicleColours[i].Tertiary);
         }
@@ -155,7 +155,7 @@ namespace OpenRCT2::RCT2
                 auto trackType = OpenRCT2TrackTypeToRCT2(trackElement.type);
                 if (trackElement.type == TrackElemType::multiDimInvertedUp90ToFlatQuarterLoop)
                 {
-                    trackType = OpenRCT2::RCT12::TrackElemType::invertedUp90ToFlatQuarterLoopAlias;
+                    trackType = RCT12::TrackElemType::invertedUp90ToFlatQuarterLoopAlias;
                 }
                 tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(trackType));
                 auto flags = RCT12::convertToTD46Flags(trackElement);

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -55,12 +55,12 @@ Vehicle* CableLiftSegmentCreate(
     current->spin_sprite = 0;
     current->spin_speed = 0;
     current->sound2_flags = 0;
-    current->sound1_id = OpenRCT2::Audio::SoundId::null;
-    current->sound2_id = OpenRCT2::Audio::SoundId::null;
+    current->sound1_id = Audio::SoundId::null;
+    current->sound2_id = Audio::SoundId::null;
     current->CollisionDetectionTimer = 0;
     current->animation_frame = 0;
     current->animationState = 0;
-    current->scream_sound_id = OpenRCT2::Audio::SoundId::null;
+    current->scream_sound_id = Audio::SoundId::null;
     current->pitch = VehiclePitch::flat;
     current->roll = VehicleRoll::unbanked;
     for (auto& peep : current->peep)

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -62,14 +62,14 @@ RideId _currentRideIndex;
 CoordsXYZ _currentTrackBegin;
 
 uint8_t _currentTrackPieceDirection;
-OpenRCT2::TrackElemType _currentTrackPieceType;
+TrackElemType _currentTrackPieceType;
 TrackSelectionFlags _currentTrackSelectionFlags;
 uint32_t _rideConstructionNextArrowPulse = 0;
 TrackPitch _currentTrackPitchEnd;
 TrackRoll _currentTrackRollEnd;
 bool _currentTrackHasLiftHill;
-OpenRCT2::SelectedAlternative _currentTrackAlternative{};
-OpenRCT2::TrackElemType _selectedTrackType;
+SelectedAlternative _currentTrackAlternative{};
+TrackElemType _selectedTrackType;
 
 TrackRoll _previousTrackRollEnd;
 TrackPitch _previousTrackPitchEnd;
@@ -182,7 +182,7 @@ void Ride::removeVehicles()
         lifecycleFlags &= ~RIDE_LIFECYCLE_ON_TRACK;
         lifecycleFlags &= ~(RIDE_LIFECYCLE_TEST_IN_PROGRESS | RIDE_LIFECYCLE_HAS_STALLED_VEHICLE);
 
-        for (size_t i = 0; i <= OpenRCT2::Limits::kMaxTrainsPerRide; i++)
+        for (size_t i = 0; i <= Limits::kMaxTrainsPerRide; i++)
         {
             auto spriteIndex = vehicles[i];
             while (!spriteIndex.IsNull())
@@ -200,7 +200,7 @@ void Ride::removeVehicles()
             vehicles[i] = EntityId::GetNull();
         }
 
-        for (size_t i = 0; i < OpenRCT2::Limits::kMaxStationsPerRide; i++)
+        for (size_t i = 0; i < Limits::kMaxStationsPerRide; i++)
             stations[i].TrainAtStation = RideStation::kNoTrain;
 
         // Also clean up orphaned vehicles for good measure.
@@ -383,7 +383,7 @@ void RideClearBlockedTiles(const Ride& ride)
  * bp : flags
  */
 std::optional<CoordsXYZ> GetTrackElementOriginAndApplyChanges(
-    const CoordsXYZD& location, OpenRCT2::TrackElemType type, uint16_t extra_params, TileElement** output_element,
+    const CoordsXYZD& location, TrackElemType type, uint16_t extra_params, TileElement** output_element,
     TrackElementSetFlags flags)
 {
     // Find the relevant track piece, prefer sequence 0 (this ensures correct behaviour for diagonal track pieces)
@@ -588,7 +588,7 @@ void RideConstructionSetDefaultNextPiece()
     const auto& rtd = ride->getRideTypeDescriptor();
 
     int32_t z, direction;
-    OpenRCT2::TrackElemType trackType;
+    TrackElemType trackType;
     TrackBeginEnd trackBeginEnd;
     CoordsXYE xyElement;
     TileElement* tileElement;
@@ -1517,7 +1517,7 @@ TrackDrawerEntry getCurrentTrackDrawerEntry(const RideTypeDescriptor& rtd)
     return getTrackDrawerEntry(rtd, isInverted, isCovered);
 }
 
-OpenRCT2::TrackElemType GetTrackTypeFromCurve(
+TrackElemType GetTrackTypeFromCurve(
     TrackCurve curve, bool startsDiagonal, TrackPitch startSlope, TrackPitch endSlope, TrackRoll startBank, TrackRoll endBank)
 {
     for (uint32_t i = 0; i < std::size(gTrackDescriptors); i++)

--- a/src/openrct2/ride/RideManager.cpp
+++ b/src/openrct2/ride/RideManager.cpp
@@ -31,16 +31,16 @@ namespace OpenRCT2
 
     RideManager::Iterator RideManager::begin()
     {
-        return RideManager::Iterator(*this, 0u, _gameState.ridesEndOfUsedRange);
+        return Iterator(*this, 0u, _gameState.ridesEndOfUsedRange);
     }
 
     RideManager::Iterator RideManager::end()
     {
-        return RideManager::Iterator(*this, _gameState.ridesEndOfUsedRange, _gameState.ridesEndOfUsedRange);
+        return Iterator(*this, _gameState.ridesEndOfUsedRange, _gameState.ridesEndOfUsedRange);
     }
 
     RideManager::Iterator RideManager::get(RideId rideId)
     {
-        return RideManager::Iterator(*this, rideId.ToUnderlying(), _gameState.ridesEndOfUsedRange);
+        return Iterator(*this, rideId.ToUnderlying(), _gameState.ridesEndOfUsedRange);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -164,7 +164,7 @@ static void RideRatingsApplyPenaltyLateralGs(RideRating::Tuple& ratings, const R
 
 void RideRating::ResetUpdateStates()
 {
-    RideRating::UpdateState nullState{};
+    UpdateState nullState{};
     nullState.State = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 
     auto& updateStates = getGameState().rideRatingUpdateStates;
@@ -179,7 +179,7 @@ void RideRating::ResetUpdateStates()
  */
 void RideRating::UpdateRide(const Ride& ride)
 {
-    RideRating::UpdateState state;
+    UpdateState state;
     if (ride.status != RideStatus::closed)
     {
         state.CurrentRide = ride.id;

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -56,7 +56,7 @@ namespace OpenRCT2
             CoordsXYZ ProximityStart;
             RideId CurrentRide;
             uint8_t State;
-            OpenRCT2::TrackElemType ProximityTrackType;
+            TrackElemType ProximityTrackType;
             uint8_t ProximityBaseHeight;
             uint16_t ProximityTotal;
             uint16_t ProximityScores[26];

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -44,13 +44,13 @@ using namespace OpenRCT2::TrackMetaData;
 using OpenRCT2::GameActions::CommandFlag;
 using OpenRCT2::GameActions::CommandFlags;
 
-PitchAndRoll TrackPitchAndRollStart(OpenRCT2::TrackElemType trackType)
+PitchAndRoll TrackPitchAndRollStart(TrackElemType trackType)
 {
     const auto& ted = GetTrackElementDescriptor(trackType);
     return { ted.definition.pitchStart, ted.definition.rollStart };
 }
 
-PitchAndRoll TrackPitchAndRollEnd(OpenRCT2::TrackElemType trackType)
+PitchAndRoll TrackPitchAndRollEnd(TrackElemType trackType)
 {
     const auto& ted = GetTrackElementDescriptor(trackType);
     return { ted.definition.pitchEnd, ted.definition.rollEnd };
@@ -220,7 +220,7 @@ ResultWithMessage TrackAddStationElement(CoordsXYZD loc, RideId rideIndex, Comma
             stationElement = find_station_element(loc, rideIndex);
             if (stationElement != nullptr)
             {
-                OpenRCT2::TrackElemType targetTrackType;
+                TrackElemType targetTrackType;
                 if (stationFrontLoc == loc)
                 {
                     auto stationIndex = RideGetFirstEmptyStationStart(*ride);
@@ -354,7 +354,7 @@ ResultWithMessage TrackRemoveStationElement(const CoordsXYZD& loc, RideId rideIn
             stationElement = find_station_element(currentLoc, rideIndex);
             if (stationElement != nullptr)
             {
-                OpenRCT2::TrackElemType targetTrackType;
+                TrackElemType targetTrackType;
                 if ((currentLoc == stationFrontLoc) || (currentLoc + CoordsDirectionDelta[currentLoc.direction] == removeLoc))
                 {
                     auto stationIndex = RideGetFirstEmptyStationStart(*ride);
@@ -620,7 +620,7 @@ TrackRoll TrackGetActualBank3(bool useInvertedSprites, TileElement* tileElement)
     return TrackGetActualBank2(ride->type, isInverted, bankStart);
 }
 
-bool TrackTypeIsStation(OpenRCT2::TrackElemType trackType)
+bool TrackTypeIsStation(TrackElemType trackType)
 {
     switch (trackType)
     {
@@ -633,7 +633,7 @@ bool TrackTypeIsStation(OpenRCT2::TrackElemType trackType)
     }
 }
 
-bool TrackTypeIsBrakes(OpenRCT2::TrackElemType trackType)
+bool TrackTypeIsBrakes(TrackElemType trackType)
 {
     switch (trackType)
     {
@@ -647,12 +647,12 @@ bool TrackTypeIsBrakes(OpenRCT2::TrackElemType trackType)
     }
 }
 
-bool TrackTypeIsBlockBrakes(OpenRCT2::TrackElemType trackType)
+bool TrackTypeIsBlockBrakes(TrackElemType trackType)
 {
     return (trackType == TrackElemType::blockBrakes) || (trackType == TrackElemType::diagBlockBrakes);
 }
 
-bool TrackTypeIsBooster(OpenRCT2::TrackElemType trackType)
+bool TrackTypeIsBooster(TrackElemType trackType)
 {
     switch (trackType)
     {
@@ -664,7 +664,7 @@ bool TrackTypeIsBooster(OpenRCT2::TrackElemType trackType)
     }
 }
 
-bool TrackElementIsCovered(OpenRCT2::TrackElemType trackElementType)
+bool TrackElementIsCovered(TrackElemType trackElementType)
 {
     switch (trackElementType)
     {
@@ -740,12 +740,12 @@ OpenRCT2::TrackElemType UncoverTrackElement(OpenRCT2::TrackElemType trackElement
     }
 }
 
-bool TrackTypeHasSpeedSetting(OpenRCT2::TrackElemType trackType)
+bool TrackTypeHasSpeedSetting(TrackElemType trackType)
 {
     return TrackTypeIsBooster(trackType) || TrackTypeIsBrakes(trackType) || TrackTypeIsBlockBrakes(trackType);
 }
 
-bool TrackTypeIsHelix(OpenRCT2::TrackElemType trackType)
+bool TrackTypeIsHelix(TrackElemType trackType)
 {
     if (trackType >= TrackElemType::leftHalfBankedHelixUpSmall && trackType <= TrackElemType::rightHalfBankedHelixDownLarge)
         return true;

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -1282,7 +1282,7 @@ namespace OpenRCT2::TrackMetaData
     };
 
     /** rct2: 0x00993D1C */
-    static constexpr OpenRCT2::TrackElemType kAlternativeTrackTypes[] = {
+    static constexpr TrackElemType kAlternativeTrackTypes[] = {
         TrackElemType::flatCovered,                        // TrackElemType::flat
         TrackElemType::none,
         TrackElemType::none,
@@ -1992,7 +1992,7 @@ namespace OpenRCT2::TrackMetaData
     static_assert(std::size(kTrackPricing) == EnumValue(TrackElemType::count));
 
     /** rct2: 0x0099EA1C */
-    static constexpr OpenRCT2::TrackElemType kTrackElementMirrorMap[] = {
+    static constexpr TrackElemType kTrackElementMirrorMap[] = {
         TrackElemType::flat,
         TrackElemType::endStation,
         TrackElemType::beginStation,
@@ -4489,7 +4489,7 @@ namespace OpenRCT2::TrackMetaData
 
 #pragma region trackBlocks
 
-    using PS = OpenRCT2::PaintSegment;
+    using PS = PaintSegment;
 
     static constexpr SequenceDescriptor kFlatSeq0 = {
         .clearance = { 0, 0, 0, 0, { 0b1111, 0 }, 0 },
@@ -16082,7 +16082,7 @@ namespace OpenRCT2::TrackMetaData
 
     static constexpr auto kTrackElementDescriptors = BuildDescriptorTable();
 
-    const TrackElementDescriptor& GetTrackElementDescriptor(OpenRCT2::TrackElemType type)
+    const TrackElementDescriptor& GetTrackElementDescriptor(TrackElemType type)
     {
         if (EnumValue(type) >= kTrackElementDescriptors.size())
             return kTrackElementDescriptors[0];

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -624,7 +624,7 @@ std::unique_ptr<TrackDesign> TrackDesignImport(const utf8* path)
  */
 static void TrackDesignLoadSceneryObjects(const TrackDesign& td)
 {
-    auto& objectManager = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objectManager = GetContext()->GetObjectManager();
     objectManager.UnloadAllTransient();
 
     // Load ride object
@@ -690,7 +690,7 @@ static std::optional<TrackSceneryEntry> TrackDesignPlaceSceneryElementGetEntry(c
 {
     TrackSceneryEntry result;
 
-    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objectMgr = GetContext()->GetObjectManager();
     if (scenery.sceneryObject.GetType() == ObjectType::paths)
     {
         auto footpathMapping = RCT2::GetFootpathSurfaceId(scenery.sceneryObject, true, scenery.isQueue());
@@ -755,7 +755,7 @@ static std::optional<TrackSceneryEntry> TrackDesignPlaceSceneryElementGetEntry(c
  */
 static void TrackDesignMirrorScenery(TrackDesign& td)
 {
-    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objectMgr = GetContext()->GetObjectManager();
     for (auto& scenery : td.sceneryElements)
     {
         auto entryInfo = TrackDesignPlaceSceneryElementGetEntry(scenery);

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -274,7 +274,7 @@ static TrackDesignSceneryElement TrackDesignSaveCreateLargeSceneryDesc(
 static TrackDesignAddStatus TrackDesignSaveAddLargeScenery(const CoordsXY& loc, LargeSceneryElement* tileElement)
 {
     auto entryIndex = tileElement->GetEntryIndex();
-    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objectMgr = GetContext()->GetObjectManager();
     auto obj = objectMgr.GetLoadedObject<LargeSceneryObject>(entryIndex);
     if (obj != nullptr && TrackDesignSaveIsSupportedObject(obj))
     {
@@ -489,7 +489,7 @@ static void TrackDesignSaveRemoveLargeScenery(const CoordsXY& loc, LargeSceneryE
     }
 
     auto entryIndex = tileElement->GetEntryIndex();
-    auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objectMgr = GetContext()->GetObjectManager();
     auto obj = objectMgr.GetLoadedObject<LargeSceneryObject>(entryIndex);
     if (obj != nullptr)
     {

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -646,15 +646,15 @@ TrackPaintFunction GetTrackPaintFunctionTwisterRC(OpenRCT2::TrackElemType trackT
 TrackPaintFunction GetTrackPaintFunctionCorkscrewRC(OpenRCT2::TrackElemType trackType);
 namespace OpenRCT2::HybridRC
 {
-    TrackPaintFunction GetTrackPaintFunction(OpenRCT2::TrackElemType trackType);
+    TrackPaintFunction GetTrackPaintFunction(TrackElemType trackType);
 }
 namespace OpenRCT2::SingleRailRC
 {
-    TrackPaintFunction GetTrackPaintFunction(OpenRCT2::TrackElemType trackType);
+    TrackPaintFunction GetTrackPaintFunction(TrackElemType trackType);
 }
 namespace OpenRCT2::AlpineRC
 {
-    TrackPaintFunction GetTrackPaintFunction(OpenRCT2::TrackElemType trackType);
+    TrackPaintFunction GetTrackPaintFunction(TrackElemType trackType);
 }
 TrackPaintFunction GetTrackPaintFunctionClassicWoodenRC(OpenRCT2::TrackElemType trackType);
 TrackPaintFunction GetTrackPaintFunctionClassicStandUpRC(OpenRCT2::TrackElemType trackType);

--- a/src/openrct2/sawyer_coding/SawyerChunk.h
+++ b/src/openrct2/sawyer_coding/SawyerChunk.h
@@ -40,7 +40,7 @@ namespace OpenRCT2::SawyerCoding
     class SawyerChunk final
     {
     private:
-        OpenRCT2::MemoryStream _data;
+        MemoryStream _data;
         ChunkEncoding _encoding = ChunkEncoding::none;
 
     public:
@@ -57,6 +57,6 @@ namespace OpenRCT2::SawyerCoding
             return _encoding;
         }
 
-        SawyerChunk(ChunkEncoding encoding, OpenRCT2::MemoryStream&& data);
+        SawyerChunk(ChunkEncoding encoding, MemoryStream&& data);
     };
 } // namespace OpenRCT2::SawyerCoding

--- a/src/openrct2/sawyer_coding/SawyerChunkReader.cpp
+++ b/src/openrct2/sawyer_coding/SawyerChunkReader.cpp
@@ -24,9 +24,9 @@ namespace OpenRCT2::SawyerCoding
     constexpr const char* kExceptionMessageInvalidChunkEncoding = "Invalid chunk encoding.";
     constexpr const char* kExceptionMessageZeroSizedChunk = "Encountered zero-sized chunk.";
 
-    static MemoryStream DecodeChunk(const void* src, const SawyerCoding::ChunkHeader& header);
+    static MemoryStream DecodeChunk(const void* src, const ChunkHeader& header);
 
-    SawyerChunkReader::SawyerChunkReader(OpenRCT2::IStream* stream)
+    SawyerChunkReader::SawyerChunkReader(IStream* stream)
         : _stream(stream)
     {
     }
@@ -36,8 +36,8 @@ namespace OpenRCT2::SawyerCoding
         uint64_t originalPosition = _stream->GetPosition();
         try
         {
-            auto header = _stream->ReadValue<SawyerCoding::ChunkHeader>();
-            _stream->Seek(header.length, OpenRCT2::STREAM_SEEK_CURRENT);
+            auto header = _stream->ReadValue<ChunkHeader>();
+            _stream->Seek(header.length, STREAM_SEEK_CURRENT);
         }
         catch (const std::exception&)
         {
@@ -52,7 +52,7 @@ namespace OpenRCT2::SawyerCoding
         uint64_t originalPosition = _stream->GetPosition();
         try
         {
-            auto header = _stream->ReadValue<SawyerCoding::ChunkHeader>();
+            auto header = _stream->ReadValue<ChunkHeader>();
             if (header.length >= kMaxUncompressedChunkSize)
                 throw SawyerChunkException(kExceptionMessageCorruptChunkSize);
 
@@ -108,7 +108,7 @@ namespace OpenRCT2::SawyerCoding
                 throw SawyerChunkException(kExceptionMessageCorruptChunkSize);
             }
 
-            SawyerCoding::ChunkHeader header{ ChunkEncoding::rle, compressedDataLength };
+            ChunkHeader header{ ChunkEncoding::rle, compressedDataLength };
             auto buffer = DecodeChunk(compressedData.get(), header);
             if (buffer.GetLength() == 0)
             {
@@ -260,7 +260,7 @@ namespace OpenRCT2::SawyerCoding
         return buf;
     }
 
-    static MemoryStream DecodeChunk(const void* src, const SawyerCoding::ChunkHeader& header)
+    static MemoryStream DecodeChunk(const void* src, const ChunkHeader& header)
     {
         MemoryStream buf;
 

--- a/src/openrct2/sawyer_coding/SawyerChunkReader.h
+++ b/src/openrct2/sawyer_coding/SawyerChunkReader.h
@@ -45,10 +45,10 @@ namespace OpenRCT2::SawyerCoding
     class SawyerChunkReader final
     {
     private:
-        OpenRCT2::IStream* const _stream = nullptr;
+        IStream* const _stream = nullptr;
 
     public:
-        explicit SawyerChunkReader(OpenRCT2::IStream* stream);
+        explicit SawyerChunkReader(IStream* stream);
 
         /**
          * Skips the next chunk in the stream without decoding or reading its data

--- a/src/openrct2/sawyer_coding/SawyerChunkWriter.cpp
+++ b/src/openrct2/sawyer_coding/SawyerChunkWriter.cpp
@@ -18,7 +18,7 @@ namespace OpenRCT2::SawyerCoding
     // Maximum buffer size to store compressed data, maximum of 16 MiB
     constexpr size_t MAX_COMPRESSED_CHUNK_SIZE = 16 * 1024 * 1024;
 
-    SawyerChunkWriter::SawyerChunkWriter(OpenRCT2::IStream* stream)
+    SawyerChunkWriter::SawyerChunkWriter(IStream* stream)
         : _stream(stream)
     {
     }

--- a/src/openrct2/sawyer_coding/SawyerChunkWriter.h
+++ b/src/openrct2/sawyer_coding/SawyerChunkWriter.h
@@ -27,10 +27,10 @@ namespace OpenRCT2::SawyerCoding
     class SawyerChunkWriter final
     {
     private:
-        OpenRCT2::IStream* const _stream = nullptr;
+        IStream* const _stream = nullptr;
 
     public:
-        explicit SawyerChunkWriter(OpenRCT2::IStream* stream);
+        explicit SawyerChunkWriter(IStream* stream);
 
         /**
          * Writes a chunk to the stream.

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -381,7 +381,7 @@ static void ScenarioUpdateDayNightCycle()
     // Only update palette if day / night cycle has changed
     if (gDayNightCycle != currentDayNightCycle)
     {
-        UpdatePalette(gGamePalette, OpenRCT2::Drawing::PaletteIndex::pi10, 236);
+        UpdatePalette(gGamePalette, Drawing::PaletteIndex::pi10, 236);
     }
 }
 

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -227,7 +227,7 @@ private:
 
         try
         {
-            auto& objRepository = OpenRCT2::GetContext()->GetObjectRepository();
+            auto& objRepository = GetContext()->GetObjectRepository();
             std::unique_ptr<IParkImporter> importer;
             std::string extension = Path::GetExtension(path);
 

--- a/src/openrct2/scenes/title/TitleSequence.cpp
+++ b/src/openrct2/scenes/title/TitleSequence.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::Title
     static std::vector<std::string> GetSaves(const std::string& path);
     static std::vector<std::string> GetSaves(IZipArchive* zip);
     static std::vector<TitleCommand> LegacyScriptRead(const std::vector<uint8_t>& script, std::vector<std::string> saves);
-    static void LegacyScriptGetLine(OpenRCT2::IStream* stream, std::vector<std::array<char, 128>>& parts);
+    static void LegacyScriptGetLine(IStream* stream, std::vector<std::array<char, 128>>& parts);
     static std::vector<uint8_t> ReadScriptFile(const std::string& path);
     static std::string LegacyScriptWrite(const TitleSequence& seq);
 
@@ -92,7 +92,7 @@ namespace OpenRCT2::Title
 
         auto commands = LegacyScriptRead(script, saves);
 
-        auto seq = OpenRCT2::Title::CreateTitleSequence();
+        auto seq = CreateTitleSequence();
         seq->Name = Path::GetFileNameWithoutExtension(path);
         seq->Path = path;
         seq->Saves = saves;
@@ -113,7 +113,7 @@ namespace OpenRCT2::Title
                 if (zip != nullptr)
                 {
                     auto data = zip->GetFileData(filename);
-                    auto ms = std::make_unique<OpenRCT2::MemoryStream>();
+                    auto ms = std::make_unique<MemoryStream>();
                     ms->Write(data.data(), data.size());
                     ms->SetPosition(0);
 
@@ -130,10 +130,10 @@ namespace OpenRCT2::Title
             else
             {
                 auto absolutePath = Path::Combine(seq.Path, filename);
-                std::unique_ptr<OpenRCT2::IStream> fileStream = nullptr;
+                std::unique_ptr<IStream> fileStream = nullptr;
                 try
                 {
-                    fileStream = std::make_unique<OpenRCT2::FileStream>(absolutePath, OpenRCT2::FileMode::open);
+                    fileStream = std::make_unique<FileStream>(absolutePath, FileMode::open);
                 }
                 catch (const IOException& exception)
                 {
@@ -330,7 +330,7 @@ namespace OpenRCT2::Title
     static std::vector<TitleCommand> LegacyScriptRead(const std::vector<uint8_t>& script, std::vector<std::string> saves)
     {
         std::vector<TitleCommand> commands;
-        auto fs = OpenRCT2::MemoryStream(script.data(), script.size());
+        auto fs = MemoryStream(script.data(), script.size());
         do
         {
             std::vector<std::array<char, 128>> parts;
@@ -412,7 +412,7 @@ namespace OpenRCT2::Title
         return commands;
     }
 
-    static void LegacyScriptGetLine(OpenRCT2::IStream* stream, std::vector<std::array<char, 128>>& parts)
+    static void LegacyScriptGetLine(IStream* stream, std::vector<std::array<char, 128>>& parts)
     {
         int32_t part = 0;
         int32_t cindex = 0;
@@ -484,7 +484,7 @@ namespace OpenRCT2::Title
         std::vector<uint8_t> result;
         try
         {
-            auto fs = OpenRCT2::FileStream(path, OpenRCT2::FileMode::open);
+            auto fs = FileStream(path, FileMode::open);
             auto size = static_cast<size_t>(fs.GetLength());
             result.resize(size);
             fs.Read(result.data(), size);

--- a/src/openrct2/scenes/title/TitleSequence.h
+++ b/src/openrct2/scenes/title/TitleSequence.h
@@ -45,7 +45,7 @@ namespace OpenRCT2::Title
     struct TitleSequenceParkHandle
     {
         std::string HintPath;
-        std::unique_ptr<OpenRCT2::IStream> Stream;
+        std::unique_ptr<IStream> Stream;
     };
 
     constexpr const utf8* TITLE_SEQUENCE_EXTENSION = ".parkseq";

--- a/src/openrct2/scenes/title/TitleSequenceManager.cpp
+++ b/src/openrct2/scenes/title/TitleSequenceManager.cpp
@@ -266,7 +266,7 @@ namespace OpenRCT2::TitleSequenceManager
 
     static bool IsNameReserved(const std::string& name)
     {
-        for (const auto& pseq : TitleSequenceManager::PredefinedSequences)
+        for (const auto& pseq : PredefinedSequences)
         {
             if (String::iequals(name, pseq.ConfigId))
             {

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1802,19 +1802,19 @@ void ScriptEngine::RemoveSockets(const std::shared_ptr<Plugin>& plugin)
     #endif
 }
 
-std::string OpenRCT2::Scripting::Stringify(const DukValue& val)
+std::string Scripting::Stringify(const DukValue& val)
 {
     return ExpressionStringifier::StringifyExpression(val);
 }
 
-std::string OpenRCT2::Scripting::ProcessString(const DukValue& value)
+std::string Scripting::ProcessString(const DukValue& value)
 {
     if (value.type() == DukValue::Type::STRING)
         return value.as_string();
     return {};
 }
 
-bool OpenRCT2::Scripting::IsGameStateMutable()
+bool Scripting::IsGameStateMutable()
 {
     // Allow single player to alter game state anywhere
     if (Network::GetMode() == Network::Mode::none)
@@ -1827,7 +1827,7 @@ bool OpenRCT2::Scripting::IsGameStateMutable()
     return execInfo.IsGameStateMutable();
 }
 
-void OpenRCT2::Scripting::ThrowIfGameStateNotMutable()
+void Scripting::ThrowIfGameStateNotMutable()
 {
     // Allow single player to alter game state anywhere
     if (Network::GetMode() != Network::Mode::none)
@@ -1842,7 +1842,7 @@ void OpenRCT2::Scripting::ThrowIfGameStateNotMutable()
     }
 }
 
-int32_t OpenRCT2::Scripting::GetTargetAPIVersion()
+int32_t Scripting::GetTargetAPIVersion()
 {
     auto& scriptEngine = GetContext()->GetScriptEngine();
     auto& execInfo = scriptEngine.GetExecInfo();

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -213,7 +213,7 @@ namespace OpenRCT2::Scripting
             for (const auto& plugin : _plugins)
             {
                 const auto& metadata = plugin->GetMetadata();
-                if (metadata.Type == OpenRCT2::Scripting::PluginType::Remote)
+                if (metadata.Type == PluginType::Remote)
                 {
                     res.push_back(plugin);
                 }

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
@@ -28,7 +28,7 @@ namespace OpenRCT2::Scripting
 
     Balloon* ScBalloon::GetBalloon() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Balloon>(_id);
+        return getGameState().entities.GetEntity<Balloon>(_id);
     }
 
     uint8_t ScBalloon::colour_get() const

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -192,7 +192,7 @@ namespace OpenRCT2::Scripting
 
         EntityBase* GetEntity() const
         {
-            return OpenRCT2::getGameState().entities.GetEntity(_id);
+            return getGameState().entities.GetEntity(_id);
         }
 
     public:

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -195,7 +195,7 @@ namespace OpenRCT2::Scripting
 
     Guest* ScGuest::GetGuest() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Guest>(_id);
+        return getGameState().entities.GetEntity<Guest>(_id);
     }
 
     uint8_t ScGuest::tshirtColour_get() const
@@ -573,7 +573,7 @@ namespace OpenRCT2::Scripting
                 }
 
                 // GuestItem
-                auto obj = OpenRCT2::Scripting::DukObject(ctx);
+                auto obj = DukObject(ctx);
                 obj.Set("type", itemEnumPair.first);
 
                 if (shopItem == ShopItem::voucher)

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::Scripting
 
     Litter* ScLitter::GetLitter() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Litter>(_id);
+        return getGameState().entities.GetEntity<Litter>(_id);
     }
 
     std::string ScLitter::litterType_get() const

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -29,7 +29,7 @@ namespace OpenRCT2::Scripting
 
     MoneyEffect* ScMoneyEffect::GetMoneyEffect() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<MoneyEffect>(_id);
+        return getGameState().entities.GetEntity<MoneyEffect>(_id);
     }
 
     money64 ScMoneyEffect::value_get() const

--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -49,7 +49,7 @@ namespace OpenRCT2::Scripting
 
     VehicleCrashParticle* ScCrashedVehicleParticle::GetCrashedVehicleParticle() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<VehicleCrashParticle>(_id);
+        return getGameState().entities.GetEntity<VehicleCrashParticle>(_id);
     }
 
     void ScCrashedVehicleParticle::frame_set(uint8_t value)

--- a/src/openrct2/scripting/bindings/entity/ScPeep.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.hpp
@@ -196,7 +196,7 @@ namespace OpenRCT2::Scripting
     protected:
         Peep* GetPeep() const
         {
-            return OpenRCT2::getGameState().entities.GetEntity<Peep>(_id);
+            return getGameState().entities.GetEntity<Peep>(_id);
         }
     };
 

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::Scripting
 
     Staff* ScStaff::GetStaff() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Staff>(_id);
+        return getGameState().entities.GetEntity<Staff>(_id);
     }
 
     std::string ScStaff::staffType_get() const
@@ -422,7 +422,7 @@ namespace OpenRCT2::Scripting
 
     Staff* ScHandyman::GetHandyman() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Staff>(_id);
+        return getGameState().entities.GetEntity<Staff>(_id);
     }
 
     DukValue ScHandyman::lawnsMown_get() const
@@ -503,7 +503,7 @@ namespace OpenRCT2::Scripting
 
     Staff* ScMechanic::GetMechanic() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Staff>(_id);
+        return getGameState().entities.GetEntity<Staff>(_id);
     }
 
     DukValue ScMechanic::ridesFixed_get() const
@@ -551,7 +551,7 @@ namespace OpenRCT2::Scripting
 
     Staff* ScSecurity::GetSecurity() const
     {
-        return OpenRCT2::getGameState().entities.GetEntity<Staff>(_id);
+        return getGameState().entities.GetEntity<Staff>(_id);
     }
 
     DukValue ScSecurity::vandalsStopped_get() const

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -102,7 +102,7 @@ namespace OpenRCT2::Scripting
 
     Vehicle* ScVehicle::GetVehicle() const
     {
-        return ::getGameState().entities.GetEntity<Vehicle>(_id);
+        return getGameState().entities.GetEntity<Vehicle>(_id);
     }
 
     ObjectEntryIndex ScVehicle::rideObject_get() const

--- a/src/openrct2/scripting/bindings/network/ScNetwork.cpp
+++ b/src/openrct2/scripting/bindings/network/ScNetwork.cpp
@@ -143,7 +143,7 @@ namespace OpenRCT2::Scripting
     DukValue ScNetwork::stats_get() const
     {
     #ifndef DISABLE_NETWORK
-        auto obj = OpenRCT2::Scripting::DukObject(_context);
+        auto obj = DukObject(_context);
         auto networkStats = Network::GetStats();
         {
             duk_push_array(_context);

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
@@ -23,14 +23,14 @@ namespace OpenRCT2::Scripting
     {
     private:
         CoordsXYZD _position;
-        OpenRCT2::TrackElemType _type;
+        TrackElemType _type;
         [[maybe_unused]] RideId _ride;
 
     public:
         static std::shared_ptr<ScTrackIterator> FromElement(const CoordsXY& position, int32_t elementIndex);
         static void Register(duk_context* ctx);
 
-        ScTrackIterator(const CoordsXYZD& position, OpenRCT2::TrackElemType type, RideId ride);
+        ScTrackIterator(const CoordsXYZD& position, TrackElemType type, RideId ride);
 
     private:
         DukValue position_get() const;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -34,10 +34,10 @@ namespace OpenRCT2::Scripting
     class ScTrackSegment
     {
     private:
-        OpenRCT2::TrackElemType _type;
+        TrackElemType _type;
 
     public:
-        ScTrackSegment(OpenRCT2::TrackElemType type);
+        ScTrackSegment(TrackElemType type);
 
         static void Register(duk_context* ctx);
 

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -225,8 +225,7 @@ namespace OpenRCT2::Scripting
         return result;
     }
 
-    std::vector<DukValue> OpenRCT2::Scripting::ScMap::getAllEntitiesOnTile(
-        const std::string& type, const DukValue& tilePos) const
+    std::vector<DukValue> ScMap::getAllEntitiesOnTile(const std::string& type, const DukValue& tilePos) const
     {
         // Get the tile position
         const auto pos = FromDuk<CoordsXY>(tilePos);
@@ -357,10 +356,10 @@ namespace OpenRCT2::Scripting
                 entity->MoveTo(entityPos);
 
                 // Reset some important vehicle vars to their null values
-                entity->sound1_id = OpenRCT2::Audio::SoundId::null;
-                entity->sound2_id = OpenRCT2::Audio::SoundId::null;
+                entity->sound1_id = Audio::SoundId::null;
+                entity->sound2_id = Audio::SoundId::null;
                 entity->next_vehicle_on_train = EntityId::GetNull();
-                entity->scream_sound_id = OpenRCT2::Audio::SoundId::null;
+                entity->scream_sound_id = Audio::SoundId::null;
                 for (size_t i = 0; i < std::size(entity->peep); i++)
                 {
                     entity->peep[i] = EntityId::GetNull();

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -27,7 +27,7 @@ namespace OpenRCT2::Ui
             return nullptr;
         }
         WindowBase* ShowError(
-            StringId /*title*/, StringId /*message*/, const OpenRCT2::Formatter& /*formatter*/, bool /*autoClose*/) override
+            StringId /*title*/, StringId /*message*/, const Formatter& /*formatter*/, bool /*autoClose*/) override
         {
             return nullptr;
         }

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -95,7 +95,7 @@ static bool landSlopeFitsUnderTrack(int32_t baseZ, uint8_t slope, const TrackEle
     const auto [slopeNorthZ, slopeEastZ, slopeSouthZ, slopeWestZ] = GetSlopeCornerHeights(baseZ, slope);
 
     const TrackElemType trackElemType = trackElement.GetTrackType();
-    const auto& ted = OpenRCT2::TrackMetaData::GetTrackElementDescriptor(trackElemType);
+    const auto& ted = TrackMetaData::GetTrackElementDescriptor(trackElemType);
     const uint8_t sequenceIndex = trackElemType == TrackElemType::maze ? 0 : trackElement.GetSequenceIndex();
     const auto& trackClearances = ted.sequences[sequenceIndex].clearance;
     const auto trackQuarters = trackClearances.quarterTile.Rotate(trackElement.GetDirection());
@@ -310,8 +310,8 @@ GameActions::Result MapCanConstructWithClearAt(
 }
 
 static bool dummyClearFunc(
-    [[maybe_unused]] OpenRCT2::TileElement** tile_element, [[maybe_unused]] const CoordsXY& coords,
-    [[maybe_unused]] CommandFlags flags, [[maybe_unused]] money64* price)
+    [[maybe_unused]] TileElement** tile_element, [[maybe_unused]] const CoordsXY& coords, [[maybe_unused]] CommandFlags flags,
+    [[maybe_unused]] money64* price)
 {
     return false;
 }

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -1778,19 +1778,19 @@ void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, TileElement* tileElement
 
 const FootpathObject* GetLegacyFootpathEntry(ObjectEntryIndex entryIndex)
 {
-    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objMgr = GetContext()->GetObjectManager();
     return objMgr.GetLoadedObject<FootpathObject>(entryIndex);
 }
 
 const FootpathSurfaceObject* GetPathSurfaceEntry(ObjectEntryIndex entryIndex)
 {
-    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objMgr = GetContext()->GetObjectManager();
     return objMgr.GetLoadedObject<FootpathSurfaceObject>(entryIndex);
 }
 
 const FootpathRailingsObject* GetPathRailingsEntry(ObjectEntryIndex entryIndex)
 {
-    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+    auto& objMgr = GetContext()->GetObjectManager();
     return objMgr.GetLoadedObject<FootpathRailingsObject>(entryIndex);
 }
 

--- a/src/openrct2/world/tile_element/EntranceElement.cpp
+++ b/src/openrct2/world/tile_element/EntranceElement.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2
 
     const FootpathObject* EntranceElement::GetLegacyPathEntry() const
     {
-        auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objMgr = GetContext()->GetObjectManager();
         return objMgr.GetLoadedObject<FootpathObject>(GetLegacyPathEntryIndex());
     }
 
@@ -101,7 +101,7 @@ namespace OpenRCT2
 
     const FootpathSurfaceObject* EntranceElement::GetSurfaceEntry() const
     {
-        auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objMgr = GetContext()->GetObjectManager();
         return objMgr.GetLoadedObject<FootpathSurfaceObject>(GetSurfaceEntryIndex());
     }
 

--- a/src/openrct2/world/tile_element/SurfaceElement.cpp
+++ b/src/openrct2/world/tile_element/SurfaceElement.cpp
@@ -27,7 +27,7 @@ namespace OpenRCT2
 
     TerrainSurfaceObject* SurfaceElement::GetSurfaceObject() const
     {
-        auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objManager = GetContext()->GetObjectManager();
         return objManager.GetLoadedObject<TerrainSurfaceObject>(GetSurfaceObjectIndex());
     }
 
@@ -38,7 +38,7 @@ namespace OpenRCT2
 
     TerrainEdgeObject* SurfaceElement::GetEdgeObject() const
     {
-        auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objManager = GetContext()->GetObjectManager();
         return objManager.GetLoadedObject<TerrainEdgeObject>(GetEdgeObjectIndex());
     }
 
@@ -65,7 +65,7 @@ namespace OpenRCT2
     bool SurfaceElement::CanGrassGrow() const
     {
         auto surfaceStyle = GetSurfaceObjectIndex();
-        auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
+        auto& objMgr = GetContext()->GetObjectManager();
         const auto* surfaceObject = objMgr.GetLoadedObject<TerrainSurfaceObject>(surfaceStyle);
         if (surfaceObject != nullptr)
         {


### PR DESCRIPTION
As always, these were verified manually and I only removed them when it made sense and I could see for myself where the namespace scope was being declared (or if it was being imported with `using`).