### PR TITLE
Refactor: Create Paint.<tile element type>.h files

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -396,6 +396,7 @@
     <ClInclude Include="paint\support\WoodenSupports.h" />
     <ClInclude Include="paint\tile_element\Paint.Entrance.h" />
     <ClInclude Include="paint\tile_element\Paint.Path.h" />
+    <ClInclude Include="paint\tile_element\Paint.SmallScenery.h" />
     <ClInclude Include="paint\tile_element\Paint.PathAddition.h" />
     <ClInclude Include="paint\tile_element\Paint.Surface.h" />
     <ClInclude Include="paint\tile_element\Paint.TileElement.h" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -400,6 +400,7 @@
     <ClInclude Include="paint\tile_element\Paint.PathAddition.h" />
     <ClInclude Include="paint\tile_element\Paint.Surface.h" />
     <ClInclude Include="paint\tile_element\Paint.TileElement.h" />
+    <ClInclude Include="paint\tile_element\Paint.Wall.h" />
     <ClInclude Include="paint\tile_element\Segment.h" />
     <ClInclude Include="paint\tile_element\Paint.Tunnel.h" />
     <ClInclude Include="paint\track\coaster\WoodenRollerCoaster.hpp" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -401,6 +401,7 @@
     <ClInclude Include="paint\tile_element\Paint.PathAddition.h" />
     <ClInclude Include="paint\tile_element\Paint.Surface.h" />
     <ClInclude Include="paint\tile_element\Paint.TileElement.h" />
+    <ClInclude Include="paint\tile_element\Paint.Track.h" />
     <ClInclude Include="paint\tile_element\Paint.Wall.h" />
     <ClInclude Include="paint\tile_element\Segment.h" />
     <ClInclude Include="paint\tile_element\Paint.Tunnel.h" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -394,6 +394,7 @@
     <ClInclude Include="paint\Painter.h" />
     <ClInclude Include="paint\support\MetalSupports.h" />
     <ClInclude Include="paint\support\WoodenSupports.h" />
+    <ClInclude Include="paint\tile_element\Paint.Entrance.h" />
     <ClInclude Include="paint\tile_element\Paint.Path.h" />
     <ClInclude Include="paint\tile_element\Paint.PathAddition.h" />
     <ClInclude Include="paint\tile_element\Paint.Surface.h" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -394,6 +394,7 @@
     <ClInclude Include="paint\Painter.h" />
     <ClInclude Include="paint\support\MetalSupports.h" />
     <ClInclude Include="paint\support\WoodenSupports.h" />
+    <ClInclude Include="paint\tile_element\Paint.Banner.h" />
     <ClInclude Include="paint\tile_element\Paint.Entrance.h" />
     <ClInclude Include="paint\tile_element\Paint.LargeScenery.h" />
     <ClInclude Include="paint\tile_element\Paint.Path.h" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -395,6 +395,7 @@
     <ClInclude Include="paint\support\MetalSupports.h" />
     <ClInclude Include="paint\support\WoodenSupports.h" />
     <ClInclude Include="paint\tile_element\Paint.Entrance.h" />
+    <ClInclude Include="paint\tile_element\Paint.LargeScenery.h" />
     <ClInclude Include="paint\tile_element\Paint.Path.h" />
     <ClInclude Include="paint\tile_element\Paint.SmallScenery.h" />
     <ClInclude Include="paint\tile_element\Paint.PathAddition.h" />

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -26,13 +26,14 @@
 #include "../../world/TileInspector.h"
 #include "../../world/tile_element/BannerElement.h"
 #include "Paint.Banner.h"
+#include "Paint.TileElement.h"
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 
 // kBannerBoundBoxes[rotation][0] is for the pole in the back
 // kBannerBoundBoxes[rotation][1] is for the pole and the banner in the front
-constexpr CoordsXY kBannerBoundBoxes[][2] = {
+const CoordsXY kBannerBoundBoxes[][2] = {
     { { 1, 2 }, { 1, 29 } },
     { { 2, 32 }, { 29, 32 } },
     { { 32, 2 }, { 32, 29 } },

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -25,7 +25,7 @@
 #include "../../world/Scenery.h"
 #include "../../world/TileInspector.h"
 #include "../../world/tile_element/BannerElement.h"
-#include "Paint.TileElement.h"
+#include "Paint.Banner.h"
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;

--- a/src/openrct2/paint/tile_element/Paint.Banner.h
+++ b/src/openrct2/paint/tile_element/Paint.Banner.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct BannerElement;
+}
+
+void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -32,6 +32,7 @@
 #include "../../world/TileInspector.h"
 #include "../../world/tile_element/EntranceElement.h"
 #include "../support/WoodenSupports.h"
+#include "Paint.Entrance.h"
 #include "Paint.TileElement.h"
 #include "Segment.h"
 

--- a/src/openrct2/paint/tile_element/Paint.Entrance.h
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct EntranceElement;
+}
+
+void PaintEntrance(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::EntranceElement& entranceElement);

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -32,6 +32,7 @@
 #include "../../world/tile_element/LargeSceneryElement.h"
 #include "../Boundbox.h"
 #include "../support/WoodenSupports.h"
