### PR TITLE
Refactor: Extract sprite declarations to Drawing.Sprite.h

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -19,11 +19,10 @@
 #include <unordered_map>
 #include <vector>
 
-struct PaletteMap;
-
 namespace OpenRCT2::Drawing
 {
     enum class FilterPaletteID : int32_t;
+    struct PaletteMap;
     struct RenderTarget;
 } // namespace OpenRCT2::Drawing
 
@@ -208,7 +207,7 @@ namespace OpenRCT2::Ui
         ~TextureCache();
         void InvalidateImage(ImageIndex image);
         BasicTextureInfo GetOrLoadImageTexture(ImageId imageId);
-        BasicTextureInfo GetOrLoadGlyphTexture(ImageId imageId, const PaletteMap& paletteMap);
+        BasicTextureInfo GetOrLoadGlyphTexture(ImageId imageId, const Drawing::PaletteMap& paletteMap);
         BasicTextureInfo GetOrLoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
 
         GLuint GetAtlasesTexture();
@@ -221,11 +220,11 @@ namespace OpenRCT2::Ui
         void GeneratePaletteTexture();
         void EnlargeAtlasesTexture(GLuint newEntries);
         AtlasTextureInfo LoadImageTexture(ImageId image);
-        AtlasTextureInfo LoadGlyphTexture(ImageId image, const PaletteMap& paletteMap);
+        AtlasTextureInfo LoadGlyphTexture(ImageId image, const Drawing::PaletteMap& paletteMap);
         AtlasTextureInfo AllocateImage(int32_t imageWidth, int32_t imageHeight);
         AtlasTextureInfo LoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
         static Drawing::RenderTarget GetImageAsRT(ImageId imageId);
-        static Drawing::RenderTarget GetGlyphAsRT(ImageId imageId, const PaletteMap& paletteMap);
+        static Drawing::RenderTarget GetGlyphAsRT(ImageId imageId, const Drawing::PaletteMap& paletteMap);
         void FreeTextures();
 
         static Drawing::RenderTarget CreateRT(int32_t width, int32_t height);

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "Drawing.h"
+#include "Drawing.Sprite.h"
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "Drawing.h"
+#include "Drawing.Sprite.h"
 
 #include <cassert>
 #include <cstring>

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "Drawing.h"
+#include "Drawing.Sprite.h"
 
 #include "../Context.h"
 #include "../Diagnostic.h"
@@ -22,6 +22,7 @@
 #include "../platform/Platform.h"
 #include "../rct1/Csg.h"
 #include "../ui/UiContext.h"
+#include "Drawing.h"
 #include "ScrollingText.h"
 
 #include <cassert>

