### PR TITLE
Add new clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,9 +2,12 @@
 Checks: >
     -*,
     cppcoreguidelines-macro-usage,
+    modernize-concat-nested-namespaces,
+    modernize-deprecated-headers,
     modernize-use-bool-literals,
     modernize-use-nullptr,
     modernize-use-override,
+    readability-redundant-typename,
     readability-uppercase-literal-suffix
 CheckOptions:
     - key: cppcoreguidelines-macro-usage.AllowedRegexp


### PR DESCRIPTION
This adds 3 new clang-tidy rules:

- [modernize-concat-nested-namespaces](https://clang.llvm.org/extra/clang-tidy/checks/modernize/concat-nested-namespaces.html): there was one instance where this happened which I cleaned up in my batch of namespace PRs.
- [modernize-deprecated-headers](https://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html): there were six cases that were being flagged by this check, three of which I cleaned up in a PR and three that I left as is because the file originated from a third-party: [TTFSDLPort.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/drawing/TTFSDLPort.cpp)
- [readability-redundant-typename](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-typename.html): there were a dozen cases of this which I cleaned up in a PR.