### PR TITLE
Re-enable multithreading on Haiku

### DIFF
--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -50,11 +50,6 @@ static constexpr bool kEnlargedUiDefault = true;
 #else
 static constexpr bool kEnlargedUiDefault = false;
 #endif
-#ifdef __HAIKU__ // Multi-threading is unstable here
-static constexpr bool kMultiThreadingDefault = false;
-#else
-static constexpr bool kMultiThreadingDefault = true;
-#endif
 
 namespace OpenRCT2::Config
 {
@@ -243,7 +238,7 @@ namespace OpenRCT2::Config
             // Always have multi-threading disabled in debug builds, this makes things slower.
             model->multiThreading = false;
 #else
-            model->multiThreading = reader->GetBoolean("multithreading", kMultiThreadingDefault);
+            model->multiThreading = reader->GetBoolean("multithreading", true);
 #endif // _DEBUG
             model->trapCursor = reader->GetBoolean("trap_cursor", false);
             model->autoOpenShops = reader->GetBoolean("auto_open_shops", false);

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -38,7 +38,7 @@
 #include "StringBuilder.h"
 #include "UTF8.h"
 
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))
     #include <strings.h>
     #define _stricmp(x, y) strcasecmp((x), (y))
 #endif


### PR DESCRIPTION
Since #25908 fixes multithreaded rendering on the OS, disabling it by default is no longer needed.

Also included a change in String.cpp to fix compilation on the platform.

Tested with 0.4.31 on Haiku's latest development revision.