--- a/src/openrct2/drawing/Drawing.Sprite.h
+++ b/src/openrct2/drawing/Drawing.Sprite.h
@@ -1,0 +1,184 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../core/CallingConventions.h"
+#include "G1Element.h"
+#include "ImageId.hpp"
+#include "PaletteIndex.h"
+#include "PaletteMap.h"
+#include "RenderTarget.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+struct ScreenCoordsXY;
+
+namespace OpenRCT2
+{
+    struct IPlatformEnvironment;
+} // namespace OpenRCT2
+
+using DrawBlendOp = uint8_t;
+
+constexpr DrawBlendOp kBlendNone = 0;
+
+/**
+ * Only supported by BITMAP. RLE images always encode transparency via the encoding.
+ * Pixel value of 0 represents transparent.
+ */
+constexpr DrawBlendOp kBlendTransparent = 1 << 0;
+
+/**
+ * Whether to use the pixel value from the source image.
+ * This is usually only unset for glass images where there the src is only a transparency mask.
+ */
+constexpr DrawBlendOp kBlendSrc = 1 << 1;
+
+/**
+ * Whether to use the pixel value of the destination image for blending.
+ * This is used for any image that filters the target image, e.g. glass or water.
+ */
+constexpr DrawBlendOp kBlendDst = 2 << 2;
+
+struct DrawSpriteArgs
+{
+    ImageId Image;
+    OpenRCT2::Drawing::PaletteMap PalMap;
+    const OpenRCT2::G1Element& SourceImage;
+    int32_t SrcX;
+    int32_t SrcY;
+    int32_t Width;
+    int32_t Height;
+    uint8_t* DestinationBits;
+
+    DrawSpriteArgs(
+        ImageId image, const OpenRCT2::Drawing::PaletteMap& palMap, const OpenRCT2::G1Element& sourceImage, int32_t srcX,
+        int32_t srcY, int32_t width, int32_t height, uint8_t* destinationBits)
+        : Image(image)
+        , PalMap(palMap)
+        , SourceImage(sourceImage)
+        , SrcX(srcX)
+        , SrcY(srcY)
+        , Width(width)
+        , Height(height)
+        , DestinationBits(destinationBits)
+    {
+    }
+};
+
+template<DrawBlendOp TBlendOp>
+bool FASTCALL BlitPixel(
+    const OpenRCT2::Drawing::PaletteIndex* src, OpenRCT2::Drawing::PaletteIndex* dst,
+    const OpenRCT2::Drawing::PaletteMap& paletteMap)
+{
+    if constexpr (TBlendOp & kBlendTransparent)
+    {
+        // Ignore transparent pixels
+        if (*src == OpenRCT2::Drawing::PaletteIndex::transparent)
+        {
+            return false;
+        }
+    }
+
+    if constexpr (((TBlendOp & kBlendSrc) != 0) && ((TBlendOp & kBlendDst) != 0))
+    {
+        auto pixel = paletteMap.Blend(*src, *dst);
+        if constexpr (TBlendOp & kBlendTransparent)
+        {
+            if (pixel == OpenRCT2::Drawing::PaletteIndex::transparent)
+            {
+                return false;
+            }
+        }
+        *dst = pixel;
+        return true;
+    }
+    else if constexpr ((TBlendOp & kBlendSrc) != 0)
+    {
+        auto pixel = paletteMap[EnumValue(*src)];
+        if constexpr (TBlendOp & kBlendTransparent)
+        {
+            if (pixel == OpenRCT2::Drawing::PaletteIndex::transparent)
+            {
+                return false;
+            }
+        }
+        *dst = pixel;
+        return true;
+    }
+    else if constexpr ((TBlendOp & kBlendDst) != 0)
+    {
+        auto pixel = paletteMap[EnumValue(*dst)];
+        if constexpr (TBlendOp & kBlendTransparent)
+        {
+            if (pixel == OpenRCT2::Drawing::PaletteIndex::transparent)
+            {
+                return false;
+            }
+        }
+        *dst = pixel;
+        return true;
+    }
+    else
+    {
+        *dst = *src;
+        return true;
+    }
+}
+
+template<DrawBlendOp TBlendOp>
+void FASTCALL
+    BlitPixels(const uint8_t* src, uint8_t* dst, const OpenRCT2::Drawing::PaletteMap& paletteMap, uint8_t zoom, size_t dstPitch)
+{
+    auto yDstSkip = dstPitch - zoom;
+    for (uint8_t yy = 0; yy < zoom; yy++)
+    {
+        for (uint8_t xx = 0; xx < zoom; xx++)
+        {
+            BlitPixel<TBlendOp>(src, dst, paletteMap);
+            dst++;
+        }
+        dst += yDstSkip;
+    }
+}
+
+// sprite catalogues
+bool GfxLoadG1(const OpenRCT2::IPlatformEnvironment& env);
+void GfxLoadG2PalettesFontsTracks();
+bool GfxLoadCsg();
+void GfxUnloadG1();
+void GfxUnloadG2PalettesFontsTracks();
+void GfxUnloadCsg();
+const OpenRCT2::G1Element* GfxGetG1Element(ImageId imageId);
+const OpenRCT2::G1Element* GfxGetG1Element(ImageIndex image_id);
+const OpenRCT2::G1Palette* GfxGetG1Palette(ImageIndex imageId);
+void GfxSetG1Element(ImageIndex imageId, const OpenRCT2::G1Element* g1);
+std::optional<OpenRCT2::Gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
+bool IsCsgLoaded();
+
+// sprite blitting
+void FASTCALL GfxSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
+void FASTCALL GfxBmpSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
+void FASTCALL GfxRleSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
+void FASTCALL GfxDrawSpriteSoftware(OpenRCT2::Drawing::RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& spriteCoords);
+void FASTCALL GfxDrawSpritePaletteSetSoftware(
+    OpenRCT2::Drawing::RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords,
+    const OpenRCT2::Drawing::PaletteMap& paletteMap);
+void FASTCALL GfxDrawSpriteRawMaskedSoftware(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& scrCoords, ImageId maskImage, ImageId colourImage);
+
+// sprite data
+size_t G1CalculateDataSize(const OpenRCT2::G1Element* g1);
+
+void MaskScalar(
+    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
+    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -14,16 +14,17 @@
 #include "../interface/ZoomLevel.h"
 #include "../world/Location.hpp"
 #include "ColourPalette.h"
+#include "Drawing.Sprite.h"
 #include "FilterPaletteIds.h"
 #include "Font.h"
 #include "G1Element.h"
 #include "ImageId.hpp"
+#include "PaletteMap.h"
 #include "RenderTarget.h"
 #include "Text.h"
 #include "TextColour.h"
 
 #include <array>
-#include <cassert>
 #include <memory>
 #include <optional>
 #include <span>
@@ -46,28 +47,6 @@ namespace OpenRCT2::Drawing
     enum class FilterPaletteID : int32_t;
 } // namespace OpenRCT2::Drawing
 
