### PR TITLE
Fix #25882: Maze construction does not auto-remove trees

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#25719] The weather change dropdown now shows icons next to the weather types for easier selection.
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
 - Improved: [#25858] macOS now supports the onboarding menu.
+- Improved: [#25882] Maze construction now auto-removes trees.
 - Change: [#25018] Add upkeep cost to booster pieces.
 - Fix: [#4643, #25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#15009] Landscaping tools do not display estimates when the game is paused (original bug).
@@ -17,7 +18,7 @@
 - Fix: [#25850] Guests do not have their happiness penalised by low energy, low hunger, low thirst, high toilet. Ride nausea generation different compared to vanilla.
 - Fix: [#25854] When a guest is at 0 happiness or energy, the game draws too big of a bar in the guest stats window.
 - Fix: [#25862] Diagonal and inclined brakes are not counted when calculating upkeep cost.
-- Fix: [#25873] Repainting a banner in OpenRCT2-specific colours results in an error message.
+- Fix: [#25873] Repainting a banner in OpenRCT2-specific colours results in an error message. 
 
 0.4.30 (2026-01-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -25,6 +25,7 @@
 #include "../world/Map.h"
 #include "../world/Park.h"
 #include "../world/Wall.h"
+#include "../world/tile_element/Slope.h"
 #include "../world/tile_element/SurfaceElement.h"
 #include "../world/tile_element/TrackElement.h"
 
@@ -151,7 +152,9 @@ namespace OpenRCT2::GameActions
                 res.errorMessage = STR_INVALID_SELECTION_OF_OBJECTS;
                 return res;
             }
-            auto constructResult = MapCanConstructAt({ _loc.ToTileStart(), baseHeight, clearanceHeight }, { 0b1111, 0 });
+            auto constructResult = MapCanConstructWithClearAt(
+                { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags(),
+                kTileSlopeFlat);
             if (constructResult.error != Status::ok)
             {
                 constructResult.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -217,7 +220,19 @@ namespace OpenRCT2::GameActions
         auto tileElement = MapGetTrackElementAtOfTypeFromRide(_loc, TrackElemType::maze, _rideIndex);
         if (tileElement == nullptr)
         {
-            res.cost = MazeCalculateCost(0, *ride, _loc);
+            auto baseHeight = _loc.z;
+            auto clearanceHeight = _loc.z + kMazeClearanceHeight;
+
+            auto canBuild = MapCanConstructWithClearAt(
+                { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 },
+                GetFlags().with(CommandFlag::apply), kTileSlopeFlat);
+            if (canBuild.error != Status::ok)
+            {
+                canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
+                return canBuild;
+            }
+
+            res.cost = MazeCalculateCost(canBuild.cost, *ride, _loc);
 
             auto startLoc = _loc.ToTileStart();
 


### PR DESCRIPTION
Fixes #25882

Changed `MazeSetTrackAction` to use `MapCanConstructWithClearAt` instead of `MapCanConstructAt` so trees get cleared like they do for regular track placement.