### PR TITLE
Use assets.json as single source of truth for OpenRCT2 assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,25 +66,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-set(TITLE_SEQUENCE_VERSION "0.4.26")
-set(TITLE_SEQUENCE_URL     "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
-set(TITLE_SEQUENCE_SHA256  "dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858")
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/assets.json" ASSETS_JSON)
 
-set(OBJECTS_VERSION "1.7.6")
-set(OBJECTS_URL     "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
-set(OBJECTS_SHA256  "6aca2eb441fbe8c022ff84d59fb51ed7ea577756640970dc989eab685ff45696")
+string(JSON TITLE_SEQUENCE_URL GET "${ASSETS_JSON}" "title-sequences" url)
+string(JSON TITLE_SEQUENCE_SHA256 GET "${ASSETS_JSON}" "title-sequences" sha256)
 
-set(OPENSFX_VERSION "1.0.6")
-set(OPENSFX_URL     "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${OPENSFX_VERSION}/opensound.zip")
-set(OPENSFX_SHA256  "06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be")
+string(JSON OBJECTS_URL GET "${ASSETS_JSON}" objects url)
+string(JSON OBJECTS_SHA256 GET "${ASSETS_JSON}" objects sha256)
 
-set(OPENMSX_VERSION "1.6.1")
-set(OPENMSX_URL     "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
-set(OPENMSX_SHA256  "994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1")
+string(JSON OPENSFX_URL GET "${ASSETS_JSON}" opensfx url)
+string(JSON OPENSFX_SHA256 GET "${ASSETS_JSON}" opensfx sha256)
 
-set(REPLAYS_VERSION "0.0.92")
-set(REPLAYS_URL     "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA256  "455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe")
+string(JSON OPENMSX_URL GET "${ASSETS_JSON}" openmsx url)
+string(JSON OPENMSX_SHA256 GET "${ASSETS_JSON}" openmsx sha256)
+
+string(JSON REPLAYS_URL GET "${ASSETS_JSON}" replays url)
+string(JSON REPLAYS_SHA256 GET "${ASSETS_JSON}" replays sha256)
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")
@@ -149,7 +146,6 @@ if (MACOS_USE_DEPENDENCIES)
     set(MACOS_DYLIBS_URL "https://github.com/OpenRCT2/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
 
     download_openrct2_zip(
-        ZIP_VERSION ${MACOS_DYLIBS_VERSION}
         DOWNLOAD_DIR ${MACOS_DYLIBS_DIR}
         ZIP_URL ${MACOS_DYLIBS_URL}
         SHA256 ${MACOS_DYLIBS_SHA256}
@@ -449,7 +445,6 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
-                ZIP_VERSION ${TITLE_SEQUENCE_VERSION}
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2/sequence/
                 SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/sequence/
                 ZIP_URL ${TITLE_SEQUENCE_URL}
@@ -463,7 +458,6 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
-                ZIP_VERSION ${OBJECTS_VERSION}
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2/object/
                 SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/object/
                 ZIP_URL ${OBJECTS_URL}
@@ -474,7 +468,6 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
-                ZIP_VERSION ${OPENSFX_VERSION}
                 SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/assetpack/openrct2.sound.parkap
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2/
                 ZIP_URL ${OPENSFX_URL}
@@ -485,7 +478,6 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
-                ZIP_VERSION ${OPENMSX_VERSION}
                 SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/assetpack/openrct2.music.alternative.parkap
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2/
                 ZIP_URL ${OPENMSX_URL}
@@ -497,7 +489,6 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
-                ZIP_VERSION ${REPLAYS_VERSION}
                 DOWNLOAD_DIR \${CMAKE_CURRENT_BINARY_DIR}/testdata/replays/
                 ZIP_URL ${REPLAYS_URL}
                 SHA256 ${REPLAYS_SHA256}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,8 @@ string(JSON OBJECTS_SHA256 GET "${ASSETS_JSON}" objects sha256)
 string(JSON OPENSFX_URL GET "${ASSETS_JSON}" opensfx url)
 string(JSON OPENSFX_SHA256 GET "${ASSETS_JSON}" opensfx sha256)
 
-string(JSON OPENMSX_URL GET "${ASSETS_JSON}" openmsx url)
-string(JSON OPENMSX_SHA256 GET "${ASSETS_JSON}" openmsx sha256)
+string(JSON OPENMUSIC_URL GET "${ASSETS_JSON}" openmusic url)
+string(JSON OPENMUSIC_SHA256 GET "${ASSETS_JSON}" openmusic sha256)
 
 string(JSON REPLAYS_URL GET "${ASSETS_JSON}" replays url)
 string(JSON REPLAYS_SHA256 GET "${ASSETS_JSON}" replays sha256)
@@ -90,7 +90,7 @@ option(APPIMAGE "Create an appimage build (-rpath=$ORIGIN/../lib)" OFF)
 option(DOWNLOAD_TITLE_SEQUENCES "Download title sequences during installation." ON)
 option(DOWNLOAD_OBJECTS "Download objects during installation." ON)
 option(DOWNLOAD_OPENSFX "Download OpenSoundEffects during installation." ON)
-option(DOWNLOAD_OPENMSX "Download OpenMusic during installation." ON)
+option(DOWNLOAD_OPENMUSIC "Download OpenMusic during installation." ON)
 CMAKE_DEPENDENT_OPTION(DOWNLOAD_REPLAYS "Download replays during installation." ON
     "WITH_TESTS" OFF)
 CMAKE_DEPENDENT_OPTION(MACOS_USE_DEPENDENCIES "Use OpenRCT2 dependencies instead of system libraries" ON
@@ -474,14 +474,14 @@ if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
                 SHA256 ${OPENSFX_SHA256}
             )")
     endif ()
-    if (DOWNLOAD_OPENMSX)
+    if (DOWNLOAD_OPENMUSIC)
         install(CODE "
             include(${ROOT_DIR}/cmake/download.cmake)
             download_openrct2_zip(
                 SKIP_IF_EXISTS ${CMAKE_SOURCE_DIR}/data/assetpack/openrct2.music.alternative.parkap
                 DOWNLOAD_DIR \$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2/
-                ZIP_URL ${OPENMSX_URL}
-                SHA256 ${OPENMSX_SHA256}
+                ZIP_URL ${OPENMUSIC_URL}
+                SHA256 ${OPENMUSIC_SHA256}
             )")
     endif ()
     if (DOWNLOAD_REPLAYS)

--- a/assets.json
+++ b/assets.json
@@ -1,0 +1,22 @@
+{
+  "objects": {
+    "url": "https://github.com/OpenRCT2/objects/releases/download/v1.7.6/objects.zip",
+    "sha256": "6aca2eb441fbe8c022ff84d59fb51ed7ea577756640970dc989eab685ff45696"
+  },
+  "openmsx": {
+    "url": "https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip",
+    "sha256": "994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1"
+  },
+  "opensfx": {
+    "url": "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.6/opensound.zip",
+    "sha256": "06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be"
+  },
+  "title-sequences": {
+    "url": "https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.26/title-sequences.zip",
+    "sha256": "dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858"
+  },
+  "replays": {
+    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.92/replays.zip",
+    "sha256": "455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe"
+  }
+}

--- a/assets.json
+++ b/assets.json
@@ -3,7 +3,7 @@
     "url": "https://github.com/OpenRCT2/objects/releases/download/v1.7.6/objects.zip",
     "sha256": "6aca2eb441fbe8c022ff84d59fb51ed7ea577756640970dc989eab685ff45696"
   },
-  "openmsx": {
+  "openmusic": {
     "url": "https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip",
     "sha256": "994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1"
   },

--- a/cmake/download.cmake
+++ b/cmake/download.cmake
@@ -1,5 +1,5 @@
 function(download_openrct2_zip)
-    set(oneValueArgs ZIP_VERSION DOWNLOAD_DIR ZIP_URL SHA256)
+    set(oneValueArgs DOWNLOAD_DIR ZIP_URL SHA256)
     set(multiValueArgs SKIP_IF_EXISTS)
     cmake_parse_arguments(DOWNLOAD_OPENRCT2 "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN} )
@@ -8,10 +8,11 @@ function(download_openrct2_zip)
 
     if (NOT EXISTS ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR})
         set(DOWNLOAD_ZIP 1)
+        file(MAKE_DIRECTORY "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}")
     else ()
         if (EXISTS "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}.zipversion")
             file(READ "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}.zipversion" DOWNLOAD_OPENRCT2_CACHED_VERSION)
-            if (NOT ${DOWNLOAD_OPENRCT2_CACHED_VERSION} STREQUAL ${DOWNLOAD_OPENRCT2_ZIP_VERSION})
+            if (NOT ${DOWNLOAD_OPENRCT2_CACHED_VERSION} STREQUAL ${DOWNLOAD_OPENRCT2_ZIP_URL})
                 message("Cache ${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR} not up to date")
                 set(DOWNLOAD_ZIP 1)
             endif ()
@@ -43,7 +44,7 @@ function(download_openrct2_zip)
         endif()
         file(WRITE
             "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}.zipversion"
-            "${DOWNLOAD_OPENRCT2_ZIP_VERSION}"
+            "${DOWNLOAD_OPENRCT2_ZIP_URL}"
         )
         file(REMOVE "${DOWNLOAD_OPENRCT2_DOWNLOAD_DIR}/${ZIP_FILE_NAME}")
     endif ()

--- a/openrct2.deps.targets
+++ b/openrct2.deps.targets
@@ -1,10 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- ReadAssetsJson task: Parse assets.json and set properties -->
+  <UsingTask TaskName="ReadAssetsJson"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <JsonFilePath           Required="true"  ParameterType="System.String" />
+      <TitleSequencesUrl      Required="false" ParameterType="System.String" Output="true" />
+      <TitleSequencesSha256   Required="false" ParameterType="System.String" Output="true" />
+      <ObjectsUrl             Required="false" ParameterType="System.String" Output="true" />
+      <ObjectsSha256          Required="false" ParameterType="System.String" Output="true" />
+      <OpenSFXUrl             Required="false" ParameterType="System.String" Output="true" />
+      <OpenSFXSha256          Required="false" ParameterType="System.String" Output="true" />
+      <OpenMSXUrl             Required="false" ParameterType="System.String" Output="true" />
+      <OpenMSXSha256          Required="false" ParameterType="System.String" Output="true" />
+      <ReplaysUrl             Required="false" ParameterType="System.String" Output="true" />
+      <ReplaysSha256          Required="false" ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Memory" />
+      <Reference Include="System.Text.Json" />
+      <Using Namespace="System"/>
+      <Using Namespace="System.IO"/>
+      <Using Namespace="System.Text.Json"/>
+      <Using Namespace="Microsoft.Build.Framework"/>
+      <Using Namespace="Microsoft.Build.Utilities"/>
+      <Code Type="Method" Language="cs">
+        <![CDATA[
+          public override bool Execute()
+          {
+              try
+              {
+                  if (!File.Exists(JsonFilePath))
+                  {
+                      Log.LogWarning("Assets JSON file not found: {0}", JsonFilePath);
+                      return true;
+                  }
+
+                  string jsonContent = File.ReadAllText(JsonFilePath);
+                  using (JsonDocument doc = JsonDocument.Parse(jsonContent))
+                  {
+                      JsonElement root = doc.RootElement;
+
+                      TitleSequencesUrl = GetAssetProperty(root, "title-sequences", "url");
+                      TitleSequencesSha256 = GetAssetProperty(root, "title-sequences", "sha256");
+
+                      ObjectsUrl = GetAssetProperty(root, "objects", "url");
+                      ObjectsSha256 = GetAssetProperty(root, "objects", "sha256");
+
+                      OpenSFXUrl = GetAssetProperty(root, "opensfx", "url");
+                      OpenSFXSha256 = GetAssetProperty(root, "opensfx", "sha256");
+
+                      OpenMSXUrl = GetAssetProperty(root, "openmsx", "url");
+                      OpenMSXSha256 = GetAssetProperty(root, "openmsx", "sha256");
+
+                      ReplaysUrl = GetAssetProperty(root, "replays", "url");
+                      ReplaysSha256 = GetAssetProperty(root, "replays", "sha256");
+                  }
+
+                  Log.LogMessage(MessageImportance.Low, "Successfully read asset definitions from {0}", JsonFilePath);
+              }
+              catch (Exception ex)
+              {
+                  Log.LogErrorFromException(ex, showStackTrace: true);
+                  return false;
+              }
+
+              return true;
+          }
+
+          private string GetAssetProperty(JsonElement assets, string assetName, string propertyName)
+          {
+              if (assets.TryGetProperty(assetName, out JsonElement asset))
+              {
+                  if (asset.TryGetProperty(propertyName, out JsonElement property))
+                  {
+                      return property.GetString() ?? string.Empty;
+                  }
+              }
+              Log.LogWarning("Could not find property '{0}' in asset '{1}'", propertyName, assetName);
+              return string.Empty;
+          }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <!-- DownloadDependency task -->
   <UsingTask TaskName="DownloadDependency"
-             TaskFactory="CodeTaskFactory"
-             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <Name            Required="true"  ParameterType="System.String" />
       <Url             Required="true"  ParameterType="System.String" />
@@ -13,8 +99,6 @@
       <OutputDirectory Required="true"  ParameterType="System.String" />
     </ParameterGroup>
     <Task>
-      <Reference Include="System.IO.Compression, Version=4.0.0.0" />
-      <Reference Include="System.IO.Compression.FileSystem" />
       <Using Namespace="System"/>
       <Using Namespace="System.IO"/>
       <Using Namespace="System.IO.Compression"/>
@@ -206,32 +290,41 @@
     </Task>
   </UsingTask>
 
-  <!-- 3rd party libraries / dependencies -->
+  <!-- 3rd party libraries / dependencies loaded from assets.json -->
   <PropertyGroup>
     <RootDir>$(MsBuildThisFileDirectory)</RootDir>
     <DependenciesCheckFile>$(RootDir).dependencies</DependenciesCheckFile>
+    <AssetsJsonPath>$(RootDir)assets.json</AssetsJsonPath>
     <LibsUrl Condition="'$(Platform)'=='ARM64'">https://github.com/OpenRCT2/Dependencies/releases/download/v41/openrct2-libs-v41-arm64-windows-static.zip</LibsUrl>
     <LibsSha256 Condition="'$(Platform)'=='ARM64'">5d171f23eee584bdc29b1186dc7a86d935a6ea58efa42b5674c196c5b581923b</LibsSha256>
     <LibsUrl Condition="'$(Platform)'=='x64'">https://github.com/OpenRCT2/Dependencies/releases/download/v41/openrct2-libs-v41-x64-windows-static.zip</LibsUrl>
     <LibsSha256 Condition="'$(Platform)'=='x64'">8e78f1c3c09c50cb0f509eab6845a93dd69771ff95cdf82d747568093d138f73</LibsSha256>
     <LibsUrl Condition="'$(Platform)'=='Win32'">https://github.com/OpenRCT2/Dependencies/releases/download/v41/openrct2-libs-v41-x86-windows-static.zip</LibsUrl>
     <LibsSha256 Condition="'$(Platform)'=='Win32'">490263b873dd02c13a043a04d26bb9837d2d378dacd8b2c8d29660fef44db3db</LibsSha256>
-    <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.26/title-sequences.zip</TitleSequencesUrl>
-    <TitleSequencesSha256>dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858</TitleSequencesSha256>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.7.6/objects.zip</ObjectsUrl>
-    <ObjectsSha256>6aca2eb441fbe8c022ff84d59fb51ed7ea577756640970dc989eab685ff45696</ObjectsSha256>
-    <OpenSFXUrl>https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v1.0.6/opensound.zip</OpenSFXUrl>
-    <OpenSFXSha256>06b90f3e19c216752df441d551b26a9e3e1ba7755bdd2102504b73bf993608be</OpenSFXSha256>
-    <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.6.1/openmusic.zip</OpenMSXUrl>
-    <OpenMSXSha256>994b350d3b180ee1cb9619fe27f7ebae3a1a5232840c4bd47a89f33fa89de1a1</OpenMSXSha256>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.92/replays.zip</ReplaysUrl>
-    <ReplaysSha256>455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe</ReplaysSha256>
   </PropertyGroup>
+
+  <!-- Load asset definitions from JSON first, before any download targets run -->
+  <Target Name="LoadAssetsJson">
+    <ReadAssetsJson
+      JsonFilePath="$(AssetsJsonPath)"
+      Condition="Exists('$(AssetsJsonPath)')">
+      <Output TaskParameter="TitleSequencesUrl" PropertyName="TitleSequencesUrl" />
+      <Output TaskParameter="TitleSequencesSha256" PropertyName="TitleSequencesSha256" />
+      <Output TaskParameter="ObjectsUrl" PropertyName="ObjectsUrl" />
+      <Output TaskParameter="ObjectsSha256" PropertyName="ObjectsSha256" />
+      <Output TaskParameter="OpenSFXUrl" PropertyName="OpenSFXUrl" />
+      <Output TaskParameter="OpenSFXSha256" PropertyName="OpenSFXSha256" />
+      <Output TaskParameter="OpenMSXUrl" PropertyName="OpenMSXUrl" />
+      <Output TaskParameter="OpenMSXSha256" PropertyName="OpenMSXSha256" />
+      <Output TaskParameter="ReplaysUrl" PropertyName="ReplaysUrl" />
+      <Output TaskParameter="ReplaysSha256" PropertyName="ReplaysSha256" />
+    </ReadAssetsJson>
+  </Target>
 
   <!-- Unified Dependency Target -->
   <Target Name="DownloadAllDependencies"
           BeforeTargets="PrepareForBuild"
-          DependsOnTargets="DownloadLibs;DownloadTitleSequences;DownloadObjects;DownloadOpenSFX;DownloadOpenMSX;DownloadReplays">
+          DependsOnTargets="LoadAssetsJson;DownloadLibs;DownloadTitleSequences;DownloadObjects;DownloadOpenSFX;DownloadOpenMSX;DownloadReplays">
 
     <!-- Add completion marker -->
     <Touch Files="$(DependenciesCheckFile)" AlwaysCreate="true" />

--- a/openrct2.deps.targets
+++ b/openrct2.deps.targets
@@ -13,8 +13,8 @@
       <ObjectsSha256          Required="false" ParameterType="System.String" Output="true" />
       <OpenSFXUrl             Required="false" ParameterType="System.String" Output="true" />
       <OpenSFXSha256          Required="false" ParameterType="System.String" Output="true" />
-      <OpenMSXUrl             Required="false" ParameterType="System.String" Output="true" />
-      <OpenMSXSha256          Required="false" ParameterType="System.String" Output="true" />
+      <OpenMusicUrl           Required="false" ParameterType="System.String" Output="true" />
+      <OpenMusicSha256        Required="false" ParameterType="System.String" Output="true" />
       <ReplaysUrl             Required="false" ParameterType="System.String" Output="true" />
       <ReplaysSha256          Required="false" ParameterType="System.String" Output="true" />
     </ParameterGroup>
@@ -52,8 +52,8 @@
                       OpenSFXUrl = GetAssetProperty(root, "opensfx", "url");
                       OpenSFXSha256 = GetAssetProperty(root, "opensfx", "sha256");
 
-                      OpenMSXUrl = GetAssetProperty(root, "openmsx", "url");
-                      OpenMSXSha256 = GetAssetProperty(root, "openmsx", "sha256");
+                      OpenMusicUrl = GetAssetProperty(root, "openmusic", "url");
+                      OpenMusicSha256 = GetAssetProperty(root, "openmusic", "sha256");
 
                       ReplaysUrl = GetAssetProperty(root, "replays", "url");
                       ReplaysSha256 = GetAssetProperty(root, "replays", "sha256");
@@ -314,8 +314,8 @@
       <Output TaskParameter="ObjectsSha256" PropertyName="ObjectsSha256" />
       <Output TaskParameter="OpenSFXUrl" PropertyName="OpenSFXUrl" />
       <Output TaskParameter="OpenSFXSha256" PropertyName="OpenSFXSha256" />
-      <Output TaskParameter="OpenMSXUrl" PropertyName="OpenMSXUrl" />
-      <Output TaskParameter="OpenMSXSha256" PropertyName="OpenMSXSha256" />
+      <Output TaskParameter="OpenMusicUrl" PropertyName="OpenMusicUrl" />
+      <Output TaskParameter="OpenMusicSha256" PropertyName="OpenMusicSha256" />
       <Output TaskParameter="ReplaysUrl" PropertyName="ReplaysUrl" />
       <Output TaskParameter="ReplaysSha256" PropertyName="ReplaysSha256" />
     </ReadAssetsJson>
@@ -324,7 +324,7 @@
   <!-- Unified Dependency Target -->
   <Target Name="DownloadAllDependencies"
           BeforeTargets="PrepareForBuild"
-          DependsOnTargets="LoadAssetsJson;DownloadLibs;DownloadTitleSequences;DownloadObjects;DownloadOpenSFX;DownloadOpenMSX;DownloadReplays">
+          DependsOnTargets="LoadAssetsJson;DownloadLibs;DownloadTitleSequences;DownloadObjects;DownloadOpenSFX;DownloadOpenMusic;DownloadReplays">
 
     <!-- Add completion marker -->
     <Touch Files="$(DependenciesCheckFile)" AlwaysCreate="true" />
@@ -368,11 +368,11 @@
                         OutputDirectory="$(TargetDir)data" />
   </Target>
 
-  <!-- Target to download OpenMSX -->
-  <Target Name="DownloadOpenMSX">
-    <DownloadDependency Name="OpenMSX"
-                        Url="$(OpenMSXUrl)"
-                        Sha256="$(OpenMSXSha256)"
+  <!-- Target to download OpenMusic -->
+  <Target Name="DownloadOpenMusic">
+    <DownloadDependency Name="OpenMusic"
+                        Url="$(OpenMusicUrl)"
+                        Sha256="$(OpenMusicSha256)"
                         CheckFile="$(DependenciesCheckFile)"
                         OutputDirectory="$(TargetDir)data" />
   </Target>

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -235,14 +235,12 @@ if(MACOS_BUNDLE)
     set(OBJECTS_DIR ${CMAKE_BINARY_DIR}/object)
     set(TITLE_SEQUENCE_DIR ${CMAKE_BINARY_DIR}/sequence)
     download_openrct2_zip(
-        ZIP_VERSION ${OBJECTS_VERSION}
         DOWNLOAD_DIR ${OBJECTS_DIR}
         ZIP_URL ${OBJECTS_URL}
         SHA256 ${OBJECTS_SHA256}
     )
 
     download_openrct2_zip(
-        ZIP_VERSION ${TITLE_SEQUENCE_VERSION}
         DOWNLOAD_DIR ${TITLE_SEQUENCE_DIR}
         ZIP_URL ${TITLE_SEQUENCE_URL}
         SHA256 ${TITLE_SEQUENCE_SHA256}
@@ -251,13 +249,11 @@ if(MACOS_BUNDLE)
     # Download opensfx and openmsx
     set(ASSET_PACK_DIR ${CMAKE_BINARY_DIR}/assetpack)
     download_openrct2_zip(
-        ZIP_VERSION ${OPENSFX_VERSION}
         DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
         ZIP_URL ${OPENSFX_URL}
         SHA256 ${OPENSFX_SHA256}
     )
     download_openrct2_zip(
-        ZIP_VERSION ${OPENMSX_VERSION}
         DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
         ZIP_URL ${OPENMSX_URL}
         SHA256 ${OPENMSX_SHA256}

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -246,7 +246,7 @@ if(MACOS_BUNDLE)
         SHA256 ${TITLE_SEQUENCE_SHA256}
     )
 
-    # Download opensfx and openmsx
+    # Download opensfx and openmusic
     set(ASSET_PACK_DIR ${CMAKE_BINARY_DIR}/assetpack)
     download_openrct2_zip(
         DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
@@ -255,8 +255,8 @@ if(MACOS_BUNDLE)
     )
     download_openrct2_zip(
         DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
-        ZIP_URL ${OPENMSX_URL}
-        SHA256 ${OPENMSX_SHA256}
+        ZIP_URL ${OPENMUSIC_URL}
+        SHA256 ${OPENMUSIC_SHA256}
     )
 
     # Copy downloaded data


### PR DESCRIPTION
This ensures there's single source of truth for all downloadable assets. I figured the "version" information is actually redundant because we can embed the whole URL as the "zipversion", therefore this is dropped now.

The newly-introdcued MSBuild task uses Roslyn-based code and I updated `DownloadDependency` task to RoslynCodeTaskFactory as well.