### PR TITLE
Add TD7 format

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#21753] Tracked rides with cheated powered launch mode can change powered launch speed without extra cheats.
 - Improved: [#25526] When a shop item cannot be recoloured, show a preview of the building instead.
 - Improved: [#25941] The command line sprite build command is now faster.
+- Improved: [#26002] Rides with newer track elements (like the zero G roll or diagonal brakes) can now be saved as track designs.
 - Change: [#26011] Audio resampling no longer depends on the third-party library libspeexdsp.
 - Fix: [#14686, #23996, #25981] Preview images from different windows overwrite each other when using OpenGL.
 - Fix: [#15128, #15626, #16331, #17443, #18626, #21597, #24175, #24971, #25963] Crash when loading corrupted RCT2/RCT1 save files with duplicate entity indices.

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -188,7 +188,7 @@ namespace OpenRCT2::Ui::FileBrowser
                 return isSave ? "*.park" : "*.park;*.sc6;*.sc4";
 
             case LoadSaveType::track:
-                return isSave ? "*.td6" : "*.td6;*.td4";
+                return isSave ? "*.td6;*.td7" : "*.td6;*.td4;*.td7";
 
             case LoadSaveType::heightmap:
                 return "*.bmp;*.png";
@@ -412,9 +412,10 @@ namespace OpenRCT2::Ui::FileBrowser
                     }
                     case LoadSaveType::track:
                     {
+                        auto extension = trackDesignGetExtension(trackDesignPtr->version);
                         SetAndSaveConfigPath(Config::Get().general.lastSaveTrackDirectory, pathBuffer);
 
-                        const auto withExtension = Path::WithExtension(pathBuffer, ".td6");
+                        const auto withExtension = Path::WithExtension(pathBuffer, extension);
                         String::set(pathBuffer, sizeof(pathBuffer), withExtension.c_str());
 
                         RCT2::T6Exporter t6Export{ *trackDesignPtr };

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -69,7 +69,7 @@ namespace OpenRCT2::Ui::FileBrowser
             const bool isSave = (action == LoadSaveAction::save);
             const auto defaultDirectory = GetDir(type);
 
-            const u8string path = OpenSystemFileBrowser(isSave, type, defaultDirectory, defaultPath);
+            const u8string path = OpenSystemFileBrowser(isSave, type, defaultDirectory, defaultPath, trackDesign);
             if (!path.empty())
             {
                 Select(path.c_str(), action, type, trackDesign);
@@ -174,7 +174,7 @@ namespace OpenRCT2::Ui::FileBrowser
             return env.GetDirectoryPath(DirBase::user);
     }
 
-    const char* GetFilterPatternByType(const LoadSaveType type, const bool isSave)
+    u8string GetFilterPatternByType(const LoadSaveType type, const bool isSave, const TrackDesign* trackDesign)
     {
         switch (type)
         {
@@ -188,7 +188,15 @@ namespace OpenRCT2::Ui::FileBrowser
                 return isSave ? "*.park" : "*.park;*.sc6;*.sc4";
 
             case LoadSaveType::track:
-                return isSave ? "*.td6;*.td7" : "*.td6;*.td4;*.td7";
+            {
+                if (!isSave)
+                    return "*.td6;*.td4;*.td7";
+
+                if (trackDesign == nullptr)
+                    return "*.td6";
+
+                return "*" + trackDesignGetExtension(trackDesign->version);
+            }
 
             case LoadSaveType::heightmap:
                 return "*.bmp;*.png";
@@ -197,7 +205,7 @@ namespace OpenRCT2::Ui::FileBrowser
                 Guard::Fail("Unsupported load/save directory type.");
         }
 
-        return nullptr;
+        return {};
     }
 
     u8string RemovePatternWildcard(u8string_view pattern)
@@ -469,28 +477,7 @@ namespace OpenRCT2::Ui::FileBrowser
         }
     }
 
-    static u8string GetDefaultExtensionByType(LoadSaveType type)
-    {
-        switch (type)
-        {
-            case LoadSaveType::park:
-                return u8".park";
-
-            case LoadSaveType::landscape:
-                return u8".park";
-
-            case LoadSaveType::scenario:
-                return u8".park";
-
-            case LoadSaveType::track:
-                return u8".td6";
-
-            default:
-                return {};
-        }
-    }
-
-    static FileDialogDesc::Filter GetFilterForType(LoadSaveType type, bool isSave)
+    static FileDialogDesc::Filter GetFilterForType(LoadSaveType type, bool isSave, const TrackDesign* trackDesign)
     {
         switch (type)
         {
@@ -504,7 +491,7 @@ namespace OpenRCT2::Ui::FileBrowser
                 return { LanguageGetString(STR_OPENRCT2_SCENARIO_FILE), GetFilterPatternByType(type, isSave) };
 
             case LoadSaveType::track:
-                return { LanguageGetString(STR_OPENRCT2_TRACK_DESIGN_FILE), GetFilterPatternByType(type, isSave) };
+                return { LanguageGetString(STR_OPENRCT2_TRACK_DESIGN_FILE), GetFilterPatternByType(type, isSave, trackDesign) };
 
             case LoadSaveType::heightmap:
                 return { LanguageGetString(STR_OPENRCT2_HEIGHTMAP_FILE), GetFilterPatternByType(type, isSave) };
@@ -515,7 +502,8 @@ namespace OpenRCT2::Ui::FileBrowser
         }
     }
 
-    u8string OpenSystemFileBrowser(bool isSave, LoadSaveType type, u8string defaultDirectory, u8string defaultPath)
+    u8string OpenSystemFileBrowser(
+        bool isSave, LoadSaveType type, u8string defaultDirectory, u8string defaultPath, const TrackDesign* trackDesign)
     {
         u8string path = defaultDirectory;
         if (isSave)
@@ -536,7 +524,6 @@ namespace OpenRCT2::Ui::FileBrowser
             }
         }
 
-        u8string extension = GetDefaultExtensionByType(type);
         StringId title = GetTitleStringId(type, isSave);
 
         FileDialogDesc desc = {
@@ -544,7 +531,7 @@ namespace OpenRCT2::Ui::FileBrowser
             .Title = LanguageGetString(title),
             .InitialDirectory = defaultDirectory,
             .DefaultFilename = isSave ? path : u8string(),
-            .Filters = { GetFilterForType(type, isSave), { LanguageGetString(STR_ALL_FILES), "*" } },
+            .Filters = { GetFilterForType(type, isSave, trackDesign), { LanguageGetString(STR_ALL_FILES), "*" } },
         };
 
         return ContextOpenCommonFileDialog(desc);

--- a/src/openrct2-ui/interface/FileBrowser.h
+++ b/src/openrct2-ui/interface/FileBrowser.h
@@ -55,14 +55,15 @@ namespace OpenRCT2::Ui::FileBrowser
     bool IsValidPath(const char* path);
     u8string GetLastDirectoryByType(LoadSaveType type);
     u8string GetInitialDirectoryByType(LoadSaveType type);
-    const char* GetFilterPatternByType(LoadSaveType type, bool isSave);
+    u8string GetFilterPatternByType(LoadSaveType type, bool isSave, const TrackDesign* trackDesign = nullptr);
     u8string RemovePatternWildcard(u8string_view pattern);
     u8string GetDir(LoadSaveType type);
     void RegisterCallback(LoadSaveCallback callback);
     void InvokeCallback(ModalResult result, const utf8* path);
     void Select(const char* path, LoadSaveAction action, LoadSaveType type, TrackDesign* trackDesignPtr);
     StringId GetTitleStringId(LoadSaveType type, bool isSave);
-    u8string OpenSystemFileBrowser(bool isSave, LoadSaveType type, u8string defaultDirectory, u8string defaultPath);
+    u8string OpenSystemFileBrowser(
+        bool isSave, LoadSaveType type, u8string defaultDirectory, u8string defaultPath, const TrackDesign* trackDesign);
     WindowBase* OpenPreferred(
         LoadSaveAction action, LoadSaveType type, u8string defaultPath, LoadSaveCallback callback, TrackDesign* trackDesign);
 } // namespace OpenRCT2::Ui::FileBrowser

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -374,7 +374,8 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            destPath = Path::Combine(destPath, _trackName + u8".td6");
+            auto extension = trackDesignGetExtension(_trackDesign->version);
+            destPath = Path::Combine(destPath, _trackName + extension);
 
             if (File::Exists(destPath))
             {

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -577,7 +577,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Populate file list
-            const char* pattern = GetFilterPatternByType(type, isSave);
+            auto pattern = GetFilterPatternByType(type, isSave, _trackDesign);
             const auto path = GetDir(type);
             PopulateList(path, pattern);
             numListItems = static_cast<uint16_t>(_listItems.size());
@@ -824,7 +824,7 @@ namespace OpenRCT2::Ui::Windows
 
                 case WIDX_SYSTEM_BROWSER:
                 {
-                    u8string path = OpenSystemFileBrowser(isSave, type, _directory, _defaultPath);
+                    u8string path = OpenSystemFileBrowser(isSave, type, _directory, _defaultPath, _trackDesign);
                     if (!path.empty())
                     {
                         Select(path.c_str(), action, type, _trackDesign);
@@ -893,13 +893,8 @@ namespace OpenRCT2::Ui::Windows
 
                 case WIDX_SAVE:
                 {
-                    u8string extension;
-                    if (_trackDesign != nullptr)
-                        extension = trackDesignGetExtension(_trackDesign->version);
-                    else
-                        extension = RemovePatternWildcard(_extensionPattern);
-
-                    const u8string path = Path::WithExtension(Path::Combine(_directory, _currentFilename), extension);
+                    const u8string path = Path::WithExtension(
+                        Path::Combine(_directory, _currentFilename), RemovePatternWildcard(_extensionPattern));
 
                     if (File::Exists(path))
                         WindowOverwritePromptOpen(_currentFilename, path, action, type, _trackDesign);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -893,8 +893,13 @@ namespace OpenRCT2::Ui::Windows
 
                 case WIDX_SAVE:
                 {
-                    const u8string path = Path::WithExtension(
-                        Path::Combine(_directory, _currentFilename), RemovePatternWildcard(_extensionPattern));
+                    u8string extension;
+                    if (_trackDesign != nullptr)
+                        extension = trackDesignGetExtension(_trackDesign->version);
+                    else
+                        extension = RemovePatternWildcard(_extensionPattern);
+
+                    const u8string path = Path::WithExtension(Path::Combine(_directory, _currentFilename), extension);
 
                     if (File::Exists(path))
                         WindowOverwritePromptOpen(_currentFilename, path, action, type, _trackDesign);

--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -220,6 +220,8 @@ FileExtension GetFileExtensionType(u8string_view path)
         return FileExtension::SV6;
     if (String::iequals(extension, ".td6"))
         return FileExtension::TD6;
+    if (String::iequals(extension, ".td7"))
+        return FileExtension::TD6;
     if (String::iequals(extension, ".park"))
         return FileExtension::PARK;
     return FileExtension::Unknown;

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -347,6 +347,7 @@ namespace OpenRCT2::Platform
         SetUpFileAssociation(".sea", "RCTC Saved Game (.sea)", "Play", "\"%1\"", 0);
         SetUpFileAssociation(".td4", "RCT1 Track Design (.td4)", "Install", "\"%1\"", 0);
         SetUpFileAssociation(".td6", "RCT2 Track Design (.td6)", "Install", "\"%1\"", 0);
+        SetUpFileAssociation(".td7", "OpenRCT2 Track Design (.td7)", "Install", "\"%1\"", 0);
 
         // Refresh explorer
         SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
@@ -478,6 +479,7 @@ namespace OpenRCT2::Platform
         RemoveFileAssociation(".sea");
         RemoveFileAssociation(".td4");
         RemoveFileAssociation(".td6");
+        RemoveFileAssociation(".td7");
 
         // Refresh explorer
         SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -79,6 +79,7 @@ namespace OpenRCT2::RCT1
             {
                 throw IOException("Version number incorrect.");
             }
+            td->version = version;
             _stream.SetPosition(0);
 
             if (version == TD46Version::td4AA)
@@ -114,7 +115,7 @@ namespace OpenRCT2::RCT1
                 _stream.Read(&t4TrackElement, sizeof(TD46TrackElement));
                 TrackDesignTrackElement trackElement{};
                 trackElement.type = RCT1TrackTypeToOpenRCT2(t4TrackElement.type, td.trackAndVehicle.rtdIndex);
-                RCT12::convertFromTD46Flags(trackElement, t4TrackElement.flags);
+                RCT12::convertFromTD46Flags(trackElement, t4TrackElement.flags, td.version);
                 td.trackElements.push_back(trackElement);
             }
         }

--- a/src/openrct2/rct12/TD46.cpp
+++ b/src/openrct2/rct12/TD46.cpp
@@ -23,7 +23,7 @@ namespace OpenRCT2::RCT12
         constexpr uint8_t hasChain = 0b10000000;
     } // namespace TD46Flags
 
-    void convertFromTD46Flags(TrackDesignTrackElement& target, uint8_t flags)
+    void convertFromTD46Flags(TrackDesignTrackElement& target, uint8_t flags, TD46Version version)
     {
         target.brakeBoosterSpeed = kRCT2DefaultBlockBrakeSpeed;
         if (::TrackTypeIsStation(target.type))
@@ -34,7 +34,8 @@ namespace OpenRCT2::RCT12
         else
         {
             auto speedOrSeatRotation = flags & TD46Flags::speedOrSeatRotationMask;
-            if (::TrackTypeHasSpeedSetting(target.type) && target.type != OpenRCT2::TrackElemType::blockBrakes)
+            if (::TrackTypeHasSpeedSetting(target.type)
+                && (target.type != OpenRCT2::TrackElemType::blockBrakes || version == TD46Version::td7))
             {
                 target.brakeBoosterSpeed = speedOrSeatRotation << 1;
             }
@@ -51,14 +52,16 @@ namespace OpenRCT2::RCT12
             target.flags.set(TrackDesignTrackElementFlag::hasChain);
     }
 
-    uint8_t convertToTD46Flags(const TrackDesignTrackElement& source)
+    uint8_t convertToTD46Flags(const TrackDesignTrackElement& source, TD46Version version)
     {
         uint8_t trackFlags = 0;
         if (::TrackTypeIsStation(source.type))
         {
             trackFlags = source.stationIndex.ToUnderlying() & TD46Flags::stationIdMask;
         }
-        else if (::TrackTypeHasSpeedSetting(source.type) && source.type != OpenRCT2::TrackElemType::blockBrakes)
+        else if (
+            ::TrackTypeHasSpeedSetting(source.type)
+            && (source.type != OpenRCT2::TrackElemType::blockBrakes || version == TD46Version::td7))
         {
             trackFlags = (source.brakeBoosterSpeed >> 1);
         }

--- a/src/openrct2/rct12/TD46.h
+++ b/src/openrct2/rct12/TD46.h
@@ -25,6 +25,7 @@ namespace OpenRCT2::RCT12
         td4,
         td4AA,
         td6,
+        td7,
         unknown
     };
 
@@ -78,7 +79,7 @@ namespace OpenRCT2::RCT12
     static_assert(sizeof(TD46TrackElement) == 0x02);
 #pragma pack(pop)
 
-    void convertFromTD46Flags(TrackDesignTrackElement& target, uint8_t flags);
-    uint8_t convertToTD46Flags(const TrackDesignTrackElement& source);
+    void convertFromTD46Flags(TrackDesignTrackElement& target, uint8_t flags, TD46Version version);
+    uint8_t convertToTD46Flags(const TrackDesignTrackElement& source, TD46Version version);
     void importMazeElement(TrackDesign& td, const TD46MazeElement& td46MazeElement);
 } // namespace OpenRCT2::RCT12

--- a/src/openrct2/rct12/TD46.h
+++ b/src/openrct2/rct12/TD46.h
@@ -16,6 +16,20 @@
 struct TrackDesign;
 struct TrackDesignTrackElement;
 
+namespace OpenRCT2
+{
+    enum class TrackElemType : uint16_t;
+
+#pragma pack(push, 1)
+    struct TD7TrackElement
+    {
+        TrackElemType type; // 0x00
+        uint8_t flags;      // 0x02
+    };
+#pragma pack(pop)
+    static_assert(sizeof(TD7TrackElement) == 0x03);
+} // namespace OpenRCT2
+
 namespace OpenRCT2::RCT12
 {
     enum class TrackElemType : uint8_t;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1091,15 +1091,6 @@ namespace OpenRCT2::RCT2
         "rct1ll.terrain_edge.green",        "rct1ll.terrain_edge.stone_brown",  "rct1ll.terrain_edge.stone_grey",
         "rct1ll.terrain_edge.skyscraper_a", "rct1ll.terrain_edge.skyscraper_b",
     };
-
-#pragma pack(push, 1)
-    struct TD7TrackElement
-    {
-        OpenRCT2::TrackElemType type; // 0x00
-        uint8_t flags;                // 0x02
-    };
-#pragma pack(pop)
-    static_assert(sizeof(TD7TrackElement) == 0x03);
 } // namespace OpenRCT2::RCT2
 
 std::vector<uint8_t> DecryptSea(const fs::path& path);

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1091,6 +1091,15 @@ namespace OpenRCT2::RCT2
         "rct1ll.terrain_edge.green",        "rct1ll.terrain_edge.stone_brown",  "rct1ll.terrain_edge.stone_grey",
         "rct1ll.terrain_edge.skyscraper_a", "rct1ll.terrain_edge.skyscraper_b",
     };
+
+#pragma pack(push, 1)
+    struct TD7TrackElement
+    {
+        OpenRCT2::TrackElemType type; // 0x00
+        uint8_t flags;                // 0x02
+    };
+#pragma pack(pop)
+    static_assert(sizeof(TD7TrackElement) == 0x03);
 } // namespace OpenRCT2::RCT2
 
 std::vector<uint8_t> DecryptSea(const fs::path& path);

--- a/src/openrct2/rct2/T6Exporter.cpp
+++ b/src/openrct2/rct2/T6Exporter.cpp
@@ -64,7 +64,7 @@ namespace OpenRCT2::RCT2
         tempStream.WriteValue<uint32_t>(0);
         tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(_trackDesign.operation.rideMode));
         tempStream.WriteValue<uint8_t>(
-            EnumValue(_trackDesign.appearance.vehicleColourSettings) | (EnumValue(RCT12::TD46Version::td6) << 2));
+            EnumValue(_trackDesign.appearance.vehicleColourSettings) | (EnumValue(_trackDesign.version) << 2));
         for (auto i = 0; i < Limits::kMaxVehicleColours; i++)
         {
             tempStream.WriteValue<Drawing::Colour>(_trackDesign.appearance.vehicleColours[i].Body);
@@ -136,7 +136,11 @@ namespace OpenRCT2::RCT2
         }
         else
         {
-            exportTrackElements(tempStream);
+            if (_trackDesign.version == RCT12::TD46Version::td7)
+                exportTrackElementsTD7(tempStream);
+            else
+                exportTrackElements(tempStream);
+
             exportEntranceElements(tempStream);
         }
 
