### PR TITLE
Set lower staff costs behind existing RCT1 interest rate option.

### DIFF
--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,8 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
-{
+        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)){
+
     switch (type)
     {
         default:

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2605,7 +2605,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 }
 
 money64 GetStaffWage(StaffType type)
-{
+{    
         if (gameState::park::flags & PARK_FLAGS_RCT1_INTEREST)         
         {
         switch (type)
@@ -2619,8 +2619,7 @@ money64 GetStaffWage(StaffType type)
             return 45.00_GBP;
         case StaffType::entertainer:
             return 40.00_GBP;
-            }
-            else
+            } else
             {
      switch (type)
     {
@@ -2635,10 +2634,10 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
+
+        }        
 }
-}
-    
-   
+           
 
 void Staff::Serialise(DataSerialiser& stream)
 {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,10 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-
-{
         if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
-
+{
     switch (type)
     {
         default:

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2605,7 +2605,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 }
 
 money64 GetStaffWage(StaffType type);
-auto& gameState = getGameState()
+auto& gameState = getGameState();
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)             
         switch (type)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2618,7 +2618,9 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
     }
+        money64 GetStaffWage(StaffType type)
         if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))
+            
         {
         switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2605,9 +2605,9 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 }
 
 money64 GetStaffWage(StaffType type)
+auto& gameState = getGameState();
 {    
-        if (gameState::park::flags & PARK_FLAGS_RCT1_INTEREST)         
-        {
+        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)             
         switch (type)
     {
         default:
@@ -2619,7 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 45.00_GBP;
         case StaffType::entertainer:
             return 40.00_GBP;
-            } else
+            }
+        else
             {
      switch (type)
     {
@@ -2636,7 +2637,6 @@ money64 GetStaffWage(StaffType type)
 }
 
         }        
-}
            
 
 void Staff::Serialise(DataSerialiser& stream)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2603,11 +2603,10 @@ void Staff::UpdateRideInspected(RideId rideIndex)
         ride->windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::main, RideInvalidateFlag::list);
     }
 }
-
+const auto& gameState = getGameState();
 money64 GetStaffWage(StaffType type)
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)
-        auto& gameState = getGameState()
 
         switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2620,9 +2620,9 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-{
     if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
-     money64 GetStaffWage(StaffType type)
+{
+money64 GetStaffWage(StaffType type)
 {
     switch (type)
     {
@@ -2638,6 +2638,7 @@ money64 GetStaffWage(StaffType type)
     }
 }
 }
+
 
 void Staff::Serialise(DataSerialiser& stream)
 {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2618,10 +2618,10 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
             
-        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))(
+        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)){
 
-    switch (type)
-    {
+    switch (type){
+
         default:
         case StaffType::handyman:
             return 35.00_GBP;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2604,8 +2604,9 @@ void Staff::UpdateRideInspected(RideId rideIndex)
     }
 }
 
-money64 GetStaffWage(StaffType type);
 auto& gameState = getGameState();
+money64 GetStaffWage(StaffType type);
+
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)             
         switch (type)
@@ -2620,7 +2621,7 @@ auto& gameState = getGameState();
         case StaffType::entertainer:
             return 40.00_GBP;
             }
-        else
+        else;
             {
      switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2603,7 +2603,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
         ride->windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::main, RideInvalidateFlag::list);
     }
 }
-const auto& gameState = getGameState();
+static int & gameState = getGameState();
 money64 GetStaffWage(StaffType type)
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2607,7 +2607,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 money64 GetStaffWage(StaffType type)
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)
-        auto& gameState = getGameState();
+        auto& gameState = getGameState()
 
         switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,7 +2619,7 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-        if (!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST))
+        if::(!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST))
         {
 
     switch (type)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2618,8 +2618,7 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
     }
-        money64 GetStaffWage(StaffType type)
-{
+        money64 GetStaffWage(StaffType type){
         if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))         
         {
         switch (type)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2618,11 +2618,8 @@ money64 GetStaffWage(StaffType type)
             return 60.00_GBP;
         case StaffType::entertainer:
             return 55.00_GBP;
-    }
-}
-    if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
-{
-money64 GetStaffWage(StaffType type)
+            
+        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
 {
     switch (type)
     {
@@ -2636,8 +2633,12 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 40.00_GBP;
     }
+   
 }
+
+    }
 }