+#include "Paint.LargeScenery.h"
 #include "Paint.TileElement.h"
 #include "Segment.h"
 

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.h
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.h
@@ -1,0 +1,22 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct LargeSceneryElement;
+}
+
+void PaintLargeScenery(
+    PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::LargeSceneryElement& tileElement);

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -20,6 +20,7 @@
 #include "../../world/TileInspector.h"
 #include "../../world/tile_element/SmallSceneryElement.h"
 #include "../support/WoodenSupports.h"
+#include "Paint.SmallScenery.h"
 #include "Paint.TileElement.h"
 #include "Segment.h"
 

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.h
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.h
@@ -1,0 +1,22 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct SmallSceneryElement;
+}
+
+void PaintSmallScenery(
+    PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::SmallSceneryElement& sceneryElement);

--- a/src/openrct2/paint/tile_element/Paint.Surface.h
+++ b/src/openrct2/paint/tile_element/Paint.Surface.h
@@ -12,7 +12,15 @@
 #include "../../SpriteIds.h"
 #include "../../world/Location.hpp"
 
+#include <cstdint>
 #include <optional>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct SurfaceElement;
+}
 
 namespace OpenRCT2::Drawing
 {
@@ -111,3 +119,5 @@ enum
 };
 
 std::optional<OpenRCT2::Drawing::Colour> GetPatrolAreaTileColour(const CoordsXY& pos);
+
+void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -35,6 +35,7 @@
 #include "Paint.Path.h"
 #include "Paint.SmallScenery.h"
 #include "Paint.Surface.h"
+#include "Paint.Track.h"
 #include "Paint.Wall.h"
 #include "Segment.h"
 

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -32,6 +32,7 @@
 #include "../VirtualFloor.h"
 #include "Paint.Entrance.h"
 #include "Paint.Path.h"
+#include "Paint.SmallScenery.h"
 #include "Paint.Surface.h"
 #include "Segment.h"
 

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -34,6 +34,7 @@
 #include "Paint.Path.h"
 #include "Paint.SmallScenery.h"
 #include "Paint.Surface.h"
+#include "Paint.Wall.h"
 #include "Segment.h"
 
 using namespace OpenRCT2;

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -31,6 +31,7 @@
 #include "../Paint.h"
 #include "../VirtualFloor.h"
 #include "Paint.Entrance.h"
+#include "Paint.LargeScenery.h"
 #include "Paint.Path.h"
 #include "Paint.SmallScenery.h"
 #include "Paint.Surface.h"

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -30,6 +30,7 @@
 #include "../Paint.SessionFlags.h"
 #include "../Paint.h"
 #include "../VirtualFloor.h"
+#include "Paint.Entrance.h"
 #include "Paint.Path.h"
 #include "Paint.Surface.h"
 #include "Segment.h"

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -30,6 +30,7 @@
 #include "../Paint.SessionFlags.h"
 #include "../Paint.h"
 #include "../VirtualFloor.h"
+#include "Paint.Banner.h"
 #include "Paint.Entrance.h"
 #include "Paint.LargeScenery.h"
 #include "Paint.Path.h"

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -16,7 +16,6 @@ namespace OpenRCT2
     struct BannerElement;
     struct PathElement;
     struct SurfaceElement;
-    struct TrackElement;
 } // namespace OpenRCT2
 
 struct PaintSession;
@@ -50,6 +49,4 @@ void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, boo
 
 void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);
 void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
-void PaintTrack(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::TrackElement& tileElement);
-
 bool PaintShouldShowHeightMarkers(const PaintSession& session, uint32_t viewportFlag);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -11,11 +11,6 @@
 
 #include "../../world/Location.hpp"
 
-namespace OpenRCT2
-{
-    struct PathElement;
-} // namespace OpenRCT2
-
 struct PaintSession;
 
 enum edge_t

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -14,7 +14,6 @@
 namespace OpenRCT2
 {
     struct BannerElement;
-    struct LargeSceneryElement;
     struct PathElement;
     struct SurfaceElement;
     struct TrackElement;
@@ -51,8 +50,6 @@ void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, boo
 
 void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);
 void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
