### PR TITLE
Fix #23859: Wrong banner text displayed after loading different park

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#18441] Replacing footpaths sometimes results in a spurious “Footpath in the way” error (original bug).
 - Fix: [#20620] In-game console caret does not update when pasting.
 - Fix: [#20652] Twister Roller Coaster design ‘u(0241)’ has no preview and cannot be built (bug in track design).
+- Fix: [#23859] Wrong banner text displayed after loading a different park.
 - Fix: [#25221] When trying to cancel game file discovery, the prompt reappears.
 - Fix: [#25703, #25889] Crash when scanning scenarios with packed objects in parallel.
 - Fix: [#25739] Game freezes when a tab in the New Ride window contains more than 384 items.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,7 +24,8 @@
 - Fix: [#25854] When a guest is at 0 happiness or energy, the game draws too big of a bar in the guest stats window.
 - Fix: [#25862] Diagonal and inclined brakes are not counted when calculating upkeep cost.
 - Fix: [#25873] Repainting a banner in OpenRCT2-specific colours results in an error message.
-- Fix: [#25879] Guest window viewport doesn’t follow vehicle when they board a ride. 
+- Fix: [#25879] Guest window viewport doesn’t follow vehicle when they board a ride.
+- Fix: [#25908] Crash from use-after-free in banner text formatting during multithreaded rendering. 
 - Fix: [objects#419] Alignment of RCT2 red, yellow and green queue previews is off.
 - Fix: [objects#424] Jet Aeroplane decor has a hole in it.
 - Fix: [objects#425] Capacity of ‘Blob from outer space ride’ is incorrectly listed.

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -24,6 +24,7 @@
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
+#include <openrct2/drawing/ScrollingText.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/interface/Viewport.h>
 #include <openrct2/localisation/StringIds.h>
@@ -438,6 +439,9 @@ namespace OpenRCT2::Title
             windowManager->SetMainView(gameState.savedView, gameState.savedViewZoom, gameState.savedViewRotation);
             gameState.entities.ResetEntitySpatialIndices();
             ResetAllSpriteQuadrantPlacements();
+
+            // Invalidate scrolling text cache to prevent stale text from previous park
+            Drawing::ScrollingText::invalidate();
 
             auto intent = Intent(INTENT_ACTION_REFRESH_NEW_RIDES);
             ContextBroadcastIntent(&intent);

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -32,6 +32,7 @@
 #include "core/Path.hpp"
 #include "core/String.hpp"
 #include "drawing/Drawing.h"
+#include "drawing/ScrollingText.h"
 #include "entity/EntityList.h"
 #include "entity/EntityRegistry.h"
 #include "entity/PatrolArea.h"
@@ -361,6 +362,10 @@ void GameLoadInit()
     snapshots->Reset();
 
     context->SetActiveScene(context->GetGameScene());
+
+    // Invalidate scrolling text cache to prevent stale text from previous park
+    // being displayed due to pointer value reuse in the cache matching logic
+    Drawing::ScrollingText::invalidate();
 
     if (!gLoadKeepWindowsOpen)
     {

--- a/src/openrct2/world/Banner.cpp
+++ b/src/openrct2/world/Banner.cpp
@@ -52,6 +52,11 @@ std::string Banner::getText() const
 
 void Banner::formatTextWithColourTo(Formatter& ft) const
 {
+    // Use thread_local buffer to avoid race conditions during multithreaded rendering.
+    // Multiple threads can call this on the same Banner simultaneously when rendering
+    // different viewport columns in parallel.
+    thread_local std::string formattedTextBuffer;
+
     auto formatToken = FormatTokenFromTextColour(textColour);
     formattedTextBuffer = FormatTokenToStringWithBraces(formatToken);
     ft.Add<StringId>(STR_STRING_STRINGID);

--- a/src/openrct2/world/Banner.h
+++ b/src/openrct2/world/Banner.h
@@ -48,7 +48,6 @@ struct Banner
     OpenRCT2::ObjectEntryIndex type = kBannerNull;
     BannerFlags flags{};
     std::string text;
-    mutable std::string formattedTextBuffer;
     OpenRCT2::Drawing::Colour colour{};
     RideId rideIndex{};
     OpenRCT2::Drawing::TextColour textColour{};


### PR DESCRIPTION
Fixes #23859 and also the crash reported in #25659 (Haiku port) where multithreaded rendering caused use-after-free in the banner text formatting

I was asked by @Gymnasiast to take a look at these bugs so here we are...


## Overviewing the problem(s)

My first assumption was that these issues were related to the formatter and text rendering code, but the actual root causes were somewhere else

Based on the Haiku developer's analysis in #25659: "This indicates pretty clearly that OpenRCT is performing a use-after-free. The freeing thread is different from the allocating thread." Combined with the knowledge that disabling multithreaded rendering completely eliminated the crashes, it pointed me toward a threading issue rather than a formatter bug

I also think both reported problems, being crashes on Haiku and wrong text across parks were actually two separate bugs that happened to manifest in similar ways, in the form of banner text issues. I'll explain why, below.

## Root Cause Analysis

**Bug 1: Race condition in `Banner::formatTextWithColourTo()`**

The `Banner` struct had a `mutable std::string formattedTextBuffer` member that was written during every call to `formatTextWithColourTo()`. When multithreaded rendering is going on, viewport columns are processed in parallel (see `Viewport.cpp`). 

When the same banner is visible in multiple columns:
1. Thread A calls `formatTextWithColourTo()`, writes to `formattedTextBuffer`, stores pointer in Formatter
2. Thread B calls `formatTextWithColourTo()` on the same Banner, writes to `formattedTextBuffer` (potentially reallocating)
3. Thread A's pointer is now dangling

This would explain both the Haiku crashes, the use-after-free detected by their malloc implementation, and the flickering text, aka threads reading partially written data.

**Bug 2: ScrollingText cache not invalidated on park load**

The scrolling text cache in `ScrollingText.cpp` matches entries using:
```cpp
std::memcmp(scrollText->string_args, ft.Buf(), sizeof(scrollText->string_args)) == 0
```

The `string_args` buffer contains raw Formatter data, including `const char*` pointers to ride/banner names. 

When loading a new park:
1. Park A has a cache entry created with pointer `0x12345678` pointing to "Wild Vines", bitmap rendered
2. Park B is loaded and the memory gets freed and reallocated
3. New ride allocated at same address `0x12345678` containing "Railroad"
4. Cache lookup happens where `memcmp` matches because the raw pointer value is identical
5. The result is that the old bitmap showing "Wild Vines" rears its head

This explains why wrong text persisted across parks specifically, and why it wasn't just momentary flickering.

It was hard to diagnose because:
1. The `mutable` keyword on `formattedTextBuffer` made it non obvious that a `const` method was modifying shared state
2. The race condition only happens with multithreading enabled, and timing dependent bugs are extremely hard to reproduce and locate
3. The cache issue requires specific memory reuse patterns that depend on allocator behavior
4. Both bugs produced similar symptoms (wrong banner text), making it seem like one issue was happening
5. The formatter code was suspected but was actually not involved at all here


## So: 

**Fix 1:** Remove `mutable std::string formattedTextBuffer` from Banner struct and replace it with `thread_local std::string` inside the function. This pattern is already used a bunch of times in the codebase (TTF.cpp, Chat.cpp, Drawing.String.cpp, ScrollingText.cpp, etc.).

**Fix 2:** Add `ScrollingText::invalidate()` calls to both park loading paths.
- `GameLoadInit()` which handles normal park loading like File menu, network, replays, scenarios
- `TitleSequencePlayer::PrepareParkForPlayback()` which handles title sequence loading, this is a separate code path that bypasses GameLoadInit

This matches the existing pattern where `invalidate()` is already called when ride names, banner names, park names, or language settings change

// End tedtalk