### PR TITLE
Fix #14686, #23996, #25981: Preview images from different windows overwrite each other when using OpenGL

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#22704] Rides can be made invisible more easily.
 - Improved: [#25941] The command line sprite build command is now faster.
+- Fix: [#14686, #23996, #25981] Preview images from different windows overwrite each other when using OpenGL.
 - Fix: [#25237] Wrong colours on the Knight costume.
 - Fix: [#25712, #25727] Crash during startup from window list race condition.
 - Fix: [#25910] Folders starting with numbers are sorted incorrectly (e.g. 1, 10, 2 instead of 1, 2, 10).

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -165,9 +165,9 @@ namespace OpenRCT2::Ui::Windows
             g1temp.width = 370;
             g1temp.height = 217;
             g1temp.flags = { G1Flag::hasTransparency };
-            GfxSetG1Element(SPR_TEMP, &g1temp);
-            DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(rt, ImageId(SPR_TEMP), screenPos);
+            GfxSetG1Element(SPR_TEMP_INSTALL_TRACK, &g1temp);
+            DrawingEngineInvalidateImage(SPR_TEMP_INSTALL_TRACK);
+            GfxDrawSprite(rt, ImageId(SPR_TEMP_INSTALL_TRACK), screenPos);
 
             screenPos = windowPos + ScreenCoordsXY{ widget->midX(), widget->bottom - 12 };
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -587,9 +587,9 @@ namespace OpenRCT2::Ui::Windows
             g1temp.offset = reinterpret_cast<uint8_t*>(_mapImageData.data());
             g1temp.width = getMiniMapWidth();
             g1temp.height = getMiniMapWidth();
-            GfxSetG1Element(SPR_TEMP, &g1temp);
-            DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(rt, ImageId(SPR_TEMP), screenOffset);
+            GfxSetG1Element(SPR_TEMP_MAP, &g1temp);
+            DrawingEngineInvalidateImage(SPR_TEMP_MAP);
+            GfxDrawSprite(rt, ImageId(SPR_TEMP_MAP), screenOffset);
 
             if (selectedTab == PAGE_PEEPS)
             {

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -373,9 +373,9 @@ namespace OpenRCT2::Ui::Windows
                 g1temp.offset = reinterpret_cast<uint8_t*>(_miniPreview.data());
                 g1temp.width = kTrackMiniPreviewSize.width;
                 g1temp.height = kTrackMiniPreviewSize.height;
-                GfxSetG1Element(SPR_TEMP, &g1temp);
-                DrawingEngineInvalidateImage(SPR_TEMP);
-                GfxDrawSprite(clippedRT, ImageId(SPR_TEMP, this->colours[0].colour), { 0, 0 });
+                GfxSetG1Element(SPR_TEMP_TRACK_PLACE, &g1temp);
+                DrawingEngineInvalidateImage(SPR_TEMP_TRACK_PLACE);
+                GfxDrawSprite(clippedRT, ImageId(SPR_TEMP_TRACK_PLACE, this->colours[0].colour), { 0, 0 });
             }
 
             // Price

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -513,9 +513,9 @@ namespace OpenRCT2::Ui::Windows
             g1temp.width = 370;
             g1temp.height = 217;
             g1temp.flags = { G1Flag::hasTransparency };
-            GfxSetG1Element(SPR_TEMP, &g1temp);
-            DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(rt, ImageId(SPR_TEMP), trackPreview);
+            GfxSetG1Element(SPR_TEMP_TRACK_LIST, &g1temp);
+            DrawingEngineInvalidateImage(SPR_TEMP_TRACK_LIST);
+            GfxDrawSprite(rt, ImageId(SPR_TEMP_TRACK_LIST), trackPreview);
 
             screenPos.y = windowPos.y + tdWidget.bottom - 12;
 

--- a/src/openrct2/SpriteIds.h
+++ b/src/openrct2/SpriteIds.h
@@ -15,10 +15,21 @@
 
 #include <cstddef>
 
+// Number of temp sprite slots available for dynamic on-demand drawing
+constexpr size_t kTempSpriteCount = 5;
+
 enum : ImageIndex
 {
     // Used for on-demand drawing of dynamic memory
-    SPR_TEMP = 0x7FFFE,
+    // Each window that uses temporary sprites gets its own slot to avoid conflicts
+    // when multiple windows are open simultaneously (especially in OpenGL mode)
+    SPR_TEMP_BEGIN = 0x7FFFA,
+    SPR_TEMP_MAP = SPR_TEMP_BEGIN + 0,           // Map.cpp minimap
+    SPR_TEMP_TRACK_LIST = SPR_TEMP_BEGIN + 1,    // TrackList.cpp track design preview
+    SPR_TEMP_TRACK_PLACE = SPR_TEMP_BEGIN + 2,   // TrackDesignPlace.cpp placement preview
+    SPR_TEMP_PARK_PREVIEW = SPR_TEMP_BEGIN + 3,  // ParkPreview.cpp scenario/save preview
+    SPR_TEMP_INSTALL_TRACK = SPR_TEMP_BEGIN + 4, // InstallTrack.cpp track install preview
+    SPR_TEMP_END = SPR_TEMP_BEGIN + kTempSpriteCount,
 
     // Unused, listed for documentation purposes only
     SPR_G1_PALETTE_DEFAULT = 1532,

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -445,7 +445,7 @@ static Gx _csg = {};
 static G1Element _scrollingText[ScrollingText::kMaxEntries]{};
 static bool _csgLoaded = false;
 
-static G1Element _g1Temp = {};
+static G1Element _g1Temp[kTempSpriteCount] = {};
 static std::vector<G1Element> _imageListElements;
 
 /**
@@ -1044,9 +1044,9 @@ const G1Element* GfxGetG1Element(ImageIndex image_id)
         return nullptr;
     }
 
-    if (offset == SPR_TEMP)
+    if (offset >= SPR_TEMP_BEGIN && offset < SPR_TEMP_END)
     {
-        return &_g1Temp;
+        return &_g1Temp[offset - SPR_TEMP_BEGIN];
     }
 
     if (offset < SPR_RCTC_G1_END)
@@ -1139,7 +1139,7 @@ const G1Palette* GfxGetG1Palette(ImageIndex imageId)
 
 void GfxSetG1Element(ImageIndex imageId, const G1Element* g1)
 {
-    bool isTemp = imageId == SPR_TEMP;
+    bool isTemp = (imageId >= SPR_TEMP_BEGIN && imageId < SPR_TEMP_END);
     bool isValid = (imageId >= SPR_IMAGE_LIST_BEGIN && imageId < SPR_IMAGE_LIST_END)
         || (imageId >= SPR_SCROLLING_TEXT_START && imageId < SPR_SCROLLING_TEXT_END);
 
@@ -1153,7 +1153,7 @@ void GfxSetG1Element(ImageIndex imageId, const G1Element* g1)
     {
         if (isTemp)
         {
-            _g1Temp = *g1;
+            _g1Temp[imageId - SPR_TEMP_BEGIN] = *g1;
         }
         else if (isValid)
         {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -454,7 +454,7 @@ const TranslucentWindowPalette kTranslucentWindowPalettes[kColourNumTotal] = {
 ImageCatalogue ImageId::GetCatalogue() const
 {
     auto index = GetIndex();
-    if (index == SPR_TEMP)
+    if (index >= SPR_TEMP_BEGIN && index < SPR_TEMP_END)
     {
         return ImageCatalogue::TEMPORARY;
     }

--- a/src/openrct2/park/ParkPreview.cpp
+++ b/src/openrct2/park/ParkPreview.cpp
@@ -255,9 +255,9 @@ namespace OpenRCT2
         g1temp.width = image.width;
         g1temp.height = image.height;
 
-        GfxSetG1Element(SPR_TEMP, &g1temp);
-        DrawingEngineInvalidateImage(SPR_TEMP);
-        GfxDrawSprite(rt, ImageId(SPR_TEMP), screenPos);
+        GfxSetG1Element(SPR_TEMP_PARK_PREVIEW, &g1temp);
+        DrawingEngineInvalidateImage(SPR_TEMP_PARK_PREVIEW);
+        GfxDrawSprite(rt, ImageId(SPR_TEMP_PARK_PREVIEW), screenPos);
     }
 
 } // namespace OpenRCT2


### PR DESCRIPTION
Fixes #14686, #23996, #25981

The Map, Track Design List, Track Design Placement, Install Track, and Park Preview windows all shared a single `SPR_TEMP` sprite ID for rendering dynamic preview images. 

The issue only manifests itself in OpenGL mode because they overwrite each other's textures when multiple windows were open at the same time

## Changes:
- Added separate temp sprite IDs for each window that needs one (`SPR_TEMP_MAP`, `SPR_TEMP_TRACK_LIST`, `SPR_TEMP_TRACK_PLACE`, `SPR_TEMP_PARK_PREVIEW`, `SPR_TEMP_INSTALL_TRACK`)
- Changed `_g1Temp` from a single `G1Element` to an array to store each sprite separately
- Updated range checks in drawing code to handle the new sprite ID range
- Kept `SPR_TEMP` as a legacy alias pointing to `SPR_TEMP_MAP`


Before:
<img width="1013" height="705" alt="image" src="https://github.com/user-attachments/assets/03db916a-90c2-4538-b7f1-d63060124e17" />


After:
<img width="1683" height="1051" alt="image" src="https://github.com/user-attachments/assets/98b1ea0a-4bad-4ae9-b7e1-6c2cbbd5feaa" />

