### PR TITLE
Add "use bool literals" rule to .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: >
     -*,
     cppcoreguidelines-macro-usage,
+    modernize-use-bool-literals,
     modernize-use-nullptr,
     modernize-use-override,
     readability-uppercase-literal-suffix


### PR DESCRIPTION
~~This adds the rules _readability-avoid-const-params-in-decls_ and _modernize-use-bool-literals_ to `.clang-tidy`. This ensures that `const` qualifiers aren't redundantly added to function declarations and that `true` or `false` are preffered to 1/0 when being attributed to bools.~~