+
 
 
 void Staff::Serialise(DataSerialiser& stream)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2606,7 +2606,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 
 money64 GetStaffWage(StaffType type)
 {    
-        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST);
+        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)
         auto& gameState = getGameState();
 
         switch (type)
@@ -2621,7 +2621,7 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 40.00_GBP;
             }
-        else;
+        else
             {
      switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2604,11 +2604,11 @@ void Staff::UpdateRideInspected(RideId rideIndex)
     }
 }
 
-auto& gameState = getGameState();
-money64 GetStaffWage(StaffType type);
-
+money64 GetStaffWage(StaffType type)
 {    
-        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)             
+        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST);
+        auto& gameState = getGameState();
+
         switch (type)
     {
         default:

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,6 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
         if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))
+        {
+        switch (type)
     {
         default:
         case StaffType::handyman:
@@ -2631,6 +2633,7 @@ money64 GetStaffWage(StaffType type)
             return 40.00_GBP;
     }
 
+}
 }
     
    

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2606,7 +2606,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 
 money64 GetStaffWage(StaffType type)
 {
-        if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))         
+        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))         
         {
         switch (type)
     {
@@ -2621,7 +2621,7 @@ money64 GetStaffWage(StaffType type)
             return 40.00_GBP;
     }
             else
-
+            {
      switch (type)
     {
         default:

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2618,7 +2618,7 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
     }
-        if (!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST))
+        if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))
         switch (type)
     {
         default:

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,7 +2619,6 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
         if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))
-        switch (type)
     {
         default:
         case StaffType::handyman:

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2620,7 +2620,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-{if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
+{
+    if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
      money64 GetStaffWage(StaffType type)
 {
     switch (type)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -8,7 +8,7 @@
  *****************************************************************************/
 
 #include "Staff.h"
-
+#include "../OpenRCT2.h"
 #include "../Context.h"
 #include "../Diagnostic.h"
 #include "../GameState.h"
@@ -43,8 +43,6 @@
 #include "../world/tile_element/TrackElement.h"
 #include "PatrolArea.h"
 #include "Peep.h"
-#include "../GameState.h"
-
 #include <cassert>
 #include <iterator>
 
@@ -2620,8 +2618,8 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
             
-        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
-{
+        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))(
+
     switch (type)
     {
         default:
@@ -2635,9 +2633,6 @@ money64 GetStaffWage(StaffType type)
             return 40.00_GBP;
     }
    
-}
-
-    }
 }
 
 

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -43,7 +43,7 @@
 #include "../world/tile_element/TrackElement.h"
 #include "PatrolArea.h"
 #include "Peep.h"
-#include <openrct2/GameState.h>
+#include "../GameState.h"
 
 #include <cassert>
 #include <iterator>

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2617,11 +2617,14 @@ money64 GetStaffWage(StaffType type)
             return 60.00_GBP;
         case StaffType::entertainer:
             return 55.00_GBP;
-            
-        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)){
+    }
+}
 
-    switch (type){
+{
+        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
 
+    switch (type)
+    {
         default:
         case StaffType::handyman:
             return 35.00_GBP;
@@ -2632,10 +2635,8 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 40.00_GBP;
     }
-   
 }
-
-
+   
 
 void Staff::Serialise(DataSerialiser& stream)
 {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2620,7 +2620,7 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
+{if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
      money64 GetStaffWage(StaffType type)
 {
     switch (type)
@@ -2635,6 +2635,7 @@ if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
         case StaffType::entertainer:
             return 40.00_GBP;
     }
+}
 }
 
 void Staff::Serialise(DataSerialiser& stream)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2606,19 +2606,6 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 
 money64 GetStaffWage(StaffType type)
 {
-    switch (type)
-    {
-        default:
-        case StaffType::handyman:
-            return 50.00_GBP;
-        case StaffType::mechanic:
-            return 80.00_GBP;
-        case StaffType::security:
-            return 60.00_GBP;
-        case StaffType::entertainer:
-            return 55.00_GBP;
-    }
-        money64 GetStaffWage(StaffType type){
         if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))         
         {
         switch (type)
@@ -2633,7 +2620,20 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 40.00_GBP;
     }
+            else
 
+     switch (type)
+    {
+        default:
+        case StaffType::handyman:
+            return 50.00_GBP;
+        case StaffType::mechanic:
+            return 80.00_GBP;
+        case StaffType::security:
+            return 60.00_GBP;
+        case StaffType::entertainer:
+            return 55.00_GBP;
+    }
 }
 }
     

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2603,7 +2603,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
         ride->windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::main, RideInvalidateFlag::list);
     }
 }
