### PR TITLE
Fix implementation mistake from #1644. Guest happiness calcs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,9 @@ set(OPENMSX_VERSION "1.6.1")
 set(OPENMSX_URL     "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA256  "994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1")
 
-set(REPLAYS_VERSION "0.0.91")
+set(REPLAYS_VERSION "0.0.92")
 set(REPLAYS_URL     "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA256  "5b99edc3d8445fcd2cb22c204708247f575d0bdd3128561322e3abf01e977c79")
+set(REPLAYS_SHA256  "455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#25844] The sprite builder now also supports adding JSON-based palettes.
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
+- Fix: [#1644] Guests do not have their happiness penalised by low energy, low hunger, low thirst, high toilet. Ride nausea generation different compared to vanilla.
 - Fix: [#4643, #25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
 - Fix: [#25745] Crash when a player connection is aborted early.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,11 +2,11 @@
 ------------------------------------------------------------------------
 - Feature: [#25844] The sprite builder now also supports adding JSON-based palettes.
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
-- Fix: [#1644] Guests do not have their happiness penalised by low energy, low hunger, low thirst, high toilet. Ride nausea generation different compared to vanilla.
 - Fix: [#4643, #25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
 - Fix: [#25745] Crash when a player connection is aborted early.
 - Fix: [#25799] The animated options tab icon of the news window does not always redraw.
+- Fix: [#25850] Guests do not have their happiness penalised by low energy, low hunger, low thirst, high toilet. Ride nausea generation different compared to vanilla.
 
 0.4.30 (2026-01-04)
 ------------------------------------------------------------------------

--- a/openrct2.deps.targets
+++ b/openrct2.deps.targets
@@ -224,8 +224,8 @@
     <OpenSFXSha256>06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be</OpenSFXSha256>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha256>994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1</OpenMSXSha256>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.91/replays.zip</ReplaysUrl>
-    <ReplaysSha256>5b99edc3d8445fcd2cb22c204708247f575d0bdd3128561322e3abf01e977c79</ReplaysSha256>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.92/replays.zip</ReplaysUrl>
+    <ReplaysSha256>455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe</ReplaysSha256>
   </PropertyGroup>
 
   <!-- Unified Dependency Target -->

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -770,9 +770,8 @@ int32_t Guest::CheckEasterEggName(int32_t index) const
 void Guest::UpdateMotivesIdle()
 {
     // Idle peep happiness tends towards 127 (50%).
-    // Falls faster when above
     if (HappinessTarget >= 128)
-        HappinessTarget -= 2;
+        HappinessTarget--;
     else
         HappinessTarget++;
 
@@ -1230,6 +1229,8 @@ void Guest::Tick128UpdateGuest(uint32_t index)
                     if (HappinessTarget < 90)
                         HappinessTarget = 90;
 
+                    // This is +2 as UpdateMotivesIdle (that is called later in the function)
+                    // will -1. We want to gradually increase happiness to 165
                     if (HappinessTarget < 165)
                         HappinessTarget += 2;
                 }

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -770,8 +770,9 @@ int32_t Guest::CheckEasterEggName(int32_t index) const
 void Guest::UpdateMotivesIdle()
 {
     // Idle peep happiness tends towards 127 (50%).
+    // Falls faster when above
     if (HappinessTarget >= 128)
-        HappinessTarget--;
+        HappinessTarget -= 2;
     else
         HappinessTarget++;
 
@@ -779,22 +780,22 @@ void Guest::UpdateMotivesIdle()
 
     if (Energy <= 50)
     {
-        Energy = std::max(Energy - 2, 0);
+        HappinessTarget = std::max(HappinessTarget - 2, 0);
     }
 
     if (Hunger < 10)
     {
-        Hunger = std::max(Hunger - 1, 0);
+        HappinessTarget = std::max(HappinessTarget - 1, 0);
     }
 
     if (Thirst < 10)
     {
-        Thirst = std::max(Thirst - 1, 0);
+        HappinessTarget = std::max(HappinessTarget - 1, 0);
     }
 
     if (Toilet >= 195)
     {
-        Toilet--;
+        HappinessTarget = std::max(HappinessTarget - 1, 0);
     }
 
     if (State == PeepState::walking && NauseaTarget >= 128)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2884,14 +2884,14 @@ static int16_t GuestCalculateRideIntensityNauseaSatisfaction(Guest& guest, const
  * Update the nausea growth of the peep based on a ride. This is calculated based on:
  * - The nausea rating of the ride
  * - Their new happiness growth rate (the higher, the less nauseous)
- * - How hungry the peep is (0% nausea at 0% hunger up to 200% nausea at 50% hunger)
+ * - How hungry the peep is (+0% nausea at 50% hunger up to +100% nausea at 100% hunger)
  * - The peep's nausea tolerance (Final modifier: none: 100%, low: 50%, average: 25%, high: 12.5%)
  */
 static void GuestUpdateRideNauseaGrowth(Guest& guest, const Ride& ride)
 {
     const auto nauseaMultiplier = std::clamp(256 - guest.HappinessTarget, 64, 200);
     const auto rideGeneratedNausea = (ride.ratings.nausea * nauseaMultiplier) / 512;
-    const auto hungerAdjustedNausea = ((rideGeneratedNausea * std::min<uint8_t>(128, guest.Hunger)) / 128) * 2;
+    const auto hungerAdjustedNausea = ((rideGeneratedNausea * std::max<uint8_t>(128, guest.Hunger)) / 128) * 2;
     const auto nauseaGrowthRateChange = hungerAdjustedNausea >> (EnumValue(guest.NauseaTolerance) & 3);
     guest.NauseaTarget = static_cast<uint8_t>(std::min<int32_t>(guest.NauseaTarget + nauseaGrowthRateChange, 255));
 }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 0;
+constexpr uint8_t kStreamVersion = 1;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
There was meant to be happiness growth rate penalties when very hungry, thirsty, low energy, high toilet

Thanks @MarcelVos96  for spotting the discrepencies.
This now brings it into alignment with vanilla.