@@ -178,11 +182,23 @@ namespace OpenRCT2::RCT2
                 trackType = RCT12::TrackElemType::invertedUp90ToFlatQuarterLoopAlias;
             }
             tempStream.WriteValue<uint8_t>(static_cast<uint8_t>(trackType));
-            auto flags = RCT12::convertToTD46Flags(trackElement);
+            auto flags = RCT12::convertToTD46Flags(trackElement, _trackDesign.version);
             tempStream.WriteValue<uint8_t>(flags);
         }
 
         tempStream.WriteValue<uint8_t>(0xFF);
+    }
+
+    void T6Exporter::exportTrackElementsTD7(IStream& tempStream) const
+    {
+        for (const auto& trackElement : _trackDesign.trackElements)
+        {
+            auto flags = RCT12::convertToTD46Flags(trackElement, _trackDesign.version);
+            TD7TrackElement element = { trackElement.type, flags };
+            tempStream.WriteValue<TD7TrackElement>(element);
+        }
+
+        tempStream.WriteValue<uint16_t>(0xFFFF);
     }
 
     void T6Exporter::exportEntranceElements(IStream& tempStream) const

--- a/src/openrct2/rct2/T6Exporter.h
+++ b/src/openrct2/rct2/T6Exporter.h
@@ -36,6 +36,7 @@ namespace OpenRCT2::RCT2
 
         void exportMazeElements(IStream& tempStream) const;
         void exportTrackElements(IStream& tempStream) const;
