### PR TITLE
Fix #25712,#25727: Crash during startup from window list race condition

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#22704] Rides can be made invisible more easily.
 - Improved: [#25941] The command line sprite build command is now faster.
 - Fix: [#25237] Wrong colours on the Knight costume.
+- Fix: [#25712, #25727] Crash during startup from window list race condition.
 - Fix: [#25910] Folders starting with numbers are sorted incorrectly (e.g. 1, 10, 2 instead of 1, 2, 10).
 - Fix: [#25954] Guests display hats, balloons, and umbrellas while puking.
 

--- a/src/openrct2/scenes/preloader/PreloaderScene.cpp
+++ b/src/openrct2/scenes/preloader/PreloaderScene.cpp
@@ -49,14 +49,19 @@ void PreloaderScene::Tick()
 {
     gInUpdateCode = true;
 
-    ContextHandleInput();
+    // Avoid race condition with background jobs modifying gWindowList.
+    const bool jobsRunning = _jobs.IsBusy();
 
-    auto* windowMgr = Ui::GetWindowManager();
-    windowMgr->InvalidateAll();
+    if (!jobsRunning)
+    {
+        ContextHandleInput();
+        auto* windowMgr = Ui::GetWindowManager();
+        windowMgr->InvalidateAll();
+    }
 
     gInUpdateCode = false;
 
-    if (!_jobs.IsBusy())
+    if (!jobsRunning)
     {
         // Make sure the job is fully completed.
         _jobs.Join();


### PR DESCRIPTION
Fixes #25727 and #25712 (and probably also #25848, #25752 and #25598)

These crashes all share fault address `0x56`, which corresponds to the `flags` field in `WindowBase`, which means a null window pointer

The main issue is a race condition in `PreloaderScene`: background jobs call `OpenProgress`/`SetProgress` which modifies `gWindowList` while the main thread iterates the same list through `ContextHandleInput()` and `InvalidateAll()`. When the vector reallocates, the iterator becomes invalid. I fixed it by skipping window iteration while background jobs are running. Should be safe because the progress window has no interactive elements during loading anyway