### PR TITLE
Fix #25749: Windows release builds are not built with LTCG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Setup environment
         run: |
           BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)
-          if [[ $BRANCH == 'develop' || $BRANCH == 'master' ]]; then
+          if [[ $BRANCH == 'develop' || $GITHUB_REF_TYPE == 'tag' ]]; then
              echo "CONFIGURATION=ReleaseLTCG" >> "$GITHUB_ENV"
           else
              echo "CONFIGURATION=Release" >> "$GITHUB_ENV"


### PR DESCRIPTION
Fix #25749

CI checks out the tag and not the master branch, so this checks for the ref type instead.

[GITHUB_REF_TYPE](https://docs.github.com/en/actions/reference/workflows-and-actions/variables)