### PR TITLE
Move some workflows to ubuntu-slim

### DIFF
--- a/.github/workflows/backtrace-commit-fix.yml
+++ b/.github/workflows/backtrace-commit-fix.yml
@@ -5,7 +5,7 @@ on:
       - opened
 jobs:
   backtrace_commit_correction:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE: ${{ github.event.issue.html_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   build_variables:
     name: Get version info
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # This job is too heavy for ubuntu-slim. It takes almost a minute to checkout the code on slim vs 23s on ubuntu-latest.
     # We want to sign tagged releases with release certificates, but it is only allowed to be ran manually.
     # Disable automatic runs for tags and force release signing for tags.
     if: |
@@ -144,7 +144,7 @@ jobs:
         run: scripts/check-code-formatting
   check-changelog-formatting:
     name: Check changelog formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     defaults:
       run:
         shell: bash
@@ -155,7 +155,7 @@ jobs:
         run: scripts/check-changelog-formatting
   g2dat:
     name: Graphics .dat files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: build_variables
     steps:
       - name: Checkout OpenRCT2
@@ -665,7 +665,7 @@ jobs:
           name: OpenRCT2-${{ needs.build_variables.outputs.name }}-emscripten
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [build_variables, linux-portable, android, linux-appimage, macos-universal, windows]
     steps:
       - name: Checkout

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -18,7 +18,7 @@ on:
     - cron: '23 */2 * * *'
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: z0al/dependent-issues@v1
         env:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       issues: write        # automatically creates labels
       pull-requests: write # assigning labels to PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'OpenRCT2/OpenRCT2'
     steps:
     - uses: actions/labeler@v6

--- a/.github/workflows/localisation.yml
+++ b/.github/workflows/localisation.yml
@@ -6,7 +6,7 @@ jobs:
   merge-localisation:
     name: Merge Localisation
     if: github.repository == 'OpenRCT2/OpenRCT2'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Store private SSH
         run: |

--- a/.github/workflows/stale-backtrace-issues.yml
+++ b/.github/workflows/stale-backtrace-issues.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'OpenRCT2/OpenRCT2'
     steps:
       - uses: actions/stale@v8

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'OpenRCT2/OpenRCT2'
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
`ubuntu-slim` is a single-CPU hosted runner that uses containers instead of VMs. It's useful for quick 'maintenance' jobs.

Depends on https://github.com/OpenRCT2/OpenRCT2/pull/25938