### PR TITLE
Fix #25018: Add upkeep cost to booster pieces

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#25844] The sprite builder now also supports adding JSON-based palettes.
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
 - Improved: [#25858] macOS now supports the onboarding menu.
+- Change: [#25018] Add upkeep cost to booster pieces.
 - Fix: [#4643, #25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#25221] When trying to cancel game file discovery, the prompt reappears.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#25799] The animated options tab icon of the news window does not always redraw.
 - Fix: [#25850] Guests do not have their happiness penalised by low energy, low hunger, low thirst, high toilet. Ride nausea generation different compared to vanilla.
 - Fix: [#25854] When a guest is at 0 happiness or energy, the game draws too big of a bar in the guest stats window.
+- Fix: [#25862] Diagonal and inclined brakes are not counted when calculating upkeep cost.
 
 0.4.30 (2026-01-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -342,6 +342,7 @@ static void ride_ratings_update_state_1(RideRating::UpdateState& state)
         state.ProximityScores[i] = 0;
     }
     state.AmountOfBrakes = 0;
+    state.amountOfBoosters = 0;
     state.AmountOfReversers = 0;
     state.State = RIDE_RATINGS_STATE_2;
     state.StationFlags = 0;
@@ -869,6 +870,10 @@ static void ride_ratings_score_close_proximity(RideRating::UpdateState& state, T
         case TrackElemType::brakes:
             state.AmountOfBrakes++;
             break;
+        case TrackElemType::booster:
+        case TrackElemType::diagBooster:
+            state.amountOfBoosters++;
+            break;
         case TrackElemType::leftReverser:
         case TrackElemType::rightReverser:
             state.AmountOfReversers++;
@@ -1212,6 +1217,9 @@ static money64 RideComputeUpkeep(RideRating::UpdateState& state, const Ride& rid
 
     // Add maintenance cost for brake track pieces
     upkeep += 20 * state.AmountOfBrakes;
+
+    // Add maintenance cost for booster track pieces
+    upkeep += 80 * state.amountOfBoosters;
 
     // these seem to be adhoc adjustments to a ride's upkeep/cost, times
     // various variables set on the ride itself.

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -865,22 +865,12 @@ static void ride_ratings_score_close_proximity(RideRating::UpdateState& state, T
     ride_ratings_score_close_proximity_in_direction(state, inputTileElement, (direction - 1) & 3);
     ride_ratings_score_close_proximity_loops(state, inputTileElement);
 
-    switch (state.ProximityTrackType)
-    {
-        case TrackElemType::brakes:
-            state.AmountOfBrakes++;
-            break;
-        case TrackElemType::booster:
-        case TrackElemType::diagBooster:
-            state.amountOfBoosters++;
-            break;
-        case TrackElemType::leftReverser:
-        case TrackElemType::rightReverser:
-            state.AmountOfReversers++;
-            break;
-        default:
-            break;
-    }
+    if (TrackTypeIsBrakes(state.ProximityTrackType))
+        state.AmountOfBrakes++;
+    else if (TrackTypeIsBooster(state.ProximityTrackType))
+        state.amountOfBoosters++;
+    else if (TrackTypeIsReverser(state.ProximityTrackType))
+        state.AmountOfReversers++;
 }
 
 static void RideRatingsCalculate(RideRating::UpdateState& state, Ride& ride)

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -61,6 +61,7 @@ namespace OpenRCT2
             uint16_t ProximityTotal;
             uint16_t ProximityScores[26];
             uint16_t AmountOfBrakes;
+            uint16_t amountOfBoosters;
             uint16_t AmountOfReversers;
             uint16_t StationFlags;
         };

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -663,6 +663,11 @@ bool TrackTypeIsBooster(TrackElemType trackType)
     }
 }
 
+bool TrackTypeIsReverser(TrackElemType trackType)
+{
+    return (trackType == TrackElemType::leftReverser) || (trackType == TrackElemType::rightReverser);
+}
+
 bool TrackElementIsCovered(TrackElemType trackElementType)
 {
     switch (trackElementType)

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -739,6 +739,7 @@ bool TrackTypeIsStation(OpenRCT2::TrackElemType trackType);
 bool TrackTypeIsBrakes(OpenRCT2::TrackElemType trackType);
 bool TrackTypeIsBlockBrakes(OpenRCT2::TrackElemType trackType);
 bool TrackTypeIsBooster(OpenRCT2::TrackElemType trackType);
+bool TrackTypeIsReverser(OpenRCT2::TrackElemType trackType);
 
 TrackRoll TrackGetActualBank(OpenRCT2::TileElement* tileElement, TrackRoll bank);
 TrackRoll TrackGetActualBank2(ride_type_t rideType, bool isInverted, TrackRoll bank);


### PR DESCRIPTION
Fixes #25018 

Booster track pieces do not exist in RCT2, but they do in RCT1 and in OpenRCT2. Since RCT2 didn't have them naturally there was no upkeep for it, but in RCT1 they do cost $80 per piece per hour. This PR adds the same running cost for boosters to OpenRCT2.