### PR TITLE
Remove redundant "typename" keyword usage

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawCommands.h
@@ -66,27 +66,27 @@ namespace OpenRCT2::Ui
             return _instances.at(idx);
         }
 
-        typename std::vector<T>::iterator begin() // NOLINT(readability-identifier-naming)
+        std::vector<T>::iterator begin() // NOLINT(readability-identifier-naming)
         {
             return _instances.begin();
         }
-        typename std::vector<T>::const_iterator begin() const // NOLINT(readability-identifier-naming)
+        std::vector<T>::const_iterator begin() const // NOLINT(readability-identifier-naming)
         {
             return _instances.cbegin();
         }
-        typename std::vector<T>::const_iterator cbegin() const // NOLINT(readability-identifier-naming)
+        std::vector<T>::const_iterator cbegin() const // NOLINT(readability-identifier-naming)
         {
             return _instances.cbegin();
         }
-        typename std::vector<T>::iterator end() // NOLINT(readability-identifier-naming)
+        std::vector<T>::iterator end() // NOLINT(readability-identifier-naming)
         {
             return _instances.begin() + _numInstances;
         }
-        typename std::vector<T>::const_iterator end() const // NOLINT(readability-identifier-naming)
+        std::vector<T>::const_iterator end() const // NOLINT(readability-identifier-naming)
         {
             return _instances.cbegin() + _numInstances;
         }
-        typename std::vector<T>::const_iterator cend() const // NOLINT(readability-identifier-naming)
+        std::vector<T>::const_iterator cend() const // NOLINT(readability-identifier-naming)
         {
             return _instances.cbegin() + _numInstances;
         }

--- a/src/openrct2/core/BackgroundWorker.hpp
+++ b/src/openrct2/core/BackgroundWorker.hpp
@@ -214,7 +214,7 @@ namespace OpenRCT2
                 "Work function must be callable with or without stop_token");
 
             constexpr bool expectsToken = std::is_invocable_v<WorkFunc, std::atomic_bool&>;
-            using Result = typename Detail::ResultType<WorkFunc, std::integral_constant<bool, expectsToken>>::type;
+            using Result = Detail::ResultType<WorkFunc, std::integral_constant<bool, expectsToken>>::type;
 
             const auto wrappedFunc = [wf = std::forward<WorkFunc>(work)](std::atomic_bool& token) {
                 if constexpr (std::is_invocable_v<WorkFunc, std::atomic_bool&>)

--- a/src/openrct2/core/BitSet.hpp
+++ b/src/openrct2/core/BitSet.hpp
@@ -135,7 +135,7 @@ namespace OpenRCT2
         template<size_t TBitSize>
         struct storage_block_type_aligned
         {
-            using value_type = typename StorageBlockType<ComputeBlockSize<TBitSize>()>::value_type;
+            using value_type = StorageBlockType<ComputeBlockSize<TBitSize>()>::value_type;
         };
     } // namespace Detail::BitSet
 
@@ -144,7 +144,7 @@ namespace OpenRCT2
     {
         static constexpr size_t kByteAlignedBitSize = Detail::BitSet::ByteAlignBits<TBitSize>();
 
-        using StorageBlockType = typename Detail::BitSet::storage_block_type_aligned<kByteAlignedBitSize>::value_type;
+        using StorageBlockType = Detail::BitSet::storage_block_type_aligned<kByteAlignedBitSize>::value_type;
 
         static constexpr size_t kBlockByteSize = sizeof(StorageBlockType);
         static constexpr size_t kBlockBitSize = kBlockByteSize * Detail::BitSet::kBitsPerByte;

--- a/src/openrct2/core/Crypt.CNG.cpp
+++ b/src/openrct2/core/Crypt.CNG.cpp
@@ -103,7 +103,7 @@ public:
         return this;
     }
 
