### PR TITLE
Fix #25460: Infinite loop when moving track design ghost queue over queue loop with zero clearances

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Change: [#25962] The station style dropdown now shows entrance icons next to the labels for easier selection.
 - Change: [#26178] Symmetric spinning trains and legacy ‘pre-reversed’ trains can no longer be reversed.
 - Fix: [#10616] Quarter-tile trees cannot be placed on dry portions of half-water tiles.
+- Fix: [#25460] Infinite loop when moving track design ghost queue over queue loop with zero clearances.
 - Fix: [#25735] Ride synchronisation z-check works incorrectly.
 - Fix: [#25962] Dropdown triangle glyphs are not optically centred.
 - Fix: [#25993] Toggling “allow arbitrary ride type changes” does not resize open ride windows.

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -803,8 +803,17 @@ namespace OpenRCT2
         int32_t baseZ = tileElement->GetBaseZ();
         int32_t lastPathDirection = direction;
 
+        // Prevent infinite loops from circular queues (possible with zero clearance checks)
+        auto& gameState = getGameState();
+        const int32_t maxIterations = gameState.mapSize.x * gameState.mapSize.y * 10;
+        int32_t iterations = 0;
+
         for (;;)
         {
+            if (++iterations > maxIterations)
+            {
+                break;
+            }
             if (tileElement->GetType() == TileElementType::Path)
             {
                 lastPathElement = tileElement;


### PR DESCRIPTION
Fixes #25460 

Ghost footpath removal no longer triggers queue chain updates on real paths, and I added an iteration limit to `FootpathChainRideQueue` as a defensive safety net.

Before video, park and ride included in original issue. 

https://github.com/user-attachments/assets/8a2d7573-65e3-4454-9b51-d479379ba545

