### PR TITLE
Fix #25775: Divide bytes by 1024 for KiB display in network progress

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#25221] When trying to cancel game file discovery, the prompt reappears.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
 - Fix: [#25745] Crash when a player connection is aborted early.
+- Fix: [#25775] Network download sizes are in bytes instead of the listed kibibytes.
 - Fix: [#25799] The animated options tab icon of the news window does not always redraw.
 - Fix: [#25850] Guests do not have their happiness penalised by low energy, low hunger, low thirst, high toilet. Ride nausea generation different compared to vanilla.
 - Fix: [#25854] When a guest is at 0 happiness or energy, the game draws too big of a bar in the guest stats window.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1793,7 +1793,7 @@ namespace OpenRCT2::Network
         }
 
         network.GetContext().SetProgress(
-            static_cast<uint32_t>(bytesReceived), static_cast<uint32_t>(bytesTotal), STR_STRING_M_OF_N_KIB);
+            static_cast<uint32_t>(bytesReceived / 1024), static_cast<uint32_t>(bytesTotal / 1024), STR_STRING_M_OF_N_KIB);
     }
 
     bool NetworkBase::ProcessConnection(Connection& connection)


### PR DESCRIPTION
Fixes #25775


Before: 
<img width="799" height="268" alt="image" src="https://github.com/user-attachments/assets/bd414d84-1ed8-447b-bd77-83071fa4859e" />


After: 
<img width="889" height="280" alt="image" src="https://github.com/user-attachments/assets/da0e2cb0-3e7d-45e8-9ffa-ac6c0418a959" />