-using DrawBlendOp = uint8_t;
-
-constexpr DrawBlendOp kBlendNone = 0;
-
-/**
- * Only supported by BITMAP. RLE images always encode transparency via the encoding.
- * Pixel value of 0 represents transparent.
- */
-constexpr DrawBlendOp kBlendTransparent = 1 << 0;
-
-/**
- * Whether to use the pixel value from the source image.
- * This is usually only unset for glass images where there the src is only a transparency mask.
- */
-constexpr DrawBlendOp kBlendSrc = 1 << 1;
-
-/**
- * Whether to use the pixel value of the destination image for blending.
- * This is used for any image that filters the target image, e.g. glass or water.
- */
-constexpr DrawBlendOp kBlendDst = 2 << 2;
-
 namespace OpenRCT2::Drawing
 {
     struct TranslucentWindowPalette
@@ -77,151 +56,6 @@ namespace OpenRCT2::Drawing
         FilterPaletteID shadow;
     };
 } // namespace OpenRCT2::Drawing
-
-/**
- * Represents an 8-bit indexed map that maps from one palette index to another.
- */
-struct PaletteMap
-{
-private:
-    std::span<OpenRCT2::Drawing::PaletteIndex> _data{};
-#ifdef _DEBUG
-    // We only require those fields for the asserts in debug builds.
-    size_t _numMaps{};
-    size_t _mapLength{};
-#endif
-
-public:
-    static PaletteMap GetDefault();
-
-    constexpr PaletteMap() = default;
-
-    constexpr PaletteMap(OpenRCT2::Drawing::PaletteIndex* data, size_t numMaps, size_t mapLength)
-        : _data{ data, numMaps * mapLength }
-#ifdef _DEBUG
-        , _numMaps(numMaps)
-        , _mapLength(mapLength)
-#endif
-    {
-    }
-
-    constexpr PaletteMap(std::span<OpenRCT2::Drawing::PaletteIndex> map)
-        : _data(map)
-#ifdef _DEBUG
-        , _numMaps(1)
-        , _mapLength(map.size())
-#endif
-    {
-    }
-
-    OpenRCT2::Drawing::PaletteIndex& operator[](size_t index);
-    OpenRCT2::Drawing::PaletteIndex operator[](size_t index) const;
-
-    OpenRCT2::Drawing::PaletteIndex Blend(OpenRCT2::Drawing::PaletteIndex src, OpenRCT2::Drawing::PaletteIndex dst) const;
-    void Copy(
-        OpenRCT2::Drawing::PaletteIndex dstIndex, const PaletteMap& src, OpenRCT2::Drawing::PaletteIndex srcIndex,
-        size_t length);
-};
-
-struct DrawSpriteArgs
-{
-    ImageId Image;
-    PaletteMap PalMap;
-    const OpenRCT2::G1Element& SourceImage;
-    int32_t SrcX;
-    int32_t SrcY;
-    int32_t Width;
-    int32_t Height;
-    uint8_t* DestinationBits;
-
-    DrawSpriteArgs(
-        ImageId image, const PaletteMap& palMap, const OpenRCT2::G1Element& sourceImage, int32_t srcX, int32_t srcY,
-        int32_t width, int32_t height, uint8_t* destinationBits)
-        : Image(image)
-        , PalMap(palMap)
-        , SourceImage(sourceImage)
-        , SrcX(srcX)
-        , SrcY(srcY)
-        , Width(width)
-        , Height(height)
-        , DestinationBits(destinationBits)
-    {
-    }
-};
-
-template<DrawBlendOp TBlendOp>
-bool FASTCALL
-    BlitPixel(const OpenRCT2::Drawing::PaletteIndex* src, OpenRCT2::Drawing::PaletteIndex* dst, const PaletteMap& paletteMap)
-{
-    if constexpr (TBlendOp & kBlendTransparent)
-    {
-        // Ignore transparent pixels
-        if (*src == OpenRCT2::Drawing::PaletteIndex::transparent)
-        {
-            return false;
-        }
-    }
-
-    if constexpr (((TBlendOp & kBlendSrc) != 0) && ((TBlendOp & kBlendDst) != 0))
-    {
-        auto pixel = paletteMap.Blend(*src, *dst);
-        if constexpr (TBlendOp & kBlendTransparent)
-        {
-            if (pixel == OpenRCT2::Drawing::PaletteIndex::transparent)
-            {
-                return false;
-            }
-        }
-        *dst = pixel;
-        return true;
-    }
-    else if constexpr ((TBlendOp & kBlendSrc) != 0)
-    {
-        auto pixel = paletteMap[EnumValue(*src)];
-        if constexpr (TBlendOp & kBlendTransparent)
-        {
-            if (pixel == OpenRCT2::Drawing::PaletteIndex::transparent)
-            {
-                return false;
-            }
-        }
-        *dst = pixel;
-        return true;
-    }
-    else if constexpr ((TBlendOp & kBlendDst) != 0)
-    {
-        auto pixel = paletteMap[EnumValue(*dst)];
-        if constexpr (TBlendOp & kBlendTransparent)
-        {
-            if (pixel == OpenRCT2::Drawing::PaletteIndex::transparent)
-            {
-                return false;
-            }
-        }
-        *dst = pixel;
-        return true;
-    }
-    else
-    {
-        *dst = *src;
-        return true;
-    }
-}
-
-template<DrawBlendOp TBlendOp>
-void FASTCALL BlitPixels(const uint8_t* src, uint8_t* dst, const PaletteMap& paletteMap, uint8_t zoom, size_t dstPitch)
-{
-    auto yDstSkip = dstPitch - zoom;
-    for (uint8_t yy = 0; yy < zoom; yy++)
-    {
-        for (uint8_t xx = 0; xx < zoom; xx++)
-        {
-            BlitPixel<TBlendOp>(src, dst, paletteMap);
-            dst++;
-        }
-        dst += yDstSkip;
-    }
-}
 
 constexpr uint8_t kPaletteTotalOffsets = 192;
 
