### PR TITLE
Fix #25954: Guests display hats, balloons and umbrellas while puking

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#25941] The command line sprite build command is now faster.
 - Fix: [#25237] Wrong colours on the Knight costume.
 - Fix: [#25910] Folders starting with numbers are sorted incorrectly (e.g. 1, 10, 2 instead of 1, 2, 10).
+- Fix: [#25954] Guests display hats, balloons, and umbrellas while puking.
 
 0.4.31 (2026-02-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/entity/Paint.Guest.cpp
+++ b/src/openrct2/paint/entity/Paint.Guest.cpp
@@ -44,8 +44,9 @@ void PaintGuest(PaintSession& session, const Guest& guest, int32_t orientation)
 void PaintGuestAccesories(
     PaintSession& session, const Guest& guest, uint8_t imageOffset, PeepAnimationType actionAnimationGroup, Direction direction)
 {
-    // Can't display any accessories whilst drowning or clapping
-    if (guest.Action == PeepActionType::drowning || guest.Action == PeepActionType::clap)
+    // Can't display any accessories whilst drowning, clapping, or throwing up
+    if (guest.Action == PeepActionType::drowning || guest.Action == PeepActionType::clap
+        || guest.Action == PeepActionType::throwUp)
         return;
 
     // There are only 6 walking frames available for each item,


### PR DESCRIPTION
Fixes #25954 by adding `throwUp` to the existing action filter in `PaintGuestAccesories()`

<img width="605" height="530" alt="image" src="https://github.com/user-attachments/assets/f7c7984e-79df-479b-9763-a1cd72e2f6f9" />