+        void exportTrackElementsTD7(IStream& tempStream) const;
         void exportEntranceElements(IStream& tempStream) const;
         void exportSceneryElements(IStream& tempStream) const;
     };

--- a/src/openrct2/rct2/T6Importer.cpp
+++ b/src/openrct2/rct2/T6Importer.cpp
@@ -82,7 +82,21 @@ namespace OpenRCT2::RCT2
                 }
 
                 trackElement.type = trackType;
-                RCT12::convertFromTD46Flags(trackElement, t6TrackElement.flags);
+                RCT12::convertFromTD46Flags(trackElement, t6TrackElement.flags, td.version);
+                td.trackElements.push_back(trackElement);
+            }
+        }
+
+        void importTrackElementsTD7(TrackDesign& td)
+        {
+            TD7TrackElement t7TrackElement{};
+            for (uint16_t endFlag = _stream.ReadValue<uint16_t>(); endFlag != 0xFFFF; endFlag = _stream.ReadValue<uint16_t>())
+            {
+                _stream.SetPosition(_stream.GetPosition() - 2);
+                _stream.Read(&t7TrackElement, sizeof(TD7TrackElement));
+                TrackDesignTrackElement trackElement{};
+                trackElement.type = t7TrackElement.type;
+                RCT12::convertFromTD46Flags(trackElement, t7TrackElement.flags, td.version);
                 td.trackElements.push_back(trackElement);
             }
         }