@@ -261,36 +95,15 @@ void GfxDrawDashedLine(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenLine& screenLine, int32_t dashedLineSegmentLength,
     OpenRCT2::Drawing::PaletteIndex colour);
 
-// sprite catalogues
-bool GfxLoadG1(const OpenRCT2::IPlatformEnvironment& env);
-void GfxLoadG2PalettesFontsTracks();
-bool GfxLoadCsg();
-void GfxUnloadG1();
-void GfxUnloadG2PalettesFontsTracks();
-void GfxUnloadCsg();
-const OpenRCT2::G1Element* GfxGetG1Element(ImageId imageId);
-const OpenRCT2::G1Element* GfxGetG1Element(ImageIndex image_id);
-const OpenRCT2::G1Palette* GfxGetG1Palette(ImageIndex imageId);
-void GfxSetG1Element(ImageIndex imageId, const OpenRCT2::G1Element* g1);
-std::optional<OpenRCT2::Gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
-bool IsCsgLoaded();
-
-// sprite blitting
-void FASTCALL GfxSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
-void FASTCALL GfxBmpSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
-void FASTCALL GfxRleSpriteToBuffer(OpenRCT2::Drawing::RenderTarget& rt, const DrawSpriteArgs& args);
+// sprite (NewDrawing.cpp functions that use the drawing engine)
 void FASTCALL GfxDrawSprite(OpenRCT2::Drawing::RenderTarget& rt, ImageId image_id, const ScreenCoordsXY& coords);
 void FASTCALL GfxDrawGlyph(
-    OpenRCT2::Drawing::RenderTarget& rt, ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    OpenRCT2::Drawing::RenderTarget& rt, ImageId image, const ScreenCoordsXY& coords,
+    const OpenRCT2::Drawing::PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteSolid(
     OpenRCT2::Drawing::RenderTarget& rt, ImageId image, const ScreenCoordsXY& coords, OpenRCT2::Drawing::PaletteIndex colour);
 void FASTCALL GfxDrawSpriteRawMasked(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, ImageId maskImage, ImageId colourImage);
-void FASTCALL GfxDrawSpriteSoftware(OpenRCT2::Drawing::RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& spriteCoords);
-void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    OpenRCT2::Drawing::RenderTarget& rt, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
-void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& scrCoords, ImageId maskImage, ImageId colourImage);
 
 // string
 void GfxDrawStringLeftCentred(
@@ -315,11 +128,6 @@ void TTFDrawString(
     OpenRCT2::Drawing::RenderTarget& rt, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords,
     bool noFormatting, FontStyle fontStyle, TextDarkness darkness);
 
-size_t G1CalculateDataSize(const OpenRCT2::G1Element* g1);
-
-void MaskScalar(
-    int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
-    int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
 void MaskSse4_1(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,
     int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
@@ -332,7 +140,7 @@ void MaskFn(
     int32_t maskWrap, int32_t colourWrap, int32_t dstWrap);
 
 std::optional<uint32_t> GetPaletteG1Index(OpenRCT2::Drawing::FilterPaletteID paletteId);
-std::optional<PaletteMap> GetPaletteMapForColour(OpenRCT2::Drawing::FilterPaletteID paletteId);
+std::optional<OpenRCT2::Drawing::PaletteMap> GetPaletteMapForColour(OpenRCT2::Drawing::FilterPaletteID paletteId);
 void UpdatePalette(
     std::span<const OpenRCT2::Drawing::BGRAColour> palette, OpenRCT2::Drawing::PaletteIndex startIndex, int32_t numColours);
 void UpdatePaletteEffects();

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -14,12 +14,12 @@
 #include "PaletteIndex.h"
 #include "TTF.h"
 
-struct PaletteMap;
 struct TextDrawInfo;
 
 namespace OpenRCT2::Drawing
 {
     struct IDrawingEngine;
+    struct PaletteMap;
     struct RenderTarget;
 
     struct IDrawingContext

--- a/src/openrct2/drawing/PaletteMap.h
+++ b/src/openrct2/drawing/PaletteMap.h
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+namespace OpenRCT2::Drawing
+{
+    enum class PaletteIndex : uint8_t;
+
+    /**
+     * Represents an 8-bit indexed map that maps from one palette index to another.
+     */
+    struct PaletteMap
+    {
+    private:
+        std::span<PaletteIndex> _data{};
+#ifdef _DEBUG
+        // We only require those fields for the asserts in debug builds.
+        size_t _numMaps{};
+        size_t _mapLength{};
+#endif
+
+    public:
+        static PaletteMap GetDefault();
+
+        constexpr PaletteMap() = default;
+
+        constexpr PaletteMap(PaletteIndex* data, size_t numMaps, size_t mapLength)
+            : _data{ data, numMaps * mapLength }
+#ifdef _DEBUG
+            , _numMaps(numMaps)
+            , _mapLength(mapLength)
+#endif
+        {
+        }
+
+        constexpr PaletteMap(std::span<PaletteIndex> map)
+            : _data(map)
+#ifdef _DEBUG
+            , _numMaps(1)
+            , _mapLength(map.size())
+#endif
+        {
+        }
+
+        PaletteIndex& operator[](size_t index);
+        PaletteIndex operator[](size_t index) const;
+
+        PaletteIndex Blend(PaletteIndex src, PaletteIndex dst) const;
+        void Copy(PaletteIndex dstIndex, const PaletteMap& src, PaletteIndex srcIndex, size_t length);
+    };
+} // namespace OpenRCT2::Drawing


### PR DESCRIPTION
Closes #25917

Creates separate header files for sprite related declarations:

- `Drawing.Sprite.h` - Contains sprite blitting types (`DrawBlendOp`, `DrawSpriteArgs`), template functions (`BlitPixel`, `BlitPixels`), and function declarations for symbols defined in `Drawing.Sprite.cpp`, `Drawing.Sprite.BMP.cpp`, and `Drawing.Sprite.RLE.cpp`
- `PaletteMap.h` - Contains the `PaletteMap` struct

Also updated the three Drawing.Sprite*.cpp files to include the new header