### PR TITLE
Invalidate tiles in RideSetVisibilityAction::Execute

### DIFF
--- a/src/openrct2/actions/RideSetVisibilityAction.cpp
+++ b/src/openrct2/actions/RideSetVisibilityAction.cpp
@@ -57,11 +57,13 @@ namespace OpenRCT2::GameActions
         {
             for (int32_t x = 1; x <= gameState.mapSize.x; x++)
             {
-                for (auto* trackElement : TileElementsView<TrackElement>(TileCoordsXY{ x, y }))
+                const TileCoordsXY tileCoords{ x, y };
+                for (auto* trackElement : TileElementsView<TrackElement>(tileCoords))
                 {
                     if (trackElement->GetRideIndex() == _rideIndex)
                     {
                         trackElement->SetInvisible(_visibility == RideSetVisibilityType::invisible);
+                        MapInvalidateTileFull(tileCoords.ToCoordsXY());
                     }
                 }
             }


### PR DESCRIPTION
Fixes this:

https://github.com/user-attachments/assets/82c709eb-299f-40c7-8415-4e1e0bab46c3