@@ -132,7 +146,7 @@ namespace OpenRCT2::RCT2
         bool Load(const utf8* path) override
         {
             const auto extension = Path::GetExtension(path);
-            if (String::iequals(extension, ".td6"))
+            if (String::iequals(extension, ".td6") || String::iequals(extension, ".td7"))
             {
                 _name = GetNameFromTrackPath(path);
                 auto fs = FileStream(path, FileMode::open);
@@ -207,11 +221,12 @@ namespace OpenRCT2::RCT2
             td->operation.numCircuits = td6.LiftHillSpeedNumCircuits >> 5;
 
             auto version = static_cast<TD46Version>(td6.VersionAndColourScheme >> 2);
-            if (version != TD46Version::td6)
+            if (version != TD46Version::td6 && version != TD46Version::td7)
             {
                 LOG_ERROR("Unsupported track design.");
                 return nullptr;
             }
+            td->version = version;
 
             td->operation.operationSetting = std::min(
                 td->operation.operationSetting, GetRideTypeDescriptor(td->trackAndVehicle.rtdIndex).OperatingSettings.MaxValue);
@@ -223,7 +238,11 @@ namespace OpenRCT2::RCT2
             }
             else
             {
-                importTrackElements(*td);
+                if (version == TD46Version::td7)
+                    importTrackElementsTD7(*td);
+                else
+                    importTrackElements(*td);
+
                 importEntranceElements(*td);
             }
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -54,6 +54,7 @@
 #include "../object/ObjectRepository.h"
 #include "../object/SmallSceneryEntry.h"
 #include "../object/StationObject.h"
+#include "../rct12/TD46.h"
 #include "../rct2/RCT2.h"
 #include "../ride/RideConstruction.h"
 #include "../sawyer_coding/SawyerCoding.h"
@@ -193,8 +194,6 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
         return { false, STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY };
     }
 