-static int & gameState = getGameState();
+const auto& gameState = getGameState();
 money64 GetStaffWage(StaffType type)
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2620,6 +2620,22 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
+if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
+     money64 GetStaffWage(StaffType type)
+{
+    switch (type)
+    {
+        default:
+        case StaffType::handyman:
+            return 35.00_GBP;
+        case StaffType::mechanic:
+            return 55.00_GBP;
+        case StaffType::security:
+            return 45.00_GBP;
+        case StaffType::entertainer:
+            return 40.00_GBP;
+    }
+}
 
 void Staff::Serialise(DataSerialiser& stream)
 {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2606,7 +2606,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 
 money64 GetStaffWage(StaffType type)
 {
-        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)         
+        if (gameState::park::flags & PARK_FLAGS_RCT1_INTEREST)         
         {
         switch (type)
     {
@@ -2619,9 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 45.00_GBP;
         case StaffType::entertainer:
             return 40.00_GBP;
-    }
+            }
             else
-        
             {
      switch (type)
     {
@@ -2635,6 +2634,7 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
     }
+}
 }
 }
     

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,8 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-        if::(!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST))
-        {
+        if (!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST)){
+        
 
     switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -43,6 +43,7 @@
 #include "../world/tile_element/TrackElement.h"
 #include "PatrolArea.h"
 #include "Peep.h"
+#include <openrct2/GameState.h>
 
 #include <cassert>
 #include <iterator>

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2604,8 +2604,8 @@ void Staff::UpdateRideInspected(RideId rideIndex)
     }
 }
 
-money64 GetStaffWage(StaffType type)
-auto& gameState = getGameState();
+money64 GetStaffWage(StaffType type);
+auto& gameState = getGameState()
 {    
         if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)             
         switch (type)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2606,7 +2606,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
 
 money64 GetStaffWage(StaffType type)
 {
-        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))         
+        if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)         
         {
         switch (type)
     {
@@ -2621,6 +2621,7 @@ money64 GetStaffWage(StaffType type)
             return 40.00_GBP;
     }
             else
+        
             {
      switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2618,11 +2618,8 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 55.00_GBP;
     }
-}
-        if (!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST)){
-        
-
-    switch (type)
+        if (!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST))
+        switch (type)
     {
         default:
         case StaffType::handyman:
@@ -2634,7 +2631,9 @@ money64 GetStaffWage(StaffType type)
         case StaffType::entertainer:
             return 40.00_GBP;
     }
+
 }
+    
    
 
 void Staff::Serialise(DataSerialiser& stream)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,8 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
         money64 GetStaffWage(StaffType type)
-        if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))
-            
+{
+        if (!(gameState::park::flags & PARK_FLAGS_RCT1_INTEREST))         
         {
         switch (type)
     {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -2619,7 +2619,8 @@ money64 GetStaffWage(StaffType type)
             return 55.00_GBP;
     }
 }
-        if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)){
+        if (!(gameState::park.flags & PARK_FLAGS_RCT1_INTEREST))
+        {
 
     switch (type)
     {


### PR DESCRIPTION
This pull request will set the staff costs lower for RCT1 which is $35 for Handyman, $ 55 for Mechanic, $ 45 for Security Guard and $ 40 for Entertainer and to avoid affecting the entire game this flag will be set behind the existing RCT1 interest calculation which already provide a ultra low interest rate of 1.33% instead of 10% per year and also all SC4 and SV4 imports will already have the lower RCT1 interest rate set!
<img width="341" height="78" alt="Screenshot from 2026-02-04 00-38-07" src="https://github.com/user-attachments/assets/6f213275-b044-4c4f-8b0d-f5e29c57dad8" />
<img width="335" height="80" alt="Screenshot from 2026-02-04 00-38-23" src="https://github.com/user-attachments/assets/a6f78882-f54a-468f-99bd-38a6859a2e8f" />
<img width="350" height="71" alt="Screenshot from 2026-02-04 00-39-03" src="https://github.com/user-attachments/assets/e5887524-ed53-4f14-b519-70237dcbc598" />
<img width="340" height="75" alt="Screenshot from 2026-02-04 00-39-14" src="https://github.com/user-attachments/assets/83bde994-5c1c-4595-ad7f-4f15ed80b6f2" />
