### PR TITLE
Fix #25927: Wall drag tool error sound stacks and shows wrong cost

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#25735] Ride synchronisation z-check works incorrectly.
 - Fix: [#25919] Path drag tool error sound stacks when placement fails.
 - Fix: [#25926] Path drag tool shows cost for single tile instead of total.
+- Fix: [#25927] Wall drag tool error sound stacks and shows wrong cost.
 - Fix: [#25962] Dropdown triangle glyphs are not optically centred.
 - Fix: [#25993] Toggling “allow arbitrary ride type changes” does not resize open ride windows.
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -3243,15 +3243,64 @@ namespace OpenRCT2::Ui::Windows
             }
 
             auto mapRange = getMapSelectRange();
-            bool anySuccessful = false;
             CoordsXYZ lastLocation = { mapRange.Point2, gSceneryPlaceZ };
+            auto& gameState = getGameState();
+
+            // First query all tiles to get total cost and check for errors
+            money64 totalCost = 0;
+            GameActions::Result lastError;
+            bool anyQueryFailed = false;
+
             for (const auto& tile : _provisionalTiles)
             {
                 auto wallPlaceAction = GameActions::WallPlaceAction(
                     selectedScenery, tile.location, tile.location.direction, _sceneryPrimaryColour, _scenerySecondaryColour,
                     _sceneryTertiaryColour);
 
-                auto& gameState = getGameState();
+                auto result = GameActions::Query(&wallPlaceAction, gameState);
+                totalCost += result.cost;
+                if (result.error != GameActions::Status::ok)
+                {
+                    anyQueryFailed = true;
+                    lastError = result;
+                }
+            }
+
+            // If any query failed, show a single combined error with total cost
+            if (anyQueryFailed)
+            {
+                Audio::Play3D(Audio::SoundId::error, lastLocation);
+
+                // Show error with accumulated cost for insufficient funds
+                auto* windowMgr = GetWindowManager();
+                if (lastError.error == GameActions::Status::insufficientFunds)
+                {
+                    Formatter ft;
+                    ft.Add<money64>(totalCost);
+                    windowMgr->ShowError(STR_CANT_BUILD_THIS_HERE, STR_NOT_ENOUGH_CASH_REQUIRES, ft);
+                }
+                else
+                {
+                    windowMgr->ShowError(lastError.getErrorTitle(), lastError.getErrorMessage());
+                }
+
+                _provisionalTiles.clear();
+                _inDragMode = false;
+                return;
+            }
+
+            // All queries passed, now execute
+            bool anySuccessful = false;
+
+            // Disable error sound during loop to prevent stacking sounds for each failed tile
+            gDisableErrorWindowSound = true;
+
+            for (const auto& tile : _provisionalTiles)
+            {
+                auto wallPlaceAction = GameActions::WallPlaceAction(
+                    selectedScenery, tile.location, tile.location.direction, _sceneryPrimaryColour, _scenerySecondaryColour,
+                    _sceneryTertiaryColour);
+
                 auto result = GameActions::Execute(&wallPlaceAction, gameState);
                 if (result.error == GameActions::Status::ok)
                 {
@@ -3260,12 +3309,19 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
+            gDisableErrorWindowSound = false;
+
             _provisionalTiles.clear();
             _inDragMode = false;
 
             if (anySuccessful)
             {
                 Audio::Play3D(Audio::SoundId::placeItem, lastLocation);
+            }
+            else
+            {
+                // Play error sound once for the entire failed operation
+                Audio::Play3D(Audio::SoundId::error, lastLocation);
             }
         }
 


### PR DESCRIPTION
Fixes #25927

Same fix as #25928 but for the wall drag tool.

Preview:

https://github.com/user-attachments/assets/31803f39-b157-4abc-bb5c-eb3f83ee46a1