-    StringId warningMessage = kStringIdNone;
-
     RideGetStartOfTrack(&trackElement);
 
     int32_t z = trackElement.element->GetBaseZ();
@@ -226,10 +225,9 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
     {
         const auto& element = trackElement.element->AsTrack();
 
-        // Remove this check for new track design format
         if (element->GetTrackType() > TrackElemType::highestAlias)
         {
-            return { false, STR_TRACK_ELEM_UNSUPPORTED_TD6 };
+            version = RCT12::TD46Version::td7;
         }
 
         TrackDesignTrackElement track{};
@@ -239,10 +237,9 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
         track.brakeBoosterSpeed = element->GetBrakeBoosterSpeed();
         track.seatRotation = element->GetSeatRotation();
 
-        // This warning will not apply to new track design format
         if (track.type == TrackElemType::blockBrakes && element->GetBrakeBoosterSpeed() != kRCT2DefaultBlockBrakeSpeed)
         {
-            warningMessage = STR_TRACK_DESIGN_BLOCK_BRAKE_SPEED_RESET;
+            version = RCT12::TD46Version::td7;
         }
 
         if (element->HasChain())
@@ -275,7 +272,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
 
         if (trackElements.size() > RCT2::Limits::kTD6MaxTrackElements)
         {
-            return { false, STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY };
+            version = RCT12::TD46Version::td7;
         }
     } while (trackElement.element != initialMap);
 
