### PR TITLE
CI images 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.20
         with:
           key: android
+      - name: Cache Gradle
+        uses: actions/cache@v5
+        with:
+          # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
+          # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
+          path: /root/.gradle/caches
+          key: gradle-${{ hashFiles('src/openrct2-android/gradle.properties') }}
       - name: Setup keystore
         run: |
           echo "${{ secrets.OPENRCT2_KEYSTORE_CONTENTS }}" | base64 -d > keystore.jks
@@ -645,6 +652,12 @@ jobs:
           name: OpenRCT2-${{ needs.build_variables.outputs.name }}-Android
           path: artifacts
           if-no-files-found: error
+      - name: Upload gradle issues
+        uses: actions/upload-artifact@v6
+        with:
+          name: OpenRCT2-${{ needs.build_variables.outputs.name }}-gradle-issues
+          path: src/openrct2-android/build/reports/problems/problems-report.html
+          if-no-files-found: ignore
   emscripten:
     name: Emscripten
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
   check-code-formatting:
     name: Check code formatting
     runs-on: ubuntu-latest
-    container: openrct2/openrct2-build:24-format
+    container: openrct2/openrct2-build:25-format
     permissions:
       pull-requests: write
       contents: read
@@ -321,7 +321,7 @@ jobs:
     name: Windows (${{ matrix.platform_name }}) using mingw
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:24-mingw
+    container: openrct2/openrct2-build:25-mingw
     strategy:
       fail-fast: false
       matrix:
@@ -459,17 +459,22 @@ jobs:
           - platform: x86_64
             distro: Ubuntu
             release: noble
-            image: openrct2/openrct2-build:24-noble
+            image: openrct2/openrct2-build:25-noble
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz -fno-var-tracking-assignments"
+          - platform: x86_64
+            distro: Ubuntu
+            release: resolute
+            image: openrct2/openrct2-build:25-resolute
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz"
           - platform: x86_64
             distro: Debian
             release: bookworm
-            image: openrct2/openrct2-build:24-bookworm
+            image: openrct2/openrct2-build:25-bookworm
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz -fno-var-tracking-assignments" -DWITH_TESTS=off
           - platform: x86_64
             distro: Debian
             release: trixie
-            image: openrct2/openrct2-build:24-trixie
+            image: openrct2/openrct2-build:25-trixie
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz -fno-var-tracking-assignments" -DWITH_TESTS=off
     steps:
       - name: Checkout
@@ -554,7 +559,7 @@ jobs:
     name: Ubuntu Linux (noble, debug, [http, network, flac, vorbis OpenGL] disabled) using clang
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:24-noble
+    container: openrct2/openrct2-build:25-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -570,7 +575,7 @@ jobs:
     name: Ubuntu Linux (debug) using clang, coverage enabled
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:24-noble
+    container: openrct2/openrct2-build:25-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -611,7 +616,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:24-android
+    container: openrct2/openrct2-build:25-android
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -644,7 +649,7 @@ jobs:
     name: Emscripten
     runs-on: ubuntu-latest
     needs: [check-code-formatting, build_variables]
-    container: openrct2/openrct2-build:24-emscripten
+    container: openrct2/openrct2-build:25-emscripten
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdk 36
+    buildToolsVersion "36.0.0"
     ndkVersion "27.3.13750724" // Latest r27d (LTS), to be synced with CI container image
     namespace "io.openrct2"
 

--- a/src/openrct2-android/gradle.properties
+++ b/src/openrct2-android/gradle.properties
@@ -18,6 +18,7 @@
 # org.gradle.parallel=true
 android.enableJetifier=false
 android.useAndroidX=true
+org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4096m
 

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -186,7 +186,6 @@ namespace OpenRCT2
                 break;
         }
 
-        assert(false);
-        return nullptr;
+        throw std::invalid_argument(String::stdFormat("Unknown file type: %d", static_cast<int>(fileType)));
     }
 } // namespace OpenRCT2

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -893,7 +893,7 @@ namespace OpenRCT2::Scripting
         auto* peep = GetGuest();
         if (peep == nullptr)
         {
-            return nullptr;
+            return "";
         }
 
         auto& availableGuestAnimations = getAnimationsByPeepType(AnimationPeepType::guest);

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -314,7 +314,7 @@ namespace OpenRCT2::Scripting
         auto* peep = GetStaff();
         if (peep == nullptr)
         {
-            return nullptr;
+            return "";
         }
 
         auto& animationGroups = animationsByStaffType(peep->AssignedStaffType);


### PR DESCRIPTION
- Addition of Resolute (Ubuntu 26.04)
- emsdk got updated to 5.0.0 and requires minor code changes, cc @mrmbernardi for ScGuest.cpp, ScStaff.cpp
- Android's gradle configuration is now cached, saving over a minute in CI
- Android's build tools are now properly set to the version already included in the image, saving about (another) minute in CI