### PR TITLE
Fix #25919, #25926: Path drag tool plays stacked error sounds and shows wrong cost

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#25460] Infinite loop when moving track design ghost queue over queue loop with zero clearances.
 - Fix: [#25735] Ride synchronisation z-check works incorrectly.
 - Fix: [#25919] Path drag tool error sound stacks when placement fails.
+- Fix: [#25926] Path drag tool shows cost for single tile instead of total.
 - Fix: [#25962] Dropdown triangle glyphs are not optically centred.
 - Fix: [#25993] Toggling “allow arbitrary ride type changes” does not resize open ride windows.
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#25128] Mute button displayed in wrong state after load.
 - Fix: [#25460] Infinite loop when moving track design ghost queue over queue loop with zero clearances.
 - Fix: [#25735] Ride synchronisation z-check works incorrectly.
+- Fix: [#25919] Path drag tool error sound stacks when placement fails.
 - Fix: [#25962] Dropdown triangle glyphs are not optically centred.
 - Fix: [#25993] Toggling “allow arbitrary ride type changes” does not resize open ride windows.
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1287,6 +1287,9 @@ namespace OpenRCT2::Ui::Windows
             money64 cost = 0;
             CoordsXYZ lastLocation;
 
+            // Disable error sound during loop to prevent stacking sounds for each failed tile
+            gDisableErrorWindowSound = true;
+
             for (const auto& tile : _provisionalFootpath.tiles)
             {
                 auto footpathPlaceAction = GameActions::FootpathPlaceAction(
@@ -1300,6 +1303,8 @@ namespace OpenRCT2::Ui::Windows
                 lastLocation = tile.position;
             }
 
+            gDisableErrorWindowSound = false;
+
             if (anySuccess)
             {
                 // Don't play sound if it is no cost to prevent multiple sounds. TODO: make this work in no
@@ -1311,6 +1316,8 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
+                // Play error sound once for the entire failed operation
+                Audio::Play3D(Audio::SoundId::error, lastLocation);
                 _footpathErrorOccured = true;
             }
         }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1283,9 +1283,50 @@ namespace OpenRCT2::Ui::Windows
             auto selectedType = gFootpathSelection.getSelectedSurface();
             PathConstructFlags constructFlags = FootpathCreateConstructFlags(selectedType);
 
+            CoordsXYZ lastLocation = _provisionalFootpath.tiles.back().position;
+
+            // First query all tiles to get total cost and check for errors
+            money64 totalCost = 0;
+            GameActions::Result lastError;
+            bool anyQueryFailed = false;
+
+            for (const auto& tile : _provisionalFootpath.tiles)
+            {
+                auto footpathPlaceAction = GameActions::FootpathPlaceAction(
+                    tile.position, tile.slope, selectedType, gFootpathSelection.railings, kInvalidDirection, constructFlags);
+                auto result = GameActions::Query(&footpathPlaceAction, getGameState());
+                totalCost += result.cost;
+                if (result.error != GameActions::Status::ok)
+                {
+                    anyQueryFailed = true;
+                    lastError = result;
+                }
+            }
+
+            // If any query failed, show a single combined error with total cost
+            if (anyQueryFailed)
+            {
+                Audio::Play3D(Audio::SoundId::error, lastLocation);
+                _footpathErrorOccured = true;
+
+                // Show error with accumulated cost for insufficient funds
+                auto* windowMgr = GetWindowManager();
+                if (lastError.error == GameActions::Status::insufficientFunds)
+                {
+                    Formatter ft;
+                    ft.Add<money64>(totalCost);
+                    windowMgr->ShowError(STR_CANT_BUILD_FOOTPATH_HERE, STR_NOT_ENOUGH_CASH_REQUIRES, ft);
+                }
+                else
+                {
+                    windowMgr->ShowError(lastError.getErrorTitle(), lastError.getErrorMessage());
+                }
+                return;
+            }
+
+            // All queries passed, now execute
             bool anySuccess = false;
             money64 cost = 0;
-            CoordsXYZ lastLocation;
 
             // Disable error sound during loop to prevent stacking sounds for each failed tile
             gDisableErrorWindowSound = true;


### PR DESCRIPTION
Fixes #25919 and #25926

Showcase:

https://github.com/user-attachments/assets/0edca2c1-a1ee-4b3f-9a3b-0fb2c481fbf6