-    typename TBase::Result Finish() override
+    TBase::Result Finish() override
     {
         typename TBase::Result result;
         auto status = BCryptFinishHash(_hHash, result.data(), static_cast<ULONG>(result.size()), 0);

--- a/src/openrct2/core/Endianness.h
+++ b/src/openrct2/core/Endianness.h
@@ -66,7 +66,7 @@ template<typename T>
 static T ByteSwapBE(const T& value)
 {
     using ByteSwap = ByteSwapT<sizeof(T)>;
-    using UIntType = typename ByteSwap::UIntType;
+    using UIntType = ByteSwap::UIntType;
 
     if constexpr (std::is_enum_v<T> || std::is_integral_v<T>)
     {

--- a/src/openrct2/core/Numerics.hpp
+++ b/src/openrct2/core/Numerics.hpp
@@ -94,7 +94,7 @@ namespace OpenRCT2::Numerics
     static constexpr _UIntType rol(_UIntType x, size_t shift)
     {
         static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
-        using limits = typename std::numeric_limits<_UIntType>;
+        using limits = std::numeric_limits<_UIntType>;
         return ((static_cast<_UIntType>(x) << shift) | (static_cast<_UIntType>(x) >> (limits::digits - shift)));
     }
 

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -346,7 +346,7 @@ namespace OpenRCT2
             template<typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
             void readWrite(T& v)
             {
-                using underlying = typename std::underlying_type<T>::type;
+                using underlying = std::underlying_type<T>::type;
                 if (_mode == Mode::reading)
                 {
                     v = static_cast<T>(readInteger<underlying>());

--- a/src/openrct2/core/Random.hpp
+++ b/src/openrct2/core/Random.hpp
@@ -135,7 +135,7 @@ namespace OpenRCT2::Random
             s1 = r.s1;
         }
 
-        template<typename TSseq, typename = typename std::enable_if<!std::is_same<TSseq, RotateEngine>::value>::type>
+        template<typename TSseq, typename = std::enable_if<!std::is_same<TSseq, RotateEngine>::value>::type>
         explicit RotateEngine(TSseq& seed_seq)
         {
             seed(seed_seq);
@@ -148,7 +148,7 @@ namespace OpenRCT2::Random
         }
 
         template<typename TSseq>
-        typename std::enable_if<std::is_class<TSseq>::value, void>::type seed(TSseq& seed_seq)
+        std::enable_if<std::is_class<TSseq>::value, void>::type seed(TSseq& seed_seq)
         {
             std::array<result_type, 2> s;
             seed_seq.generate(s.begin(), s.end());

--- a/src/openrct2/localisation/Formatter.h
+++ b/src/openrct2/localisation/Formatter.h
@@ -89,18 +89,18 @@ namespace OpenRCT2
 
             // clang-format off
             static_assert(
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, char*> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, const char*> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, int16_t> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, int32_t> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, money64> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, RideId> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, EntityId> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, StringId> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, uint16_t> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, uint32_t> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, utf8*> ||
-                std::is_same_v<typename std::remove_cv_t<TSpecified>, const utf8*>
+                std::is_same_v<std::remove_cv_t<TSpecified>, char*> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, const char*> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, int16_t> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, int32_t> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, money64> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, RideId> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, EntityId> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, StringId> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, uint16_t> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, uint32_t> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, utf8*> ||
+                std::is_same_v<std::remove_cv_t<TSpecified>, const utf8*>
             );
             // clang-format on
 

--- a/src/openrct2/management/NewsItem.h
+++ b/src/openrct2/management/NewsItem.h
@@ -132,13 +132,13 @@ namespace OpenRCT2::News
     public:
         static_assert(N > 0, "Cannot instantiate News::ItemQueue with size=0");
 
-        using value_type = typename std::array<Item, N>::value_type;
+        using value_type = std::array<Item, N>::value_type;
         using pointer = value_type*;
         using const_pointer = const value_type*;
         using reference = value_type&;
         using const_reference = const value_type&;
-        using iterator = typename std::array<Item, N>::iterator;
-        using const_iterator = typename std::array<Item, N>::const_iterator;
+        using iterator = std::array<Item, N>::iterator;
+        using const_iterator = std::array<Item, N>::const_iterator;
         using size_type = std::size_t;
         using difference_type = std::ptrdiff_t;
         using reverse_iterator = std::reverse_iterator<iterator>;

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -358,7 +358,7 @@ private:
 
     // Taken from http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
     template<class T>
-    static typename std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type AlmostEqual(T x, T y, int32_t ulp = 20)
+    static std::enable_if<!std::numeric_limits<T>::is_integer, bool>::type AlmostEqual(T x, T y, int32_t ulp = 20)
     {
         // the machine epsilon has to be scaled to the magnitude of the values used
         // and multiplied by the desired precision in ULPs (units in the last place)


### PR DESCRIPTION
These were being flagged by clang-tidy.