### PR TITLE
Remove deprecated C headers

### DIFF
--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -26,7 +26,6 @@
 #endif
 
 #include "../Context.h"
-#include "../Game.h"
 #include "../core/CallingConventions.h"
 #include "../core/File.h"
 #include "../core/Path.hpp"
@@ -38,8 +37,8 @@
 #include <array>
 #include <chrono>
 #include <cstring>
+#include <ctime>
 #include <thread>
-#include <time.h>
 
 #ifdef _WIN32
 static constexpr std::array _prohibitedCharacters = { '<', '>', '*', '\\', ':', '|', '?', '"', '/' };

--- a/test/tests/CircularBuffer.cpp
+++ b/test/tests/CircularBuffer.cpp
@@ -6,9 +6,9 @@
  *
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <openrct2/core/CircularBuffer.h>
-#include <stdint.h>
 #include <vector>
 
 // CircularBuffer capacity.

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -30,7 +30,6 @@
 #include <openrct2/ride/Ride.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/world/MapAnimation.h>
-#include <stdio.h>
 #include <string>
 
 using namespace OpenRCT2;


### PR DESCRIPTION
This removes deprecated C headers and replaces them with their C++ equivalent when applicable.

In `S6ImportExportTests.cpp`, the `stdio.h`/`cstdio` header was unused so I removed it.

In `Platform.Common.cpp`, `game.h` was also unused so I also took the opportunity to remove it.