-void PaintLargeScenery(
-    PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::LargeSceneryElement& tileElement);
 void PaintTrack(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::TrackElement& tileElement);
 
 bool PaintShouldShowHeightMarkers(const PaintSession& session, uint32_t viewportFlag);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -13,7 +13,6 @@
 
 namespace OpenRCT2
 {
-    struct BannerElement;
     struct PathElement;
     struct SurfaceElement;
 } // namespace OpenRCT2
@@ -47,6 +46,5 @@ uint16_t PaintUtilRotateSegments(uint16_t segments, uint8_t rotation);
 
 void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, bool isTrackPiecePreview = false);
 
-void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);
 void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
 bool PaintShouldShowHeightMarkers(const PaintSession& session, uint32_t viewportFlag);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -14,7 +14,6 @@
 namespace OpenRCT2
 {
     struct PathElement;
-    struct SurfaceElement;
 } // namespace OpenRCT2
 
 struct PaintSession;
@@ -46,5 +45,4 @@ uint16_t PaintUtilRotateSegments(uint16_t segments, uint8_t rotation);
 
 void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, bool isTrackPiecePreview = false);
 
-void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
 bool PaintShouldShowHeightMarkers(const PaintSession& session, uint32_t viewportFlag);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -16,7 +16,6 @@ namespace OpenRCT2
     struct BannerElement;
     struct LargeSceneryElement;
     struct PathElement;
-    struct SmallSceneryElement;
     struct SurfaceElement;
     struct TrackElement;
     struct WallElement;
@@ -53,8 +52,6 @@ void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, boo
 
 void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);
 void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
-void PaintSmallScenery(
-    PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::SmallSceneryElement& sceneryElement);
 void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::WallElement& tileElement);
 void PaintLargeScenery(
     PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::LargeSceneryElement& tileElement);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -14,7 +14,6 @@
 namespace OpenRCT2
 {
     struct BannerElement;
-    struct EntranceElement;
     struct LargeSceneryElement;
     struct PathElement;
     struct SmallSceneryElement;
@@ -52,7 +51,6 @@ uint16_t PaintUtilRotateSegments(uint16_t segments, uint8_t rotation);
 
 void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, bool isTrackPiecePreview = false);
 
-void PaintEntrance(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::EntranceElement& entranceElement);
 void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);
 void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
 void PaintSmallScenery(

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -11,6 +11,11 @@
 
 #include "../../world/Location.hpp"
 
+namespace OpenRCT2
+{
+    struct TrackElement;
+}
+
 struct PaintSession;
 
 enum edge_t

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -18,7 +18,6 @@ namespace OpenRCT2
     struct PathElement;
     struct SurfaceElement;
     struct TrackElement;
-    struct WallElement;
 } // namespace OpenRCT2
 
 struct PaintSession;
@@ -52,7 +51,6 @@ void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, boo
 
 void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::BannerElement& bannerElement);
 void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::SurfaceElement& tileElement);
-void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::WallElement& tileElement);
 void PaintLargeScenery(
     PaintSession& session, uint8_t direction, uint16_t height, const OpenRCT2::LargeSceneryElement& tileElement);
 void PaintTrack(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::TrackElement& tileElement);

--- a/src/openrct2/paint/tile_element/Paint.Track.h
+++ b/src/openrct2/paint/tile_element/Paint.Track.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct TrackElement;
+}
+
+void PaintTrack(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::TrackElement& tileElement);

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -27,6 +27,7 @@
 #include "../../world/TileInspector.h"
 #include "../../world/tile_element/WallElement.h"
 #include "Paint.TileElement.h"
+#include "Paint.Wall.h"
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;

--- a/src/openrct2/paint/tile_element/Paint.Wall.h
+++ b/src/openrct2/paint/tile_element/Paint.Wall.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+struct PaintSession;
+
+namespace OpenRCT2
+{
+    struct WallElement;
+}
+
+void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const OpenRCT2::WallElement& tileElement);

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -23,6 +23,7 @@
 #include "../paint/support/MetalSupports.h"
 #include "../paint/support/WoodenSupports.h"
 #include "../paint/tile_element/Paint.TileElement.h"
+#include "../paint/tile_element/Paint.Track.h"
 #include "../paint/tile_element/Segment.h"
 #include "../paint/track/Segment.h"
 #include "../paint/track/Support.h"


### PR DESCRIPTION
Closes #25803

Creates separate header files for each tile element paint function:
- Paint.Entrance.h
- Paint.SmallScenery.h
- Paint.Wall.h
- Paint.LargeScenery.h
- Paint.Track.h
- Paint.Banner.h
- Adds PaintSurface to existing Paint.Surface.h

Each commit is freestanding as requested in the issue