### PR TITLE
Close #25362: Dragged footpaths over hills are disconnected

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -130,6 +130,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Kendall Frey (kendfrey) - Add plugin API for spawning guests
 * Marino Rottier (rinode) - Plugin API & UI
 * Ben Spurlock (BenDaSpur) - Plugin API automation helpers
+* (frozensnowy) - Draggable path slopes, self-intersecting track designs, refactors, bug fixes, misc.
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------
+- Improved: [#25362] When dragging footpaths, they will now properly adapt to uneven terrain.
 - Improved: [#26560] [Plugin] Scripts can now be used to trigger saving a game (limited to the user save folder).
 - Improved: [#26638] Guests will no longer watch rides while they’re underground.
 - Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.
@@ -84,7 +85,6 @@
 
 0.5.1 (2026-05-17)
 ------------------------------------------------------------------------
-- Feature: [#25362] Dragged footpaths over terrain now automatically create connected slopes.
 - Feature: [#24242] [Plugin] Add ride-breakdown hooktype.
 - Feature: [#24879] [Plugin] Add methods for showing and hiding gridlines.
 - Feature: [#26327] Add ‘guests entertained’ statistic to entertainers.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#26827] [Plugin] Add map resize hook to scripting api.
 - Feature: [#26877] Clear Scenery can remove footpath additions or walls separately.
 - Improved: [#23872] Loading a park outside the game now sets the folder of the load/save window, as loading one in-game does.
+- Improved: [#25362] When dragging footpaths, they will now properly adapt to uneven terrain.
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Improved: [#26441, #26958] Change result.position.z of SmallScenery- and WallPlaceAction to match the actual position of the placed tile element.
@@ -28,7 +29,6 @@
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------
-- Improved: [#25362] When dragging footpaths, they will now properly adapt to uneven terrain.
 - Improved: [#26560] [Plugin] Scripts can now be used to trigger saving a game (limited to the user save folder).
 - Improved: [#26638] Guests will no longer watch rides while they’re underground.
 - Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -143,6 +143,7 @@
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------
 - Feature: [#22704] Rides can be made invisible more easily.
+- Feature: [#25362] Dragged footpaths over terrain now automatically create connected slopes.
 - Improved: [#21753] Tracked rides with cheated powered launch mode can change powered launch speed without extra cheats.
 - Improved: [#25526] When a shop item cannot be recoloured, show a preview of the building instead.
 - Improved: [#25941] The command line sprite build command is now faster.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -84,6 +84,7 @@
 
 0.5.1 (2026-05-17)
 ------------------------------------------------------------------------
+- Feature: [#25362] Dragged footpaths over terrain now automatically create connected slopes.
 - Feature: [#24242] [Plugin] Add ride-breakdown hooktype.
 - Feature: [#24879] [Plugin] Add methods for showing and hiding gridlines.
 - Feature: [#26327] Add ‘guests entertained’ statistic to entertainers.
@@ -143,7 +144,6 @@
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------
 - Feature: [#22704] Rides can be made invisible more easily.
-- Feature: [#25362] Dragged footpaths over terrain now automatically create connected slopes.
 - Improved: [#21753] Tracked rides with cheated powered launch mode can change powered launch speed without extra cheats.
 - Improved: [#25526] When a shop item cannot be recoloured, show a preview of the building instead.
 - Improved: [#25941] The command line sprite build command is now faster.

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -982,8 +982,16 @@ namespace OpenRCT2::Ui::Windows
 
                 if (_footpathPlaceShiftState)
                 {
-                    auto res = FootpathGetPlacementFromInfo(info);
-                    auto mapZ = res.baseZ + _footpathPlaceShiftZ;
+                    int32_t mapZ = info.Element->GetBaseZ();
+                    if (info.Element->GetType() == TileElementType::Surface)
+                    {
+                        uint8_t slope = info.Element->AsSurface()->GetSlope();
+                        if (slope & kTileSlopeRaisedCornersMask)
+                            mapZ += kPathHeightStep;
+                        if (slope & kTileSlopeDiagonalFlag)
+                            mapZ += kPathHeightStep;
+                    }
+                    mapZ += _footpathPlaceShiftZ;
                     mapZ = std::max<int16_t>(mapZ, 16);
                     _footpathPlaceZ = mapZ;
                 }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -80,7 +80,7 @@ namespace OpenRCT2::Ui::Windows
         {
             // Calculate max surface height including raised corners and steep slopes
             int32_t z = surfaceElement->getBaseZ();
-            uint8_t slope = surfaceElement->GetSlope();
+            uint8_t slope = surfaceElement->getSlope();
             if (slope & kTileSlopeRaisedCornersMask)
                 z += kPathHeightStep;
             if (slope & kTileSlopeDiagonalFlag)
@@ -985,7 +985,7 @@ namespace OpenRCT2::Ui::Windows
                     int32_t mapZ = info.Element->getBaseZ();
                     if (info.Element->getType() == TileElementType::surface)
                     {
-                        uint8_t slope = info.Element->asSurface()->GetSlope();
+                        uint8_t slope = info.Element->asSurface()->getSlope();
                         if (slope & kTileSlopeRaisedCornersMask)
                             mapZ += kPathHeightStep;
                         if (slope & kTileSlopeDiagonalFlag)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -65,6 +65,17 @@ namespace OpenRCT2::Ui::Windows
         }
     };
 
+    /**
+     * Stores terrain height information for a "slice" of tiles along the primary drag axis.
+     * Used by buildConnectedTileVector to determine path heights and slopes.
+     */
+    struct SliceInfo
+    {
+        int32_t primaryCoord;
+        int32_t baseZ;
+        int32_t maxZ;
+    };
+
     static money64 FootpathProvisionalSet(
         ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXY& footpathLocA, const CoordsXY& footpathLocB,
         int32_t startZ, std::span<const ProvisionalTile> tiles, PathConstructFlags constructFlags);
@@ -1101,6 +1112,208 @@ namespace OpenRCT2::Ui::Windows
             return tiles;
         }
 
+        /**
+         * Build a vector of path tiles that follow terrain naturally, creating
+         * a continuous connected path with appropriate slopes.
+         *
+         * Algorithm:
+         *
+         * Phase 1 - Gather terrain heights for each slice along the primary drag axis
+         * Phase 2 - Filter out obstacle spikes (isolated height jumps)
+         * Phase 3 - Build path tiles with slopes to bridge height differences
+         */
+        static std::vector<ProvisionalTile> buildConnectedTileVector(MapRange range, CoordsXY dragStart)
+        {
+            std::vector<ProvisionalTile> result;
+
+            int32_t dragWidth = range.GetX2() - range.GetX1();
+            int32_t dragHeight = range.GetY2() - range.GetY1();
+            CoordsXY startPos = dragStart.ToTileStart();
+
+            // Clamp start position to range
+            startPos.x = std::clamp(startPos.x, range.GetX1(), range.GetX2());
+            startPos.y = std::clamp(startPos.y, range.GetY1(), range.GetY2());
+
+            bool primaryIsX = dragWidth >= dragHeight;
+
+            // Determine direction along primary axis
+            int32_t primaryStart, primaryEnd, primaryStep;
+            int32_t secondaryStart, secondaryEnd;
+            Direction slopeDirection;
+
+            if (primaryIsX)
+            {
+                secondaryStart = range.GetY1();
+                secondaryEnd = range.GetY2();
+
+                if (startPos.x <= (range.GetX1() + range.GetX2()) / 2)
+                {
+                    primaryStart = range.GetX1();
+                    primaryEnd = range.GetX2();
+                    primaryStep = kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_EAST;
+                }
+                else
+                {
+                    primaryStart = range.GetX2();
+                    primaryEnd = range.GetX1();
+                    primaryStep = -kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_WEST;
+                }
+            }
+            else
+            {
+                secondaryStart = range.GetX1();
+                secondaryEnd = range.GetX2();
+
+                if (startPos.y <= (range.GetY1() + range.GetY2()) / 2)
+                {
+                    primaryStart = range.GetY1();
+                    primaryEnd = range.GetY2();
+                    primaryStep = kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_NORTH;
+                }
+                else
+                {
+                    primaryStart = range.GetY2();
+                    primaryEnd = range.GetY1();
+                    primaryStep = -kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_SOUTH;
+                }
+            }
+
+            // PHASE 1: Calculate terrain heights for each slice
+            // Track both baseZ (the ground level) and maxZ (the highest point including slopes)
+            // - maxZ is used for going UP, needed to reach the peak
+            // - baseZ is used for going DOWN, detects when ground drops
+            std::vector<SliceInfo> slices;
+
+            for (int32_t primary = primaryStart; primaryStep > 0 ? primary <= primaryEnd : primary >= primaryEnd;
+                 primary += primaryStep)
+            {
+                int32_t sliceBaseZ = INT32_MIN;
+                int32_t sliceMaxZ = INT32_MIN;
+
+                for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
+                {
+                    CoordsXY pos = primaryIsX ? CoordsXY{ primary, secondary } : CoordsXY{ secondary, primary };
+                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
+                    if (surfaceElement != nullptr)
+                    {
+                        int32_t base = surfaceElement->GetBaseZ();
+                        int32_t top = base;
+                        uint8_t slope = surfaceElement->GetSlope();
+
+                        // Add height for any raised corners
+                        if (slope & kTileSlopeRaisedCornersMask)
+                            top += kPathHeightStep;
+                        // Add another height step for steep diagonal slopes
+                        if (slope & kTileSlopeDiagonalFlag)
+                            top += kPathHeightStep;
+
+                        sliceBaseZ = std::max(sliceBaseZ, base);
+                        sliceMaxZ = std::max(sliceMaxZ, top);
+                    }
+                }
+
+                slices.push_back({ primary, sliceBaseZ, sliceMaxZ });
+            }
+
+            if (slices.empty())
+            {
+                return buildTileVector(range, 0);
+            }
+
+            // PHASE 2: Detect and filter out obstacles (sudden height spikes)
+            for (size_t i = 0; i < slices.size(); i++)
+            {
+                if (slices.size() == 1)
+                    continue;
+
+                int32_t prevZ = (i > 0) ? slices[i - 1].maxZ : slices[1].maxZ;
+                int32_t nextZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : slices[i - 1].maxZ;
+
+                bool spikeFromPrev = (slices[i].maxZ - prevZ) > kPathHeightStep;
+                bool spikeFromNext = (slices[i].maxZ - nextZ) > kPathHeightStep;
+
+                if (spikeFromPrev && spikeFromNext)
+                {
+                    int32_t newZ = std::min(prevZ, nextZ);
+                    slices[i].maxZ = newZ;
+                    slices[i].baseZ = std::min(slices[i].baseZ, newZ);
+                }
+            }
+
+            // PHASE 3: Build the path by bridging height differences
+            // I noticed that terrain slopes have maxZ > baseZ, flat raised areas have maxZ == baseZ
+            // Terrain slope: slope up ON the tile, it has raised corners
+            // Raised block: slope up BEFORE the tile. We look ahead
+            int32_t currentPathZ = slices[0].maxZ;
+
+            for (size_t i = 0; i < slices.size(); i++)
+            {
+                int32_t thisBaseZ = slices[i].baseZ;
+                int32_t thisMaxZ = slices[i].maxZ;
+                int32_t nextMaxZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : thisMaxZ;
+                int32_t nextBaseZ = (i + 1 < slices.size()) ? slices[i + 1].baseZ : thisBaseZ;
+
+                // Is current tile a terrain slope? Does it have raised corners?
+                bool thisIsSlope = (thisMaxZ > thisBaseZ);
+                // Is next tile a flat raised block? Does it have no slope, but higher base?
+                bool nextIsRaisedBlock = (nextMaxZ == nextBaseZ) && (nextBaseZ > currentPathZ);
+
+                int32_t useZ = currentPathZ;
+                FootpathSlope useSlope = { FootpathSlopeType::flat, 0 };
+
+                // Going UP logic
+                if (thisIsSlope && thisMaxZ > currentPathZ)
+                {
+                    // Current tile is a terrain slope above us, so we slope up HERE
+                    useSlope = { FootpathSlopeType::sloped, slopeDirection };
+                    currentPathZ += kPathHeightStep;
+                }
+                else if (nextIsRaisedBlock && (nextBaseZ - currentPathZ) >= kPathHeightStep)
+                {
+                    // Next tile is a raised block, so we slope up NOW but before the block
+                    useSlope = { FootpathSlopeType::sloped, slopeDirection };
+                    currentPathZ += kPathHeightStep;
+                }
+                // Going DOWN logic
+                // On terrain slopes (thisMaxZ > thisBaseZ) we go down ON the slope tile
+                // On flat raised blocks (thisMaxZ == thisBaseZ) we stay flat, go down AFTER
+                else if ((currentPathZ - nextMaxZ) >= kPathHeightStep)
+                {
+                    // Check if we should go down now or stay flat
+                    bool thisIsFlatBlock = (thisMaxZ == thisBaseZ) && (thisMaxZ >= currentPathZ);
+
+                    if (!thisIsFlatBlock)
+                    {
+                        // Either it's a slope tile OR we're above the terrain, so we go down NOW
+                        useZ = currentPathZ - kPathHeightStep;
+                        useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                        currentPathZ -= kPathHeightStep;
+                    }
+                    // else we stay flat on the raised block, that's handled by else clause below
+                }
+                else
+                {
+                    // Flat, match current terrain height
+                    useZ = thisMaxZ;
+                    currentPathZ = thisMaxZ;
+                }
+
+                // Add tiles for this slice
+                for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
+                {
+                    CoordsXY pos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondary }
+                                              : CoordsXY{ secondary, slices[i].primaryCoord };
+                    result.push_back({ CoordsXYZ(pos.x, pos.y, useZ), useSlope });
+                }
+            }
+
+            return result;
+        }
+
         void WindowFootpathSetProvisionalPathDragArea(MapRange range, int32_t baseZ)
         {
             gMapSelectFlags.unset(MapSelectFlag::enableArrow);
@@ -1119,7 +1332,19 @@ namespace OpenRCT2::Ui::Windows
             FootpathUpdateProvisional();
 
             // Set provisional path
-            auto tiles = buildTileVector(range, baseZ);
+            // When no modifier keys are pressed (baseZ == 0), use the connected algorithm
+            // that automatically adds slopes to create a continuous path over terrain.
+            // When Shift or Ctrl is pressed, fall back to the original behavior.
+            std::vector<ProvisionalTile> tiles;
+            if (baseZ == 0 && !_footpathPlaceShiftState && !_footpathPlaceCtrlState)
+            {
+                tiles = buildConnectedTileVector(range, _dragStartPos);
+            }
+            else
+            {
+                tiles = buildTileVector(range, baseZ);
+            }
+
             auto pathType = gFootpathSelection.getSelectedSurface();
             auto constructFlags = FootpathCreateConstructFlags(pathType);
             const auto footpathCost = FootpathProvisionalSet(

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -133,19 +133,13 @@ namespace OpenRCT2::Ui::Windows
         ObjectEntryIndex type{};
         CoordsXY positionA{};
         CoordsXY positionB{};
-        /**
-         * Z of the first tile. Used for checking if the provisional path needs updating.
-         */
         int32_t startZ{};
         ProvisionalPathFlags flags{};
         ObjectEntryIndex surfaceIndex{};
         ObjectEntryIndex railingsIndex{};
         PathConstructFlags constructFlags{};
         std::vector<ProvisionalTile> tiles{};
-        /**
-         * Stores the last error from provisional path placement, so it can be shown
-         * when the user tries to place paths but all tiles failed.
-         */
+        bool usingModifiers{};
         GameActions::Result lastError{};
     };
 
@@ -1083,8 +1077,10 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Check for change
+            bool currentlyUsingModifiers = _footpathPlaceShiftState || _footpathPlaceCtrlState;
             if (_provisionalFootpath.flags.has(ProvisionalPathFlag::placed) && _provisionalFootpath.positionA == mapPos
-                && _provisionalFootpath.startZ == _footpathPlaceZ)
+                && _provisionalFootpath.startZ == _footpathPlaceZ
+                && _provisionalFootpath.usingModifiers == currentlyUsingModifiers)
             {
                 return;
             }
@@ -1115,6 +1111,7 @@ namespace OpenRCT2::Ui::Windows
             auto tiles = std::array<ProvisionalTile, 1>({ footpathLoc, placement.slope });
             const auto footpathCost = FootpathProvisionalSet(
                 pathType, gFootpathSelection.railings, *mapPos, *mapPos, placement.baseZ, tiles, constructFlags);
+            _provisionalFootpath.usingModifiers = currentlyUsingModifiers;
 
             if (_windowFootpathCost != footpathCost)
             {
@@ -1164,33 +1161,28 @@ namespace OpenRCT2::Ui::Windows
         {
             gMapSelectFlags.unset(MapSelectFlag::enableArrow);
 
-            // Calculate expected tile count based on range
             int32_t rangeXTiles = (range.GetX2() - range.GetX1()) / kCoordsXYStep + 1;
             int32_t rangeYTiles = (range.GetY2() - range.GetY1()) / kCoordsXYStep + 1;
             size_t expectedTileCount = static_cast<size_t>(rangeXTiles * rangeYTiles);
 
-            // Check for change
+            bool currentlyUsingModifiers = _footpathPlaceShiftState || _footpathPlaceCtrlState;
             if (_provisionalFootpath.flags.has(ProvisionalPathFlag::placed) && range.Point1 == _provisionalFootpath.positionA
                 && range.Point2 == _provisionalFootpath.positionB && baseZ == _provisionalFootpath.startZ
-                && _provisionalFootpath.tiles.size() == expectedTileCount)
+                && _provisionalFootpath.tiles.size() == expectedTileCount
+                && _provisionalFootpath.usingModifiers == currentlyUsingModifiers)
             {
                 return;
             }
 
-            // Set map selection
             gMapSelectFlags.set(MapSelectFlag::enable);
             gMapSelectType = MapSelectType::full;
 
             FootpathUpdateProvisional();
 
-            // Set provisional path
-            // When no modifier keys are pressed (baseZ == 0), use the connected algorithm
-            // that automatically adds slopes to create a continuous path over terrain.
-            // When Shift or Ctrl is pressed, fall back to the original behavior.
             std::vector<ProvisionalTile> tiles;
             bool isSingleTile = (range.Point1 == range.Point2);
 
-            if (baseZ == 0 && !_footpathPlaceShiftState && !_footpathPlaceCtrlState && !isSingleTile)
+            if (baseZ == 0 && !currentlyUsingModifiers && !isSingleTile)
             {
                 tiles = buildConnectedTileVector(range, _dragStartPos);
             }
@@ -1203,6 +1195,7 @@ namespace OpenRCT2::Ui::Windows
             auto constructFlags = FootpathCreateConstructFlags(pathType);
             const auto footpathCost = FootpathProvisionalSet(
                 pathType, gFootpathSelection.railings, range.Point1, range.Point2, baseZ, tiles, constructFlags);
+            _provisionalFootpath.usingModifiers = currentlyUsingModifiers;
 
             if (_windowFootpathCost != footpathCost)
             {

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -79,7 +79,7 @@ namespace OpenRCT2::Ui::Windows
         if (surfaceElement != nullptr)
         {
             // Calculate max surface height including raised corners and steep slopes
-            int32_t z = surfaceElement->GetBaseZ();
+            int32_t z = surfaceElement->getBaseZ();
             uint8_t slope = surfaceElement->GetSlope();
             if (slope & kTileSlopeRaisedCornersMask)
                 z += kPathHeightStep;
@@ -982,10 +982,10 @@ namespace OpenRCT2::Ui::Windows
 
                 if (_footpathPlaceShiftState)
                 {
-                    int32_t mapZ = info.Element->GetBaseZ();
-                    if (info.Element->GetType() == TileElementType::Surface)
+                    int32_t mapZ = info.Element->getBaseZ();
+                    if (info.Element->getType() == TileElementType::Surface)
                     {
-                        uint8_t slope = info.Element->AsSurface()->GetSlope();
+                        uint8_t slope = info.Element->asSurface()->GetSlope();
                         if (slope & kTileSlopeRaisedCornersMask)
                             mapZ += kPathHeightStep;
                         if (slope & kTileSlopeDiagonalFlag)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1336,7 +1336,8 @@ namespace OpenRCT2::Ui::Windows
             // that automatically adds slopes to create a continuous path over terrain.
             // When Shift or Ctrl is pressed, fall back to the original behavior.
             std::vector<ProvisionalTile> tiles;
-            if (baseZ == 0 && !_footpathPlaceShiftState && !_footpathPlaceCtrlState)
+            bool isSingleTile = (range.Point1 == range.Point2);
+            if (baseZ == 0 && !_footpathPlaceShiftState && !_footpathPlaceCtrlState && !isSingleTile)
             {
                 tiles = buildConnectedTileVector(range, _dragStartPos);
             }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -70,7 +70,7 @@ namespace OpenRCT2::Ui::Windows
      * Resolve an irregular slope placement (e.g., corner-raised terrain) by calculating the
      * max surface height and treating it as a flat path. This allows placement on uneven terrain.
      */
-    static void ResolveIrregularPlacement(FootpathPlacementResult& placement, const TileCoordsXY& location)
+    static void resolveIrregularPlacement(FootpathPlacementResult& placement, const TileCoordsXY& location)
     {
         if (placement.slope.type != FootpathSlopeType::irregular)
             return;
@@ -1106,7 +1106,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            ResolveIrregularPlacement(placement, TileCoordsXY(*mapPos));
+            resolveIrregularPlacement(placement, TileCoordsXY(*mapPos));
 
             // Set provisional path
             auto pathType = gFootpathSelection.getSelectedSurface();
@@ -1134,7 +1134,7 @@ namespace OpenRCT2::Ui::Windows
                     if (baseZ == 0)
                     {
                         placement = FootpathGetOnTerrainPlacement(TileCoordsXY(CoordsXY(x, y)));
-                        ResolveIrregularPlacement(placement, TileCoordsXY(CoordsXY(x, y)));
+                        resolveIrregularPlacement(placement, TileCoordsXY(CoordsXY(x, y)));
                     }
 
                     auto calculatedLocation = CoordsXYZ(x, y, placement.baseZ);
@@ -1147,7 +1147,7 @@ namespace OpenRCT2::Ui::Windows
 
         static std::vector<ProvisionalTile> buildConnectedTileVector(MapRange range, CoordsXY dragStart)
         {
-            auto placements = CalculateConnectedPathSlopes(range, dragStart);
+            auto placements = calculateConnectedPathSlopes(range, dragStart);
             if (placements.empty())
                 return buildTileVector(range, 0);
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -42,6 +42,7 @@
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/world/ConstructionClearance.h>
 #include <openrct2/world/Footpath.h>
+#include <openrct2/world/FootpathDragSlope.h>
 #include <openrct2/world/Map.h>
 #include <openrct2/world/MapSelection.h>
 #include <openrct2/world/TileElementsView.h>
@@ -66,21 +67,6 @@ namespace OpenRCT2::Ui::Windows
     };
 
     /**
-     * Calculate the maximum height of a surface element, including any raised corners
-     * and steep diagonal slopes. Used for path placement on irregular terrain.
-     */
-    static int32_t GetMaxSurfaceHeight(const SurfaceElement& surface)
-    {
-        int32_t z = surface.GetBaseZ();
-        uint8_t slope = surface.GetSlope();
-        if (slope & kTileSlopeRaisedCornersMask)
-            z += kPathHeightStep;
-        if (slope & kTileSlopeDiagonalFlag)
-            z += kPathHeightStep;
-        return z;
-    }
-
-    /**
      * Resolve an irregular slope placement (e.g., corner-raised terrain) by calculating the
      * max surface height and treating it as a flat path. This allows placement on uneven terrain.
      */
@@ -92,21 +78,18 @@ namespace OpenRCT2::Ui::Windows
         auto* surfaceElement = MapGetSurfaceElementAt(location);
         if (surfaceElement != nullptr)
         {
-            placement.baseZ = GetMaxSurfaceHeight(*surfaceElement);
+            // Calculate max surface height including raised corners and steep slopes
+            int32_t z = surfaceElement->GetBaseZ();
+            uint8_t slope = surfaceElement->GetSlope();
+            if (slope & kTileSlopeRaisedCornersMask)
+                z += kPathHeightStep;
+            if (slope & kTileSlopeDiagonalFlag)
+                z += kPathHeightStep;
+
+            placement.baseZ = z;
             placement.slope = { FootpathSlopeType::flat, 0 };
         }
     }
-
-    /**
-     * Stores terrain height information for a "slice" of tiles along the primary drag axis.
-     * Used by buildConnectedTileVector to determine path heights and slopes.
-     */
-    struct SliceInfo
-    {
-        int32_t primaryCoord;
-        int32_t baseZ;
-        int32_t maxZ;
-    };
 
     static money64 FootpathProvisionalSet(
         ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXY& footpathLocA, const CoordsXY& footpathLocB,
@@ -1162,348 +1145,18 @@ namespace OpenRCT2::Ui::Windows
             return tiles;
         }
 
-        /**
-         * Build a vector of path tiles that follow terrain naturally, creating
-         * a continuous connected path with appropriate slopes.
-         *
-         * Algorithm:
-         *
-         * Phase 1 - Gather terrain heights for each slice along the primary drag axis
-         * Phase 2 - Filter out obstacle spikes (isolated height jumps)
-         * Phase 3 - Build path tiles with slopes to bridge height differences
-         */
         static std::vector<ProvisionalTile> buildConnectedTileVector(MapRange range, CoordsXY dragStart)
         {
-            std::vector<ProvisionalTile> result;
-
-            int32_t dragWidth = range.GetX2() - range.GetX1();
-            int32_t dragHeight = range.GetY2() - range.GetY1();
-            CoordsXY startPos = dragStart.ToTileStart();
-
-            // Clamp start position to range
-            startPos.x = std::clamp(startPos.x, range.GetX1(), range.GetX2());
-            startPos.y = std::clamp(startPos.y, range.GetY1(), range.GetY2());
-
-            bool primaryIsX = dragWidth >= dragHeight;
-
-            // Determine direction along primary axis
-            int32_t primaryStart, primaryEnd, primaryStep;
-            int32_t secondaryStart, secondaryEnd;
-            Direction slopeDirection;
-
-            if (primaryIsX)
-            {
-                secondaryStart = range.GetY1();
-                secondaryEnd = range.GetY2();
-
-                if (startPos.x <= (range.GetX1() + range.GetX2()) / 2)
-                {
-                    primaryStart = range.GetX1();
-                    primaryEnd = range.GetX2();
-                    primaryStep = kCoordsXYStep;
-                    slopeDirection = TILE_ELEMENT_DIRECTION_EAST;
-                }
-                else
-                {
-                    primaryStart = range.GetX2();
-                    primaryEnd = range.GetX1();
-                    primaryStep = -kCoordsXYStep;
-                    slopeDirection = TILE_ELEMENT_DIRECTION_WEST;
-                }
-            }
-            else
-            {
-                secondaryStart = range.GetX1();
-                secondaryEnd = range.GetX2();
-
-                if (startPos.y <= (range.GetY1() + range.GetY2()) / 2)
-                {
-                    primaryStart = range.GetY1();
-                    primaryEnd = range.GetY2();
-                    primaryStep = kCoordsXYStep;
-                    slopeDirection = TILE_ELEMENT_DIRECTION_NORTH;
-                }
-                else
-                {
-                    primaryStart = range.GetY2();
-                    primaryEnd = range.GetY1();
-                    primaryStep = -kCoordsXYStep;
-                    slopeDirection = TILE_ELEMENT_DIRECTION_SOUTH;
-                }
-            }
-
-            // PHASE 1: Calculate terrain heights for each slice
-            // Track both baseZ (the ground level) and maxZ (the highest point including slopes)
-            // - maxZ is used for going UP, needed to reach the peak
-            // - baseZ is used for going DOWN, detects when ground drops
-            std::vector<SliceInfo> slices;
-
-            for (int32_t primary = primaryStart; primaryStep > 0 ? primary <= primaryEnd : primary >= primaryEnd;
-                 primary += primaryStep)
-            {
-                int32_t sliceBaseZ = INT32_MIN;
-                int32_t sliceMaxZ = INT32_MIN;
-
-                for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
-                {
-                    CoordsXY pos = primaryIsX ? CoordsXY{ primary, secondary } : CoordsXY{ secondary, primary };
-                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
-                    if (surfaceElement != nullptr)
-                    {
-                        int32_t base = surfaceElement->GetBaseZ();
-                        int32_t top = GetMaxSurfaceHeight(*surfaceElement);
-
-                        sliceBaseZ = std::max(sliceBaseZ, base);
-                        sliceMaxZ = std::max(sliceMaxZ, top);
-                    }
-                }
-
-                // Skip slices where no valid surface was found
-                if (sliceBaseZ == INT32_MIN)
-                    continue;
-
-                slices.push_back({ primary, sliceBaseZ, sliceMaxZ });
-            }
-
-            if (slices.empty())
-            {
+            auto placements = CalculateConnectedPathSlopes(range, dragStart);
+            if (placements.empty())
                 return buildTileVector(range, 0);
-            }
 
-            // PHASE 2: Detect and filter out obstacles (sudden height spikes)
-            if (slices.size() > 1)
+            std::vector<ProvisionalTile> result;
+            result.reserve(placements.size());
+            for (const auto& placement : placements)
             {
-                for (size_t i = 0; i < slices.size(); i++)
-                {
-                    int32_t prevZ = (i > 0) ? slices[i - 1].maxZ : slices[1].maxZ;
-                    int32_t nextZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : slices[i - 1].maxZ;
-
-                    bool spikeFromPrev = (slices[i].maxZ - prevZ) > kPathHeightStep;
-                    bool spikeFromNext = (slices[i].maxZ - nextZ) > kPathHeightStep;
-
-                    if (spikeFromPrev && spikeFromNext)
-                    {
-                        int32_t newZ = std::min(prevZ, nextZ);
-                        slices[i].maxZ = newZ;
-                        slices[i].baseZ = std::min(slices[i].baseZ, newZ);
-                    }
-                }
+                result.push_back({ placement.position, placement.slope });
             }
-
-            // PHASE 3: Build the path by bridging height differences
-            // I noticed that terrain slopes have maxZ > baseZ, flat raised areas have maxZ == baseZ
-            // Terrain slope: slope up ON the tile, it has raised corners
-            // Raised block: slope up BEFORE the tile. We look ahead
-            int32_t secondaryCount = (secondaryEnd - secondaryStart) / kCoordsXYStep + 1;
-            result.reserve(slices.size() * secondaryCount);
-
-            // Determine initial height based on first tile and its immediate neighbor only.
-            // When the first tile is a slope and we're heading upward, start at baseZ to detect it.
-            // For steep diagonal slopes (2 height steps), start at the midpoint since a path
-            // can only slope one step at a time.
-            // BUT NOT: 3 corner up things, because they are NOT TRAVERSABLE so always start at maxZ.
-            // WTF so many edge cases!?
-            bool firstTileIsRaiseType = false;
-            {
-                CoordsXY firstPos = primaryIsX ? CoordsXY{ slices[0].primaryCoord, secondaryStart }
-                                               : CoordsXY{ secondaryStart, slices[0].primaryCoord };
-                auto* firstSurf = MapGetSurfaceElementAt(TileCoordsXY(firstPos));
-                if (firstSurf != nullptr)
-                {
-                    uint8_t slope = firstSurf->GetSlope();
-                    uint8_t corners = slope & kTileSlopeRaisedCornersMask;
-                    bool isDiag = (slope & kTileSlopeDiagonalFlag) != 0;
-                    firstTileIsRaiseType = !isDiag
-                        && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
-                }
-            }
-            bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep && !firstTileIsRaiseType;
-            bool firstTileIsSteep = (slices[0].maxZ - slices[0].baseZ) >= 2 * kPathHeightStep;
-            // > not >= because if the next tile is at SAME height, stay flat at top instead of sloping up.
-            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ);
-            int32_t currentPathZ;
-            if (firstTileIsSlope && nextTileIsHigher)
-                currentPathZ = firstTileIsSteep ? slices[0].baseZ + kPathHeightStep : slices[0].baseZ;
-            else
-                currentPathZ = slices[0].maxZ;
-
-            // Track if we just went up/down a slope (to distinguish landing from going down,
-            // and to continue descent on diagonal hill edges)
-            bool justWentUp = false;
-            bool justWentDown = false;
-
-            for (size_t i = 0; i < slices.size(); i++)
-            {
-                int32_t thisBaseZ = slices[i].baseZ;
-                int32_t thisMaxZ = slices[i].maxZ;
-                int32_t nextMaxZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : thisMaxZ;
-                int32_t nextBaseZ = (i + 1 < slices.size()) ? slices[i + 1].baseZ : thisBaseZ;
-
-                // Is current tile a terrain slope? Requires at least one height step difference.
-                bool thisIsSlope = (thisMaxZ - thisBaseZ) >= kPathHeightStep;
-                // Is next tile a flat raised block? Does it have no slope, but higher base?
-                bool nextIsRaisedBlock = (nextMaxZ == nextBaseZ) && (nextBaseZ > currentPathZ);
-
-                int32_t useZ = currentPathZ;
-                FootpathSlope useSlope = { FootpathSlopeType::flat, 0 };
-
-                bool isLastTile = (i == slices.size() - 1);
-
-                // Going UP logic
-                if (thisIsSlope && thisMaxZ > currentPathZ)
-                {
-                    // Current tile is a terrain slope above us, so we slope up HERE
-                    useSlope = { FootpathSlopeType::sloped, slopeDirection };
-                    currentPathZ += kPathHeightStep;
-                    justWentUp = true;
-                    justWentDown = false;
-                }
-                else if (nextIsRaisedBlock && (nextBaseZ - currentPathZ) >= kPathHeightStep)
-                {
-                    // Next tile is a raised block, so we slope up NOW but before the block
-                    useSlope = { FootpathSlopeType::sloped, slopeDirection };
-                    currentPathZ += kPathHeightStep;
-                    justWentUp = true;
-                    justWentDown = false;
-                }
-                // Going DOWN logic
-                // On terrain slopes (thisMaxZ > thisBaseZ) we go down ON the slope tile
-                // On flat raised blocks (thisMaxZ == thisBaseZ) we stay flat, go down AFTER
-                else if ((currentPathZ - nextMaxZ) >= kPathHeightStep)
-                {
-                    // Check if we should go down now or stay flat
-                    bool thisIsFlatBlock = !thisIsSlope && (thisMaxZ >= currentPathZ);
-
-                    if (!thisIsFlatBlock)
-                    {
-                        // Either it's a slope tile OR we're above the terrain, so we go down NOW
-                        useZ = currentPathZ - kPathHeightStep;
-                        useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
-                        currentPathZ -= kPathHeightStep;
-                        justWentDown = true;
-                    }
-                    else
-                    {
-                        justWentDown = false;
-                    }
-                    justWentUp = false;
-                }
-                // Last tile slope handling: if we're ending on a slope and need to come down
-                // Only go down if we didn't just come UP (which would mean this is a landing tile)
-                // Use terrain slope direction check OR continuation of a descent (justWentDown)
-                else if (isLastTile && thisIsSlope && !justWentUp && currentPathZ >= thisMaxZ)
-                {
-                    bool shouldSlopeDown = false;
-
-                    // If we were already descending, continue the descent
-                    // This handles diagonal hill edges where terrain slope direction is oblique
-                    if (justWentDown)
-                    {
-                        shouldSlopeDown = true;
-                    }
-                    else
-                    {
-                        // Check terrain slope direction for cases where descent starts on the last tile
-                        CoordsXY tilePos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondaryStart }
-                                                      : CoordsXY{ secondaryStart, slices[i].primaryCoord };
-                        auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(tilePos));
-
-                        if (surfaceElement != nullptr)
-                        {
-                            uint8_t slope = surfaceElement->GetSlope();
-                            uint8_t corners = slope & kTileSlopeRaisedCornersMask;
-                            bool isDiagonal = (slope & kTileSlopeDiagonalFlag) != 0;
-
-                            if (isDiagonal)
-                            {
-                                // Diagonal slope: 3 corners up, 1 corner down
-                                // The down corner indicates the direction the slope descends toward
-                                Direction downDirection = TILE_ELEMENT_DIRECTION_WEST;
-                                if (corners == kTileSlopeNCornerDown)
-                                    downDirection = TILE_ELEMENT_DIRECTION_NORTH;
-                                else if (corners == kTileSlopeECornerDown)
-                                    downDirection = TILE_ELEMENT_DIRECTION_EAST;
-                                else if (corners == kTileSlopeSCornerDown)
-                                    downDirection = TILE_ELEMENT_DIRECTION_SOUTH;
-                                else if (corners == kTileSlopeWCornerDown)
-                                    downDirection = TILE_ELEMENT_DIRECTION_WEST;
-
-                                // If traveling in the down direction, we're going down
-                                if (downDirection == slopeDirection)
-                                    shouldSlopeDown = true;
-                            }
-                            else
-                            {
-                                // Regular slope: use FootpathGetOnTerrainPlacement
-                                auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
-                                // Terrain slopes UP in terrainPlacement.slope.direction
-                                // If terrain slopes UP opposite to our travel, we're going DOWN
-                                if (terrainPlacement.slope.type == FootpathSlopeType::sloped
-                                    && terrainPlacement.slope.direction == DirectionReverse(slopeDirection))
-                                {
-                                    shouldSlopeDown = true;
-                                }
-                            }
-                        }
-                    }
-
-                    if (shouldSlopeDown)
-                    {
-                        useZ = currentPathZ - kPathHeightStep;
-                        useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
-                        currentPathZ -= kPathHeightStep;
-                    }
-                    // Otherwise: terrain slopes in our direction (we climbed up) or perpendicular (edge)
-                    // Stay flat in these cases
-                    justWentUp = false;
-                    justWentDown = false;
-                }
-                else
-                {
-                    // Flat, match current terrain height
-                    useZ = thisMaxZ;
-                    currentPathZ = thisMaxZ;
-                    justWentUp = false;
-                    justWentDown = false;
-                }
-
-                // Add tiles for this slice
-                for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
-                {
-                    CoordsXY pos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondary }
-                                              : CoordsXY{ secondary, slices[i].primaryCoord };
-
-                    int32_t tileZ = useZ;
-                    FootpathSlope tileSlope = useSlope;
-
-                    // Check if this specific tile has terrain that can't support slopes
-                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
-                    if (surfaceElement != nullptr)
-                    {
-                        auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
-
-                        // Check for raise type tiles the ones with the 3 corners up, no diagonal flag.
-                        uint8_t rawSlope = surfaceElement->GetSlope();
-                        uint8_t corners = rawSlope & kTileSlopeRaisedCornersMask;
-                        bool isDiagonal = (rawSlope & kTileSlopeDiagonalFlag) != 0;
-                        bool isRaiseType = !isDiagonal
-                            && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
-
-                        // Only convert to flat for the 3 corners up tiles
-                        // ALSO: Only apply this if:
-                        // 1. The terrain height is at or above the path height
-                        // 2. The path is already FLAT... DON'T interrupt sloped paths going down.
-                        if (isRaiseType && tileSlope.type == FootpathSlopeType::flat && terrainPlacement.baseZ > tileZ)
-                        {
-                            // Adjust flat path height to match raise-type terrain
-                            tileZ = terrainPlacement.baseZ;
-                        }
-                    }
-
-                    result.push_back({ CoordsXYZ(pos.x, pos.y, tileZ), tileSlope });
-                }
-            }
-
             return result;
         }
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -159,6 +159,11 @@ namespace OpenRCT2::Ui::Windows
         ObjectEntryIndex railingsIndex{};
         PathConstructFlags constructFlags{};
         std::vector<ProvisionalTile> tiles{};
+        /**
+         * Stores the last error from provisional path placement, so it can be shown
+         * when the user tries to place paths but all tiles failed.
+         */
+        GameActions::Result lastError{};
     };
 
     static ProvisionalFootpath _provisionalFootpath;
@@ -1296,9 +1301,26 @@ namespace OpenRCT2::Ui::Windows
             // When the first tile is a slope and we're heading upward, start at baseZ to detect it.
             // For steep diagonal slopes (2 height steps), start at the midpoint since a path
             // can only slope one step at a time.
-            bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep;
+            // BUT NOT: 3 corner up things, because they are NOT TRAVERSABLE so always start at maxZ.
+            // WTF so many edge cases!?
+            bool firstTileIsRaiseType = false;
+            {
+                CoordsXY firstPos = primaryIsX ? CoordsXY{ slices[0].primaryCoord, secondaryStart }
+                                               : CoordsXY{ secondaryStart, slices[0].primaryCoord };
+                auto* firstSurf = MapGetSurfaceElementAt(TileCoordsXY(firstPos));
+                if (firstSurf != nullptr)
+                {
+                    uint8_t slope = firstSurf->GetSlope();
+                    uint8_t corners = slope & kTileSlopeRaisedCornersMask;
+                    bool isDiag = (slope & kTileSlopeDiagonalFlag) != 0;
+                    firstTileIsRaiseType = !isDiag
+                        && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
+                }
+            }
+            bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep && !firstTileIsRaiseType;
             bool firstTileIsSteep = (slices[0].maxZ - slices[0].baseZ) >= 2 * kPathHeightStep;
-            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ >= slices[0].maxZ);
+            // > not >= because if the next tile is at SAME height, stay flat at top instead of sloping up.
+            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ);
             int32_t currentPathZ;
             if (firstTileIsSlope && nextTileIsHigher)
                 currentPathZ = firstTileIsSteep ? slices[0].baseZ + kPathHeightStep : slices[0].baseZ;
@@ -1450,7 +1472,35 @@ namespace OpenRCT2::Ui::Windows
                 {
                     CoordsXY pos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondary }
                                               : CoordsXY{ secondary, slices[i].primaryCoord };
-                    result.push_back({ CoordsXYZ(pos.x, pos.y, useZ), useSlope });
+
+                    int32_t tileZ = useZ;
+                    FootpathSlope tileSlope = useSlope;
+
+                    // Check if this specific tile has terrain that can't support slopes
+                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
+                    if (surfaceElement != nullptr)
+                    {
+                        auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
+
+                        // Check for raise type tiles the ones with the 3 corners up, no diagonal flag.
+                        uint8_t rawSlope = surfaceElement->GetSlope();
+                        uint8_t corners = rawSlope & kTileSlopeRaisedCornersMask;
+                        bool isDiagonal = (rawSlope & kTileSlopeDiagonalFlag) != 0;
+                        bool isRaiseType = !isDiagonal
+                            && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
+
+                        // Only convert to flat for the 3 corners up tiles
+                        // ALSO: Only apply this if:
+                        // 1. The terrain height is at or above the path height
+                        // 2. The path is already FLAT... DON'T interrupt sloped paths going down.
+                        if (isRaiseType && tileSlope.type == FootpathSlopeType::flat && terrainPlacement.baseZ > tileZ)
+                        {
+                            // Adjust flat path height to match raise-type terrain
+                            tileZ = terrainPlacement.baseZ;
+                        }
+                    }
+
+                    result.push_back({ CoordsXYZ(pos.x, pos.y, tileZ), tileSlope });
                 }
             }
 
@@ -1638,7 +1688,17 @@ namespace OpenRCT2::Ui::Windows
 
             FootpathUpdateProvisional();
             if (_provisionalFootpath.tiles.empty())
+            {
+                // Show the error from the last failed provisional placement
+                if (_provisionalFootpath.lastError.error != GameActions::Status::ok)
+                {
+                    auto windowManager = Ui::GetWindowManager();
+                    windowManager->ShowError(
+                        _provisionalFootpath.lastError.getErrorTitle(), _provisionalFootpath.lastError.getErrorMessage());
+                }
+                _footpathErrorOccured = true;
                 return;
+            }
 
             // Try and place path
             auto selectedType = gFootpathSelection.getSelectedSurface();
@@ -2397,6 +2457,8 @@ namespace OpenRCT2::Ui::Windows
             // Clear stale tile data to prevent placing paths at old positions
             // when clicking on invalid locations (e.g., blocked by clearances)
             _provisionalFootpath.tiles.clear();
+            // Store the last error so it can be shown when the user tries to place paths
+            _provisionalFootpath.lastError = res;
         }
 
         if (!isToolActive(WindowClass::scenery))

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1248,7 +1248,12 @@ namespace OpenRCT2::Ui::Windows
             // I noticed that terrain slopes have maxZ > baseZ, flat raised areas have maxZ == baseZ
             // Terrain slope: slope up ON the tile, it has raised corners
             // Raised block: slope up BEFORE the tile. We look ahead
-            int32_t currentPathZ = slices[0].maxZ;
+
+            // Determine initial height based on first tile and its immediate neighbor only.
+            // When the first tile is a slope and we're heading upward, start at baseZ to detect it.
+            bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep;
+            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ);
+            int32_t currentPathZ = (firstTileIsSlope && nextTileIsHigher) ? slices[0].baseZ : slices[0].maxZ;
 
             for (size_t i = 0; i < slices.size(); i++)
             {
@@ -1257,13 +1262,15 @@ namespace OpenRCT2::Ui::Windows
                 int32_t nextMaxZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : thisMaxZ;
                 int32_t nextBaseZ = (i + 1 < slices.size()) ? slices[i + 1].baseZ : thisBaseZ;
 
-                // Is current tile a terrain slope? Does it have raised corners?
-                bool thisIsSlope = (thisMaxZ > thisBaseZ);
+                // Is current tile a terrain slope? Requires at least one height step difference.
+                bool thisIsSlope = (thisMaxZ - thisBaseZ) >= kPathHeightStep;
                 // Is next tile a flat raised block? Does it have no slope, but higher base?
                 bool nextIsRaisedBlock = (nextMaxZ == nextBaseZ) && (nextBaseZ > currentPathZ);
 
                 int32_t useZ = currentPathZ;
                 FootpathSlope useSlope = { FootpathSlopeType::flat, 0 };
+
+                bool isLastTile = (i == slices.size() - 1);
 
                 // Going UP logic
                 if (thisIsSlope && thisMaxZ > currentPathZ)
@@ -1284,7 +1291,7 @@ namespace OpenRCT2::Ui::Windows
                 else if ((currentPathZ - nextMaxZ) >= kPathHeightStep)
                 {
                     // Check if we should go down now or stay flat
-                    bool thisIsFlatBlock = (thisMaxZ == thisBaseZ) && (thisMaxZ >= currentPathZ);
+                    bool thisIsFlatBlock = !thisIsSlope && (thisMaxZ >= currentPathZ);
 
                     if (!thisIsFlatBlock)
                     {
@@ -1294,6 +1301,14 @@ namespace OpenRCT2::Ui::Windows
                         currentPathZ -= kPathHeightStep;
                     }
                     // else we stay flat on the raised block, that's handled by else clause below
+                }
+                // Last tile slope handling: if we're ending on a slope and need to come down
+                else if (isLastTile && thisIsSlope && (currentPathZ - thisBaseZ) >= kPathHeightStep)
+                {
+                    // We're on the last tile, it's a slope, and we're significantly above the base
+                    useZ = currentPathZ - kPathHeightStep;
+                    useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                    currentPathZ -= kPathHeightStep;
                 }
                 else
                 {

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -66,6 +66,38 @@ namespace OpenRCT2::Ui::Windows
     };
 
     /**
+     * Calculate the maximum height of a surface element, including any raised corners
+     * and steep diagonal slopes. Used for path placement on irregular terrain.
+     */
+    static int32_t GetMaxSurfaceHeight(const SurfaceElement& surface)
+    {
+        int32_t z = surface.GetBaseZ();
+        uint8_t slope = surface.GetSlope();
+        if (slope & kTileSlopeRaisedCornersMask)
+            z += kPathHeightStep;
+        if (slope & kTileSlopeDiagonalFlag)
+            z += kPathHeightStep;
+        return z;
+    }
+
+    /**
+     * Resolve an irregular slope placement (e.g., corner-raised terrain) by calculating the
+     * max surface height and treating it as a flat path. This allows placement on uneven terrain.
+     */
+    static void ResolveIrregularPlacement(FootpathPlacementResult& placement, const TileCoordsXY& location)
+    {
+        if (placement.slope.type != FootpathSlopeType::irregular)
+            return;
+
+        auto* surfaceElement = MapGetSurfaceElementAt(location);
+        if (surfaceElement != nullptr)
+        {
+            placement.baseZ = GetMaxSurfaceHeight(*surfaceElement);
+            placement.slope = { FootpathSlopeType::flat, 0 };
+        }
+    }
+
+    /**
      * Stores terrain height information for a "slice" of tiles along the primary drag axis.
      * Used by buildConnectedTileVector to determine path heights and slopes.
      */
@@ -1053,7 +1085,14 @@ namespace OpenRCT2::Ui::Windows
             // Get current map pos and handle key modifier state
             auto mapPos = FootpathGetPlacePositionFromScreenPosition(screenCoords);
             if (!mapPos)
+            {
+                // Cursor is over invalid area (e.g., ride track), clear provisional path
+                // to prevent placing at the last valid position when clicking
+                gMapSelectFlags.unset(MapSelectFlag::enable);
+                FootpathUpdateProvisional();
+                _provisionalFootpath.tiles.clear();
                 return;
+            }
 
             // Check for change
             if (_provisionalFootpath.flags.has(ProvisionalPathFlag::placed) && _provisionalFootpath.positionA == mapPos
@@ -1075,8 +1114,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 gMapSelectFlags.unset(MapSelectFlag::enable);
                 FootpathUpdateProvisional();
+                _provisionalFootpath.tiles.clear();
                 return;
             }
+
+            ResolveIrregularPlacement(placement, TileCoordsXY(*mapPos));
 
             // Set provisional path
             auto pathType = gFootpathSelection.getSelectedSurface();
@@ -1102,7 +1144,10 @@ namespace OpenRCT2::Ui::Windows
                 {
                     FootpathPlacementResult placement = { baseZ, {} };
                     if (baseZ == 0)
+                    {
                         placement = FootpathGetOnTerrainPlacement(TileCoordsXY(CoordsXY(x, y)));
+                        ResolveIrregularPlacement(placement, TileCoordsXY(CoordsXY(x, y)));
+                    }
 
                     auto calculatedLocation = CoordsXYZ(x, y, placement.baseZ);
                     tiles.push_back({ calculatedLocation, placement.slope });
@@ -1201,20 +1246,16 @@ namespace OpenRCT2::Ui::Windows
                     if (surfaceElement != nullptr)
                     {
                         int32_t base = surfaceElement->GetBaseZ();
-                        int32_t top = base;
-                        uint8_t slope = surfaceElement->GetSlope();
-
-                        // Add height for any raised corners
-                        if (slope & kTileSlopeRaisedCornersMask)
-                            top += kPathHeightStep;
-                        // Add another height step for steep diagonal slopes
-                        if (slope & kTileSlopeDiagonalFlag)
-                            top += kPathHeightStep;
+                        int32_t top = GetMaxSurfaceHeight(*surfaceElement);
 
                         sliceBaseZ = std::max(sliceBaseZ, base);
                         sliceMaxZ = std::max(sliceMaxZ, top);
                     }
                 }
+
+                // Skip slices where no valid surface was found
+                if (sliceBaseZ == INT32_MIN)
+                    continue;
 
                 slices.push_back({ primary, sliceBaseZ, sliceMaxZ });
             }
@@ -1225,22 +1266,22 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // PHASE 2: Detect and filter out obstacles (sudden height spikes)
-            for (size_t i = 0; i < slices.size(); i++)
+            if (slices.size() > 1)
             {
-                if (slices.size() == 1)
-                    continue;
-
-                int32_t prevZ = (i > 0) ? slices[i - 1].maxZ : slices[1].maxZ;
-                int32_t nextZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : slices[i - 1].maxZ;
-
-                bool spikeFromPrev = (slices[i].maxZ - prevZ) > kPathHeightStep;
-                bool spikeFromNext = (slices[i].maxZ - nextZ) > kPathHeightStep;
-
-                if (spikeFromPrev && spikeFromNext)
+                for (size_t i = 0; i < slices.size(); i++)
                 {
-                    int32_t newZ = std::min(prevZ, nextZ);
-                    slices[i].maxZ = newZ;
-                    slices[i].baseZ = std::min(slices[i].baseZ, newZ);
+                    int32_t prevZ = (i > 0) ? slices[i - 1].maxZ : slices[1].maxZ;
+                    int32_t nextZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : slices[i - 1].maxZ;
+
+                    bool spikeFromPrev = (slices[i].maxZ - prevZ) > kPathHeightStep;
+                    bool spikeFromNext = (slices[i].maxZ - nextZ) > kPathHeightStep;
+
+                    if (spikeFromPrev && spikeFromNext)
+                    {
+                        int32_t newZ = std::min(prevZ, nextZ);
+                        slices[i].maxZ = newZ;
+                        slices[i].baseZ = std::min(slices[i].baseZ, newZ);
+                    }
                 }
             }
 
@@ -1248,12 +1289,26 @@ namespace OpenRCT2::Ui::Windows
             // I noticed that terrain slopes have maxZ > baseZ, flat raised areas have maxZ == baseZ
             // Terrain slope: slope up ON the tile, it has raised corners
             // Raised block: slope up BEFORE the tile. We look ahead
+            int32_t secondaryCount = (secondaryEnd - secondaryStart) / kCoordsXYStep + 1;
+            result.reserve(slices.size() * secondaryCount);
 
             // Determine initial height based on first tile and its immediate neighbor only.
             // When the first tile is a slope and we're heading upward, start at baseZ to detect it.
+            // For steep diagonal slopes (2 height steps), start at the midpoint since a path
+            // can only slope one step at a time.
             bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep;
-            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ);
-            int32_t currentPathZ = (firstTileIsSlope && nextTileIsHigher) ? slices[0].baseZ : slices[0].maxZ;
+            bool firstTileIsSteep = (slices[0].maxZ - slices[0].baseZ) >= 2 * kPathHeightStep;
+            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ >= slices[0].maxZ);
+            int32_t currentPathZ;
+            if (firstTileIsSlope && nextTileIsHigher)
+                currentPathZ = firstTileIsSteep ? slices[0].baseZ + kPathHeightStep : slices[0].baseZ;
+            else
+                currentPathZ = slices[0].maxZ;
+
+            // Track if we just went up/down a slope (to distinguish landing from going down,
+            // and to continue descent on diagonal hill edges)
+            bool justWentUp = false;
+            bool justWentDown = false;
 
             for (size_t i = 0; i < slices.size(); i++)
             {
@@ -1278,12 +1333,16 @@ namespace OpenRCT2::Ui::Windows
                     // Current tile is a terrain slope above us, so we slope up HERE
                     useSlope = { FootpathSlopeType::sloped, slopeDirection };
                     currentPathZ += kPathHeightStep;
+                    justWentUp = true;
+                    justWentDown = false;
                 }
                 else if (nextIsRaisedBlock && (nextBaseZ - currentPathZ) >= kPathHeightStep)
                 {
                     // Next tile is a raised block, so we slope up NOW but before the block
                     useSlope = { FootpathSlopeType::sloped, slopeDirection };
                     currentPathZ += kPathHeightStep;
+                    justWentUp = true;
+                    justWentDown = false;
                 }
                 // Going DOWN logic
                 // On terrain slopes (thisMaxZ > thisBaseZ) we go down ON the slope tile
@@ -1299,22 +1358,91 @@ namespace OpenRCT2::Ui::Windows
                         useZ = currentPathZ - kPathHeightStep;
                         useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
                         currentPathZ -= kPathHeightStep;
+                        justWentDown = true;
                     }
-                    // else we stay flat on the raised block, that's handled by else clause below
+                    else
+                    {
+                        justWentDown = false;
+                    }
+                    justWentUp = false;
                 }
                 // Last tile slope handling: if we're ending on a slope and need to come down
-                else if (isLastTile && thisIsSlope && (currentPathZ - thisBaseZ) >= kPathHeightStep)
+                // Only go down if we didn't just come UP (which would mean this is a landing tile)
+                // Use terrain slope direction check OR continuation of a descent (justWentDown)
+                else if (isLastTile && thisIsSlope && !justWentUp && currentPathZ >= thisMaxZ)
                 {
-                    // We're on the last tile, it's a slope, and we're significantly above the base
-                    useZ = currentPathZ - kPathHeightStep;
-                    useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
-                    currentPathZ -= kPathHeightStep;
+                    bool shouldSlopeDown = false;
+
+                    // If we were already descending, continue the descent
+                    // This handles diagonal hill edges where terrain slope direction is oblique
+                    if (justWentDown)
+                    {
+                        shouldSlopeDown = true;
+                    }
+                    else
+                    {
+                        // Check terrain slope direction for cases where descent starts on the last tile
+                        CoordsXY tilePos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondaryStart }
+                                                      : CoordsXY{ secondaryStart, slices[i].primaryCoord };
+                        auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(tilePos));
+
+                        if (surfaceElement != nullptr)
+                        {
+                            uint8_t slope = surfaceElement->GetSlope();
+                            uint8_t corners = slope & kTileSlopeRaisedCornersMask;
+                            bool isDiagonal = (slope & kTileSlopeDiagonalFlag) != 0;
+
+                            if (isDiagonal)
+                            {
+                                // Diagonal slope: 3 corners up, 1 corner down
+                                // The down corner indicates the direction the slope descends toward
+                                Direction downDirection = TILE_ELEMENT_DIRECTION_WEST;
+                                if (corners == kTileSlopeNCornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_NORTH;
+                                else if (corners == kTileSlopeECornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_EAST;
+                                else if (corners == kTileSlopeSCornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_SOUTH;
+                                else if (corners == kTileSlopeWCornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_WEST;
+
+                                // If traveling in the down direction, we're going down
+                                if (downDirection == slopeDirection)
+                                    shouldSlopeDown = true;
+                            }
+                            else
+                            {
+                                // Regular slope: use FootpathGetOnTerrainPlacement
+                                auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
+                                // Terrain slopes UP in terrainPlacement.slope.direction
+                                // If terrain slopes UP opposite to our travel, we're going DOWN
+                                if (terrainPlacement.slope.type == FootpathSlopeType::sloped
+                                    && terrainPlacement.slope.direction == DirectionReverse(slopeDirection))
+                                {
+                                    shouldSlopeDown = true;
+                                }
+                            }
+                        }
+                    }
+
+                    if (shouldSlopeDown)
+                    {
+                        useZ = currentPathZ - kPathHeightStep;
+                        useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                        currentPathZ -= kPathHeightStep;
+                    }
+                    // Otherwise: terrain slopes in our direction (we climbed up) or perpendicular (edge)
+                    // Stay flat in these cases
+                    justWentUp = false;
+                    justWentDown = false;
                 }
                 else
                 {
                     // Flat, match current terrain height
                     useZ = thisMaxZ;
                     currentPathZ = thisMaxZ;
+                    justWentUp = false;
+                    justWentDown = false;
                 }
 
                 // Add tiles for this slice
@@ -1333,9 +1461,15 @@ namespace OpenRCT2::Ui::Windows
         {
             gMapSelectFlags.unset(MapSelectFlag::enableArrow);
 
+            // Calculate expected tile count based on range
+            int32_t rangeXTiles = (range.GetX2() - range.GetX1()) / kCoordsXYStep + 1;
+            int32_t rangeYTiles = (range.GetY2() - range.GetY1()) / kCoordsXYStep + 1;
+            size_t expectedTileCount = static_cast<size_t>(rangeXTiles * rangeYTiles);
+
             // Check for change
             if (_provisionalFootpath.flags.has(ProvisionalPathFlag::placed) && range.Point1 == _provisionalFootpath.positionA
-                && range.Point2 == _provisionalFootpath.positionB && baseZ == _provisionalFootpath.startZ)
+                && range.Point2 == _provisionalFootpath.positionB && baseZ == _provisionalFootpath.startZ
+                && _provisionalFootpath.tiles.size() == expectedTileCount)
             {
                 return;
             }
@@ -1352,6 +1486,7 @@ namespace OpenRCT2::Ui::Windows
             // When Shift or Ctrl is pressed, fall back to the original behavior.
             std::vector<ProvisionalTile> tiles;
             bool isSingleTile = (range.Point1 == range.Point2);
+
             if (baseZ == 0 && !_footpathPlaceShiftState && !_footpathPlaceCtrlState && !isSingleTile)
             {
                 tiles = buildConnectedTileVector(range, _dragStartPos);
@@ -1481,7 +1616,8 @@ namespace OpenRCT2::Ui::Windows
             }
 
             setMapSelectRange({ _dragStartPos, correctedPos });
-            WindowFootpathSetProvisionalPathDragArea(getMapSelectRange(), _footpathPlaceZ);
+            auto actualRange = getMapSelectRange();
+            WindowFootpathSetProvisionalPathDragArea(actualRange, _footpathPlaceZ);
         }
 
         void WindowFootpathPlaceDragAreaHover(const ScreenCoordsXY& screenCoords)
@@ -2255,6 +2391,12 @@ namespace OpenRCT2::Ui::Windows
             {
                 ViewportSetVisibility(ViewportVisibility::undergroundViewOff);
             }
+        }
+        else
+        {
+            // Clear stale tile data to prevent placing paths at old positions
+            // when clicking on invalid locations (e.g., blocked by clearances)
+            _provisionalFootpath.tiles.clear();
         }
 
         if (!isToolActive(WindowClass::scenery))

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1411,7 +1411,6 @@ namespace OpenRCT2::Ui::Windows
             {
                 return;
             }
-            _provisionalFootpath.tiles.clear();
 
             auto mapPos = FootpathGetPlacePositionFromScreenPosition(screenCoords);
             if (!mapPos)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -983,7 +983,7 @@ namespace OpenRCT2::Ui::Windows
                 if (_footpathPlaceShiftState)
                 {
                     int32_t mapZ = info.Element->getBaseZ();
-                    if (info.Element->getType() == TileElementType::Surface)
+                    if (info.Element->getType() == TileElementType::surface)
                     {
                         uint8_t slope = info.Element->asSurface()->GetSlope();
                         if (slope & kTileSlopeRaisedCornersMask)

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -1276,6 +1276,7 @@
     <ClCompile Include="world\ConstructionClearance.cpp" />
     <ClCompile Include="world\Entrance.cpp" />
     <ClCompile Include="world\Footpath.cpp" />
+    <ClCompile Include="world\FootpathDragSlope.cpp" />
     <ClCompile Include="world\Map.cpp" />
     <ClCompile Include="world\MapAnimation.cpp" />
     <ClCompile Include="world\MapOwnership.cpp" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -700,6 +700,7 @@
     <ClInclude Include="world\ConstructionClearance.h" />
     <ClInclude Include="world\Entrance.h" />
     <ClInclude Include="world\Footpath.h" />
+    <ClInclude Include="world\FootpathDragSlope.h" />
     <ClInclude Include="world\LargeScenery.h" />
     <ClInclude Include="world\Location.hpp" />
     <ClInclude Include="world\Map.h" />

--- a/src/openrct2/world/FootpathDragSlope.cpp
+++ b/src/openrct2/world/FootpathDragSlope.cpp
@@ -28,7 +28,7 @@ namespace OpenRCT2
     };
 
     // Get surface height including raised corners and steep slopes
-    static int32_t GetMaxSurfaceHeight(const SurfaceElement& surface)
+    static int32_t getMaxSurfaceHeight(const SurfaceElement& surface)
     {
         int32_t z = surface.GetBaseZ();
         uint8_t slope = surface.GetSlope();
@@ -39,7 +39,7 @@ namespace OpenRCT2
         return z;
     }
 
-    std::vector<FootpathDragPlacement> CalculateConnectedPathSlopes(MapRange range, CoordsXY dragStart)
+    std::vector<FootpathDragPlacement> calculateConnectedPathSlopes(MapRange range, CoordsXY dragStart)
     {
         std::vector<FootpathDragPlacement> result;
 
@@ -112,7 +112,7 @@ namespace OpenRCT2
                 if (surfaceElement != nullptr)
                 {
                     int32_t base = surfaceElement->GetBaseZ();
-                    int32_t top = GetMaxSurfaceHeight(*surfaceElement);
+                    int32_t top = getMaxSurfaceHeight(*surfaceElement);
 
                     sliceBaseZ = std::max(sliceBaseZ, base);
                     sliceMaxZ = std::max(sliceMaxZ, top);

--- a/src/openrct2/world/FootpathDragSlope.cpp
+++ b/src/openrct2/world/FootpathDragSlope.cpp
@@ -1,0 +1,327 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "FootpathDragSlope.h"
+
+#include "Footpath.h"
+#include "Map.h"
+#include "tile_element/Slope.h"
+#include "tile_element/SurfaceElement.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace OpenRCT2
+{
+    // Terrain height info for a row of tiles along the primary drag axis
+    struct SliceInfo
+    {
+        int32_t primaryCoord;
+        int32_t baseZ;
+        int32_t maxZ;
+    };
+
+    // Get surface height including raised corners and steep slopes
+    static int32_t GetMaxSurfaceHeight(const SurfaceElement& surface)
+    {
+        int32_t z = surface.GetBaseZ();
+        uint8_t slope = surface.GetSlope();
+        if (slope & kTileSlopeRaisedCornersMask)
+            z += kPathHeightStep;
+        if (slope & kTileSlopeDiagonalFlag)
+            z += kPathHeightStep;
+        return z;
+    }
+
+    std::vector<FootpathDragPlacement> CalculateConnectedPathSlopes(MapRange range, CoordsXY dragStart)
+    {
+        std::vector<FootpathDragPlacement> result;
+
+        int32_t dragWidth = range.GetX2() - range.GetX1();
+        int32_t dragHeight = range.GetY2() - range.GetY1();
+        CoordsXY startPos = dragStart.ToTileStart();
+
+        startPos.x = std::clamp(startPos.x, range.GetX1(), range.GetX2());
+        startPos.y = std::clamp(startPos.y, range.GetY1(), range.GetY2());
+
+        bool primaryIsX = dragWidth >= dragHeight;
+        int32_t primaryStart, primaryEnd, primaryStep;
+        int32_t secondaryStart, secondaryEnd;
+        Direction slopeDirection;
+
+        if (primaryIsX)
+        {
+            secondaryStart = range.GetY1();
+            secondaryEnd = range.GetY2();
+
+            if (startPos.x <= (range.GetX1() + range.GetX2()) / 2)
+            {
+                primaryStart = range.GetX1();
+                primaryEnd = range.GetX2();
+                primaryStep = kCoordsXYStep;
+                slopeDirection = TILE_ELEMENT_DIRECTION_EAST;
+            }
+            else
+            {
+                primaryStart = range.GetX2();
+                primaryEnd = range.GetX1();
+                primaryStep = -kCoordsXYStep;
+                slopeDirection = TILE_ELEMENT_DIRECTION_WEST;
+            }
+        }
+        else
+        {
+            secondaryStart = range.GetX1();
+            secondaryEnd = range.GetX2();
+
+            if (startPos.y <= (range.GetY1() + range.GetY2()) / 2)
+            {
+                primaryStart = range.GetY1();
+                primaryEnd = range.GetY2();
+                primaryStep = kCoordsXYStep;
+                slopeDirection = TILE_ELEMENT_DIRECTION_NORTH;
+            }
+            else
+            {
+                primaryStart = range.GetY2();
+                primaryEnd = range.GetY1();
+                primaryStep = -kCoordsXYStep;
+                slopeDirection = TILE_ELEMENT_DIRECTION_SOUTH;
+            }
+        }
+
+        // Gather terrain heights: baseZ for going down, maxZ for going up
+        std::vector<SliceInfo> slices;
+
+        for (int32_t primary = primaryStart; primaryStep > 0 ? primary <= primaryEnd : primary >= primaryEnd;
+             primary += primaryStep)
+        {
+            int32_t sliceBaseZ = INT32_MIN;
+            int32_t sliceMaxZ = INT32_MIN;
+
+            for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
+            {
+                CoordsXY pos = primaryIsX ? CoordsXY{ primary, secondary } : CoordsXY{ secondary, primary };
+                auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
+                if (surfaceElement != nullptr)
+                {
+                    int32_t base = surfaceElement->GetBaseZ();
+                    int32_t top = GetMaxSurfaceHeight(*surfaceElement);
+
+                    sliceBaseZ = std::max(sliceBaseZ, base);
+                    sliceMaxZ = std::max(sliceMaxZ, top);
+                }
+            }
+
+            if (sliceBaseZ == INT32_MIN)
+                continue;
+
+            slices.push_back({ primary, sliceBaseZ, sliceMaxZ });
+        }
+
+        if (slices.empty())
+            return {};
+
+        // Filter out obstacle spikes (isolated height jumps)
+        if (slices.size() > 1)
+        {
+            for (size_t i = 0; i < slices.size(); i++)
+            {
+                int32_t prevZ = (i > 0) ? slices[i - 1].maxZ : slices[1].maxZ;
+                int32_t nextZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : slices[i - 1].maxZ;
+
+                bool spikeFromPrev = (slices[i].maxZ - prevZ) > kPathHeightStep;
+                bool spikeFromNext = (slices[i].maxZ - nextZ) > kPathHeightStep;
+
+                if (spikeFromPrev && spikeFromNext)
+                {
+                    int32_t newZ = std::min(prevZ, nextZ);
+                    slices[i].maxZ = newZ;
+                    slices[i].baseZ = std::min(slices[i].baseZ, newZ);
+                }
+            }
+        }
+
+        // Build path: terrain slopes (maxZ > baseZ) slope ON tile, raised blocks slope BEFORE
+        int32_t secondaryCount = (secondaryEnd - secondaryStart) / kCoordsXYStep + 1;
+        result.reserve(slices.size() * secondaryCount);
+
+        // Initial height: start at baseZ for slopes heading up, midpoint for steep diagonals,
+        // but 3-corner-up tiles aren't traversable so always maxZ. WTF so many edge cases!?
+        bool firstTileIsRaiseType = false;
+        {
+            CoordsXY firstPos = primaryIsX ? CoordsXY{ slices[0].primaryCoord, secondaryStart }
+                                           : CoordsXY{ secondaryStart, slices[0].primaryCoord };
+            auto* firstSurf = MapGetSurfaceElementAt(TileCoordsXY(firstPos));
+            if (firstSurf != nullptr)
+            {
+                uint8_t slope = firstSurf->GetSlope();
+                uint8_t corners = slope & kTileSlopeRaisedCornersMask;
+                bool isDiag = (slope & kTileSlopeDiagonalFlag) != 0;
+                firstTileIsRaiseType = !isDiag
+                    && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
+            }
+        }
+        bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep && !firstTileIsRaiseType;
+        bool firstTileIsSteep = (slices[0].maxZ - slices[0].baseZ) >= 2 * kPathHeightStep;
+        bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ); // > not >=
+        int32_t currentPathZ;
+        if (firstTileIsSlope && nextTileIsHigher)
+            currentPathZ = firstTileIsSteep ? slices[0].baseZ + kPathHeightStep : slices[0].baseZ;
+        else
+            currentPathZ = slices[0].maxZ;
+
+        // Track slope direction to distinguish landing from descent
+        bool justWentUp = false;
+        bool justWentDown = false;
+
+        for (size_t i = 0; i < slices.size(); i++)
+        {
+            int32_t thisBaseZ = slices[i].baseZ;
+            int32_t thisMaxZ = slices[i].maxZ;
+            int32_t nextMaxZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : thisMaxZ;
+            int32_t nextBaseZ = (i + 1 < slices.size()) ? slices[i + 1].baseZ : thisBaseZ;
+
+            bool thisIsSlope = (thisMaxZ - thisBaseZ) >= kPathHeightStep;
+            bool nextIsRaisedBlock = (nextMaxZ == nextBaseZ) && (nextBaseZ > currentPathZ);
+
+            int32_t useZ = currentPathZ;
+            FootpathSlope useSlope = { FootpathSlopeType::flat, 0 };
+
+            bool isLastTile = (i == slices.size() - 1);
+
+            // Going UP
+            if (thisIsSlope && thisMaxZ > currentPathZ)
+            {
+                useSlope = { FootpathSlopeType::sloped, slopeDirection };
+                currentPathZ += kPathHeightStep;
+                justWentUp = true;
+                justWentDown = false;
+            }
+            else if (nextIsRaisedBlock && (nextBaseZ - currentPathZ) >= kPathHeightStep)
+            {
+                useSlope = { FootpathSlopeType::sloped, slopeDirection };
+                currentPathZ += kPathHeightStep;
+                justWentUp = true;
+                justWentDown = false;
+            }
+            // Going DOWN: on slopes go down ON tile, on flat blocks go down AFTER
+            else if ((currentPathZ - nextMaxZ) >= kPathHeightStep)
+            {
+                bool thisIsFlatBlock = !thisIsSlope && (thisMaxZ >= currentPathZ);
+                if (!thisIsFlatBlock)
+                {
+                    useZ = currentPathZ - kPathHeightStep;
+                    useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                    currentPathZ -= kPathHeightStep;
+                    justWentDown = true;
+                }
+                else
+                {
+                    justWentDown = false;
+                }
+                justWentUp = false;
+            }
+            // Last tile: check if we should slope down (not if we just came up)
+            else if (isLastTile && thisIsSlope && !justWentUp && currentPathZ >= thisMaxZ)
+            {
+                bool shouldSlopeDown = false;
+
+                if (justWentDown)
+                {
+                    shouldSlopeDown = true;
+                }
+                else
+                {
+                    CoordsXY tilePos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondaryStart }
+                                                  : CoordsXY{ secondaryStart, slices[i].primaryCoord };
+                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(tilePos));
+
+                    if (surfaceElement != nullptr)
+                    {
+                        uint8_t slope = surfaceElement->GetSlope();
+                        uint8_t corners = slope & kTileSlopeRaisedCornersMask;
+                        bool isDiagonal = (slope & kTileSlopeDiagonalFlag) != 0;
+
+                        if (isDiagonal)
+                        {
+                            // Diagonal: down corner indicates descent direction
+                            Direction downDirection = TILE_ELEMENT_DIRECTION_WEST;
+                            if (corners == kTileSlopeNCornerDown)
+                                downDirection = TILE_ELEMENT_DIRECTION_NORTH;
+                            else if (corners == kTileSlopeECornerDown)
+                                downDirection = TILE_ELEMENT_DIRECTION_EAST;
+                            else if (corners == kTileSlopeSCornerDown)
+                                downDirection = TILE_ELEMENT_DIRECTION_SOUTH;
+                            else if (corners == kTileSlopeWCornerDown)
+                                downDirection = TILE_ELEMENT_DIRECTION_WEST;
+
+                            if (downDirection == slopeDirection)
+                                shouldSlopeDown = true;
+                        }
+                        else
+                        {
+                            auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
+                            if (terrainPlacement.slope.type == FootpathSlopeType::sloped
+                                && terrainPlacement.slope.direction == DirectionReverse(slopeDirection))
+                            {
+                                shouldSlopeDown = true;
+                            }
+                        }
+                    }
+                }
+
+                if (shouldSlopeDown)
+                {
+                    useZ = currentPathZ - kPathHeightStep;
+                    useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                    currentPathZ -= kPathHeightStep;
+                }
+                justWentUp = false;
+                justWentDown = false;
+            }
+            else
+            {
+                useZ = thisMaxZ;
+                currentPathZ = thisMaxZ;
+                justWentUp = false;
+                justWentDown = false;
+            }
+
+            for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
+            {
+                CoordsXY pos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondary }
+                                          : CoordsXY{ secondary, slices[i].primaryCoord };
+
+                int32_t tileZ = useZ;
+                FootpathSlope tileSlope = useSlope;
+
+                // Handle 3-corner-up tiles (raise flat paths to match terrain)
+                auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
+                if (surfaceElement != nullptr)
+                {
+                    auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
+                    uint8_t rawSlope = surfaceElement->GetSlope();
+                    uint8_t corners = rawSlope & kTileSlopeRaisedCornersMask;
+                    bool isDiagonal = (rawSlope & kTileSlopeDiagonalFlag) != 0;
+                    bool isRaiseType = !isDiagonal
+                        && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
+
+                    if (isRaiseType && tileSlope.type == FootpathSlopeType::flat && terrainPlacement.baseZ > tileZ)
+                        tileZ = terrainPlacement.baseZ;
+                }
+
+                result.push_back({ CoordsXYZ(pos.x, pos.y, tileZ), tileSlope });
+            }
+        }
+
+        return result;
+    }
+
+} // namespace OpenRCT2

--- a/src/openrct2/world/FootpathDragSlope.cpp
+++ b/src/openrct2/world/FootpathDragSlope.cpp
@@ -39,98 +39,110 @@ namespace OpenRCT2
         return z;
     }
 
-    std::vector<FootpathDragPlacement> calculateConnectedPathSlopes(MapRange range, CoordsXY dragStart)
+    struct ConnectedPathSlopes
     {
-        std::vector<FootpathDragPlacement> result;
+    private:
+        int32_t dragWidth;
+        int32_t dragHeight;
+        CoordsXY startPos;
 
-        int32_t dragWidth = range.GetX2() - range.GetX1();
-        int32_t dragHeight = range.GetY2() - range.GetY1();
-        CoordsXY startPos = dragStart.ToTileStart();
-
-        startPos.x = std::clamp(startPos.x, range.GetX1(), range.GetX2());
-        startPos.y = std::clamp(startPos.y, range.GetY1(), range.GetY2());
-
-        bool primaryIsX = dragWidth >= dragHeight;
+        bool primaryIsX;
         int32_t primaryStart, primaryEnd, primaryStep;
         int32_t secondaryStart, secondaryEnd;
+
         Direction slopeDirection;
 
-        if (primaryIsX)
+    public:
+        ConnectedPathSlopes(MapRange range, CoordsXY dragStart)
         {
-            secondaryStart = range.GetY1();
-            secondaryEnd = range.GetY2();
+            dragWidth = range.GetX2() - range.GetX1();
+            dragHeight = range.GetY2() - range.GetY1();
+            startPos = dragStart.ToTileStart();
 
-            if (startPos.x <= (range.GetX1() + range.GetX2()) / 2)
-            {
-                primaryStart = range.GetX1();
-                primaryEnd = range.GetX2();
-                primaryStep = kCoordsXYStep;
-                slopeDirection = TILE_ELEMENT_DIRECTION_EAST;
-            }
-            else
-            {
-                primaryStart = range.GetX2();
-                primaryEnd = range.GetX1();
-                primaryStep = -kCoordsXYStep;
-                slopeDirection = TILE_ELEMENT_DIRECTION_WEST;
-            }
-        }
-        else
-        {
-            secondaryStart = range.GetX1();
-            secondaryEnd = range.GetX2();
+            startPos.x = std::clamp(startPos.x, range.GetX1(), range.GetX2());
+            startPos.y = std::clamp(startPos.y, range.GetY1(), range.GetY2());
 
-            if (startPos.y <= (range.GetY1() + range.GetY2()) / 2)
-            {
-                primaryStart = range.GetY1();
-                primaryEnd = range.GetY2();
-                primaryStep = kCoordsXYStep;
-                slopeDirection = TILE_ELEMENT_DIRECTION_NORTH;
-            }
-            else
-            {
-                primaryStart = range.GetY2();
-                primaryEnd = range.GetY1();
-                primaryStep = -kCoordsXYStep;
-                slopeDirection = TILE_ELEMENT_DIRECTION_SOUTH;
-            }
-        }
+            primaryIsX = dragWidth >= dragHeight;
 
-        // Gather terrain heights: baseZ for going down, maxZ for going up
-        std::vector<SliceInfo> slices;
-
-        for (int32_t primary = primaryStart; primaryStep > 0 ? primary <= primaryEnd : primary >= primaryEnd;
-             primary += primaryStep)
-        {
-            int32_t sliceBaseZ = INT32_MIN;
-            int32_t sliceMaxZ = INT32_MIN;
-
-            for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
+            if (primaryIsX)
             {
-                CoordsXY pos = primaryIsX ? CoordsXY{ primary, secondary } : CoordsXY{ secondary, primary };
-                auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
-                if (surfaceElement != nullptr)
+                secondaryStart = range.GetY1();
+                secondaryEnd = range.GetY2();
+
+                if (startPos.x <= (range.GetX1() + range.GetX2()) / 2)
                 {
-                    int32_t base = surfaceElement->getBaseZ();
-                    int32_t top = getMaxSurfaceHeight(*surfaceElement);
-
-                    sliceBaseZ = std::max(sliceBaseZ, base);
-                    sliceMaxZ = std::max(sliceMaxZ, top);
+                    primaryStart = range.GetX1();
+                    primaryEnd = range.GetX2();
+                    primaryStep = kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_EAST;
+                }
+                else
+                {
+                    primaryStart = range.GetX2();
+                    primaryEnd = range.GetX1();
+                    primaryStep = -kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_WEST;
                 }
             }
+            else
+            {
+                secondaryStart = range.GetX1();
+                secondaryEnd = range.GetX2();
 
-            if (sliceBaseZ == INT32_MIN)
-                continue;
-
-            slices.push_back({ primary, sliceBaseZ, sliceMaxZ });
+                if (startPos.y <= (range.GetY1() + range.GetY2()) / 2)
+                {
+                    primaryStart = range.GetY1();
+                    primaryEnd = range.GetY2();
+                    primaryStep = kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_NORTH;
+                }
+                else
+                {
+                    primaryStart = range.GetY2();
+                    primaryEnd = range.GetY1();
+                    primaryStep = -kCoordsXYStep;
+                    slopeDirection = TILE_ELEMENT_DIRECTION_SOUTH;
+                }
+            }
         }
 
-        if (slices.empty())
-            return {};
-
-        // Filter out obstacle spikes (isolated height jumps)
-        if (slices.size() > 1)
+        std::vector<SliceInfo> calculateSlices()
         {
+            // Gather terrain heights: baseZ for going down, maxZ for going up
+            std::vector<SliceInfo> slices;
+
+            for (int32_t primary = primaryStart; primaryStep > 0 ? primary <= primaryEnd : primary >= primaryEnd;
+                 primary += primaryStep)
+            {
+                int32_t sliceBaseZ = INT32_MIN;
+                int32_t sliceMaxZ = INT32_MIN;
+
+                for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
+                {
+                    CoordsXY pos = primaryIsX ? CoordsXY{ primary, secondary } : CoordsXY{ secondary, primary };
+                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
+                    if (surfaceElement != nullptr)
+                    {
+                        int32_t base = surfaceElement->getBaseZ();
+                        int32_t top = getMaxSurfaceHeight(*surfaceElement);
+
+                        sliceBaseZ = std::max(sliceBaseZ, base);
+                        sliceMaxZ = std::max(sliceMaxZ, top);
+                    }
+                }
+
+                if (sliceBaseZ == INT32_MIN)
+                    continue;
+
+                slices.push_back({ primary, sliceBaseZ, sliceMaxZ });
+            }
+
+            return slices;
+        }
+
+        void flattenSpikes(std::vector<SliceInfo>& slices)
+        {
+            // Filter out obstacle spikes (isolated height jumps)
             for (size_t i = 0; i < slices.size(); i++)
             {
                 int32_t prevZ = (i > 0) ? slices[i - 1].maxZ : slices[1].maxZ;
@@ -148,14 +160,11 @@ namespace OpenRCT2
             }
         }
 
-        // Build path: terrain slopes (maxZ > baseZ) slope ON tile, raised blocks slope BEFORE
-        int32_t secondaryCount = (secondaryEnd - secondaryStart) / kCoordsXYStep + 1;
-        result.reserve(slices.size() * secondaryCount);
-
-        // Initial height: start at baseZ for slopes heading up, midpoint for steep diagonals,
-        // but 3-corner-up tiles aren't traversable so always maxZ. WTF so many edge cases!?
-        bool firstTileIsRaiseType = false;
+        int32_t getInitPathZFromSlices(std::vector<SliceInfo>& slices)
         {
+            // Initial height: start at baseZ for slopes heading up, midpoint for steep diagonals,
+            // but 3-corner-up tiles aren't traversable so always maxZ. WTF so many edge cases!?
+            bool firstTileIsRaiseType = false;
             CoordsXY firstPos = primaryIsX ? CoordsXY{ slices[0].primaryCoord, secondaryStart }
                                            : CoordsXY{ secondaryStart, slices[0].primaryCoord };
             auto* firstSurf = MapGetSurfaceElementAt(TileCoordsXY(firstPos));
@@ -167,161 +176,187 @@ namespace OpenRCT2
                 firstTileIsRaiseType = !isDiag
                     && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
             }
+
+            bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep && !firstTileIsRaiseType;
+            bool firstTileIsSteep = (slices[0].maxZ - slices[0].baseZ) >= 2 * kPathHeightStep;
+            bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ); // > not >=
+            int32_t currentPathZ;
+            if (firstTileIsSlope && nextTileIsHigher)
+                currentPathZ = firstTileIsSteep ? slices[0].baseZ + kPathHeightStep : slices[0].baseZ;
+            else
+                currentPathZ = slices[0].maxZ;
+
+            return currentPathZ;
         }
-        bool firstTileIsSlope = (slices[0].maxZ - slices[0].baseZ) >= kPathHeightStep && !firstTileIsRaiseType;
-        bool firstTileIsSteep = (slices[0].maxZ - slices[0].baseZ) >= 2 * kPathHeightStep;
-        bool nextTileIsHigher = (slices.size() > 1) && (slices[1].maxZ > slices[0].maxZ); // > not >=
-        int32_t currentPathZ;
-        if (firstTileIsSlope && nextTileIsHigher)
-            currentPathZ = firstTileIsSteep ? slices[0].baseZ + kPathHeightStep : slices[0].baseZ;
-        else
-            currentPathZ = slices[0].maxZ;
 
-        // Track slope direction to distinguish landing from descent
-        bool justWentUp = false;
-        bool justWentDown = false;
-
-        for (size_t i = 0; i < slices.size(); i++)
+        std::vector<FootpathDragPlacement> calculateConnectedPathSlopes()
         {
-            int32_t thisBaseZ = slices[i].baseZ;
-            int32_t thisMaxZ = slices[i].maxZ;
-            int32_t nextMaxZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : thisMaxZ;
-            int32_t nextBaseZ = (i + 1 < slices.size()) ? slices[i + 1].baseZ : thisBaseZ;
+            std::vector<FootpathDragPlacement> result;
 
-            bool thisIsSlope = (thisMaxZ - thisBaseZ) >= kPathHeightStep;
-            bool nextIsRaisedBlock = (nextMaxZ == nextBaseZ) && (nextBaseZ > currentPathZ);
+            auto slices = calculateSlices();
+            if (slices.empty())
+                return {};
 
-            int32_t useZ = currentPathZ;
-            FootpathSlope useSlope = { FootpathSlopeType::flat, 0 };
+            flattenSpikes(slices);
 
-            bool isLastTile = (i == slices.size() - 1);
+            // Build path: terrain slopes (maxZ > baseZ) slope ON tile, raised blocks slope BEFORE
+            int32_t secondaryCount = (secondaryEnd - secondaryStart) / kCoordsXYStep + 1;
+            result.reserve(slices.size() * secondaryCount);
 
-            // Going UP
-            if (thisIsSlope && thisMaxZ > currentPathZ)
+            int32_t currentPathZ = getInitPathZFromSlices(slices);
+
+            // Track slope direction to distinguish landing from descent
+            bool justWentUp = false;
+            bool justWentDown = false;
+
+            for (size_t i = 0; i < slices.size(); i++)
             {
-                useSlope = { FootpathSlopeType::sloped, slopeDirection };
-                currentPathZ += kPathHeightStep;
-                justWentUp = true;
-                justWentDown = false;
-            }
-            else if (nextIsRaisedBlock && (nextBaseZ - currentPathZ) >= kPathHeightStep)
-            {
-                useSlope = { FootpathSlopeType::sloped, slopeDirection };
-                currentPathZ += kPathHeightStep;
-                justWentUp = true;
-                justWentDown = false;
-            }
-            // Going DOWN: on slopes go down ON tile, on flat blocks go down AFTER
-            else if ((currentPathZ - nextMaxZ) >= kPathHeightStep)
-            {
-                bool thisIsFlatBlock = !thisIsSlope && (thisMaxZ >= currentPathZ);
-                if (!thisIsFlatBlock)
+                int32_t thisBaseZ = slices[i].baseZ;
+                int32_t thisMaxZ = slices[i].maxZ;
+                int32_t nextMaxZ = (i + 1 < slices.size()) ? slices[i + 1].maxZ : thisMaxZ;
+                int32_t nextBaseZ = (i + 1 < slices.size()) ? slices[i + 1].baseZ : thisBaseZ;
+
+                bool thisIsSlope = (thisMaxZ - thisBaseZ) >= kPathHeightStep;
+                bool nextIsRaisedBlock = (nextMaxZ == nextBaseZ) && (nextBaseZ > currentPathZ);
+
+                int32_t useZ = currentPathZ;
+                FootpathSlope useSlope = { FootpathSlopeType::flat, 0 };
+
+                bool isLastTile = (i == slices.size() - 1);
+
+                // Going UP
+                if (thisIsSlope && thisMaxZ > currentPathZ)
                 {
-                    useZ = currentPathZ - kPathHeightStep;
-                    useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
-                    currentPathZ -= kPathHeightStep;
-                    justWentDown = true;
-                }
-                else
-                {
+                    useSlope = { FootpathSlopeType::sloped, slopeDirection };
+                    currentPathZ += kPathHeightStep;
+                    justWentUp = true;
                     justWentDown = false;
                 }
-                justWentUp = false;
-            }
-            // Last tile: check if we should slope down (not if we just came up)
-            else if (isLastTile && thisIsSlope && !justWentUp && currentPathZ >= thisMaxZ)
-            {
-                bool shouldSlopeDown = false;
-
-                if (justWentDown)
+                else if (nextIsRaisedBlock && (nextBaseZ - currentPathZ) >= kPathHeightStep)
                 {
-                    shouldSlopeDown = true;
+                    useSlope = { FootpathSlopeType::sloped, slopeDirection };
+                    currentPathZ += kPathHeightStep;
+                    justWentUp = true;
+                    justWentDown = false;
                 }
-                else
+                // Going DOWN: on slopes go down ON tile, on flat blocks go down AFTER
+                else if ((currentPathZ - nextMaxZ) >= kPathHeightStep)
                 {
-                    CoordsXY tilePos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondaryStart }
-                                                  : CoordsXY{ secondaryStart, slices[i].primaryCoord };
-                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(tilePos));
-
-                    if (surfaceElement != nullptr)
+                    bool thisIsFlatBlock = !thisIsSlope && (thisMaxZ >= currentPathZ);
+                    if (!thisIsFlatBlock)
                     {
-                        uint8_t slope = surfaceElement->GetSlope();
-                        uint8_t corners = slope & kTileSlopeRaisedCornersMask;
-                        bool isDiagonal = (slope & kTileSlopeDiagonalFlag) != 0;
+                        useZ = currentPathZ - kPathHeightStep;
+                        useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                        currentPathZ -= kPathHeightStep;
+                        justWentDown = true;
+                    }
+                    else
+                    {
+                        justWentDown = false;
+                    }
+                    justWentUp = false;
+                }
+                // Last tile: check if we should slope down (not if we just came up)
+                else if (isLastTile && thisIsSlope && !justWentUp && currentPathZ >= thisMaxZ)
+                {
+                    bool shouldSlopeDown = false;
 
-                        if (isDiagonal)
-                        {
-                            // Diagonal: down corner indicates descent direction
-                            Direction downDirection = TILE_ELEMENT_DIRECTION_WEST;
-                            if (corners == kTileSlopeNCornerDown)
-                                downDirection = TILE_ELEMENT_DIRECTION_NORTH;
-                            else if (corners == kTileSlopeECornerDown)
-                                downDirection = TILE_ELEMENT_DIRECTION_EAST;
-                            else if (corners == kTileSlopeSCornerDown)
-                                downDirection = TILE_ELEMENT_DIRECTION_SOUTH;
-                            else if (corners == kTileSlopeWCornerDown)
-                                downDirection = TILE_ELEMENT_DIRECTION_WEST;
+                    if (justWentDown)
+                    {
+                        shouldSlopeDown = true;
+                    }
+                    else
+                    {
+                        CoordsXY tilePos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondaryStart }
+                                                      : CoordsXY{ secondaryStart, slices[i].primaryCoord };
+                        auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(tilePos));
 
-                            if (downDirection == slopeDirection)
-                                shouldSlopeDown = true;
-                        }
-                        else
+                        if (surfaceElement != nullptr)
                         {
-                            auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
-                            if (terrainPlacement.slope.type == FootpathSlopeType::sloped
-                                && terrainPlacement.slope.direction == DirectionReverse(slopeDirection))
+                            uint8_t slope = surfaceElement->GetSlope();
+                            uint8_t corners = slope & kTileSlopeRaisedCornersMask;
+                            bool isDiagonal = (slope & kTileSlopeDiagonalFlag) != 0;
+
+                            if (isDiagonal)
                             {
-                                shouldSlopeDown = true;
+                                // Diagonal: down corner indicates descent direction
+                                Direction downDirection = TILE_ELEMENT_DIRECTION_WEST;
+                                if (corners == kTileSlopeNCornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_NORTH;
+                                else if (corners == kTileSlopeECornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_EAST;
+                                else if (corners == kTileSlopeSCornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_SOUTH;
+                                else if (corners == kTileSlopeWCornerDown)
+                                    downDirection = TILE_ELEMENT_DIRECTION_WEST;
+
+                                if (downDirection == slopeDirection)
+                                    shouldSlopeDown = true;
+                            }
+                            else
+                            {
+                                auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
+                                if (terrainPlacement.slope.type == FootpathSlopeType::sloped
+                                    && terrainPlacement.slope.direction == DirectionReverse(slopeDirection))
+                                {
+                                    shouldSlopeDown = true;
+                                }
                             }
                         }
                     }
-                }
 
-                if (shouldSlopeDown)
+                    if (shouldSlopeDown)
+                    {
+                        useZ = currentPathZ - kPathHeightStep;
+                        useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
+                        currentPathZ -= kPathHeightStep;
+                    }
+                    justWentUp = false;
+                    justWentDown = false;
+                }
+                else
                 {
-                    useZ = currentPathZ - kPathHeightStep;
-                    useSlope = { FootpathSlopeType::sloped, DirectionReverse(slopeDirection) };
-                    currentPathZ -= kPathHeightStep;
+                    useZ = thisMaxZ;
+                    currentPathZ = thisMaxZ;
+                    justWentUp = false;
+                    justWentDown = false;
                 }
-                justWentUp = false;
-                justWentDown = false;
-            }
-            else
-            {
-                useZ = thisMaxZ;
-                currentPathZ = thisMaxZ;
-                justWentUp = false;
-                justWentDown = false;
-            }
 
-            for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
-            {
-                CoordsXY pos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondary }
-                                          : CoordsXY{ secondary, slices[i].primaryCoord };
-
-                int32_t tileZ = useZ;
-                FootpathSlope tileSlope = useSlope;
-
-                // Handle 3-corner-up tiles (raise flat paths to match terrain)
-                auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
-                if (surfaceElement != nullptr)
+                for (int32_t secondary = secondaryStart; secondary <= secondaryEnd; secondary += kCoordsXYStep)
                 {
-                    auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
-                    uint8_t rawSlope = surfaceElement->GetSlope();
-                    uint8_t corners = rawSlope & kTileSlopeRaisedCornersMask;
-                    bool isDiagonal = (rawSlope & kTileSlopeDiagonalFlag) != 0;
-                    bool isRaiseType = !isDiagonal
-                        && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
+                    CoordsXY pos = primaryIsX ? CoordsXY{ slices[i].primaryCoord, secondary }
+                                              : CoordsXY{ secondary, slices[i].primaryCoord };
 
-                    if (isRaiseType && tileSlope.type == FootpathSlopeType::flat && terrainPlacement.baseZ > tileZ)
-                        tileZ = terrainPlacement.baseZ;
+                    int32_t tileZ = useZ;
+                    FootpathSlope tileSlope = useSlope;
+
+                    // Handle 3-corner-up tiles (raise flat paths to match terrain)
+                    auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
+                    if (surfaceElement != nullptr)
+                    {
+                        auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
+                        uint8_t rawSlope = surfaceElement->GetSlope();
+                        uint8_t corners = rawSlope & kTileSlopeRaisedCornersMask;
+                        bool isDiagonal = (rawSlope & kTileSlopeDiagonalFlag) != 0;
+                        bool isRaiseType = !isDiagonal
+                            && (corners == 0b0111 || corners == 0b1011 || corners == 0b1101 || corners == 0b1110);
+
+                        if (isRaiseType && tileSlope.type == FootpathSlopeType::flat && terrainPlacement.baseZ > tileZ)
+                            tileZ = terrainPlacement.baseZ;
+                    }
+
+                    result.push_back({ CoordsXYZ(pos.x, pos.y, tileZ), tileSlope });
                 }
-
-                result.push_back({ CoordsXYZ(pos.x, pos.y, tileZ), tileSlope });
             }
+
+            return result;
         }
+    };
 
-        return result;
+    std::vector<FootpathDragPlacement> calculateConnectedPathSlopes(MapRange range, CoordsXY dragStart)
+    {
+        ConnectedPathSlopes calc(range, dragStart);
+        return calc.calculateConnectedPathSlopes();
     }
 
 } // namespace OpenRCT2

--- a/src/openrct2/world/FootpathDragSlope.cpp
+++ b/src/openrct2/world/FootpathDragSlope.cpp
@@ -30,7 +30,7 @@ namespace OpenRCT2
     // Get surface height including raised corners and steep slopes
     static int32_t getMaxSurfaceHeight(const SurfaceElement& surface)
     {
-        int32_t z = surface.GetBaseZ();
+        int32_t z = surface.getBaseZ();
         uint8_t slope = surface.GetSlope();
         if (slope & kTileSlopeRaisedCornersMask)
             z += kPathHeightStep;
@@ -111,7 +111,7 @@ namespace OpenRCT2
                 auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY(pos));
                 if (surfaceElement != nullptr)
                 {
-                    int32_t base = surfaceElement->GetBaseZ();
+                    int32_t base = surfaceElement->getBaseZ();
                     int32_t top = getMaxSurfaceHeight(*surfaceElement);
 
                     sliceBaseZ = std::max(sliceBaseZ, base);

--- a/src/openrct2/world/FootpathDragSlope.cpp
+++ b/src/openrct2/world/FootpathDragSlope.cpp
@@ -31,7 +31,7 @@ namespace OpenRCT2
     static int32_t getMaxSurfaceHeight(const SurfaceElement& surface)
     {
         int32_t z = surface.getBaseZ();
-        uint8_t slope = surface.GetSlope();
+        uint8_t slope = surface.getSlope();
         if (slope & kTileSlopeRaisedCornersMask)
             z += kPathHeightStep;
         if (slope & kTileSlopeDiagonalFlag)
@@ -170,7 +170,7 @@ namespace OpenRCT2
             auto* firstSurf = MapGetSurfaceElementAt(TileCoordsXY(firstPos));
             if (firstSurf != nullptr)
             {
-                uint8_t slope = firstSurf->GetSlope();
+                uint8_t slope = firstSurf->getSlope();
                 uint8_t corners = slope & kTileSlopeRaisedCornersMask;
                 bool isDiag = (slope & kTileSlopeDiagonalFlag) != 0;
                 firstTileIsRaiseType = !isDiag
@@ -273,7 +273,7 @@ namespace OpenRCT2
 
                         if (surfaceElement != nullptr)
                         {
-                            uint8_t slope = surfaceElement->GetSlope();
+                            uint8_t slope = surfaceElement->getSlope();
                             uint8_t corners = slope & kTileSlopeRaisedCornersMask;
                             bool isDiagonal = (slope & kTileSlopeDiagonalFlag) != 0;
 
@@ -335,7 +335,7 @@ namespace OpenRCT2
                     if (surfaceElement != nullptr)
                     {
                         auto terrainPlacement = FootpathGetOnTerrainPlacement(*surfaceElement);
-                        uint8_t rawSlope = surfaceElement->GetSlope();
+                        uint8_t rawSlope = surfaceElement->getSlope();
                         uint8_t corners = rawSlope & kTileSlopeRaisedCornersMask;
                         bool isDiagonal = (rawSlope & kTileSlopeDiagonalFlag) != 0;
                         bool isRaiseType = !isDiagonal

--- a/src/openrct2/world/FootpathDragSlope.h
+++ b/src/openrct2/world/FootpathDragSlope.h
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "Footpath.h"
+#include "Location.hpp"
+#include "Map.h"
+
+#include <vector>
+
+namespace OpenRCT2
+{
+    struct FootpathDragPlacement
+    {
+        CoordsXYZ position;
+        FootpathSlope slope;
+
+        constexpr bool operator==(const FootpathDragPlacement& rhs) const
+        {
+            return position == rhs.position && slope == rhs.slope;
+        }
+    };
+
+    /**
+     * Build path placements that follow terrain with appropriate slopes.
+     * Returns empty if no valid terrain (caller handles fallback).
+     */
+    std::vector<FootpathDragPlacement> CalculateConnectedPathSlopes(MapRange range, CoordsXY dragStart);
+
+} // namespace OpenRCT2

--- a/src/openrct2/world/FootpathDragSlope.h
+++ b/src/openrct2/world/FootpathDragSlope.h
@@ -32,6 +32,6 @@ namespace OpenRCT2
      * Build path placements that follow terrain with appropriate slopes.
      * Returns empty if no valid terrain (caller handles fallback).
      */
-    std::vector<FootpathDragPlacement> CalculateConnectedPathSlopes(MapRange range, CoordsXY dragStart);
+    std::vector<FootpathDragPlacement> calculateConnectedPathSlopes(MapRange range, CoordsXY dragStart);
 
 } // namespace OpenRCT2


### PR DESCRIPTION
Fixes/implements #25362

Dragging footpath with the area drag tool over hills or valleys now creates a continuous connected path with slopes. The algorithm detects terrain height changes and automatically adds appropriate slope tiles. This only affects placement when no modifier keys are pressed (Shift/Ctrl fall back to original behavior). Of course it works with queue lines as well, but those stay one wide like the original implementation.


### Features:
Dragging over slopes:
![openrct2_bEuv3Il0lW](https://github.com/user-attachments/assets/d60fc827-3a79-4c04-9d75-b6def0115c96)

Dragging over valleys and hills continuously: 
![openrct2_GqoHdoWTp8](https://github.com/user-attachments/assets/1ae5939e-202d-4c4e-a4d8-9283a4fa576f)

Dragging over diagonal land and, properly scaling:
![openrct2_OrPEXQxOze](https://github.com/user-attachments/assets/f0eaf8cd-b9de-443c-89ed-385356c7bbc2)

Jumping up over one height of land but staying under anything over two:
![openrct2_LQxGjWPRt3](https://github.com/user-attachments/assets/40e89bb9-f4a3-40f2-89e6-398c9d89729b)
