### PR TITLE
Add experimental boosters flag

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3853,3 +3853,7 @@ STR_7023    :Make invisible
 STR_7024    :Makes the whole ride invisible
 STR_7025    :Make visible
 STR_7026    :Makes the whole ride visible
+STR_8022    :Can’t make changes…
+STR_8023    :Experimental boosters
+STR_8024    :Developer testing of new booster system and related features
+STR_8025    :Ride behaviours subject to change during development. This ride may operate differently in the future

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -144,6 +144,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_VEHICLE_TYPE = 14,
         WIDX_VEHICLE_TYPE_DROPDOWN,
         WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX,
+        WIDX_VEHICLE_LEGACY_BOOSTERS_CHECKBOX,
         WIDX_VEHICLE_TRAINS_PREVIEW,
         WIDX_VEHICLE_TRAINS,
         WIDX_VEHICLE_TRAINS_INCREASE,
@@ -291,6 +292,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget        ({  7,  50}, {302, 12}, WidgetType::dropdownMenu, WindowColour::secondary                                                          ),
         makeWidget        ({297,  51}, { 11, 10}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                      ),
         makeWidget        ({  7, 137}, {302, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_OPTION_REVERSE_TRAINS, STR_OPTION_REVERSE_TRAINS_TIP),
+        makeWidget        ({164, 137}, {145, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_OPTION_EXPERIMENTAL_BOOSTERS, STR_OPTION_EXPERIMENTAL_BOOSTERS_TIP),
         makeWidget        ({  7, 154}, {302, 43}, WidgetType::scroll,       WindowColour::secondary, kStringIdEmpty                                          ),
         makeSpinnerWidgets({  7, 203}, {145, 12}, WidgetType::spinner,      WindowColour::secondary, STR_RIDE_VEHICLE_COUNT, STR_MAX_VEHICLES_TIP            ),
         makeSpinnerWidgets({164, 203}, {145, 12}, WidgetType::spinner,      WindowColour::secondary, STR_1_CAR_PER_TRAIN,    STR_MAX_CARS_PER_TRAIN_TIP      )
@@ -2684,6 +2686,16 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX:
                     ride->setReversedTrains(!ride->hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS));
                     break;
+                case WIDX_VEHICLE_LEGACY_BOOSTERS_CHECKBOX:
+                    // During development, the legacy booster flag is shown to users as the "experimental boosters" option and
+                    // displayed the opposite polarity, to convince users to not enable it. Thus, disabling the flag should
+                    // trigger the warning.
+                    if (ride->hasLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS))
+                    {
+                        ContextShowError(STR_WARNING_IN_CAPS, STR_EXPERIMENTAL_BOOSTERS_WARNING, {});
+                    }
+                    ride->setLegacyBoosters(!ride->hasLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS));
+                    break;
                 case WIDX_VEHICLE_TRAINS_INCREASE:
                     if (ride->numTrains < Limits::kMaxTrainsPerRide)
                         ride->setNumTrains(ride->numTrains + 1);
@@ -2846,6 +2858,25 @@ namespace OpenRCT2::Ui::Windows
             else
             {
                 widgets[WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX].type = WidgetType::empty;
+            }
+
+            if (Config::Get().general.debuggingTools)
+            {
+                widgets[WIDX_VEHICLE_LEGACY_BOOSTERS_CHECKBOX].type = WidgetType::checkbox;
+                // During development, the legacy booster flag is shown to users as the "experimental boosters" option and
+                // displayed the opposite polarity, to convince users to not enable it.
+                if (!ride->hasLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS))
+                {
+                    pressedWidgets |= (1uLL << WIDX_VEHICLE_LEGACY_BOOSTERS_CHECKBOX);
+                }
+                else
+                {
+                    pressedWidgets &= ~(1uLL << WIDX_VEHICLE_LEGACY_BOOSTERS_CHECKBOX);
+                }
+            }
+            else
+            {
+                widgets[WIDX_VEHICLE_LEGACY_BOOSTERS_CHECKBOX].type = WidgetType::empty;
             }
 
             auto ft = Formatter::Common();

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -184,6 +184,7 @@ namespace OpenRCT2::GameActions
         ride->minWaitingTime = 10;
         ride->maxWaitingTime = 60;
         ride->departFlags = RIDE_DEPART_WAIT_FOR_MINIMUM_LENGTH | 3;
+        ride->setLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS, true);
 
         const auto& rtd = ride->getRideTypeDescriptor();
         if (rtd.flags.has(RtdFlag::allowMusic))

--- a/src/openrct2/actions/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/RideSetVehicleAction.cpp
@@ -32,6 +32,7 @@ namespace OpenRCT2::GameActions
         STR_RIDE_SET_VEHICLE_SET_NUM_CARS_PER_TRAIN_FAIL,
         STR_RIDE_SET_VEHICLE_TYPE_FAIL,
         STR_RIDE_SET_VEHICLE_REVERSED_FAIL,
+        STR_RIDE_SET_VEHICLE_LEGACY_BOOSTERS_FAIL,
     };
 
     RideSetVehicleAction::RideSetVehicleAction(RideId rideIndex, RideSetVehicleType type, uint16_t value, uint8_t colour)
@@ -91,6 +92,7 @@ namespace OpenRCT2::GameActions
             case RideSetVehicleType::NumTrains:
             case RideSetVehicleType::NumCarsPerTrain:
             case RideSetVehicleType::TrainsReversed:
+            case RideSetVehicleType::LegacyBoosters:
                 break;
             case RideSetVehicleType::RideEntry:
             {
@@ -195,6 +197,15 @@ namespace OpenRCT2::GameActions
                 ride->vehicleChangeTimeout = 100;
 
                 ride->setLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS, _value);
+                break;
+            }
+            case RideSetVehicleType::LegacyBoosters:
+            {
+                RideClearForConstruction(*ride);
+                ride->removePeeps();
+                ride->vehicleChangeTimeout = 100;
+
+                ride->setLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS, _value);
                 break;
             }
 

--- a/src/openrct2/actions/RideSetVehicleAction.h
+++ b/src/openrct2/actions/RideSetVehicleAction.h
@@ -19,6 +19,7 @@ namespace OpenRCT2::GameActions
         NumCarsPerTrain,
         RideEntry,
         TrainsReversed,
+        LegacyBoosters,
         Count,
     };
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1766,6 +1766,14 @@ enum : StringId
 
     STR_ACTION_PATH_DRAG_AREA = 7013,
 
+    STR_RIDE_SET_VEHICLE_LEGACY_BOOSTERS_FAIL = 7022,
+
+    // 7023-7025 are temporary and used during development of the booster unification feature. When doing final changes to the
+    // UI, delete these strings and create new ones.
+    STR_OPTION_EXPERIMENTAL_BOOSTERS = 8023,
+    STR_OPTION_EXPERIMENTAL_BOOSTERS_TIP = 8024,
+    STR_EXPERIMENTAL_BOOSTERS_WARNING = 8025,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1430,6 +1430,10 @@ namespace OpenRCT2
                     cs.readWrite(ride.status);
                     cs.readWrite(ride.departFlags);
                     cs.readWrite(ride.lifecycleFlags);
+                    if (version < kAddLegacyBoosterFlag)
+                    {
+                        ride.setLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS, true);
+                    }
 
                     // Meta
                     cs.readWrite(ride.customName);

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -21,10 +21,10 @@ namespace OpenRCT2
     struct ObjectRepositoryItem;
 
     // Current version that is saved.
-    constexpr uint32_t kParkFileCurrentVersion = 59;
+    constexpr uint32_t kParkFileCurrentVersion = 60;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t kParkFileMinVersion = 57;
+    constexpr uint32_t kParkFileMinVersion = 60;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!
@@ -61,6 +61,7 @@ namespace OpenRCT2
     constexpr uint16_t kHigherInversionsHolesHelicesStatsVersion = 55;
     constexpr uint16_t kFixedObsoleteFootpathsVersion = 56;
     constexpr uint16_t kRevertToVanillaFairRidePriceCalculation = 58;
+    constexpr uint16_t kAddLegacyBoosterFlag = 60;
 
     class ParkFileExporter
     {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -866,6 +866,7 @@ namespace OpenRCT2::RCT1
             {
                 dst->lifecycleFlags |= RIDE_LIFECYCLE_REVERSED_TRAINS;
             }
+            dst->setLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS, true);
 
             // Station
             if (src->overallView.IsNull())

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -992,6 +992,7 @@ namespace OpenRCT2::RCT2
             {
                 dst->vehicleColours[i].Tertiary = src->vehicleColoursExtended[i];
             }
+            dst->setLifecycleFlag(RIDE_LIFECYCLE_LEGACY_BOOSTERS, true);
 
             dst->totalAirTime = src->totalAirTime;
             dst->currentTestStation = StationIndex::FromUnderlying(src->currentTestStation);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5293,6 +5293,13 @@ void Ride::setReversedTrains(bool reverseTrains)
     GameActions::Execute(&rideSetVehicleAction, getGameState());
 }
 
+void Ride::setLegacyBoosters(bool legacyBoosters)
+{
+    auto rideSetVehicleAction = GameActions::RideSetVehicleAction(
+        id, GameActions::RideSetVehicleType::LegacyBoosters, legacyBoosters);
+    GameActions::Execute(&rideSetVehicleAction, getGameState());
+}
+
 /**
  *
  *  rct2: 0x006B752C

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -528,6 +528,7 @@ enum
     RIDE_LIFECYCLE_FIXED_RATINGS = 1 << 20,        // When set, the ratings will not be updated (useful for hacked rides).
     RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS = 1 << 21,
     RIDE_LIFECYCLE_REVERSED_TRAINS = 1 << 22,
+    RIDE_LIFECYCLE_LEGACY_BOOSTERS = 1 << 23, // Vehicles use legacy calculations for booster speed. Currently in development.
 };
 
 enum

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -394,6 +394,7 @@ public:
     void setNumTrains(int32_t newNumTrains);
     void setNumCarsPerTrain(int32_t numCarsPerVehicle);
     void setReversedTrains(bool reversedTrains);
+    void setLegacyBoosters(bool legacyBoosters);
     void updateMaxVehicles();
     void updateNumberOfCircuits();
 


### PR DESCRIPTION
One of the blockers of getting the booster upgrade merged is that there are several components which are not necessarily interconnected, but they currently all hinge on a single flag - this flag. This PR is a slice of https://github.com/OpenRCT2/OpenRCT2/pull/16692 It adds the flag and no other behaviors. This allows implementing components in separate PRs, to make it easy to review.


My expectation is that users expect the default state to be all the settings disabled. During development, the legacy option is the desired default, so to encourage users not to mess with it, the flag is inverted.

After development, the new default will be the flag disabled, so the user interface will present the flag in its true polarity, with the expectation that users who want the new behavior will disable the flag, restoring things to default. Also the three strings introduced will be removed and new ones introduced, so that old translations do not present incorrect information.