@@ -356,7 +353,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
     gMapSelectFlags.unset(MapSelectFlag::green);
 
     statistics.spaceRequired = TileCoordsXY(tds.previewMax - tds.previewMin) + TileCoordsXY{ 1, 1 };
-    return { true, warningMessage };
+    return { true, kStringIdNone };
 }
 
 ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, const Ride& ride)
@@ -397,7 +394,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, cons
 
                 if (mazeElements.size() >= RCT2::Limits::kTD6MaxMazeElements)
                 {
-                    return { false, STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY };
+                    version = RCT12::TD46Version::td7;
                 }
             } while (!(tileElement++)->IsLastForTile());
         }
@@ -502,6 +499,9 @@ CoordsXYE TrackDesign::MazeGetFirstElement(const Ride& ride)
 ResultWithMessage TrackDesign::CreateTrackDesignScenery(TrackDesignState& tds)
 {
     sceneryElements = _trackSavedTileElementsDesc;
+    if (sceneryElements.size() >= RCT2::Limits::kTD6MaxSceneryElements)
+        version = RCT12::TD46Version::td7;
+
     // Run an element loop
     for (auto& scenery : sceneryElements)
     {
@@ -2212,4 +2212,22 @@ void TrackDesignGameStateData::setFlag(TrackDesignGameStateFlag flag, bool on)
         flags |= EnumToFlag(flag);
     else
         flags &= ~EnumToFlag(flag);
+}
+
+u8string trackDesignGetExtension(RCT12::TD46Version version)
+{
+    switch (version)
+    {
+        case RCT12::TD46Version::td4:
+        case RCT12::TD46Version::td4AA:
+            return ".td4";
+        case RCT12::TD46Version::td6:
+            return ".td6";
+        case RCT12::TD46Version::td7:
+            return ".td7";
+        case RCT12::TD46Version::unknown:
+            break;
+    }
+
+    return "";
 }

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -15,6 +15,7 @@
 #include "../core/EnumUtils.hpp"
 #include "../drawing/Colour.h"
 #include "../object/Object.h"
+#include "../rct12/TD46.h"
 #include "../ride/RideColour.h"
 #include "../ride/Track.h"
 #include "RideRatings.h"
@@ -22,6 +23,10 @@
 
 #include <memory>
 
+namespace OpenRCT2::RCT12
+{
+    enum class TD46Version : uint8_t;
+}
 struct Ride;
 struct ResultWithMessage;
 enum class ViewportInteractionItem : uint8_t;
@@ -205,6 +210,7 @@ struct TrackDesign
     std::vector<TrackDesignSceneryElement> sceneryElements;
 
     TrackDesignGameStateData gameStateData{};
+    OpenRCT2::RCT12::TD46Version version = OpenRCT2::RCT12::TD46Version::td6;
 
 public:
     ResultWithMessage CreateTrackDesign(TrackDesignState& tds, const Ride& ride);
@@ -256,4 +262,5 @@ void TrackDesignSaveSelectTileElement(
 bool TrackDesignAreEntranceAndExitPlaced();
 
 extern std::vector<TrackDesignSceneryElement> _trackSavedTileElementsDesc;
-extern std::vector<const OpenRCT2::TileElement*> _trackSavedTileElements;
+
+u8string trackDesignGetExtension(OpenRCT2::RCT12::TD46Version version);

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -57,7 +57,7 @@ class TrackDesignFileIndex final : public FileIndex<TrackRepositoryItem>
 private:
     static constexpr uint32_t kMagicNumber = 0x58444954; // TIDX
     static constexpr uint16_t kVersion = 5;
-    static constexpr auto kPattern = "*.td4;*.td6";
+    static constexpr auto kPattern = "*.td4;*.td6;*.td7";
 
 public:
     explicit TrackDesignFileIndex(const IPlatformEnvironment& env)

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -51,7 +51,7 @@ constexpr int32_t TRACK_NEARBY_SCENERY_DISTANCE = 1;
 bool gTrackDesignSaveMode = false;
 RideId gTrackDesignSaveRideIndex = RideId::GetNull();
 
-std::vector<const TileElement*> _trackSavedTileElements;
+static std::vector<const TileElement*> _trackSavedTileElements;
 std::vector<TrackDesignSceneryElement> _trackSavedTileElementsDesc;
 
 struct TrackDesignAddStatus
@@ -180,14 +180,6 @@ static bool TrackDesignSaveCanAddTileElement(TileElement* tileElement)
         return false;
     }
 
-    // Get number of spare elements left
-    size_t spareSavedElements = RCT2::Limits::kTD6MaxSceneryElements - _trackSavedTileElements.size();
-    if (newElementCount > spareSavedElements)
-    {
-        // No more spare saved elements left
-        return false;
-    }
-
     return true;
 }
 
