### PR TITLE
Remove last redundant const qualifiers and integers being used as booleans

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -74,7 +74,7 @@ struct GameStateSnapshot_t
     }
 
     // Must pass a function that can access the sprite.
-    void SerialiseSprites(std::function<EntitySnapshot*(const EntityId)> getEntity, const size_t numSprites, bool saving)
+    void SerialiseSprites(std::function<EntitySnapshot*(EntityId)> getEntity, const size_t numSprites, bool saving)
     {
         const bool loading = !saving;
 

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -247,15 +247,16 @@ namespace OpenRCT2::RCT1
             const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
             if (rtd.specialType == RtdSpecialType::maze)
             {
-                TD46MazeElement t4MazeElement{};
-                t4MazeElement.all = !0;
-                while (t4MazeElement.all != 0)
+                TD46MazeElement t4MazeElement;
+                while (true)
                 {
                     _stream.Read(&t4MazeElement, sizeof(TD46MazeElement));
-                    if (t4MazeElement.all != 0)
+                    if (t4MazeElement.all == 0)
                     {
-                        importMazeElement(*td, t4MazeElement);
+                        break;
                     }
+
+                    importMazeElement(*td, t4MazeElement);
                 }
             }
             else

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -139,15 +139,16 @@ namespace OpenRCT2::RCT2
             const auto& rtd = GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex);
             if (rtd.specialType == RtdSpecialType::maze)
             {
-                TD46MazeElement t6MazeElement{};
-                t6MazeElement.all = !0;
-                while (t6MazeElement.all != 0)
+                TD46MazeElement t6MazeElement;
+                while (true)
                 {
                     _stream.Read(&t6MazeElement, sizeof(TD46MazeElement));
-                    if (t6MazeElement.all != 0)
+                    if (t6MazeElement.all == 0)
                     {
-                        importMazeElement(*td, t6MazeElement);
+                        break;
                     }
+
+                    importMazeElement(*td, t6MazeElement);
                 }
             }
             else

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -113,7 +113,7 @@ namespace OpenRCT2::TrackMetaData
         }
     };
 
-    using TrackComputeFunction = int32_t (*)(const int16_t);
+    using TrackComputeFunction = int32_t (*)(int16_t);
     struct TrackElementDescriptor
     {
         StringId description;

--- a/src/openrct2/world/map_generator/MapHelpers.h
+++ b/src/openrct2/world/map_generator/MapHelpers.h
@@ -23,7 +23,7 @@ namespace OpenRCT2::World::MapGenerator
         SLOPE_E_THRESHOLD_FLAGS = (1 << 3)
     };
 
-    using SmoothFunction = std::function<int32_t(const TileCoordsXY)>;
+    using SmoothFunction = std::function<int32_t(TileCoordsXY)>;
 
     int32_t smoothTileStrong(TileCoordsXY tileCoord);
     int32_t smoothTileWeak(TileCoordsXY tileCoord);


### PR DESCRIPTION
This tackles the last remaining cases to prepare the code for clang-tidy's _readability-avoid-const-params-in-decls_ and _modernize-use-bool-literals_.