### PR TITLE
Fix #25889, #25703: Crash when scanning scenarios with packed objects

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#18441] Replacing footpaths sometimes results in a spurious “Footpath in the way” error (original bug).
 - Fix: [#20620] In-game console caret does not update when pasting.
 - Fix: [#25221] When trying to cancel game file discovery, the prompt reappears.
+- Fix: [#25703, #25889] Crash when scanning scenarios with packed objects in parallel.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.
 - Fix: [#25745] Crash when a player connection is aborted early.
 - Fix: [#25775] Network download sizes are in bytes instead of the listed kibibytes.

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -245,7 +245,8 @@ private:
             {
                 importer = ParkImporter::CreateS6(objRepository);
                 auto stream = GetStreamFromRCT2Scenario(path);
-                importer->LoadFromStream(stream.get(), true);
+                // Skip packed object extraction during scanning - they'll be extracted when actually loading
+                importer->LoadFromStream(stream.get(), true, true);
             }
 
             if (importer)


### PR DESCRIPTION
Fixes #25889 and #25703

From what I can tell when `ScenarioFileIndex` scans scenarios in parallel via `JobPool`, S6 files with packed objects called `ExportPackedObject` from multiple threads a race condition in `ObjectRepository` was caused. Multiple threads calling `push_back` on the same vector simultaneously leads to crashes during vector reallocation.

This small fix passes `skipObjectCheck=true` when loading S6 files during scenario scanning, so its consistent with how `.park` and `.sc4` files already handle this. Packed objects are extracted later when the scenario is actually loaded (This seems to happen single threaded).