@@ -197,11 +189,8 @@ static bool TrackDesignSaveCanAddTileElement(TileElement* tileElement)
  */
 static void TrackDesignSavePushTileElement(const CoordsXY& loc, TileElement* tileElement)
 {
-    if (_trackSavedTileElements.size() < RCT2::Limits::kTD6MaxSceneryElements)
-    {
-        _trackSavedTileElements.push_back(tileElement);
-        MapInvalidateTileFull(loc);
-    }
+    _trackSavedTileElements.push_back(tileElement);
+    MapInvalidateTileFull(loc);
 }
 
 static bool TrackDesignSaveIsSupportedObject(const Object* obj)


### PR DESCRIPTION
NTDF is still a while away, since the plan is to have lots of refactors in place at that point in order to avoid carrying legacy baggage (e.g. making RTDs into objects, saving the track style and support in tile elements and other stuff).

In the meantime, users frequently run into problems saving their track designs, as even seemingly innocuous stuff (like diagonal brakes) cannot be saved in TD6. It also cannot handle block brakes with speed settings.

This PR extends the TD6 format in a minimal way, keeping the diff as small as possible, in order to address the most common problems users have when saving track designs. This extension is called TD7.

The changes from TD6 are as follows:
- Extends the track type field into a 16-bit unsigned integer.
- No aliasing of flat ride track types and the spinning control toggle
- The list of track elements is concluded by 0xFFFF instead of 0xFF.
- Block brakes save speed instead of seat rotation
- No hard limit on the number of track elements, maze elements and scenery elements (OpenRCT2 already handles this fine even for TD6, but vanilla does not).

Other limitations from TD6 are still in place. Again, this is deliberate, so as not to complicate the code too much. Notably, custom vehicles will still need to set a legacy identifier in order to be saved, so will scenery.

The TD7 format will _only_ be used if the user has used the newer track types, has set the speed on a block brake, or exceeded the maximum amount of scenery. Otherwise, it will write a plain TD6 that will still work in vanilla and RCTC.