### PR TITLE
Remove outdated comment from RideObject.cpp

### DIFF
--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -873,9 +873,6 @@ namespace OpenRCT2
                 { "isWaterRide", CarEntryFlag::isWaterRide },
                 { "isGoKart", CarEntryFlag::isGoKart },
                 { "useDodgemCarPlacement", CarEntryFlag::useDodgemCarPlacement },
-
-                // Obsolete flag, only used on Boat Hire. Remaining usages have not yet been updated as of 2022-07-11.
-                // TODO: Is this comment outdated?
                 { "VEHICLE_ENTRY_FLAG_11", CarEntryFlag::use16RotationFrames },
             });
         if (Json::GetBoolean(jCar["hasBaseColour"], true))


### PR DESCRIPTION
The comment seems to be outdated because the `use16RotationFrames` flag is still used by Boat Hire vehicles and CTRs, and from what I can tell it's not likely to become obsolete in the future. Unfortunately the JSON property name can't be updated, otherwise we could use something more fitting. The TODO was added on accident on a PR I made, it was supposed to be resolved before merging but it ended up staying.

(Not ready to merge yet)