### PR TITLE
Remove global "using namespace" declarative in header files

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -33,6 +33,7 @@
     #include <vector>
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::Scripting;
 
 namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -18,25 +18,23 @@
     #include <openrct2/drawing/RenderTarget.h>
     #include <openrct2/scripting/Duktape.hpp>
 
-using namespace OpenRCT2::Drawing;
-
 namespace OpenRCT2::Scripting
 {
     class ScGraphicsContext
     {
     private:
         duk_context* _ctx{};
-        RenderTarget _rt{};
+        Drawing::RenderTarget _rt{};
 
         std::optional<uint8_t> _colour{};
         std::optional<uint8_t> _secondaryColour{};
         std::optional<uint8_t> _tertiaryColour{};
         std::optional<uint8_t> _paletteId{};
-        PaletteIndex _stroke{};
-        PaletteIndex _fill{};
+        Drawing::PaletteIndex _stroke{};
+        Drawing::PaletteIndex _fill{};
 
     public:
-        ScGraphicsContext(duk_context* ctx, const RenderTarget& rt)
+        ScGraphicsContext(duk_context* ctx, const Drawing::RenderTarget& rt)
             : _ctx(ctx)
             , _rt(rt)
         {
@@ -130,7 +128,7 @@ namespace OpenRCT2::Scripting
 
         void fill_set(uint8_t value)
         {
-            _fill = static_cast<PaletteIndex>(value);
+            _fill = static_cast<Drawing::PaletteIndex>(value);
         }
 
         uint8_t stroke_get() const
@@ -140,7 +138,7 @@ namespace OpenRCT2::Scripting
 
         void stroke_set(uint8_t value)
         {
-            _stroke = static_cast<PaletteIndex>(value);
+            _stroke = static_cast<Drawing::PaletteIndex>(value);
         }
 
         int32_t width_get() const
@@ -167,14 +165,16 @@ namespace OpenRCT2::Scripting
 
         void box(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            Rectangle::fillInset(_rt, { x, y, x + width - 1, y + height - 1 }, { static_cast<Colour>(_colour.value_or(0)) });
+            Drawing::Rectangle::fillInset(
+                _rt, { x, y, x + width - 1, y + height - 1 }, { static_cast<Drawing::Colour>(_colour.value_or(0)) });
         }
 
         void well(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            Rectangle::fillInset(
-                _rt, { x, y, x + width - 1, y + height - 1 }, { static_cast<Colour>(_colour.value_or(0)) },
-                Rectangle::BorderStyle::inset, Rectangle::FillBrightness::light, Rectangle::FillMode::dontLightenWhenInset);
+            Drawing::Rectangle::fillInset(
+                _rt, { x, y, x + width - 1, y + height - 1 }, { static_cast<Drawing::Colour>(_colour.value_or(0)) },
+                Drawing::Rectangle::BorderStyle::inset, Drawing::Rectangle::FillBrightness::light,
+                Drawing::Rectangle::FillMode::dontLightenWhenInset);
         }
 
         void clear()
@@ -184,7 +184,7 @@ namespace OpenRCT2::Scripting
 
         void clip(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            RenderTarget newRT;
+            Drawing::RenderTarget newRT;
             ClipRenderTarget(newRT, _rt, { x, y }, width, height);
             _rt = newRT;
         }
@@ -201,15 +201,15 @@ namespace OpenRCT2::Scripting
             {
                 if (_colour)
                 {
-                    img = img.WithPrimary(static_cast<Colour>(*_colour));
+                    img = img.WithPrimary(static_cast<Drawing::Colour>(*_colour));
                 }
                 if (_secondaryColour)
                 {
-                    img = img.WithSecondary(static_cast<Colour>(*_secondaryColour));
+                    img = img.WithSecondary(static_cast<Drawing::Colour>(*_secondaryColour));
                 }
             }
 
-            GfxDrawSprite(_rt, img.WithTertiary(static_cast<Colour>(_tertiaryColour.value_or(0))), { x, y });
+            GfxDrawSprite(_rt, img.WithTertiary(static_cast<Drawing::Colour>(_tertiaryColour.value_or(0))), { x, y });
         }
 
         void line(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
@@ -219,7 +219,7 @@ namespace OpenRCT2::Scripting
 
         void rect(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            if (_stroke != PaletteIndex::transparent)
+            if (_stroke != Drawing::PaletteIndex::transparent)
             {
                 line(x, y, x + width, y);
                 line(x + width - 1, y + 1, x + width - 1, y + height - 1);
@@ -231,15 +231,15 @@ namespace OpenRCT2::Scripting
                 width -= 2;
                 height -= 2;
             }
-            if (_fill != PaletteIndex::transparent)
+            if (_fill != Drawing::PaletteIndex::transparent)
             {
-                Rectangle::fill(_rt, { x, y, x + width - 1, y + height - 1 }, _fill);
+                Drawing::Rectangle::fill(_rt, { x, y, x + width - 1, y + height - 1 }, _fill);
             }
         }
 
         void text(const std::string& text, int32_t x, int32_t y)
         {
-            DrawText(_rt, { x, y }, { static_cast<Colour>(_colour.value_or(0)) }, text.c_str());
+            DrawText(_rt, { x, y }, { static_cast<Drawing::Colour>(_colour.value_or(0)) }, text.c_str());
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicWoodenRollerCoaster.cpp
@@ -22,6 +22,7 @@
 #include "WoodenRollerCoaster.hpp"
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::WoodenRC;
 
 enum
 {
@@ -629,7 +630,7 @@ static void ClassicWoodenRCTrackLeftBankToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<true, kFlatToRightBankImages>(
+    TrackFlatToBank<true, kFlatToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -637,7 +638,7 @@ static void ClassicWoodenRCTrackRightBankToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<true, kFlatToLeftBankImages>(
+    TrackFlatToBank<true, kFlatToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -645,7 +646,7 @@ static void ClassicWoodenRCTrackRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<true, kLeftBankImages>(
+    TrackFlatToBank<true, kLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -653,7 +654,7 @@ static void ClassicWoodenRCTrackLeftBankTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrack25DegUpToBank<true, kUp25ToRightBankImages>(
+    Track25DegUpToBank<true, kUp25ToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -661,7 +662,7 @@ static void ClassicWoodenRCTrackRightBankTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrack25DegUpToBank<true, kUp25ToLeftBankImages>(
+    Track25DegUpToBank<true, kUp25ToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -669,7 +670,7 @@ static void ClassicWoodenRCTrack25DegDownToLeftBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackBankTo25DegUp<true, kRightBankToUp25Images>(
+    TrackBankTo25DegUp<true, kRightBankToUp25Images>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -677,7 +678,7 @@ static void ClassicWoodenRCTrack25DegDownToRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackBankTo25DegUp<true, kLeftBankToUp25Images>(
+    TrackBankTo25DegUp<true, kLeftBankToUp25Images>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1098,7 +1099,7 @@ static void ClassicWoodenRCTrackDiagLeftBankToFlat(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagFlatToBank<true, kDiagFlatToRightBankImages>(
+    return TrackDiagFlatToBank<true, kDiagFlatToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1107,7 +1108,7 @@ static void ClassicWoodenRCTrackDiagRightBankToFlat(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagFlatToBank<true, kDiagFlatToLeftBankImages>(
+    return TrackDiagFlatToBank<true, kDiagFlatToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1116,7 +1117,7 @@ static void ClassicWoodenRCTrackDiagDown25ToLeftBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagBankTo25DegUp<true, kDiagRightBankTo25DegUpImages>(
+    return TrackDiagBankTo25DegUp<true, kDiagRightBankTo25DegUpImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1125,7 +1126,7 @@ static void ClassicWoodenRCTrackDiagDown25ToRightBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagBankTo25DegUp<true, kDiagLeftBankTo25DegUpImages>(
+    return TrackDiagBankTo25DegUp<true, kDiagLeftBankTo25DegUpImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1134,7 +1135,7 @@ static void ClassicWoodenRCTrackDiagLeftBankToDown25(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagUp25ToBank<true, kDiagUp25ToRightBankImages>(
+    return TrackDiagUp25ToBank<true, kDiagUp25ToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1143,7 +1144,7 @@ static void ClassicWoodenRCTrackDiagRightBankToDown25(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagUp25ToBank<true, kDiagUp25ToLeftBankImages>(
+    return TrackDiagUp25ToBank<true, kDiagUp25ToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1152,7 +1153,7 @@ static void ClassicWoodenRCTrackLeftEighthBankToOrthogonal(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    WoodenRCTrackRightEighthBankToDiag<true, kRightEighthBankToDiagImages>(
+    TrackRightEighthBankToDiag<true, kRightEighthBankToDiagImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 static void ClassicWoodenRCTrackRightEighthBankToOrthogonal(
@@ -1160,7 +1161,7 @@ static void ClassicWoodenRCTrackRightEighthBankToOrthogonal(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    WoodenRCTrackLeftEighthBankToDiag<true, kLeftEighthBankToDiagImages>(
+    TrackLeftEighthBankToDiag<true, kLeftEighthBankToDiagImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -1169,7 +1170,7 @@ static void ClassicWoodenRCTrackDiagRightBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagLeftBank<true, kDiagLeftBankImages>(
+    return TrackDiagLeftBank<true, kDiagLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1186,29 +1187,29 @@ TrackPaintFunction GetTrackPaintFunctionClassicWoodenRC(TrackElemType trackType)
     switch (trackType)
     {
         case TrackElemType::flatToLeftBank:
-            return WoodenRCTrackFlatToBank<true, kFlatToLeftBankImages>;
+            return TrackFlatToBank<true, kFlatToLeftBankImages>;
         case TrackElemType::flatToRightBank:
-            return WoodenRCTrackFlatToBank<true, kFlatToRightBankImages>;
+            return TrackFlatToBank<true, kFlatToRightBankImages>;
         case TrackElemType::leftBankToFlat:
             return ClassicWoodenRCTrackLeftBankToFlat;
         case TrackElemType::rightBankToFlat:
             return ClassicWoodenRCTrackRightBankToFlat;
         case TrackElemType::leftBank:
-            return WoodenRCTrackFlatToBank<true, kLeftBankImages>;
+            return TrackFlatToBank<true, kLeftBankImages>;
         case TrackElemType::rightBank:
             return ClassicWoodenRCTrackRightBank;
         case TrackElemType::up25ToLeftBank:
-            return WoodenRCTrack25DegUpToBank<true, kUp25ToLeftBankImages>;
+            return Track25DegUpToBank<true, kUp25ToLeftBankImages>;
         case TrackElemType::up25ToRightBank:
-            return WoodenRCTrack25DegUpToBank<true, kUp25ToRightBankImages>;
+            return Track25DegUpToBank<true, kUp25ToRightBankImages>;
         case TrackElemType::leftBankToDown25:
             return ClassicWoodenRCTrackLeftBankTo25DegDown;
         case TrackElemType::rightBankToDown25:
             return ClassicWoodenRCTrackRightBankTo25DegDown;
         case TrackElemType::leftBankToUp25:
-            return WoodenRCTrackBankTo25DegUp<true, kLeftBankToUp25Images>;
+            return TrackBankTo25DegUp<true, kLeftBankToUp25Images>;
         case TrackElemType::rightBankToUp25:
-            return WoodenRCTrackBankTo25DegUp<true, kRightBankToUp25Images>;
+            return TrackBankTo25DegUp<true, kRightBankToUp25Images>;
         case TrackElemType::down25ToLeftBank:
             return ClassicWoodenRCTrack25DegDownToLeftBank;
         case TrackElemType::down25ToRightBank:
@@ -1222,37 +1223,37 @@ TrackPaintFunction GetTrackPaintFunctionClassicWoodenRC(TrackElemType trackType)
         case TrackElemType::rightBankedQuarterTurn3Tiles:
             return ClassicWoodenRCTrackRightQuarterTurn3Bank;
         case TrackElemType::diagFlatToLeftBank:
-            return WoodenRCTrackDiagFlatToBank<true, kDiagFlatToLeftBankImages>;
+            return TrackDiagFlatToBank<true, kDiagFlatToLeftBankImages>;
         case TrackElemType::diagFlatToRightBank:
-            return WoodenRCTrackDiagFlatToBank<true, kDiagFlatToRightBankImages>;
+            return TrackDiagFlatToBank<true, kDiagFlatToRightBankImages>;
         case TrackElemType::diagLeftBankToFlat:
             return ClassicWoodenRCTrackDiagLeftBankToFlat;
         case TrackElemType::diagRightBankToFlat:
             return ClassicWoodenRCTrackDiagRightBankToFlat;
         case TrackElemType::diagLeftBankToUp25:
-            return WoodenRCTrackDiagBankTo25DegUp<true, kDiagLeftBankTo25DegUpImages>;
+            return TrackDiagBankTo25DegUp<true, kDiagLeftBankTo25DegUpImages>;
         case TrackElemType::diagRightBankToUp25:
-            return WoodenRCTrackDiagBankTo25DegUp<true, kDiagRightBankTo25DegUpImages>;
+            return TrackDiagBankTo25DegUp<true, kDiagRightBankTo25DegUpImages>;
         case TrackElemType::diagDown25ToLeftBank:
             return ClassicWoodenRCTrackDiagDown25ToLeftBank;
         case TrackElemType::diagDown25ToRightBank:
             return ClassicWoodenRCTrackDiagDown25ToRightBank;
         case TrackElemType::diagUp25ToLeftBank:
-            return WoodenRCTrackDiagUp25ToBank<true, kDiagUp25ToLeftBankImages>;
+            return TrackDiagUp25ToBank<true, kDiagUp25ToLeftBankImages>;
         case TrackElemType::diagUp25ToRightBank:
-            return WoodenRCTrackDiagUp25ToBank<true, kDiagUp25ToRightBankImages>;
+            return TrackDiagUp25ToBank<true, kDiagUp25ToRightBankImages>;
         case TrackElemType::diagLeftBankToDown25:
             return ClassicWoodenRCTrackDiagLeftBankToDown25;
         case TrackElemType::diagRightBankToDown25:
             return ClassicWoodenRCTrackDiagRightBankToDown25;
         case TrackElemType::diagLeftBank:
-            return WoodenRCTrackDiagLeftBank<true, kDiagLeftBankImages>;
+            return TrackDiagLeftBank<true, kDiagLeftBankImages>;
         case TrackElemType::diagRightBank:
             return ClassicWoodenRCTrackDiagRightBank;
         case TrackElemType::leftEighthBankToDiag:
-            return WoodenRCTrackLeftEighthBankToDiag<true, kLeftEighthBankToDiagImages>;
+            return TrackLeftEighthBankToDiag<true, kLeftEighthBankToDiagImages>;
         case TrackElemType::rightEighthBankToDiag:
-            return WoodenRCTrackRightEighthBankToDiag<true, kRightEighthBankToDiagImages>;
+            return TrackRightEighthBankToDiag<true, kRightEighthBankToDiagImages>;
         case TrackElemType::leftEighthBankToOrthogonal:
             return ClassicWoodenRCTrackLeftEighthBankToOrthogonal;
         case TrackElemType::rightEighthBankToOrthogonal:

--- a/src/openrct2/paint/track/coaster/ClassicWoodenTwisterRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/ClassicWoodenTwisterRollerCoaster.cpp
@@ -15,6 +15,7 @@
 #include "WoodenRollerCoaster.hpp"
 
 using namespace OpenRCT2;
+using namespace OpenRCT2::WoodenRC;
 
 // static constexpr TunnelGroup kTunnelGroup = TunnelGroup::Square;
 
@@ -1859,7 +1860,7 @@ static void ClassicWoodenTwisterRCTrackLeftBankToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<false, kFlatToRightBankImages>(
+    TrackFlatToBank<false, kFlatToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1867,7 +1868,7 @@ static void ClassicWoodenTwisterRCTrackRightBankToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<false, kFlatToLeftBankImages>(
+    TrackFlatToBank<false, kFlatToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1875,7 +1876,7 @@ static void ClassicWoodenTwisterRCTrackRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<false, kLeftBankImages>(
+    TrackFlatToBank<false, kLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1883,7 +1884,7 @@ static void ClassicWoodenTwisterRCTrackLeftBankTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrack25DegUpToBank<false, kUp25ToRightBankImages>(
+    Track25DegUpToBank<false, kUp25ToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1891,7 +1892,7 @@ static void ClassicWoodenTwisterRCTrackRightBankTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrack25DegUpToBank<false, kUp25ToLeftBankImages>(
+    Track25DegUpToBank<false, kUp25ToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1899,7 +1900,7 @@ static void ClassicWoodenTwisterRCTrack25DegDownToLeftBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackBankTo25DegUp<false, kRightBankToUp25Images>(
+    TrackBankTo25DegUp<false, kRightBankToUp25Images>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1907,7 +1908,7 @@ static void ClassicWoodenTwisterRCTrack25DegDownToRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackBankTo25DegUp<false, kLeftBankToUp25Images>(
+    TrackBankTo25DegUp<false, kLeftBankToUp25Images>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -1916,7 +1917,7 @@ static void ClassicWoodenTwisterRCTrackRightQuarterTurn3Bank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackLeftQuarterTurn3Bank<false, kBankedQuarterTurn3Images>(
+    TrackLeftQuarterTurn3Bank<false, kBankedQuarterTurn3Images>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -1925,7 +1926,7 @@ static void ClassicWoodenTwisterRCTrackBankedLeftQuarterTurn5(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    WoodenRCTrackBankedRightQuarterTurn5<false, kBankedQuarterTurn5Images>(
+    TrackBankedRightQuarterTurn5<false, kBankedQuarterTurn5Images>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 static void ClassicWoodenTwisterRCTrackLeftHalfBankedHelixDownSmall(
@@ -1938,7 +1939,7 @@ static void ClassicWoodenTwisterRCTrackLeftHalfBankedHelixDownSmall(
         direction = DirectionPrev(direction);
     }
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackRightHalfBankedHelixUpSmall<false, kRightHalfBankedHelixUpSmallImages>(
+    TrackRightHalfBankedHelixUpSmall<false, kRightHalfBankedHelixUpSmallImages>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
@@ -1952,7 +1953,7 @@ static void ClassicWoodenTwisterRCTrackRightHalfBankedHelixDownSmall(
         direction = DirectionNext(direction);
     }
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackLeftHalfBankedHelixUpSmall<false, kLeftHalfBankedHelixUpSmallImages>(
+    TrackLeftHalfBankedHelixUpSmall<false, kLeftHalfBankedHelixUpSmallImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -1966,7 +1967,7 @@ static void ClassicWoodenTwisterRCTrackLeftHalfBankedHelixDownLarge(
         direction = DirectionPrev(direction);
     }
     trackSequence = kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    WoodenRCTrackRightHalfBankedHelixUpLarge<false, kRightHalfBankedHelixUpLargeImages>(
+    TrackRightHalfBankedHelixUpLarge<false, kRightHalfBankedHelixUpLargeImages>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
@@ -1980,7 +1981,7 @@ static void ClassicWoodenTwisterRCTrackRightHalfBankedHelixDownLarge(
         direction = DirectionNext(direction);
     }
     trackSequence = kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    WoodenRCTrackLeftHalfBankedHelixUpLarge<false, kLeftHalfBankedHelixUpLargeImages>(
+    TrackLeftHalfBankedHelixUpLarge<false, kLeftHalfBankedHelixUpLargeImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -1989,7 +1990,7 @@ static void ClassicWoodenTwisterRCTrackLeftQuarterTurn325DegDownToLeftBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackRightBankToRightQuarterTurn325DegUp<false, kRightBankToRightQuarterTurn325DegUpImages>(
+    TrackRightBankToRightQuarterTurn325DegUp<false, kRightBankToRightQuarterTurn325DegUpImages>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
@@ -1998,7 +1999,7 @@ static void ClassicWoodenTwisterRCTrackRightQuarterTurn325DegDownToRightBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp<false, kLeftBankToLeftQuarterTurn325DegUpImages>(
+    TrackLeftBankToLeftQuarterTurn325DegUp<false, kLeftBankToLeftQuarterTurn325DegUpImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -2007,7 +2008,7 @@ static void ClassicWoodenTwisterRCTrackDiagLeftBankToFlat(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagFlatToBank<false, kDiagFlatToRightBankImages>(
+    return TrackDiagFlatToBank<false, kDiagFlatToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2016,7 +2017,7 @@ static void ClassicWoodenTwisterRCTrackDiagRightBankToFlat(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagFlatToBank<false, kDiagFlatToLeftBankImages>(
+    return TrackDiagFlatToBank<false, kDiagFlatToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2025,7 +2026,7 @@ static void ClassicWoodenTwisterRCTrackDiagDown25ToLeftBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagBankTo25DegUp<false, kDiagRightBankTo25DegUpImages>(
+    return TrackDiagBankTo25DegUp<false, kDiagRightBankTo25DegUpImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2034,7 +2035,7 @@ static void ClassicWoodenTwisterRCTrackDiagDown25ToRightBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagBankTo25DegUp<false, kDiagLeftBankTo25DegUpImages>(
+    return TrackDiagBankTo25DegUp<false, kDiagLeftBankTo25DegUpImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2043,7 +2044,7 @@ static void ClassicWoodenTwisterRCTrackDiagLeftBankToDown25(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagUp25ToBank<false, kDiagUp25ToRightBankImages>(
+    return TrackDiagUp25ToBank<false, kDiagUp25ToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2052,7 +2053,7 @@ static void ClassicWoodenTwisterRCTrackDiagRightBankToDown25(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagUp25ToBank<false, kDiagUp25ToLeftBankImages>(
+    return TrackDiagUp25ToBank<false, kDiagUp25ToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2061,7 +2062,7 @@ static void ClassicWoodenTwisterRCTrackDiagRightBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagLeftBank<false, kDiagLeftBankImages>(
+    return TrackDiagLeftBank<false, kDiagLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -2070,7 +2071,7 @@ static void ClassicWoodenTwisterRCTrackLeftEighthBankToOrthogonal(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    WoodenRCTrackRightEighthBankToDiag<false, kRightEighthBankToDiagImages>(
+    TrackRightEighthBankToDiag<false, kRightEighthBankToDiagImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 static void ClassicWoodenTwisterRCTrackRightEighthBankToOrthogonal(
@@ -2078,7 +2079,7 @@ static void ClassicWoodenTwisterRCTrackRightEighthBankToOrthogonal(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    WoodenRCTrackLeftEighthBankToDiag<false, kLeftEighthBankToDiagImages>(
+    TrackLeftEighthBankToDiag<false, kLeftEighthBankToDiagImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -2095,108 +2096,108 @@ TrackPaintFunction GetTrackPaintFunctionClassicWoodenTwisterRC(TrackElemType tra
     switch (trackType)
     {
         case TrackElemType::flatToLeftBank:
-            return WoodenRCTrackFlatToBank<false, kFlatToLeftBankImages>;
+            return TrackFlatToBank<false, kFlatToLeftBankImages>;
         case TrackElemType::flatToRightBank:
-            return WoodenRCTrackFlatToBank<false, kFlatToRightBankImages>;
+            return TrackFlatToBank<false, kFlatToRightBankImages>;
         case TrackElemType::leftBankToFlat:
             return ClassicWoodenTwisterRCTrackLeftBankToFlat;
         case TrackElemType::rightBankToFlat:
             return ClassicWoodenTwisterRCTrackRightBankToFlat;
         case TrackElemType::leftBank:
-            return WoodenRCTrackFlatToBank<false, kLeftBankImages>;
+            return TrackFlatToBank<false, kLeftBankImages>;
         case TrackElemType::rightBank:
             return ClassicWoodenTwisterRCTrackRightBank;
         case TrackElemType::up25ToLeftBank:
-            return WoodenRCTrack25DegUpToBank<false, kUp25ToLeftBankImages>;
+            return Track25DegUpToBank<false, kUp25ToLeftBankImages>;
         case TrackElemType::up25ToRightBank:
-            return WoodenRCTrack25DegUpToBank<false, kUp25ToRightBankImages>;
+            return Track25DegUpToBank<false, kUp25ToRightBankImages>;
         case TrackElemType::leftBankToDown25:
             return ClassicWoodenTwisterRCTrackLeftBankTo25DegDown;
         case TrackElemType::rightBankToDown25:
             return ClassicWoodenTwisterRCTrackRightBankTo25DegDown;
 
         case TrackElemType::leftBankToUp25:
-            return WoodenRCTrackBankTo25DegUp<false, kLeftBankToUp25Images>;
+            return TrackBankTo25DegUp<false, kLeftBankToUp25Images>;
         case TrackElemType::rightBankToUp25:
-            return WoodenRCTrackBankTo25DegUp<false, kRightBankToUp25Images>;
+            return TrackBankTo25DegUp<false, kRightBankToUp25Images>;
         case TrackElemType::down25ToLeftBank:
             return ClassicWoodenTwisterRCTrack25DegDownToLeftBank;
         case TrackElemType::down25ToRightBank:
             return ClassicWoodenTwisterRCTrack25DegDownToRightBank;
 
         case TrackElemType::leftBankedQuarterTurn3Tiles:
-            return WoodenRCTrackLeftQuarterTurn3Bank<false, kBankedQuarterTurn3Images>;
+            return TrackLeftQuarterTurn3Bank<false, kBankedQuarterTurn3Images>;
         case TrackElemType::rightBankedQuarterTurn3Tiles:
             return ClassicWoodenTwisterRCTrackRightQuarterTurn3Bank;
 
         case TrackElemType::bankedLeftQuarterTurn5Tiles:
             return ClassicWoodenTwisterRCTrackBankedLeftQuarterTurn5;
         case TrackElemType::bankedRightQuarterTurn5Tiles:
-            return WoodenRCTrackBankedRightQuarterTurn5<false, kBankedQuarterTurn5Images>;
+            return TrackBankedRightQuarterTurn5<false, kBankedQuarterTurn5Images>;
 
         case TrackElemType::leftHalfBankedHelixUpSmall:
-            return WoodenRCTrackLeftHalfBankedHelixUpSmall<false, kLeftHalfBankedHelixUpSmallImages>;
+            return TrackLeftHalfBankedHelixUpSmall<false, kLeftHalfBankedHelixUpSmallImages>;
         case TrackElemType::rightHalfBankedHelixUpSmall:
-            return WoodenRCTrackRightHalfBankedHelixUpSmall<false, kRightHalfBankedHelixUpSmallImages>;
+            return TrackRightHalfBankedHelixUpSmall<false, kRightHalfBankedHelixUpSmallImages>;
         case TrackElemType::leftHalfBankedHelixDownSmall:
             return ClassicWoodenTwisterRCTrackLeftHalfBankedHelixDownSmall;
         case TrackElemType::rightHalfBankedHelixDownSmall:
             return ClassicWoodenTwisterRCTrackRightHalfBankedHelixDownSmall;
 
         case TrackElemType::leftHalfBankedHelixUpLarge:
-            return WoodenRCTrackLeftHalfBankedHelixUpLarge<false, kLeftHalfBankedHelixUpLargeImages>;
+            return TrackLeftHalfBankedHelixUpLarge<false, kLeftHalfBankedHelixUpLargeImages>;
         case TrackElemType::rightHalfBankedHelixUpLarge:
-            return WoodenRCTrackRightHalfBankedHelixUpLarge<false, kRightHalfBankedHelixUpLargeImages>;
+            return TrackRightHalfBankedHelixUpLarge<false, kRightHalfBankedHelixUpLargeImages>;
         case TrackElemType::leftHalfBankedHelixDownLarge:
             return ClassicWoodenTwisterRCTrackLeftHalfBankedHelixDownLarge;
         case TrackElemType::rightHalfBankedHelixDownLarge:
             return ClassicWoodenTwisterRCTrackRightHalfBankedHelixDownLarge;
 
         case TrackElemType::leftBankToLeftQuarterTurn3TilesUp25:
-            return WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp<false, kLeftBankToLeftQuarterTurn325DegUpImages>;
+            return TrackLeftBankToLeftQuarterTurn325DegUp<false, kLeftBankToLeftQuarterTurn325DegUpImages>;
         case TrackElemType::rightBankToRightQuarterTurn3TilesUp25:
-            return WoodenRCTrackRightBankToRightQuarterTurn325DegUp<false, kRightBankToRightQuarterTurn325DegUpImages>;
+            return TrackRightBankToRightQuarterTurn325DegUp<false, kRightBankToRightQuarterTurn325DegUpImages>;
         case TrackElemType::leftQuarterTurn3TilesDown25ToLeftBank:
             return ClassicWoodenTwisterRCTrackLeftQuarterTurn325DegDownToLeftBank;
         case TrackElemType::rightQuarterTurn3TilesDown25ToRightBank:
             return ClassicWoodenTwisterRCTrackRightQuarterTurn325DegDownToRightBank;
 
         case TrackElemType::diagFlatToLeftBank:
-            return WoodenRCTrackDiagFlatToBank<false, kDiagFlatToLeftBankImages>;
+            return TrackDiagFlatToBank<false, kDiagFlatToLeftBankImages>;
         case TrackElemType::diagFlatToRightBank:
-            return WoodenRCTrackDiagFlatToBank<false, kDiagFlatToRightBankImages>;
+            return TrackDiagFlatToBank<false, kDiagFlatToRightBankImages>;
         case TrackElemType::diagLeftBankToFlat:
             return ClassicWoodenTwisterRCTrackDiagLeftBankToFlat;
         case TrackElemType::diagRightBankToFlat:
             return ClassicWoodenTwisterRCTrackDiagRightBankToFlat;
 
         case TrackElemType::diagLeftBankToUp25:
-            return WoodenRCTrackDiagBankTo25DegUp<false, kDiagLeftBankTo25DegUpImages>;
+            return TrackDiagBankTo25DegUp<false, kDiagLeftBankTo25DegUpImages>;
         case TrackElemType::diagRightBankToUp25:
-            return WoodenRCTrackDiagBankTo25DegUp<false, kDiagRightBankTo25DegUpImages>;
+            return TrackDiagBankTo25DegUp<false, kDiagRightBankTo25DegUpImages>;
         case TrackElemType::diagDown25ToLeftBank:
             return ClassicWoodenTwisterRCTrackDiagDown25ToLeftBank;
         case TrackElemType::diagDown25ToRightBank:
             return ClassicWoodenTwisterRCTrackDiagDown25ToRightBank;
 
         case TrackElemType::diagUp25ToLeftBank:
-            return WoodenRCTrackDiagUp25ToBank<false, kDiagUp25ToLeftBankImages>;
+            return TrackDiagUp25ToBank<false, kDiagUp25ToLeftBankImages>;
         case TrackElemType::diagUp25ToRightBank:
-            return WoodenRCTrackDiagUp25ToBank<false, kDiagUp25ToRightBankImages>;
+            return TrackDiagUp25ToBank<false, kDiagUp25ToRightBankImages>;
         case TrackElemType::diagLeftBankToDown25:
             return ClassicWoodenTwisterRCTrackDiagLeftBankToDown25;
         case TrackElemType::diagRightBankToDown25:
             return ClassicWoodenTwisterRCTrackDiagRightBankToDown25;
 
         case TrackElemType::diagLeftBank:
-            return WoodenRCTrackDiagLeftBank<false, kDiagLeftBankImages>;
+            return TrackDiagLeftBank<false, kDiagLeftBankImages>;
         case TrackElemType::diagRightBank:
             return ClassicWoodenTwisterRCTrackDiagRightBank;
 
         case TrackElemType::leftEighthBankToDiag:
-            return WoodenRCTrackLeftEighthBankToDiag<false, kLeftEighthBankToDiagImages>;
+            return TrackLeftEighthBankToDiag<false, kLeftEighthBankToDiagImages>;
         case TrackElemType::rightEighthBankToDiag:
-            return WoodenRCTrackRightEighthBankToDiag<false, kRightEighthBankToDiagImages>;
+            return TrackRightEighthBankToDiag<false, kRightEighthBankToDiagImages>;
         case TrackElemType::leftEighthBankToOrthogonal:
             return ClassicWoodenTwisterRCTrackLeftEighthBankToOrthogonal;
         case TrackElemType::rightEighthBankToOrthogonal:

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.cpp
@@ -27,6 +27,7 @@
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
+using namespace OpenRCT2::WoodenRC;
 
 // static constexpr TunnelGroup kTunnelGroup = TunnelGroup::Square;
 
@@ -869,14 +870,14 @@ static constexpr ImageIndex kStationBlockBrakesImageIds[2][kNumOrthogonalDirecti
     },
 };
 
-static constexpr const uint32_t kWoodenRCDiagBrakeImages[kNumOrthogonalDirections] = {
+static constexpr uint32_t kWoodenRCDiagBrakeImages[kNumOrthogonalDirections] = {
     SPR_TRACKS_WOODEN_RC_DIAG_BRAKES,
     SPR_TRACKS_WOODEN_RC_DIAG_BRAKES + 1,
     SPR_TRACKS_WOODEN_RC_DIAG_BRAKES,
     SPR_TRACKS_WOODEN_RC_DIAG_BRAKES + 1,
 };
 
-static constexpr const uint32_t kWoodenRCDiagBlockBrakeImages[2][kNumOrthogonalDirections] = {
+static constexpr uint32_t kWoodenRCDiagBlockBrakeImages[2][kNumOrthogonalDirections] = {
     {
         SPR_TRACKS_WOODEN_RC_DIAG_BRAKES + 3,
         SPR_TRACKS_WOODEN_RC_DIAG_BRAKES + 5,
@@ -2007,7 +2008,7 @@ static constexpr std::array<std::array<WoodenTrackSection, kNumOrthogonalDirecti
     } },
 } };
 
-ImageId WoodenRCGetRailsColour(PaintSession& session)
+ImageId WoodenRC::WoodenRCGetRailsColour(PaintSession& session)
 {
     return session.TrackColours;
 }
@@ -2032,7 +2033,7 @@ static void WoodenRCTrackFlat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, imageIds[direction][isChained], railsImageIds[direction][isChained], { 0, 2, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     WoodenASupportsPaintSetupRotated(
@@ -2145,12 +2146,12 @@ static void WoodenRCTrack25DegUp(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, imageIds[isChained][direction][0], imageIds[isChained][direction][1], { 0, 0, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     if (direction == 1 || direction == 2)
     {
-        WoodenRCTrackPaint<isClassic>(
+        TrackPaint<isClassic>(
             session, direction, imageIds[isChained][direction][2], imageIds[isChained][direction][3], { 0, 0, height },
             { { 0, 26, height + 5 }, { 32, 1, 9 } });
     }
@@ -2195,13 +2196,13 @@ static void WoodenRCTrack60DegUp(
     {
         if (direction == 0 || direction == 3)
         {
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
         }
         else
         {
-            session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+            session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
                 { { 28, 4, height - 16 }, { 2, 24, 93 } });
         }
@@ -2210,13 +2211,13 @@ static void WoodenRCTrack60DegUp(
     {
         if (direction == 0 || direction == 3)
         {
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
         }
         else
         {
-            session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+            session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
                 { { 28, 4, height - 16 }, { 2, 24, 93 } });
         }
@@ -2301,12 +2302,12 @@ static void WoodenRCTrackFlatTo25DegUp(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, imageIds[isChained][direction][0], imageIds[isChained][direction][1], { 0, 0, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     if (direction == 1 || direction == 2)
     {
-        WoodenRCTrackPaint<isClassic>(
+        TrackPaint<isClassic>(
             session, direction, imageIds[isChained][direction][2], imageIds[isChained][direction][3], { 0, 0, height },
             { { 0, 26, height + 5 }, { 32, 1, 9 } });
     }
@@ -2390,16 +2391,16 @@ static void WoodenRCTrack25DegUpTo60DegUp(
     {
         if (direction == 0 || direction == 3)
         {
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
         }
         else
         {
-            session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+            session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
                 { { 28, 4, height + 2 }, { 2, 24, 43 } });
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][2], imageIdsChained[direction][3], { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 43 } });
         }
@@ -2408,16 +2409,16 @@ static void WoodenRCTrack25DegUpTo60DegUp(
     {
         if (direction == 0 || direction == 3)
         {
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
         }
         else
         {
-            session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+            session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
                 { { 28, 4, height + 2 }, { 2, 24, 43 } });
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIds[direction][2], imageIds[direction][3], { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 43 } });
         }
@@ -2504,16 +2505,16 @@ static void WoodenRCTrack60DegUpTo25DegUp(
     {
         if (direction == 0 || direction == 3)
         {
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
         }
         else
         {
-            session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+            session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][0], imageIdsChained[direction][1], { 0, 0, height },
                 { { 28, 4, height + 2 }, { 2, 24, 43 } });
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIdsChained[direction][2], imageIdsChained[direction][3], { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 43 } });
         }
@@ -2522,16 +2523,16 @@ static void WoodenRCTrack60DegUpTo25DegUp(
     {
         if (direction == 0 || direction == 3)
         {
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
         }
         else
         {
-            session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+            session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                 session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 0, height },
                 { { 28, 4, height + 2 }, { 2, 24, 43 } });
-            WoodenRCTrackPaint<isClassic>(
+            TrackPaint<isClassic>(
                 session, direction, imageIds[direction][2], imageIds[direction][3], { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 43 } });
         }
@@ -2616,12 +2617,12 @@ static void WoodenRCTrack25DegUpToFlat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, imageIds[isChained][direction][0], imageIds[isChained][direction][1], { 0, 0, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     if (direction == 1 || direction == 2)
     {
-        WoodenRCTrackPaint<isClassic>(
+        TrackPaint<isClassic>(
             session, direction, imageIds[isChained][direction][2], imageIds[isChained][direction][3], { 0, 0, height },
             { { 0, 26, height + 5 }, { 32, 1, 9 } });
     }
@@ -3063,7 +3064,7 @@ static void WoodenRCTrackLeftBankToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<isClassic, kFlatToRightBankImages>(
+    TrackFlatToBank<isClassic, kFlatToRightBankImages>(
         session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
@@ -3073,7 +3074,7 @@ static void WoodenRCTrackRightBankToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<isClassic, kFlatToLeftBankImages>(
+    TrackFlatToBank<isClassic, kFlatToLeftBankImages>(
         session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
@@ -3083,7 +3084,7 @@ static void WoodenRCTrackBankedLeftQuarterTurn5(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    WoodenRCTrackBankedRightQuarterTurn5<isClassic, kBankedQuarterTurn5Images>(
+    TrackBankedRightQuarterTurn5<isClassic, kBankedQuarterTurn5Images>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
@@ -3095,7 +3096,7 @@ static void WoodenRCTrackLeftBankTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrack25DegUpToBank<isClassic, kUp25ToRightBankImages>(
+    Track25DegUpToBank<isClassic, kUp25ToRightBankImages>(
         session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
@@ -3105,7 +3106,7 @@ static void WoodenRCTrackRightBankTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrack25DegUpToBank<isClassic, kUp25ToLeftBankImages>(
+    Track25DegUpToBank<isClassic, kUp25ToLeftBankImages>(
         session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
@@ -3115,7 +3116,7 @@ static void WoodenRCTrack25DegDownToLeftBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackBankTo25DegUp<isClassic, kRightBankToUp25Images>(
+    TrackBankTo25DegUp<isClassic, kRightBankToUp25Images>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -3125,7 +3126,7 @@ static void WoodenRCTrack25DegDownToRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackBankTo25DegUp<isClassic, kLeftBankToUp25Images>(
+    TrackBankTo25DegUp<isClassic, kLeftBankToUp25Images>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -3135,7 +3136,7 @@ static void WoodenRCTrackRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
-    WoodenRCTrackFlatToBank<isClassic, kLeftBankImages>(
+    TrackFlatToBank<isClassic, kLeftBankImages>(
         session, ride, trackSequence, (direction + 2) & 3, height, trackElement, supportType);
 }
 
@@ -5195,7 +5196,7 @@ static void WoodenRCTrackRightQuarterTurn3Bank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackLeftQuarterTurn3Bank<isClassic, kBankedQuarterTurn3Images>(
+    TrackLeftQuarterTurn3Bank<isClassic, kBankedQuarterTurn3Images>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -5554,7 +5555,7 @@ static void WoodenRCTrackLeftHalfBankedHelixDownSmall(
         direction = DirectionPrev(direction);
     }
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackRightHalfBankedHelixUpSmall<isClassic, kRightHalfBankedHelixUpSmallImages>(
+    TrackRightHalfBankedHelixUpSmall<isClassic, kRightHalfBankedHelixUpSmallImages>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
@@ -5570,7 +5571,7 @@ static void WoodenRCTrackRightHalfBankedHelixDownSmall(
         direction = DirectionNext(direction);
     }
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackLeftHalfBankedHelixUpSmall<isClassic, kLeftHalfBankedHelixUpSmallImages>(
+    TrackLeftHalfBankedHelixUpSmall<isClassic, kLeftHalfBankedHelixUpSmallImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -5586,7 +5587,7 @@ static void WoodenRCTrackLeftHalfBankedHelixDownLarge(
         direction = DirectionPrev(direction);
     }
     trackSequence = kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    WoodenRCTrackRightHalfBankedHelixUpLarge<isClassic, kRightHalfBankedHelixUpLargeImages>(
+    TrackRightHalfBankedHelixUpLarge<isClassic, kRightHalfBankedHelixUpLargeImages>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
@@ -5602,7 +5603,7 @@ static void WoodenRCTrackRightHalfBankedHelixDownLarge(
         direction = DirectionNext(direction);
     }
     trackSequence = kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
-    WoodenRCTrackLeftHalfBankedHelixUpLarge<isClassic, kLeftHalfBankedHelixUpLargeImages>(
+    TrackLeftHalfBankedHelixUpLarge<isClassic, kLeftHalfBankedHelixUpLargeImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -5781,7 +5782,7 @@ static void WoodenRCTrackBrakes(
         { SPR_WOODEN_RC_BRAKES_NW_SE, SPR_WOODEN_RC_BRAKES_RAILS_NW_SE },
     };
 
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, imageIds[direction][0], imageIds[direction][1], { 0, 2, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     WoodenASupportsPaintSetupRotated(
@@ -6229,13 +6230,13 @@ static void WoodenRCTrackFlatTo60DegUpLongBase(
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
-                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                    session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                         session, direction, SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP + 7,
                         SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP_RAILS + 7, { 0, 0, height },
                         { { 28, 4, height - 16 }, { 2, 24, 56 } });
                     break;
                 case 2:
-                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                    session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                         session, direction, SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP + 11,
                         SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP_RAILS + 11, { 0, 0, height },
                         { { 28, 4, height - 16 }, { 2, 24, 56 } });
@@ -6290,13 +6291,13 @@ static void WoodenRCTrack60DegUpToFlatLongBase(
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 1:
-                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                    session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                         session, direction, SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP + 20,
                         SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP_RAILS + 20, { 0, 0, height },
                         { { 28, 4, height - 16 }, { 2, 24, 76 } });
                     break;
                 case 2:
-                    session.WoodenSupportsPrependTo = WoodenRCTrackPaint<isClassic>(
+                    session.WoodenSupportsPrependTo = TrackPaint<isClassic>(
                         session, direction, SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP + 24,
                         SPR_TRACKS_WOODEN_RC_FLAT_TO_STEEP_RAILS + 24, { 0, 0, height },
                         { { 28, 4, height - 16 }, { 2, 24, 76 } });
@@ -7627,7 +7628,7 @@ static void WoodenRCTrackLeftEighthBankToOrthogonal(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    WoodenRCTrackRightEighthBankToDiag<isClassic, kRightEighthBankToDiagImages>(
+    TrackRightEighthBankToDiag<isClassic, kRightEighthBankToDiagImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -7638,7 +7639,7 @@ static void WoodenRCTrackRightEighthBankToOrthogonal(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
-    WoodenRCTrackLeftEighthBankToDiag<isClassic, kLeftEighthBankToDiagImages>(
+    TrackLeftEighthBankToDiag<isClassic, kLeftEighthBankToDiagImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -7774,10 +7775,10 @@ static void WoodenRCTrackDiagBrakes(
     WoodenRCTrackPaintBb<isClassic>(session, &imageIds[trackSequence][direction][0], height);
     WoodenRCTrackPaintBb<isClassic>(session, &imageIds[trackSequence][direction][0], height);
 
-    if (kWoodenRCDiagonalSupports[trackSequence][direction] != WoodenSupportSubType::null)
+    if (kDiagonalSupports[trackSequence][direction] != WoodenSupportSubType::null)
     {
         WoodenASupportsPaintSetup(
-            session, supportType.wooden, kWoodenRCDiagonalSupports[trackSequence][direction], height, session.SupportColours);
+            session, supportType.wooden, kDiagonalSupports[trackSequence][direction], height, session.SupportColours);
     }
 
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(kSegmentsAll, direction), 0xFFFF, 0);
@@ -8043,10 +8044,10 @@ static void WoodenRCTrackDiagBlockBrakes(
     WoodenRCTrackPaintBb<isClassic>(session, &imageIds[trackElement.IsBrakeClosed()][trackSequence][direction][0], height);
     WoodenRCTrackPaintBb<isClassic>(session, &imageIds[trackElement.IsBrakeClosed()][trackSequence][direction][0], height);
 
-    if (kWoodenRCDiagonalSupports[trackSequence][direction] != WoodenSupportSubType::null)
+    if (kDiagonalSupports[trackSequence][direction] != WoodenSupportSubType::null)
     {
         WoodenASupportsPaintSetup(
-            session, supportType.wooden, kWoodenRCDiagonalSupports[trackSequence][direction], height, session.SupportColours);
+            session, supportType.wooden, kDiagonalSupports[trackSequence][direction], height, session.SupportColours);
     }
 
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(kSegmentsAll, direction), 0xFFFF, 0);
@@ -9870,7 +9871,7 @@ static void WoodenRCTrackDiagLeftBankToFlat(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagFlatToBank<isClassic, kDiagFlatToRightBankImages>(
+    return TrackDiagFlatToBank<isClassic, kDiagFlatToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -9880,7 +9881,7 @@ static void WoodenRCTrackDiagRightBankToFlat(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagFlatToBank<isClassic, kDiagFlatToLeftBankImages>(
+    return TrackDiagFlatToBank<isClassic, kDiagFlatToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -9889,7 +9890,7 @@ static void WoodenRCTrackDiagLeftBankToDown25(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagUp25ToBank<false, kDiagUp25ToRightBankImages>(
+    return TrackDiagUp25ToBank<false, kDiagUp25ToRightBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -9898,7 +9899,7 @@ static void WoodenRCTrackDiagRightBankToDown25(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagUp25ToBank<false, kDiagUp25ToLeftBankImages>(
+    return TrackDiagUp25ToBank<false, kDiagUp25ToLeftBankImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -9908,7 +9909,7 @@ static void WoodenRCTrackDiagDown25ToLeftBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagBankTo25DegUp<isClassic, kDiagRightBankTo25DegUpImages>(
+    return TrackDiagBankTo25DegUp<isClassic, kDiagRightBankTo25DegUpImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
@@ -9918,13 +9919,13 @@ static void WoodenRCTrackDiagDown25ToRightBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapReversedDiagonalStraight[trackSequence];
-    return WoodenRCTrackDiagBankTo25DegUp<isClassic, kDiagLeftBankTo25DegUpImages>(
+    return TrackDiagBankTo25DegUp<isClassic, kDiagLeftBankTo25DegUpImages>(
         session, ride, trackSequence, DirectionReverse(direction), height, trackElement, supportType);
 }
 
 /** rct2: 0x008AC9D8 */
 template<bool isClassic>
-static void WoodenRCTrackDiagLeftBank(
+static void TrackDiagLeftBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
@@ -10151,18 +10152,18 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackRightBankToRightQuarterTurn325DegUp<isClassic, kRightBankToRightQuarterTurn325DegUpImages>(
+    TrackRightBankToRightQuarterTurn325DegUp<isClassic, kRightBankToRightQuarterTurn325DegUpImages>(
         session, ride, trackSequence, DirectionNext(direction), height, trackElement, supportType);
 }
 
 /** rct2: 0x008ACB68 */
 template<bool isClassic>
-static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
+static void TrackRightQuarterTurn325DegDownToRightBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement, SupportType supportType)
 {
     trackSequence = kMapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
-    WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp<isClassic, kLeftBankToLeftQuarterTurn325DegUpImages>(
+    TrackLeftBankToLeftQuarterTurn325DegUp<isClassic, kLeftBankToLeftQuarterTurn325DegUpImages>(
         session, ride, trackSequence, DirectionPrev(direction), height, trackElement, supportType);
 }
 
@@ -10174,7 +10175,7 @@ static void WoodenRCTrackBlockBrakes(
 {
     const auto brakeImg = trackElement.IsBrakeClosed() ? kBlockBrakesImageIds[direction][1]
                                                        : kBlockBrakesImageIds[direction][0];
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, brakeImg, kBlockBrakesImageIds[direction][2], { 0, 2, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     WoodenASupportsPaintSetupRotated(
@@ -12345,7 +12346,7 @@ static void WoodenRCTrackBooster(
         SPR_WOODEN_RC_FLAT_CHAIN_RAILS_SE_NW,
     };
 
-    WoodenRCTrackPaint<isClassic>(
+    TrackPaint<isClassic>(
         session, direction, imageIds[direction], railsImageIds[direction], { 0, 2, height },
         { { 0, 3, height }, { 32, 25, 2 } });
     WoodenASupportsPaintSetupRotated(
@@ -13397,9 +13398,9 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::rightQuarterTurn5Tiles:
             return WoodenRCTrackRightQuarterTurn5<isClassic>;
         case TrackElemType::flatToLeftBank:
-            return WoodenRCTrackFlatToBank<isClassic, kFlatToLeftBankImages>;
+            return TrackFlatToBank<isClassic, kFlatToLeftBankImages>;
         case TrackElemType::flatToRightBank:
-            return WoodenRCTrackFlatToBank<isClassic, kFlatToRightBankImages>;
+            return TrackFlatToBank<isClassic, kFlatToRightBankImages>;
         case TrackElemType::leftBankToFlat:
             return WoodenRCTrackLeftBankToFlat<isClassic>;
         case TrackElemType::rightBankToFlat:
@@ -13407,15 +13408,15 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::bankedLeftQuarterTurn5Tiles:
             return WoodenRCTrackBankedLeftQuarterTurn5<isClassic>;
         case TrackElemType::bankedRightQuarterTurn5Tiles:
-            return WoodenRCTrackBankedRightQuarterTurn5<isClassic, kBankedQuarterTurn5Images>;
+            return TrackBankedRightQuarterTurn5<isClassic, kBankedQuarterTurn5Images>;
         case TrackElemType::leftBankToUp25:
-            return WoodenRCTrackBankTo25DegUp<isClassic, kLeftBankToUp25Images>;
+            return TrackBankTo25DegUp<isClassic, kLeftBankToUp25Images>;
         case TrackElemType::rightBankToUp25:
-            return WoodenRCTrackBankTo25DegUp<isClassic, kRightBankToUp25Images>;
+            return TrackBankTo25DegUp<isClassic, kRightBankToUp25Images>;
         case TrackElemType::up25ToLeftBank:
-            return WoodenRCTrack25DegUpToBank<isClassic, kUp25ToLeftBankImages>;
+            return Track25DegUpToBank<isClassic, kUp25ToLeftBankImages>;
         case TrackElemType::up25ToRightBank:
-            return WoodenRCTrack25DegUpToBank<isClassic, kUp25ToRightBankImages>;
+            return Track25DegUpToBank<isClassic, kUp25ToRightBankImages>;
         case TrackElemType::leftBankToDown25:
             return WoodenRCTrackLeftBankTo25DegDown<isClassic>;
         case TrackElemType::rightBankToDown25:
@@ -13425,7 +13426,7 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::down25ToRightBank:
             return WoodenRCTrack25DegDownToRightBank<isClassic>;
         case TrackElemType::leftBank:
-            return WoodenRCTrackFlatToBank<isClassic, kLeftBankImages>;
+            return TrackFlatToBank<isClassic, kLeftBankImages>;
         case TrackElemType::rightBank:
             return WoodenRCTrackRightBank<isClassic>;
         case TrackElemType::leftQuarterTurn5TilesUp25:
@@ -13449,7 +13450,7 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::rightQuarterTurn3Tiles:
             return WoodenRCTrackRightQuarterTurn3<isClassic>;
         case TrackElemType::leftBankedQuarterTurn3Tiles:
-            return WoodenRCTrackLeftQuarterTurn3Bank<isClassic, kBankedQuarterTurn3Images>;
+            return TrackLeftQuarterTurn3Bank<isClassic, kBankedQuarterTurn3Images>;
         case TrackElemType::rightBankedQuarterTurn3Tiles:
             return WoodenRCTrackRightQuarterTurn3Bank<isClassic>;
         case TrackElemType::leftQuarterTurn3TilesUp25:
@@ -13461,17 +13462,17 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::rightQuarterTurn3TilesDown25:
             return WoodenRCTrackRightQuarterTurn325DegDown<isClassic>;
         case TrackElemType::leftHalfBankedHelixUpSmall:
-            return WoodenRCTrackLeftHalfBankedHelixUpSmall<isClassic, kLeftHalfBankedHelixUpSmallImages>;
+            return TrackLeftHalfBankedHelixUpSmall<isClassic, kLeftHalfBankedHelixUpSmallImages>;
         case TrackElemType::rightHalfBankedHelixUpSmall:
-            return WoodenRCTrackRightHalfBankedHelixUpSmall<isClassic, kRightHalfBankedHelixUpSmallImages>;
+            return TrackRightHalfBankedHelixUpSmall<isClassic, kRightHalfBankedHelixUpSmallImages>;
         case TrackElemType::leftHalfBankedHelixDownSmall:
             return WoodenRCTrackLeftHalfBankedHelixDownSmall<isClassic>;
         case TrackElemType::rightHalfBankedHelixDownSmall:
             return WoodenRCTrackRightHalfBankedHelixDownSmall<isClassic>;
         case TrackElemType::leftHalfBankedHelixUpLarge:
-            return WoodenRCTrackLeftHalfBankedHelixUpLarge<isClassic, kLeftHalfBankedHelixUpLargeImages>;
+            return TrackLeftHalfBankedHelixUpLarge<isClassic, kLeftHalfBankedHelixUpLargeImages>;
         case TrackElemType::rightHalfBankedHelixUpLarge:
-            return WoodenRCTrackRightHalfBankedHelixUpLarge<isClassic, kRightHalfBankedHelixUpLargeImages>;
+            return TrackRightHalfBankedHelixUpLarge<isClassic, kRightHalfBankedHelixUpLargeImages>;
         case TrackElemType::leftHalfBankedHelixDownLarge:
             return WoodenRCTrackLeftHalfBankedHelixDownLarge<isClassic>;
         case TrackElemType::rightHalfBankedHelixDownLarge:
@@ -13515,9 +13516,9 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::rightEighthToOrthogonal:
             return WoodenRCTrackRightEighthToOrthogonal<isClassic>;
         case TrackElemType::leftEighthBankToDiag:
-            return WoodenRCTrackLeftEighthBankToDiag<isClassic, kLeftEighthBankToDiagImages>;
+            return TrackLeftEighthBankToDiag<isClassic, kLeftEighthBankToDiagImages>;
         case TrackElemType::rightEighthBankToDiag:
-            return WoodenRCTrackRightEighthBankToDiag<isClassic, kRightEighthBankToDiagImages>;
+            return TrackRightEighthBankToDiag<isClassic, kRightEighthBankToDiagImages>;
         case TrackElemType::leftEighthBankToOrthogonal:
             return WoodenRCTrackLeftEighthBankToOrthogonal<isClassic>;
         case TrackElemType::rightEighthBankToOrthogonal:
@@ -13549,21 +13550,21 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::diagDown25ToFlat:
             return WoodenRCTrackDiag25DegDownToFlat<isClassic>;
         case TrackElemType::diagFlatToLeftBank:
-            return WoodenRCTrackDiagFlatToBank<isClassic, kDiagFlatToLeftBankImages>;
+            return TrackDiagFlatToBank<isClassic, kDiagFlatToLeftBankImages>;
         case TrackElemType::diagFlatToRightBank:
-            return WoodenRCTrackDiagFlatToBank<isClassic, kDiagFlatToRightBankImages>;
+            return TrackDiagFlatToBank<isClassic, kDiagFlatToRightBankImages>;
         case TrackElemType::diagLeftBankToFlat:
             return WoodenRCTrackDiagLeftBankToFlat<isClassic>;
         case TrackElemType::diagRightBankToFlat:
             return WoodenRCTrackDiagRightBankToFlat<isClassic>;
         case TrackElemType::diagLeftBankToUp25:
-            return WoodenRCTrackDiagBankTo25DegUp<isClassic, kDiagLeftBankTo25DegUpImages>;
+            return TrackDiagBankTo25DegUp<isClassic, kDiagLeftBankTo25DegUpImages>;
         case TrackElemType::diagRightBankToUp25:
-            return WoodenRCTrackDiagBankTo25DegUp<isClassic, kDiagRightBankTo25DegUpImages>;
+            return TrackDiagBankTo25DegUp<isClassic, kDiagRightBankTo25DegUpImages>;
         case TrackElemType::diagUp25ToLeftBank:
-            return WoodenRCTrackDiagUp25ToBank<isClassic, kDiagUp25ToLeftBankImages>;
+            return TrackDiagUp25ToBank<isClassic, kDiagUp25ToLeftBankImages>;
         case TrackElemType::diagUp25ToRightBank:
-            return WoodenRCTrackDiagUp25ToBank<isClassic, kDiagUp25ToRightBankImages>;
+            return TrackDiagUp25ToBank<isClassic, kDiagUp25ToRightBankImages>;
         case TrackElemType::diagLeftBankToDown25:
             return WoodenRCTrackDiagLeftBankToDown25;
         case TrackElemType::diagRightBankToDown25:
@@ -13573,17 +13574,17 @@ TrackPaintFunction GetTrackPaintFunctionWoodenAndClassicWoodenRC(TrackElemType t
         case TrackElemType::diagDown25ToRightBank:
             return WoodenRCTrackDiagDown25ToRightBank<isClassic>;
         case TrackElemType::diagLeftBank:
-            return WoodenRCTrackDiagLeftBank<isClassic>;
+            return TrackDiagLeftBank<isClassic>;
         case TrackElemType::diagRightBank:
             return WoodenRCTrackDiagRightBank<isClassic>;
         case TrackElemType::leftBankToLeftQuarterTurn3TilesUp25:
-            return WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp<isClassic, kLeftBankToLeftQuarterTurn325DegUpImages>;
+            return TrackLeftBankToLeftQuarterTurn325DegUp<isClassic, kLeftBankToLeftQuarterTurn325DegUpImages>;
         case TrackElemType::rightBankToRightQuarterTurn3TilesUp25:
-            return WoodenRCTrackRightBankToRightQuarterTurn325DegUp<isClassic, kRightBankToRightQuarterTurn325DegUpImages>;
+            return TrackRightBankToRightQuarterTurn325DegUp<isClassic, kRightBankToRightQuarterTurn325DegUpImages>;
         case TrackElemType::leftQuarterTurn3TilesDown25ToLeftBank:
             return WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank<isClassic>;
         case TrackElemType::rightQuarterTurn3TilesDown25ToRightBank:
-            return WoodenRCTrackRightQuarterTurn325DegDownToRightBank<isClassic>;
+            return TrackRightQuarterTurn325DegDownToRightBank<isClassic>;
         case TrackElemType::blockBrakes:
             return WoodenRCTrackBlockBrakes<isClassic>;
         case TrackElemType::leftBankedQuarterTurn3TileUp25:
@@ -13682,7 +13683,7 @@ TrackPaintFunction GetTrackPaintFunctionWoodenRC(TrackElemType trackType)
     return GetTrackPaintFunctionWoodenAndClassicWoodenRC<false>(trackType);
 }
 
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(TrackElemType trackType)
+TrackPaintFunction WoodenRC::GetTrackPaintFunctionClassicWoodenRCFallback(TrackElemType trackType)
 {
     return GetTrackPaintFunctionWoodenAndClassicWoodenRC<true>(trackType);
 }

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
@@ -120,13 +120,13 @@ static void WoodenRCTrackStraightBankTrack(PaintSession& session, uint8_t direct
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 void WoodenRCTrackFlatToBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     WoodenRCTrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
     WoodenASupportsPaintSetupRotated(
         session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours);
     PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
@@ -134,7 +134,7 @@ void WoodenRCTrackFlatToBank(
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 static void WoodenRCTrack25DegUpToBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     WoodenRCTrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
     WoodenASupportsPaintSetupRotated(
@@ -148,7 +148,7 @@ static void WoodenRCTrack25DegUpToBank(
     {
         PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::FlatTo25Deg);
     }
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 40);
 }
 
@@ -156,7 +156,7 @@ static void WoodenRCTrack25DegUpToBank(
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 static void WoodenRCTrackBankTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     WoodenRCTrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
     WoodenASupportsPaintSetupRotated(
@@ -170,7 +170,7 @@ static void WoodenRCTrackBankTo25DegUp(
     {
         PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::SlopeEnd);
     }
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
@@ -178,7 +178,7 @@ static void WoodenRCTrackBankTo25DegUp(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
 static void WoodenRCTrackLeftQuarterTurn3Bank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -297,13 +297,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
     TrackPaintUtilLeftQuarterTurn3TilesTunnel(session, kTunnelGroup, TunnelSubType::Flat, height, direction, trackSequence);
 
     static constexpr int blockedSegments[4] = {
-        kSegmentsAll,
-        kSegmentsNone,
-        EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
-        kSegmentsAll,
+        OpenRCT2::kSegmentsAll,
+        OpenRCT2::kSegmentsNone,
+        EnumsToFlags(
+            OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+            OpenRCT2::PaintSegment::bottomLeft),
+        OpenRCT2::kSegmentsAll,
     };
 
-    DrawSupportForSequenceA<TrackElemType::leftBankedQuarterTurn3Tiles>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftBankedQuarterTurn3Tiles>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -312,7 +314,7 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
 static void WoodenRCTrackBankedRightQuarterTurn5(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -506,22 +508,23 @@ static void WoodenRCTrackBankedRightQuarterTurn5(
     TrackPaintUtilRightQuarterTurn5TilesTunnel(session, kTunnelGroup, TunnelSubType::Flat, height, direction, trackSequence);
 
     static constexpr int blockedSegments[7] = {
-        kSegmentsAll,
-        EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight),
+        OpenRCT2::kSegmentsAll,
+        EnumsToFlags(OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
         EnumsToFlags(
-            PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
-            PaintSegment::bottomRight),
+            OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+            OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
         EnumsToFlags(
-            PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::centre, PaintSegment::topLeft,
-            PaintSegment::topRight, PaintSegment::bottomLeft, PaintSegment::bottomRight),
-        EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight),
+            OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
+            OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight,
+            OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
+        EnumsToFlags(OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
         EnumsToFlags(
-            PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-            PaintSegment::bottomRight),
-        kSegmentsAll,
+            OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+            OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
+        OpenRCT2::kSegmentsAll,
     };
 
-    DrawSupportForSequenceA<TrackElemType::bankedRightQuarterTurn5Tiles>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::bankedRightQuarterTurn5Tiles>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -531,7 +534,7 @@ static void WoodenRCTrackBankedRightQuarterTurn5(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
 static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -586,15 +589,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
-                        PaintSegment::bottomLeft),
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -660,7 +665,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -721,15 +728,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -790,15 +799,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -865,7 +876,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -921,15 +933,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topLeft),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -941,7 +955,7 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
 static void WoodenRCTrackRightHalfBankedHelixUpSmall(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -996,15 +1010,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topLeft),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1071,7 +1087,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1132,15 +1149,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1201,15 +1220,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1275,7 +1296,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1331,15 +1354,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
-                        PaintSegment::bottomLeft),
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1351,7 +1376,7 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
 static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -1406,15 +1431,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
-                        PaintSegment::bottomLeft),
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1423,7 +1450,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -1475,8 +1504,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::topRight, PaintSegment::bottomLeft),
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1528,13 +1557,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::bottom, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1543,7 +1576,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -1595,8 +1630,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1657,15 +1693,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1726,15 +1764,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1743,7 +1783,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -1795,8 +1837,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1848,13 +1891,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1863,7 +1910,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -1915,8 +1964,9 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1972,15 +2022,17 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topLeft),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -1992,7 +2044,7 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
 static void WoodenRCTrackRightHalfBankedHelixUpLarge(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -2047,15 +2099,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topLeft),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2064,7 +2118,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -2116,8 +2172,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2169,13 +2226,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2184,7 +2245,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -2236,8 +2299,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2298,15 +2362,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2367,15 +2433,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
+                        OpenRCT2::PaintSegment::topRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
-                        PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2384,7 +2452,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -2436,8 +2506,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2489,13 +2560,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::top, PaintSegment::bottom, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2504,7 +2579,9 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
+                    direction),
                 48, 0x20);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
             break;
@@ -2556,8 +2633,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
-                        PaintSegment::topRight, PaintSegment::bottomLeft),
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre,
+                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2613,15 +2690,17 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 48, 0x20);
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
-                        PaintSegment::bottomLeft),
+                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
@@ -2633,7 +2712,7 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
 static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -2685,143 +2764,7 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
             {
                 PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
             }
-            PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
-        case 1:
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-        case 2:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 2:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
-                    break;
-                case 3:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
-    }
-}
-
-/** rct2: 0x008ACB48 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
-static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
-    {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 64);
             break;
         case 1:
@@ -2832,7 +2775,146 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                 session,
                 PaintUtilRotateSegments(
                     EnumsToFlags(
-                        PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
+                        OpenRCT2::PaintSegment::bottomLeft),
+                    direction),
+                0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 48);
+            break;
+        case 3:
+            switch (direction)
+            {
+                case 0:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                    break;
+                case 1:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
+                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                    {
+                        WoodenRCTrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                    }
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                    break;
+                case 2:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
+                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                    {
+                        WoodenRCTrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                    }
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                    break;
+                case 3:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
+                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                    {
+                        WoodenRCTrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                    }
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                    break;
+            }
+            switch (direction)
+            {
+                case 2:
+                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+                    break;
+                case 3:
+                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+                    break;
+            }
+            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 64);
+            break;
+    }
+}
+
+/** rct2: 0x008ACB48 */
+template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
+static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
+{
+    switch (trackSequence)
+    {
+        case 0:
+            switch (direction)
+            {
+                case 0:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
+                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                    {
+                        WoodenRCTrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
+                    }
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                    break;
+                case 1:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                    break;
+                case 2:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
+                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                    {
+                        WoodenRCTrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
+                    }
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                    break;
+                case 3:
+                    WoodenRCTrackPaint<isClassic>(
+                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
+                    WoodenASupportsPaintSetup(
+                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                    break;
+            }
+            if (direction == 0 || direction == 3)
+            {
+                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+            }
+            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
+            PaintUtilSetGeneralSupportHeight(session, height + 64);
+            break;
+        case 1:
+            PaintUtilSetGeneralSupportHeight(session, height + 48);
+            break;
+        case 2:
+            PaintUtilSetSegmentSupportHeight(
+                session,
+                PaintUtilRotateSegments(
+                    EnumsToFlags(
+                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::bottomLeft,
+                        OpenRCT2::PaintSegment::bottomRight),
                     direction),
                 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 48);
@@ -2896,7 +2978,7 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                     PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
                     break;
             }
-            PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
             PaintUtilSetGeneralSupportHeight(session, height + 64);
             break;
     }
@@ -2906,7 +2988,7 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 static void WoodenRCTrackDiagFlatToBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -2964,9 +3046,9 @@ static void WoodenRCTrackDiagFlatToBank(
             break;
     }
 
-    DrawSupportForSequenceA<TrackElemType::diagFlat>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlat>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
@@ -2974,7 +3056,7 @@ static void WoodenRCTrackDiagFlatToBank(
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 static void WoodenRCTrackDiagBankTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -3032,9 +3114,9 @@ static void WoodenRCTrackDiagBankTo25DegUp(
             break;
     }
 
-    DrawSupportForSequenceA<TrackElemType::diagFlatToUp25>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlatToUp25>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48);
 }
 
@@ -3042,7 +3124,7 @@ static void WoodenRCTrackDiagBankTo25DegUp(
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 static void WoodenRCTrackDiagUp25ToBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -3100,9 +3182,9 @@ static void WoodenRCTrackDiagUp25ToBank(
             break;
     }
 
-    DrawSupportForSequenceB<TrackElemType::diagUp25ToFlat>(
+    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp25ToFlat>(
         session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56);
 }
 
@@ -3110,7 +3192,7 @@ static void WoodenRCTrackDiagUp25ToBank(
 template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
 static void WoodenRCTrackDiagLeftBank(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -3168,9 +3250,9 @@ static void WoodenRCTrackDiagLeftBank(
             break;
     }
 
-    DrawSupportForSequenceA<TrackElemType::diagLeftBank>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagLeftBank>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
@@ -3178,7 +3260,7 @@ static void WoodenRCTrackDiagLeftBank(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 4> imageIds>
 static void WoodenRCTrackLeftEighthBankToDiag(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -3336,9 +3418,9 @@ static void WoodenRCTrackLeftEighthBankToDiag(
             break;
     }
 
-    DrawSupportForSequenceA<TrackElemType::leftEighthBankToDiag>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftEighthBankToDiag>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
@@ -3346,7 +3428,7 @@ static void WoodenRCTrackLeftEighthBankToDiag(
 template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 4> imageIds>
 static void WoodenRCTrackRightEighthBankToDiag(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const TrackElement& trackElement, SupportType supportType)
+    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
 {
     switch (trackSequence)
     {
@@ -3504,10 +3586,10 @@ static void WoodenRCTrackRightEighthBankToDiag(
             break;
     }
 
-    DrawSupportForSequenceA<TrackElemType::rightEighthBankToDiag>(
+    DrawSupportForSequenceA<OpenRCT2::TrackElemType::rightEighthBankToDiag>(
         session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
 }
 
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(TrackElemType trackType);
+TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(OpenRCT2::TrackElemType trackType);

--- a/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
+++ b/src/openrct2/paint/track/coaster/WoodenRollerCoaster.hpp
@@ -23,3573 +23,3502 @@
 
 static constexpr TunnelGroup kTunnelGroup = TunnelGroup::Square;
 
-struct WoodenTrackSection
+namespace OpenRCT2::WoodenRC
 {
-    ImageIndex track;
-    ImageIndex handrail = kImageIndexUndefined;
-    ImageIndex frontTrack = kImageIndexUndefined;
-    ImageIndex frontHandrail = kImageIndexUndefined;
-};
-
-struct SpriteBoundBox2
-{
-    ImageIndex ImageIdA;
-    ImageIndex ImageIdB;
-    CoordsXYZ offset;
-    ::BoundBoxXYZ BoundBox;
-};
-
-// Magic number 4 refers to the number of track blocks in a diagonal track element
-static constexpr const WoodenSupportSubType kWoodenRCDiagonalSupports[4][kNumOrthogonalDirections] = {
-    { WoodenSupportSubType::null, WoodenSupportSubType::null, WoodenSupportSubType::null,
-      WoodenSupportSubType::null }, // sequence 0
-    { WoodenSupportSubType::corner0, WoodenSupportSubType::corner1, WoodenSupportSubType::corner2,
-      WoodenSupportSubType::corner3 }, // sequence 1
-    { WoodenSupportSubType::corner2, WoodenSupportSubType::corner3, WoodenSupportSubType::corner0,
-      WoodenSupportSubType::corner1 }, // sequence 2
-    { WoodenSupportSubType::null, WoodenSupportSubType::null, WoodenSupportSubType::null,
-      WoodenSupportSubType::null } // sequence 3
-};
-
-template<bool isClassic>
-ImageId WoodenRCGetTrackColour(const PaintSession& session)
-{
-    if (isClassic)
-        return session.TrackColours;
-    else
-        return session.SupportColours;
-}
-
-ImageId WoodenRCGetRailsColour(PaintSession& session);
-
-template<bool isClassic>
-PaintStruct* WoodenRCTrackPaint(
-    PaintSession& session, uint8_t direction, ImageIndex imageIdTrack, ImageIndex imageIdRails, const CoordsXYZ& offset,
-    const BoundBoxXYZ& boundBox)
-{
-    if (isClassic)
+    struct WoodenTrackSection
     {
-        const ImageId imageId = session.TrackColours.WithIndex(imageIdTrack);
+        ImageIndex track;
+        ImageIndex handrail = kImageIndexUndefined;
+        ImageIndex frontTrack = kImageIndexUndefined;
+        ImageIndex frontHandrail = kImageIndexUndefined;
+    };
 
-        return PaintAddImageAsParentRotated(session, direction, imageId, offset, boundBox);
+    struct SpriteBoundBox2
+    {
+        ImageIndex ImageIdA;
+        ImageIndex ImageIdB;
+        CoordsXYZ offset;
+        BoundBoxXYZ BoundBox;
+    };
+
+    // Magic number 4 refers to the number of track blocks in a diagonal track element
+    static constexpr WoodenSupportSubType kDiagonalSupports[4][kNumOrthogonalDirections] = {
+        { WoodenSupportSubType::null, WoodenSupportSubType::null, WoodenSupportSubType::null,
+          WoodenSupportSubType::null }, // sequence 0
+        { WoodenSupportSubType::corner0, WoodenSupportSubType::corner1, WoodenSupportSubType::corner2,
+          WoodenSupportSubType::corner3 }, // sequence 1
+        { WoodenSupportSubType::corner2, WoodenSupportSubType::corner3, WoodenSupportSubType::corner0,
+          WoodenSupportSubType::corner1 }, // sequence 2
+        { WoodenSupportSubType::null, WoodenSupportSubType::null, WoodenSupportSubType::null,
+          WoodenSupportSubType::null } // sequence 3
+    };
+
+    template<bool isClassic>
+    ImageId WoodenRCGetTrackColour(const PaintSession& session)
+    {
+        if (isClassic)
+            return session.TrackColours;
+        else
+            return session.SupportColours;
     }
-    else
-    {
-        const ImageId imageId = session.SupportColours.WithIndex(imageIdTrack);
-        const ImageId railsImageId = WoodenRCGetRailsColour(session).WithIndex(imageIdRails);
 
-        PaintAddImageAsParentRotated(session, direction, imageId, offset, boundBox);
-        return PaintAddImageAsChildRotated(session, direction, railsImageId, offset, boundBox);
+    ImageId WoodenRCGetRailsColour(PaintSession& session);
+
+    template<bool isClassic>
+    PaintStruct* TrackPaint(
+        PaintSession& session, uint8_t direction, ImageIndex imageIdTrack, ImageIndex imageIdRails, const CoordsXYZ& offset,
+        const BoundBoxXYZ& boundBox)
+    {
+        if (isClassic)
+        {
+            const ImageId imageId = session.TrackColours.WithIndex(imageIdTrack);
+
+            return PaintAddImageAsParentRotated(session, direction, imageId, offset, boundBox);
+        }
+        else
+        {
+            const ImageId imageId = session.SupportColours.WithIndex(imageIdTrack);
+            const ImageId railsImageId = WoodenRCGetRailsColour(session).WithIndex(imageIdRails);
+
+            PaintAddImageAsParentRotated(session, direction, imageId, offset, boundBox);
+            return PaintAddImageAsChildRotated(session, direction, railsImageId, offset, boundBox);
+        }
     }
-}
 
-template<bool isClassic>
-void WoodenRCTrackPaintBb(PaintSession& session, const SpriteBoundBox2* bb, int16_t height)
-{
-    if (bb->ImageIdA == 0)
-        return;
-
-    ImageId imageId = WoodenRCGetTrackColour<isClassic>(session).WithIndex(bb->ImageIdA);
-    PaintAddImageAsParent(
-        session, imageId, { bb->offset.x, bb->offset.y, height + bb->offset.z },
-        { { bb->BoundBox.offset.x, bb->BoundBox.offset.y, height + bb->BoundBox.offset.z }, bb->BoundBox.length });
-    if (bb->ImageIdB != 0)
+    template<bool isClassic>
+    void WoodenRCTrackPaintBb(PaintSession& session, const SpriteBoundBox2* bb, int16_t height)
     {
-        ImageId railsImageId = WoodenRCGetRailsColour(session).WithIndex(bb->ImageIdB);
-        PaintAddImageAsChild(
-            session, railsImageId, { bb->offset.x, bb->offset.y, height + bb->offset.z },
-            { { bb->BoundBox.offset, height + bb->BoundBox.offset.z }, bb->BoundBox.length });
+        if (bb->ImageIdA == 0)
+            return;
+
+        ImageId imageId = WoodenRCGetTrackColour<isClassic>(session).WithIndex(bb->ImageIdA);
+        PaintAddImageAsParent(
+            session, imageId, { bb->offset.x, bb->offset.y, height + bb->offset.z },
+            { { bb->BoundBox.offset.x, bb->BoundBox.offset.y, height + bb->BoundBox.offset.z }, bb->BoundBox.length });
+        if (bb->ImageIdB != 0)
+        {
+            ImageId railsImageId = WoodenRCGetRailsColour(session).WithIndex(bb->ImageIdB);
+            PaintAddImageAsChild(
+                session, railsImageId, { bb->offset.x, bb->offset.y, height + bb->offset.z },
+                { { bb->BoundBox.offset, height + bb->BoundBox.offset.z }, bb->BoundBox.length });
+        }
     }
-}
 
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrackStraightBankTrack(PaintSession& session, uint8_t direction, int32_t height)
-{
-    WoodenRCTrackPaint<isClassic>(
-        session, direction, imageIds[direction].track, imageIds[direction].handrail, { 0, 0, height },
-        { { 0, 3, height }, { 32, 25, 2 } });
-    if (imageIds[direction].frontTrack != kImageIndexUndefined)
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void TrackStraightBankTrack(PaintSession& session, uint8_t direction, int32_t height)
     {
-        WoodenRCTrackPaint<isClassic>(
-            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail, { 0, 0, height },
-            { { 0, 26, height + 5 }, { 32, 1, 9 } });
+        TrackPaint<isClassic>(
+            session, direction, imageIds[direction].track, imageIds[direction].handrail, { 0, 0, height },
+            { { 0, 3, height }, { 32, 25, 2 } });
+        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+        {
+            TrackPaint<isClassic>(
+                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail, { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
+        }
     }
-}
 
-/** rct2: 0x008AC658, 0x008AC668, 0x008AC738 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-void WoodenRCTrackFlatToBank(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    WoodenRCTrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
-    WoodenASupportsPaintSetupRotated(
-        session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours);
-    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
-
-/** rct2: 0x008AC6D8, 0x008AC6E8 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrack25DegUpToBank(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    WoodenRCTrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
-    WoodenASupportsPaintSetupRotated(
-        session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::up25DegToFlat);
-    if (direction == 0 || direction == 3)
+    /** rct2: 0x008AC658, 0x008AC668, 0x008AC738 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    void TrackFlatToBank(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::Flat);
-    }
-    else
-    {
-        PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::FlatTo25Deg);
-    }
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 40);
-}
-
-/** rct2: 0x008AC6B8, 0x008AC6C8 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrackBankTo25DegUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    WoodenRCTrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
-    WoodenASupportsPaintSetupRotated(
-        session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
-        WoodenSupportTransitionType::flatToUp25Deg);
-    if (direction == 0 || direction == 3)
-    {
+        TrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
+        WoodenASupportsPaintSetupRotated(
+            session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours);
         PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
     }
-    else
+
+    /** rct2: 0x008AC6D8, 0x008AC6E8 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void Track25DegUpToBank(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+        TrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
+        WoodenASupportsPaintSetupRotated(
+            session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
+            WoodenSupportTransitionType::up25DegToFlat);
+        if (direction == 0 || direction == 3)
+        {
+            PaintUtilPushTunnelRotated(session, direction, height - 8, kTunnelGroup, TunnelSubType::Flat);
+        }
+        else
+        {
+            PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::FlatTo25Deg);
+        }
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + 40);
     }
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 48);
-}
 
-/** rct2: 0x008AC808 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
-static void WoodenRCTrackLeftQuarterTurn3Bank(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008AC6B8, 0x008AC6C8 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void TrackBankTo25DegUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    break;
-            }
+        TrackStraightBankTrack<isClassic, imageIds>(session, direction, height);
+        WoodenASupportsPaintSetupRotated(
+            session, supportType.wooden, WoodenSupportSubType::neSw, direction, height, session.SupportColours,
+            WoodenSupportTransitionType::flatToUp25Deg);
+        if (direction == 0 || direction == 3)
+        {
+            PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+        }
+        else
+        {
+            PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+        }
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + 48);
     }
 
-    TrackPaintUtilLeftQuarterTurn3TilesTunnel(session, kTunnelGroup, TunnelSubType::Flat, height, direction, trackSequence);
-
-    static constexpr int blockedSegments[4] = {
-        OpenRCT2::kSegmentsAll,
-        OpenRCT2::kSegmentsNone,
-        EnumsToFlags(
-            OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-            OpenRCT2::PaintSegment::bottomLeft),
-        OpenRCT2::kSegmentsAll,
-    };
-
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftBankedQuarterTurn3Tiles>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
-
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
-static void WoodenRCTrackBankedRightQuarterTurn5(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008AC808 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
+    static void TrackLeftQuarterTurn3Bank(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 32, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 32, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 27, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 27, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 27, 2 } });
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    break;
-            }
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-            }
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    break;
-            }
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 32, 32, 2 } });
-                    if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
-                            { 0, 0, height }, { { 2, 0, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 27, 32, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 27, 32, 2 } });
-                    if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
-                            { 0, 0, height }, { { 2, 0, height + 27 }, { 27, 32, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        break;
+                }
+        }
+
+        TrackPaintUtilLeftQuarterTurn3TilesTunnel(session, kTunnelGroup, TunnelSubType::Flat, height, direction, trackSequence);
+
+        static constexpr int blockedSegments[4] = {
+            kSegmentsAll,
+            kSegmentsNone,
+            EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+            kSegmentsAll,
+        };
+
+        DrawSupportForSequenceA<TrackElemType::leftBankedQuarterTurn3Tiles>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(
+            session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
     }
 
-    TrackPaintUtilRightQuarterTurn5TilesTunnel(session, kTunnelGroup, TunnelSubType::Flat, height, direction, trackSequence);
-
-    static constexpr int blockedSegments[7] = {
-        OpenRCT2::kSegmentsAll,
-        EnumsToFlags(OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
-        EnumsToFlags(
-            OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-            OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-        EnumsToFlags(
-            OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
-            OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight,
-            OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-        EnumsToFlags(OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
-        EnumsToFlags(
-            OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-            OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-        OpenRCT2::kSegmentsAll,
-    };
-
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::bankedRightQuarterTurn5Tiles>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
-
-/** rct2: 0x008ACAB8 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
-static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
+    static void TrackBankedRightQuarterTurn5(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 2:
-                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 3:
-                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 4:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[0][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][3].frontTrack, imageIds[0][3].frontHandrail, { 0, 0, height },
-                            { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[0][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][1].frontTrack, imageIds[0][1].frontHandrail, { 0, 0, height },
-                            { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 0:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 1:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[1][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][3].frontTrack, imageIds[1][3].frontHandrail, { 0, 0, height },
-                            { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[1][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][1].frontTrack, imageIds[1][1].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 7:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
-                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
-                    if (imageIds[2][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][3].frontTrack, imageIds[2][3].frontHandrail, { 0, 0, height },
-                            { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[2][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][1].frontTrack, imageIds[2][1].frontHandrail, { 0, 0, height },
-                            { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topLeft),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-    }
-}
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 32, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 32, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 27, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 27, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 27, 2 } });
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        break;
+                }
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                }
+                break;
+            case 5:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        break;
+                }
+                break;
+            case 6:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 32, 32, 2 } });
+                        if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
+                                { 0, 0, height }, { { 2, 0, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 27, 32, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 27, 32, 2 } });
+                        if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
+                                { 0, 0, height }, { { 2, 0, height + 27 }, { 27, 32, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+        }
 
-/** rct2: 0x008ACAC8 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
-static void WoodenRCTrackRightHalfBankedHelixUpSmall(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+        TrackPaintUtilRightQuarterTurn5TilesTunnel(
+            session, kTunnelGroup, TunnelSubType::Flat, height, direction, trackSequence);
+
+        static constexpr int blockedSegments[7] = {
+            kSegmentsAll,
+            EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight),
+            EnumsToFlags(
+                PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                PaintSegment::bottomLeft, PaintSegment::bottomRight),
+            EnumsToFlags(
+                PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::centre, PaintSegment::topLeft,
+                PaintSegment::topRight, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+            EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight),
+            EnumsToFlags(
+                PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                PaintSegment::bottomRight),
+            kSegmentsAll,
+        };
+
+        DrawSupportForSequenceA<TrackElemType::bankedRightQuarterTurn5Tiles>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(
+            session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+    }
+
+    /** rct2: 0x008ACAB8 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
+    static void TrackLeftHalfBankedHelixUpSmall(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topLeft),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 0:
-                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 1:
-                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 4:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[0][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][2].frontTrack, imageIds[0][2].frontHandrail, { 0, 0, height },
-                            { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[0][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][0].frontTrack, imageIds[0][0].frontHandrail, { 0, 0, height },
-                            { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 2:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 3:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[1][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][2].frontTrack, imageIds[1][2].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[1][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][0].frontTrack, imageIds[1][0].frontHandrail, { 0, 0, height },
-                            { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 7:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[2][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][2].frontTrack, imageIds[2][2].frontHandrail, { 0, 0, height },
-                            { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
-                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
-                    if (imageIds[2][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][0].frontTrack, imageIds[2][0].frontHandrail, { 0, 0, height },
-                            { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
+                            PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 1:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 2:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 3:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height + 8 }, { 20, 32, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 2:
+                        PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 3:
+                        PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 4:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[0][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][3].frontTrack, imageIds[0][3].frontHandrail, { 0, 0, height },
+                                { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[0][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][1].frontTrack, imageIds[0][1].frontHandrail, { 0, 0, height },
+                                { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 0:
+                        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 1:
+                        PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 5:
+                switch (direction)
+                {
+                    case 0:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 1:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 2:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 3:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 6:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[1][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][3].frontTrack, imageIds[1][3].frontHandrail, { 0, 0, height },
+                                { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[1][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][1].frontTrack, imageIds[1][1].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 7:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
+                            { { 0, 6, height + 8 }, { 32, 20, 2 } });
+                        if (imageIds[2][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][3].frontTrack, imageIds[2][3].frontHandrail, { 0, 0, height },
+                                { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[2][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][1].frontTrack, imageIds[2][1].frontHandrail, { 0, 0, height },
+                                { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+        }
     }
-}
 
-/** rct2: 0x008ACAF8 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
-static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACAC8 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 3> imageIds>
+    static void TrackRightHalfBankedHelixUpSmall(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 27, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 27, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 1:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 29 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 4:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 33 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 27, 32, 2 } });
-                    if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
-                            { 0, 0, height }, { { 2, 0, height + 33 }, { 27, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
-                    if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 2:
-                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 3:
-                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 7:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[0][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][3].frontTrack, imageIds[0][3].frontHandrail, { 0, 0, height },
-                            { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 27, 32, 2 } });
-                    if (imageIds[0][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][1].frontTrack, imageIds[0][1].frontHandrail, { 0, 0, height },
-                            { { 2, 0, height + 27 }, { 27, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 0:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 1:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 8:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 9:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[1][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][3].frontTrack, imageIds[1][3].frontHandrail, { 0, 0, height },
-                            { { 16, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[1][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][1].frontTrack, imageIds[1][1].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 10:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][3].frontTrack, imageIds[2][3].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[2][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][1].frontTrack, imageIds[2][1].frontHandrail, { 0, 0, height },
-                            { { 16, 16, height + 29 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 11:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 12:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][3].track, imageIds[3][3].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[3][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][3].frontTrack, imageIds[3][3].frontHandrail, { 0, 0, height },
-                            { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][0].track, imageIds[3][0].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][1].track, imageIds[3][1].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    if (imageIds[3][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][1].frontTrack, imageIds[3][1].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 33 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][2].track, imageIds[3][2].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 13:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][3].track, imageIds[4][3].handrail, { 0, 0, height },
-                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
-                    if (imageIds[4][3].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][3].frontTrack, imageIds[4][3].frontHandrail, { 0, 0, height },
-                            { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][0].track, imageIds[4][0].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][1].track, imageIds[4][1].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 27, 2 } });
-                    if (imageIds[4][1].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][1].frontTrack, imageIds[4][1].frontHandrail, { 0, 0, height },
-                            { { 0, 2, height + 33 }, { 32, 27, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][2].track, imageIds[4][2].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topLeft),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 1:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 2:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 3:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height + 8 }, { 20, 32, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 0:
+                        PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 1:
+                        PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 4:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[0][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][2].frontTrack, imageIds[0][2].frontHandrail, { 0, 0, height },
+                                { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[0][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][0].frontTrack, imageIds[0][0].frontHandrail, { 0, 0, height },
+                                { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 2:
+                        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 3:
+                        PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 5:
+                switch (direction)
+                {
+                    case 0:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 1:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 2:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 3:
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 6:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[1][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][2].frontTrack, imageIds[1][2].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[1][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][0].frontTrack, imageIds[1][0].frontHandrail, { 0, 0, height },
+                                { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 7:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[2][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][2].frontTrack, imageIds[2][2].frontHandrail, { 0, 0, height },
+                                { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
+                            { { 0, 6, height + 8 }, { 32, 20, 2 } });
+                        if (imageIds[2][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][0].frontTrack, imageIds[2][0].frontHandrail, { 0, 0, height },
+                                { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
+                            PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+        }
     }
-}
 
-/** rct2: 0x008ACB08 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
-static void WoodenRCTrackRightHalfBankedHelixUpLarge(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACAF8 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
+    static void TrackLeftHalfBankedHelixUpLarge(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 27, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 27, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topLeft),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 1:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 29 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 4:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 5:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 33 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 6:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
-                    if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
-                            { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 27, 32, 2 } });
-                    if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
-                            { 0, 0, height }, { { 2, 0, height + 33 }, { 27, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 0:
-                    PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 1:
-                    PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 7:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
-                        { { 2, 0, height }, { 27, 32, 2 } });
-                    if (imageIds[0][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][2].frontTrack, imageIds[0][2].frontHandrail, { 0, 0, height },
-                            { { 2, 0, height + 27 }, { 27, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[0][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][0].frontTrack, imageIds[0][0].frontHandrail, { 0, 0, height },
-                            { { 6, 0, height + 27 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 2:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-                case 3:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right,
-                        OpenRCT2::PaintSegment::topRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 8:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 9:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[1][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][2].frontTrack, imageIds[1][2].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 32, 2 } });
-                    if (imageIds[1][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][0].frontTrack, imageIds[1][0].frontHandrail, { 0, 0, height },
-                            { { 16, 0, height + 27 }, { 16, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 10:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[2][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][2].frontTrack, imageIds[2][2].frontHandrail, { 0, 0, height },
-                            { { 16, 16, height + 29 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][0].frontTrack, imageIds[2][0].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topRight,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 11:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 12:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][1].track, imageIds[3][1].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][2].track, imageIds[3][2].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    if (imageIds[3][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][2].frontTrack, imageIds[3][2].frontHandrail, { 0, 0, height },
-                            { { 0, 0, height + 33 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][3].track, imageIds[3][3].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][0].track, imageIds[3][0].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[3][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][0].frontTrack, imageIds[3][0].frontHandrail, { 0, 0, height },
-                            { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre,
-                        OpenRCT2::PaintSegment::topLeft, OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
-        case 13:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][1].track, imageIds[4][1].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][2].track, imageIds[4][2].handrail, { 0, 0, height },
-                        { { 0, 2, height }, { 32, 27, 2 } });
-                    if (imageIds[4][2].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][2].frontTrack, imageIds[4][2].frontHandrail, { 0, 0, height },
-                            { { 0, 2, height + 33 }, { 32, 27, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][3].track, imageIds[4][3].handrail, { 0, 0, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[4][0].track, imageIds[4][0].handrail, { 0, 0, height },
-                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
-                    if (imageIds[4][0].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[4][0].frontTrack, imageIds[4][0].frontHandrail, { 0, 0, height },
-                            { { 0, 6, height + 27 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::right, OpenRCT2::PaintSegment::bottom,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                48, 0x20);
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::top, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::topRight, OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 27, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 27, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
+                            PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 1:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
+                            PaintSegment::topRight, PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 29 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::bottom, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 4:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 5:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 33 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
+                            PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 6:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 27, 32, 2 } });
+                        if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
+                                { 0, 0, height }, { { 2, 0, height + 33 }, { 27, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height + 8 }, { 20, 32, 2 } });
+                        if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 2:
+                        PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 3:
+                        PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 7:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[0][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][3].frontTrack, imageIds[0][3].frontHandrail, { 0, 0, height },
+                                { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 27, 32, 2 } });
+                        if (imageIds[0][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][1].frontTrack, imageIds[0][1].frontHandrail, { 0, 0, height },
+                                { { 2, 0, height + 27 }, { 27, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 0:
+                        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 1:
+                        PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 8:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 9:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[1][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][3].frontTrack, imageIds[1][3].frontHandrail, { 0, 0, height },
+                                { { 16, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[1][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][1].frontTrack, imageIds[1][1].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
+                            PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 10:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][3].frontTrack, imageIds[2][3].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[2][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][1].frontTrack, imageIds[2][1].frontHandrail, { 0, 0, height },
+                                { { 16, 16, height + 29 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::right, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 11:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 12:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][3].track, imageIds[3][3].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[3][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][3].frontTrack, imageIds[3][3].frontHandrail, { 0, 0, height },
+                                { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][0].track, imageIds[3][0].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][1].track, imageIds[3][1].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        if (imageIds[3][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][1].frontTrack, imageIds[3][1].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 33 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][2].track, imageIds[3][2].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                            PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 13:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][3].track, imageIds[4][3].handrail, { 0, 0, height },
+                            { { 0, 6, height + 8 }, { 32, 20, 2 } });
+                        if (imageIds[4][3].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][3].frontTrack, imageIds[4][3].frontHandrail, { 0, 0, height },
+                                { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][0].track, imageIds[4][0].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][1].track, imageIds[4][1].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 27, 2 } });
+                        if (imageIds[4][1].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][1].frontTrack, imageIds[4][1].frontHandrail, { 0, 0, height },
+                                { { 0, 2, height + 33 }, { 32, 27, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][2].track, imageIds[4][2].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+        }
     }
-}
 
-/** rct2: 0x008ACB38 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
-static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACB08 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 5> imageIds>
+    static void TrackRightHalfBankedHelixUpLarge(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
-        case 1:
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-        case 2:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::left, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::topLeft,
-                        OpenRCT2::PaintSegment::bottomLeft),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 2:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
-                    break;
-                case 3:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 27, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 2, height + 27 }, { 32, 27, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::bottom, PaintSegment::topLeft),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 1:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topRight,
+                            PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 29 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::right, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 4:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::topLeft, PaintSegment::topRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 5:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 33 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
+                            PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 6:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height + 8 }, { 20, 32, 2 } });
+                        if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
+                                { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 27, 32, 2 } });
+                        if (imageIds[4][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][direction].frontTrack, imageIds[4][direction].frontHandrail,
+                                { 0, 0, height }, { { 2, 0, height + 33 }, { 27, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][direction].track, imageIds[4][direction].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 0:
+                        PaintUtilPushTunnelRight(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 1:
+                        PaintUtilPushTunnelLeft(session, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::right, PaintSegment::bottom, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 7:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][1].track, imageIds[0][1].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][2].track, imageIds[0][2].handrail, { 0, 0, height },
+                            { { 2, 0, height }, { 27, 32, 2 } });
+                        if (imageIds[0][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][2].frontTrack, imageIds[0][2].frontHandrail, { 0, 0, height },
+                                { { 2, 0, height + 27 }, { 27, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][3].track, imageIds[0][3].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][0].track, imageIds[0][0].handrail, { 0, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[0][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][0].frontTrack, imageIds[0][0].frontHandrail, { 0, 0, height },
+                                { { 6, 0, height + 27 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 2:
+                        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                    case 3:
+                        PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::Flat);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::left, PaintSegment::right, PaintSegment::topRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft,
+                            PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 8:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 9:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][1].track, imageIds[1][1].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][2].track, imageIds[1][2].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[1][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][2].frontTrack, imageIds[1][2].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][3].track, imageIds[1][3].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][0].track, imageIds[1][0].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 32, 2 } });
+                        if (imageIds[1][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][0].frontTrack, imageIds[1][0].frontHandrail, { 0, 0, height },
+                                { { 16, 0, height + 27 }, { 16, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::left, PaintSegment::bottom, PaintSegment::centre, PaintSegment::topLeft,
+                            PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 10:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][1].track, imageIds[2][1].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][2].track, imageIds[2][2].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[2][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][2].frontTrack, imageIds[2][2].frontHandrail, { 0, 0, height },
+                                { { 16, 16, height + 29 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][3].track, imageIds[2][3].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][0].track, imageIds[2][0].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][0].frontTrack, imageIds[2][0].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::top, PaintSegment::bottom, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::right, PaintSegment::centre, PaintSegment::topRight, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 11:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::right, PaintSegment::topRight, PaintSegment::bottomRight), direction),
+                    48, 0x20);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 12:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][1].track, imageIds[3][1].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][2].track, imageIds[3][2].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        if (imageIds[3][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][2].frontTrack, imageIds[3][2].frontHandrail, { 0, 0, height },
+                                { { 0, 0, height + 33 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][3].track, imageIds[3][3].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][0].track, imageIds[3][0].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[3][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][0].frontTrack, imageIds[3][0].frontHandrail, { 0, 0, height },
+                                { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::top, PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft,
+                            PaintSegment::topRight, PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+            case 13:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][1].track, imageIds[4][1].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][2].track, imageIds[4][2].handrail, { 0, 0, height },
+                            { { 0, 2, height }, { 32, 27, 2 } });
+                        if (imageIds[4][2].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][2].frontTrack, imageIds[4][2].frontHandrail, { 0, 0, height },
+                                { { 0, 2, height + 33 }, { 32, 27, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][3].track, imageIds[4][3].handrail, { 0, 0, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::neSw, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[4][0].track, imageIds[4][0].handrail, { 0, 0, height },
+                            { { 0, 6, height + 8 }, { 32, 20, 2 } });
+                        if (imageIds[4][0].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[4][0].frontTrack, imageIds[4][0].frontHandrail, { 0, 0, height },
+                                { { 0, 6, height + 27 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::nwSe, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height + 8, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::right, PaintSegment::bottom, PaintSegment::bottomRight),
+                        direction),
+                    48, 0x20);
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::top, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::topRight,
+                            PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+                break;
+        }
     }
-}
 
-/** rct2: 0x008ACB48 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
-static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACB38 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
+    static void TrackLeftBankToLeftQuarterTurn325DegUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
-                        { { 0, 6, height }, { 32, 20, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
-        case 1:
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-        case 2:
-            PaintUtilSetSegmentSupportHeight(
-                session,
-                PaintUtilRotateSegments(
-                    EnumsToFlags(
-                        OpenRCT2::PaintSegment::bottom, OpenRCT2::PaintSegment::centre, OpenRCT2::PaintSegment::bottomLeft,
-                        OpenRCT2::PaintSegment::bottomRight),
-                    direction),
-                0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 48);
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
-                    }
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
-                        { { 6, 0, height }, { 20, 32, 2 } });
-                    WoodenASupportsPaintSetup(
-                        session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
-                    break;
-            }
-            switch (direction)
-            {
-                case 0:
-                    PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
-                    break;
-                case 1:
-                    PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
-                    break;
-            }
-            PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-            PaintUtilSetGeneralSupportHeight(session, height + 64);
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + 64);
+                break;
+            case 1:
+                PaintUtilSetGeneralSupportHeight(session, height + 48);
+                break;
+            case 2:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(PaintSegment::left, PaintSegment::centre, PaintSegment::topLeft, PaintSegment::bottomLeft),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + 48);
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 2:
+                        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+                        break;
+                    case 3:
+                        PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + 64);
+                break;
+        }
     }
-}
 
-/** rct2: 0x008ACA18, 0x008AC9F8 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrackDiagFlatToBank(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACB48 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 2> imageIds>
+    static void TrackRightBankToRightQuarterTurn325DegUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 6, height }, { { 0, 6, height + 67 }, { 32, 20, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 6, height },
+                            { { 0, 6, height }, { 32, 20, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + 64);
+                break;
+            case 1:
+                PaintUtilSetGeneralSupportHeight(session, height + 48);
+                break;
+            case 2:
+                PaintUtilSetSegmentSupportHeight(
+                    session,
+                    PaintUtilRotateSegments(
+                        EnumsToFlags(
+                            PaintSegment::bottom, PaintSegment::centre, PaintSegment::bottomLeft, PaintSegment::bottomRight),
+                        direction),
+                    0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + 48);
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner2, height, session.SupportColours);
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner3, height, session.SupportColours);
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 6, 0, height }, { { 6, 0, height + 67 }, { 20, 32, 0 } });
+                        }
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner0, height, session.SupportColours);
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 6, 0, height },
+                            { { 6, 0, height }, { 20, 32, 2 } });
+                        WoodenASupportsPaintSetup(
+                            session, supportType.wooden, WoodenSupportSubType::corner1, height, session.SupportColours);
+                        break;
+                }
+                switch (direction)
+                {
+                    case 0:
+                        PaintUtilPushTunnelRight(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+                        break;
+                    case 1:
+                        PaintUtilPushTunnelLeft(session, height, kTunnelGroup, TunnelSubType::SlopeEnd);
+                        break;
+                }
+                PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+                PaintUtilSetGeneralSupportHeight(session, height + 64);
+                break;
+        }
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlat>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
-
-/** rct2: 0x008ACA58, 0x008ACA68 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrackDiagBankTo25DegUp(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACA18, 0x008AC9F8 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void TrackDiagFlatToBank(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+        }
+
+        DrawSupportForSequenceA<TrackElemType::diagFlat>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagFlatToUp25>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 48);
-}
-
-/** rct2: 0x008ACA38, 0x008ACA48 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrackDiagUp25ToBank(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACA58, 0x008ACA68 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void TrackDiagBankTo25DegUp(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+        }
+
+        DrawSupportForSequenceA<TrackElemType::diagFlatToUp25>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + 48);
     }
 
-    DrawSupportForSequenceB<OpenRCT2::TrackElemType::diagUp25ToFlat>(
-        session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + 56);
-}
-
-/** rct2: 0x008AC9D8 */
-template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
-static void WoodenRCTrackDiagLeftBank(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008ACA38, 0x008ACA48 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void TrackDiagUp25ToBank(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    if (imageIds[direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
-                            { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 3:
-            switch (direction)
-            {
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
-                        { { -16, -16, height }, { 32, 32, 2 } });
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+        }
+
+        DrawSupportForSequenceB<TrackElemType::diagUp25ToFlat>(
+            session, supportType.wooden, trackSequence, direction, height + 16, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + 56);
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::diagLeftBank>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
-
-/** rct2: 0x008AC998 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 4> imageIds>
-static void WoodenRCTrackLeftEighthBankToDiag(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008AC9D8 */
+    template<bool isClassic, std::array<WoodenTrackSection, kNumOrthogonalDirections> imageIds>
+    static void TrackDiagLeftBank(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 34, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-            }
-            break;
-        case 4:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 18, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        if (imageIds[direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[direction].frontTrack, imageIds[direction].frontHandrail,
+                                { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 3:
+                switch (direction)
+                {
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[direction].track, imageIds[direction].handrail, { -16, -16, height },
+                            { { -16, -16, height }, { 32, 32, 2 } });
+                        break;
+                }
+                break;
+        }
+
+        DrawSupportForSequenceA<TrackElemType::diagLeftBank>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::leftEighthBankToDiag>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
-
-/** rct2: 0x008AC9A8 */
-template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 4> imageIds>
-static void WoodenRCTrackRightEighthBankToDiag(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
-    const OpenRCT2::TrackElement& trackElement, SupportType supportType)
-{
-    switch (trackSequence)
+    /** rct2: 0x008AC998 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 4> imageIds>
+    static void TrackLeftEighthBankToDiag(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
     {
-        case 0:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 32, 2 } });
-                    break;
-            }
-            if (direction == 0 || direction == 3)
-            {
-                PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
-            }
-            break;
-        case 1:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 34, 16, 2 } });
-                    if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 2 } });
-                    break;
-            }
-            break;
-        case 2:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 4, 4, height }, { 28, 28, 2 } });
-                    if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
-                            { 0, 0, height }, { { 4, 4, height + 27 }, { 28, 28, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 16, 2 } });
-                    break;
-            }
-            break;
-        case 4:
-            switch (direction)
-            {
-                case 0:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 0, height }, { 16, 16, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 1:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 0, height }, { 16, 16, 2 } });
-                    break;
-                case 2:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 0, 16, height }, { 16, 18, 2 } });
-                    if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
-                    {
-                        WoodenRCTrackPaint<isClassic>(
-                            session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
-                            { 0, 0, height }, { { 0, 16, height + 27 }, { 16, 16, 0 } });
-                    }
-                    break;
-                case 3:
-                    WoodenRCTrackPaint<isClassic>(
-                        session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
-                        { { 16, 16, height }, { 16, 16, 2 } });
-                    break;
-            }
-            break;
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 34, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                }
+                break;
+            case 4:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 18, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                }
+                break;
+        }
+
+        DrawSupportForSequenceA<TrackElemType::leftEighthBankToDiag>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
     }
 
-    DrawSupportForSequenceA<OpenRCT2::TrackElemType::rightEighthBankToDiag>(
-        session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
-    PaintUtilSetSegmentSupportHeight(session, OpenRCT2::kSegmentsAll, 0xFFFF, 0);
-    PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
-}
+    /** rct2: 0x008AC9A8 */
+    template<bool isClassic, std::array<std::array<WoodenTrackSection, kNumOrthogonalDirections>, 4> imageIds>
+    static void TrackRightEighthBankToDiag(
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        const TrackElement& trackElement, SupportType supportType)
+    {
+        switch (trackSequence)
+        {
+            case 0:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        if (imageIds[0][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[0][direction].frontTrack, imageIds[0][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 32, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[0][direction].track, imageIds[0][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 32, 2 } });
+                        break;
+                }
+                if (direction == 0 || direction == 3)
+                {
+                    PaintUtilPushTunnelRotated(session, direction, height, kTunnelGroup, TunnelSubType::Flat);
+                }
+                break;
+            case 1:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 32, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 32, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 34, 16, 2 } });
+                        if (imageIds[1][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[1][direction].frontTrack, imageIds[1][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 32, 16, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[1][direction].track, imageIds[1][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 32, 16, 2 } });
+                        break;
+                }
+                break;
+            case 2:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 4, 4, height }, { 28, 28, 2 } });
+                        if (imageIds[2][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[2][direction].frontTrack, imageIds[2][direction].frontHandrail,
+                                { 0, 0, height }, { { 4, 4, height + 27 }, { 28, 28, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[2][direction].track, imageIds[2][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 16, 2 } });
+                        break;
+                }
+                break;
+            case 4:
+                switch (direction)
+                {
+                    case 0:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 0, height }, { 16, 16, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 16, 0, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 1:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 0, height }, { 16, 16, 2 } });
+                        break;
+                    case 2:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 0, 16, height }, { 16, 18, 2 } });
+                        if (imageIds[3][direction].frontTrack != kImageIndexUndefined)
+                        {
+                            TrackPaint<isClassic>(
+                                session, direction, imageIds[3][direction].frontTrack, imageIds[3][direction].frontHandrail,
+                                { 0, 0, height }, { { 0, 16, height + 27 }, { 16, 16, 0 } });
+                        }
+                        break;
+                    case 3:
+                        TrackPaint<isClassic>(
+                            session, direction, imageIds[3][direction].track, imageIds[3][direction].handrail, { 0, 0, height },
+                            { { 16, 16, height }, { 16, 16, 2 } });
+                        break;
+                }
+                break;
+        }
 
-TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(OpenRCT2::TrackElemType trackType);
+        DrawSupportForSequenceA<TrackElemType::rightEighthBankToDiag>(
+            session, supportType.wooden, trackSequence, direction, height, session.SupportColours);
+        PaintUtilSetSegmentSupportHeight(session, kSegmentsAll, 0xFFFF, 0);
+        PaintUtilSetGeneralSupportHeight(session, height + kDefaultGeneralSupportHeight);
+    }
+
+    TrackPaintFunction GetTrackPaintFunctionClassicWoodenRCFallback(TrackElemType trackType);
+
+} // namespace OpenRCT2::WoodenRC

--- a/src/openrct2/ride/TrackData.h
+++ b/src/openrct2/ride/TrackData.h
@@ -12,8 +12,6 @@
 #include "../paint/support/MetalSupports.h"
 #include "ted/TrackElemType.h"
 
-using namespace OpenRCT2;
-
 namespace OpenRCT2::TrackMetadata
 {
     enum class TrackCurve : uint8_t;


### PR DESCRIPTION
This was causing namespace imports to happen in all files that included these headers and triggered Clang warnings. Unfortunately, `WoodenRollerCoaster.hpp` got hit really hard by these changes.