### PR TITLE
Fix #3788: Self intersecting track designs cannot be placed

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#25765] The ‘View options’ and ‘Special track elements’ dropdowns no longer need click-and-hold.
 - Improved: [#25858] macOS now supports the onboarding menu.
 - Change: [#25018] Add upkeep cost to booster pieces.
+- Fix: [#3788] Self-intersecting track designs cannot be placed.
 - Fix: [#4643, #25167] Many metal supports draw with a filled in top when they didn't in vanilla, causing some slight misalignment and glitching.
 - Fix: [#15009] Landscaping tools do not display estimates when the game is paused (original bug).
 - Fix: [#18441] Replacing footpaths sometimes results in a spurious “Footpath in the way” error (original bug).

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -263,9 +263,11 @@ namespace OpenRCT2::GameActions
             auto crossingMode = (rtd.HasFlag(RtdFlag::supportsLevelCrossings) && _trackType == TrackElemType::flat)
                 ? CreateCrossingMode::trackOverPath
                 : CreateCrossingMode::none;
+            // When placing from a track design, ignore track elements from the same ride to allow it to intersect itself.
+            auto ignoreRideId = _fromTrackDesign ? _rideIndex : RideId::GetNull();
             auto canBuild = MapCanConstructWithClearAt(
                 { mapLoc, baseZ, clearanceZ }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
-                crossingMode);
+                crossingMode, false, ignoreRideId);
             if (canBuild.error != Status::ok)
             {
                 canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -467,9 +469,11 @@ namespace OpenRCT2::GameActions
             auto crossingMode = (rtd.HasFlag(RtdFlag::supportsLevelCrossings) && _trackType == TrackElemType::flat)
                 ? CreateCrossingMode::trackOverPath
                 : CreateCrossingMode::none;
+            // When placing from a track design, ignore track elements from the same ride to allow it to intersect itself.
+            auto ignoreRideId = _fromTrackDesign ? _rideIndex : RideId::GetNull();
             auto canBuild = MapCanConstructWithClearAt(
                 mapLocWithClearance, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags().with(CommandFlag::apply),
-                kTileSlopeFlat, crossingMode);
+                kTileSlopeFlat, crossingMode, false, ignoreRideId);
             if (canBuild.error != Status::ok)
             {
                 canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -182,7 +182,7 @@ static bool MapLoc68BABCShouldContinue(
  */
 GameActions::Result MapCanConstructWithClearAt(
     const CoordsXYRangedZ& pos, ClearingFunction clearFunc, const QuarterTile quarterTile, const CommandFlags flags,
-    const uint8_t slope, const CreateCrossingMode crossingMode, const bool isTree)
+    const uint8_t slope, const CreateCrossingMode crossingMode, const bool isTree, const RideId ignoreRideId)
 {
     auto res = GameActions::Result();
 
@@ -215,6 +215,13 @@ GameActions::Result MapCanConstructWithClearAt(
     {
         if (tileElement->GetType() != TileElementType::Surface)
         {
+            // Skip track elements belonging to the ride that's being ignored for rides that intersect themselves.
+            if (!ignoreRideId.IsNull() && tileElement->GetType() == TileElementType::Track
+                && tileElement->AsTrack()->GetRideIndex() == ignoreRideId)
+            {
+                continue;
+            }
+
             if (pos.baseZ < tileElement->GetClearanceZ() && pos.clearanceZ > tileElement->GetBaseZ()
                 && !(tileElement->IsGhost()))
             {

--- a/src/openrct2/world/ConstructionClearance.h
+++ b/src/openrct2/world/ConstructionClearance.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../Identifiers.h"
 #include "../actions/CommandFlag.h"
 #include "../actions/GameActionResult.h"
 #include "Location.hpp"
@@ -56,7 +57,8 @@ struct ConstructClearResult
 
 [[nodiscard]] OpenRCT2::GameActions::Result MapCanConstructWithClearAt(
     const CoordsXYRangedZ& pos, ClearingFunction clearFunc, QuarterTile quarterTile, OpenRCT2::GameActions::CommandFlags flags,
-    uint8_t slope, CreateCrossingMode crossingMode = CreateCrossingMode::none, bool isTree = false);
+    uint8_t slope, CreateCrossingMode crossingMode = CreateCrossingMode::none, bool isTree = false,
+    RideId ignoreRideId = RideId::GetNull());
 
 [[nodiscard]] OpenRCT2::GameActions::Result MapCanConstructAt(const CoordsXYRangedZ& pos, QuarterTile bl);
 


### PR DESCRIPTION
Fixes #3788

Track designs that intersect themselves fail to place with an error. The error shows states "[Ride name] in the way" because earlier placed track pieces block later ones during clearance checks. This PR adds an optional `RideId ignoreRideId` parameter to `MapCanConstructWithClearAt`. When placing from a track design, track elements belonging to the same ride are skipped during clearance checks. The parameter defaults to null so existing callers are unaffected.


Before: 
![OpenRCT-3788Before](https://github.com/user-attachments/assets/46a875f5-0bcb-4f00-b951-33262eeb9bce)

After:
![OpenRCT-3788After](https://github.com/user-attachments/assets/02e466d7-45a3-4b4e-ab0e-d09e06c18805)




