### PR TITLE
Pass ParkData ref to game actions

### DIFF
--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -737,7 +737,9 @@ namespace OpenRCT2::Ui::Windows
         void ShowObjectiveDropdown()
         {
             const auto& gameState = getGameState();
+            const auto& park = gameState.park;
             const auto& scenarioOptions = gameState.scenarioOptions;
+
             auto objectiveType = EnumValue(scenarioOptions.objective.Type);
 
             int32_t numItems = 0;
@@ -752,7 +754,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // This objective can only work if the player can ask money for rides.
                 const bool objectiveAllowedByPaymentSettings = (obj != Scenario::ObjectiveType::monthlyRideIncome)
-                    || Park::RidePricesUnlocked();
+                    || Park::RidePricesUnlocked(park);
 
                 if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
                 {
@@ -1036,15 +1038,18 @@ namespace OpenRCT2::Ui::Windows
             onPrepareDraw();
             invalidateWidget(WIDX_TAB_1);
 
-            auto objectiveType = getGameState().scenarioOptions.objective.Type;
+            auto& gameState = getGameState();
+            auto& park = gameState.park;
+
+            auto objectiveType = gameState.scenarioOptions.objective.Type;
 
             // Check if objective is allowed by money and pay-per-ride settings.
-            const bool objectiveAllowedByMoneyUsage = !(getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+            const bool objectiveAllowedByMoneyUsage = !(park.flags & PARK_FLAGS_NO_MONEY)
                 || !ObjectiveNeedsMoney(objectiveType);
 
             // This objective can only work if the player can ask money for rides.
             const bool objectiveAllowedByPaymentSettings = (objectiveType != Scenario::ObjectiveType::monthlyRideIncome)
-                || Park::RidePricesUnlocked();
+                || Park::RidePricesUnlocked(park);
 
             if (!objectiveAllowedByMoneyUsage || !objectiveAllowedByPaymentSettings)
             {
@@ -1616,7 +1621,9 @@ namespace OpenRCT2::Ui::Windows
             SetPressedTab();
 
             auto& gameState = getGameState();
-            bool noMoney = gameState.park.flags & PARK_FLAGS_NO_MONEY;
+            auto& park = gameState.park;
+
+            bool noMoney = park.flags & PARK_FLAGS_NO_MONEY;
             setWidgetPressed(WIDX_NO_MONEY, noMoney);
 
             setWidgetDisabled(WIDX_GROUP_LOAN, noMoney);
@@ -1629,7 +1636,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_MAXIMUM_LOAN_INCREASE, noMoney);
             setWidgetDisabled(WIDX_MAXIMUM_LOAN_DECREASE, noMoney);
 
-            if (gameState.park.flags & PARK_FLAGS_RCT1_INTEREST)
+            if (park.flags & PARK_FLAGS_RCT1_INTEREST)
             {
                 widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::empty;
                 widgets[WIDX_INTEREST_RATE].type = WidgetType::empty;
@@ -1662,7 +1669,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN, noMoney);
             setWidgetDisabled(WIDX_FORBID_MARKETING, noMoney);
 
-            if (!Park::EntranceFeeUnlocked())
+            if (!Park::EntranceFeeUnlocked(park))
             {
                 widgets[WIDX_ENTRY_PRICE_LABEL].type = WidgetType::empty;
                 widgets[WIDX_ENTRY_PRICE].type = WidgetType::empty;
@@ -1681,7 +1688,7 @@ namespace OpenRCT2::Ui::Windows
                 setWidgetDisabled(WIDX_ENTRY_PRICE_DECREASE, noMoney);
             }
 
-            setWidgetPressed(WIDX_FORBID_MARKETING, gameState.park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
+            setWidgetPressed(WIDX_FORBID_MARKETING, park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
 
             widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
         }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -412,6 +412,7 @@ namespace OpenRCT2::Ui::Windows
 #pragma region Entrance page
         void onMouseUpEntrance(WidgetIndex widgetIndex)
         {
+            auto& park = getGameState().park;
             switch (widgetIndex)
             {
                 case WIDX_BUY_LAND_RIGHTS:
@@ -422,16 +423,15 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WIDX_RENAME:
                 {
-                    auto& park = getGameState().park;
                     WindowTextInputRawOpen(
                         this, WIDX_RENAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.name.c_str(), kUserStringMaxLength);
                     break;
                 }
                 case WIDX_CLOSE_LIGHT:
-                    Park::SetOpen(false);
+                    Park::SetOpen(park, false);
                     break;
                 case WIDX_OPEN_LIGHT:
-                    Park::SetOpen(true);
+                    Park::SetOpen(park, true);
                     break;
             }
         }
@@ -468,6 +468,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onDropdownEntrance(WidgetIndex widgetIndex, int32_t dropdownIndex)
         {
+            auto& park = getGameState().park;
             if (widgetIndex == WIDX_OPEN_OR_CLOSE)
             {
                 if (dropdownIndex == -1)
@@ -475,11 +476,11 @@ namespace OpenRCT2::Ui::Windows
 
                 if (dropdownIndex != 0)
                 {
-                    Park::SetOpen(true);
+                    Park::SetOpen(park, true);
                 }
                 else
                 {
-                    Park::SetOpen(false);
+                    Park::SetOpen(park, false);
                 }
             }
         }
@@ -812,6 +813,8 @@ namespace OpenRCT2::Ui::Windows
         void onMouseDownPrice(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
+            auto& park = gameState.park;
+
             switch (widgetIndex)
             {
                 case WIDX_INCREASE_PRICE:
@@ -831,7 +834,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_PRICE:
                 {
                     utf8 _moneyInputText[kMoneyStringMaxlength] = {};
-                    MoneyToString(Park::GetEntranceFee(), _moneyInputText, kMoneyStringMaxlength, false);
+                    MoneyToString(Park::GetEntranceFee(park), _moneyInputText, kMoneyStringMaxlength, false);
                     WindowTextInputRawOpen(
                         this, WIDX_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneyInputText, kMoneyStringMaxlength);
                 }
@@ -853,14 +856,16 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PRICE_LABEL].tooltip = kStringIdNone;
             widgets[WIDX_PRICE].tooltip = kStringIdNone;
 
-            if (!Park::EntranceFeeUnlocked())
+            auto& park = getGameState().park;
+
+            if (!Park::EntranceFeeUnlocked(park))
             {
                 widgets[WIDX_PRICE_LABEL].tooltip = STR_ADMISSION_PRICE_PAY_PER_RIDE_TIP;
                 widgets[WIDX_PRICE].tooltip = STR_ADMISSION_PRICE_PAY_PER_RIDE_TIP;
             }
 
             // If the entry price is locked at free, disable the widget, unless the unlock_all_prices cheat is active.
-            if ((getGameState().park.flags & PARK_FLAGS_NO_MONEY) || !Park::EntranceFeeUnlocked())
+            if ((park.flags & PARK_FLAGS_NO_MONEY) || !Park::EntranceFeeUnlocked(park))
             {
                 widgets[WIDX_PRICE].type = WidgetType::labelCentred;
                 widgets[WIDX_INCREASE_PRICE].type = WidgetType::empty;
@@ -887,7 +892,9 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<money64>(getGameState().park.totalIncomeFromAdmissions);
             drawText(rt, screenCoords, STR_INCOME_FROM_ADMISSIONS, ft);
 
-            money64 parkEntranceFee = Park::GetEntranceFee();
+            auto& park = getGameState().park;
+
+            money64 parkEntranceFee = Park::GetEntranceFee(park);
             ft = Formatter();
             ft.Add<money64>(parkEntranceFee);
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -6573,7 +6573,10 @@ namespace OpenRCT2::Ui::Windows
 
             auto rideEntry = ride->getRideEntry();
             const auto& rtd = ride->getRideTypeDescriptor();
-            return Park::RidePricesUnlocked() || rtd.specialType == RtdSpecialType::toilet
+
+            auto& park = getGameState().park;
+
+            return Park::RidePricesUnlocked(park) || rtd.specialType == RtdSpecialType::toilet
                 || (rideEntry != nullptr && rideEntry->shop_item[0] != ShopItem::none);
         }
 
@@ -6734,9 +6737,11 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_PRIMARY_PRICE_LABEL].tooltip = kStringIdNone;
             widgets[WIDX_PRIMARY_PRICE].tooltip = kStringIdNone;
 
+            auto& park = getGameState().park;
+
             // If ride prices are locked, do not allow setting the price, unless we're dealing with a shop or toilet.
             const auto& rtd = ride->getRideTypeDescriptor();
-            if (!Park::RidePricesUnlocked() && rideEntry->shop_item[0] == ShopItem::none
+            if (!Park::RidePricesUnlocked(park) && rideEntry->shop_item[0] == ShopItem::none
                 && rtd.specialType != RtdSpecialType::toilet)
             {
                 disabledWidgets |= (1uLL << WIDX_PRIMARY_PRICE);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -3158,7 +3158,7 @@ namespace OpenRCT2::Ui::Windows
                 location.z = tile.calculatedZ;
                 auto wallRemoveAction = GameActions::WallRemoveAction(location);
                 wallRemoveAction.SetFlags({ CommandFlag::allowDuringPaused, CommandFlag::noSpend, CommandFlag::ghost });
-                wallRemoveAction.Execute(gameState);
+                GameActions::Execute(&wallRemoveAction, gameState);
             }
         }
 

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -61,7 +61,7 @@ namespace OpenRCT2
         gameState.currentTicks = 0;
 
         MapInit(mapSize);
-        Park::Initialise(gameState);
+        Park::Initialise(gameState.park, gameState);
         FinanceInit();
         BannerInit(gameState);
         RideInitAll();

--- a/src/openrct2/actions/GameAction.hpp
+++ b/src/openrct2/actions/GameAction.hpp
@@ -23,6 +23,11 @@ namespace OpenRCT2
     struct GameState_t;
 }
 
+namespace OpenRCT2::Park
+{
+    struct ParkData;
+}
+
 namespace OpenRCT2::GameActions
 {
     namespace Flags
@@ -162,12 +167,12 @@ namespace OpenRCT2::GameActions
         /**
          * Query the result of the game action without changing the game state.
          */
-        virtual Result Query(GameState_t& gameState) const = 0;
+        virtual Result Query(GameState_t& gameState, Park::ParkData& park) const = 0;
 
         /**
          * Apply the game action and change the game state.
          */
-        virtual Result Execute(GameState_t& gameState) const = 0;
+        virtual Result Execute(GameState_t& gameState, Park::ParkData& park) const = 0;
 
         bool LocationValid(const CoordsXY& coords) const;
     };

--- a/src/openrct2/actions/GameActionRunner.cpp
+++ b/src/openrct2/actions/GameActionRunner.cpp
@@ -186,8 +186,10 @@ namespace OpenRCT2::GameActions
             return result;
         }
 
-        auto result = action->Query(gameState);
+        // TODO: pass different park based on player
+        auto& park = gameState.park;
 
+        auto result = action->Query(gameState, park);
         if (result.error == Status::ok)
         {
             if (!FinanceCheckAffordability(result.cost, action->GetFlags()))
@@ -337,8 +339,11 @@ namespace OpenRCT2::GameActions
                 LogActionBegin(gameState, logContext, action);
             }
 
+            // TODO: pass different park based on player
+            auto& park = gameState.park;
+
             // Execute the action, changing the game state
-            result = action->Execute(gameState);
+            result = action->Execute(gameState, park);
 #ifdef ENABLE_SCRIPTING
             if (result.error == Status::ok)
             {

--- a/src/openrct2/actions/GameActionRunner.h
+++ b/src/openrct2/actions/GameActionRunner.h
@@ -11,11 +11,6 @@
 
 #include "GameAction.hpp"
 
-namespace OpenRCT2
-{
-    struct GameState_t;
-}
-
 namespace OpenRCT2::GameActions
 {
     // Halts the queue processing until ResumeQueue is called, any calls to ProcessQueue

--- a/src/openrct2/actions/cheats/CheatSetAction.cpp
+++ b/src/openrct2/actions/cheats/CheatSetAction.cpp
@@ -234,7 +234,7 @@ namespace OpenRCT2::GameActions
                 gameState.scenarioOptions.objective.Type = Scenario::ObjectiveType::haveFun;
                 break;
             case CheatType::setForcedParkRating:
-                Park::SetForcedRating(_param1);
+                Park::SetForcedRating(park, _param1);
                 break;
             case CheatType::allowArbitraryRideTypeChanges:
                 gameState.cheats.allowArbitraryRideTypeChanges = _param1 != 0;

--- a/src/openrct2/actions/cheats/CheatSetAction.cpp
+++ b/src/openrct2/actions/cheats/CheatSetAction.cpp
@@ -157,16 +157,16 @@ namespace OpenRCT2::GameActions
                 gameState.cheats.disableLittering = _param1 != 0;
                 break;
             case CheatType::noMoney:
-                SetScenarioNoMoney(gameState, _param1 != 0);
+                SetScenarioNoMoney(park, _param1 != 0);
                 break;
             case CheatType::addMoney:
-                AddMoney(gameState, _param1);
+                AddMoney(park, _param1);
                 break;
             case CheatType::setMoney:
-                SetMoney(gameState, _param1);
+                SetMoney(park, _param1);
                 break;
             case CheatType::clearLoan:
-                ClearLoan(gameState);
+                ClearLoan(gameState, park);
                 break;
             case CheatType::setGuestParameter:
                 SetGuestParameter(_param1, _param2);
@@ -228,7 +228,7 @@ namespace OpenRCT2::GameActions
                 gameState.cheats.neverendingMarketing = _param1 != 0;
                 break;
             case CheatType::openClosePark:
-                ParkSetOpen(!Park::IsOpen(gameState.park), gameState);
+                ParkSetOpen(!Park::IsOpen(park), gameState);
                 break;
             case CheatType::haveFun:
                 gameState.scenarioOptions.objective.Type = Scenario::ObjectiveType::haveFun;
@@ -577,9 +577,8 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::ride);
     }
 
-    void CheatSetAction::SetScenarioNoMoney(GameState_t& gameState, bool enabled) const
+    void CheatSetAction::SetScenarioNoMoney(Park::ParkData& park, bool enabled) const
     {
-        auto& park = gameState.park;
         if (enabled)
         {
             park.flags |= PARK_FLAGS_NO_MONEY;
@@ -600,18 +599,17 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::cheats);
     }
 
-    void CheatSetAction::SetMoney(GameState_t& gameState, money64 amount) const
+    void CheatSetAction::SetMoney(Park::ParkData& park, money64 amount) const
     {
-        gameState.park.cash = amount;
+        park.cash = amount;
 
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByClass(WindowClass::finances);
         windowMgr->InvalidateByClass(WindowClass::bottomToolbar);
     }
 
-    void CheatSetAction::AddMoney(GameState_t& gameState, money64 amount) const
+    void CheatSetAction::AddMoney(Park::ParkData& park, money64 amount) const
     {
-        auto& park = gameState.park;
         park.cash = AddClamp(park.cash, amount);
 
         auto* windowMgr = Ui::GetWindowManager();
@@ -619,10 +617,10 @@ namespace OpenRCT2::GameActions
         windowMgr->InvalidateByClass(WindowClass::bottomToolbar);
     }
 
-    void CheatSetAction::ClearLoan(GameState_t& gameState) const
+    void CheatSetAction::ClearLoan(GameState_t& gameState, Park::ParkData& park) const
     {
         // First give money
-        AddMoney(gameState, gameState.park.bankLoan);
+        AddMoney(park, park.bankLoan);
 
         // Then pay the loan
         auto gameAction = ParkSetLoanAction(0.00_GBP);

--- a/src/openrct2/actions/cheats/CheatSetAction.cpp
+++ b/src/openrct2/actions/cheats/CheatSetAction.cpp
@@ -73,7 +73,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_cheatType) << DS_TAG(_param1) << DS_TAG(_param2);
     }
 
-    Result CheatSetAction::Query(GameState_t& gameState) const
+    Result CheatSetAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (static_cast<uint32_t>(_cheatType) >= static_cast<uint32_t>(CheatType::count))
         {
@@ -101,7 +101,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result CheatSetAction::Execute(GameState_t& gameState) const
+    Result CheatSetAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* windowMgr = Ui::GetWindowManager();
 

--- a/src/openrct2/actions/cheats/CheatSetAction.h
+++ b/src/openrct2/actions/cheats/CheatSetAction.h
@@ -31,8 +31,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         ParametersRange GetParameterRange(CheatType cheatType) const;

--- a/src/openrct2/actions/cheats/CheatSetAction.h
+++ b/src/openrct2/actions/cheats/CheatSetAction.h
@@ -44,10 +44,10 @@ namespace OpenRCT2::GameActions
         void RenewRides(GameState_t& gameState) const;
         void ResetRideCrashStatus(GameState_t& gameState) const;
         void Set10MinuteInspection(GameState_t& gameState) const;
-        void SetScenarioNoMoney(GameState_t& gameState, bool enabled) const;
-        void SetMoney(GameState_t& gameState, money64 amount) const;
-        void AddMoney(GameState_t& gameState, money64 amount) const;
-        void ClearLoan(GameState_t& gameState) const;
+        void SetScenarioNoMoney(Park::ParkData& park, bool enabled) const;
+        void SetMoney(Park::ParkData& park, money64 amount) const;
+        void AddMoney(Park::ParkData& park, money64 amount) const;
+        void ClearLoan(GameState_t& gameState, Park::ParkData& park) const;
         void GenerateGuests(int32_t count) const;
         void SetGuestParameter(int32_t parameter, int32_t value) const;
         void GiveObjectToGuests(int32_t object) const;

--- a/src/openrct2/actions/footpath/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathAdditionPlaceAction.cpp
@@ -51,7 +51,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_entryIndex);
     }
 
-    Result FootpathAdditionPlaceAction::Query(GameState_t& gameState) const
+    Result FootpathAdditionPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landscaping;
@@ -140,7 +140,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result FootpathAdditionPlaceAction::Execute(GameState_t& gameState) const
+    Result FootpathAdditionPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position = _loc;

--- a/src/openrct2/actions/footpath/FootpathAdditionPlaceAction.h
+++ b/src/openrct2/actions/footpath/FootpathAdditionPlaceAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/footpath/FootpathAdditionRemoveAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathAdditionRemoveAction.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc);
     }
 
-    Result FootpathAdditionRemoveAction::Query(GameState_t& gameState) const
+    Result FootpathAdditionRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (!LocationValid(_loc))
         {
@@ -93,7 +93,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result FootpathAdditionRemoveAction::Execute(GameState_t& gameState) const
+    Result FootpathAdditionRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* pathElement = MapGetFootpathElement(_loc);
         if (!GetFlags().has(CommandFlag::ghost))

--- a/src/openrct2/actions/footpath/FootpathAdditionRemoveAction.h
+++ b/src/openrct2/actions/footpath/FootpathAdditionRemoveAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/footpath/FootpathLayoutPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathLayoutPlaceAction.cpp
@@ -67,7 +67,7 @@ namespace OpenRCT2::GameActions
         return GameAction::GetActionFlags();
     }
 
-    Result FootpathLayoutPlaceAction::Query(GameState_t& gameState) const
+    Result FootpathLayoutPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.cost = 0;
@@ -99,7 +99,7 @@ namespace OpenRCT2::GameActions
         return ElementInsertQuery(gameState, std::move(res));
     }
 
-    Result FootpathLayoutPlaceAction::Execute(GameState_t& gameState) const
+    Result FootpathLayoutPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.cost = 0;

--- a/src/openrct2/actions/footpath/FootpathLayoutPlaceAction.h
+++ b/src/openrct2/actions/footpath/FootpathLayoutPlaceAction.h
@@ -35,8 +35,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result ElementInsertQuery(GameState_t& gameState, Result res) const;

--- a/src/openrct2/actions/footpath/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathPlaceAction.cpp
@@ -75,7 +75,7 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_constructFlags);
     }
 
-    Result FootpathPlaceAction::Query(GameState_t& gameState) const
+    Result FootpathPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.cost = 0;
@@ -126,7 +126,7 @@ namespace OpenRCT2::GameActions
         return ElementUpdateQuery(tileElement, std::move(res));
     }
 
-    Result FootpathPlaceAction::Execute(GameState_t& gameState) const
+    Result FootpathPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.cost = 0;

--- a/src/openrct2/actions/footpath/FootpathPlaceAction.h
+++ b/src/openrct2/actions/footpath/FootpathPlaceAction.h
@@ -34,8 +34,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result ElementUpdateQuery(PathElement* pathElement, Result res) const;

--- a/src/openrct2/actions/footpath/FootpathRemoveAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathRemoveAction.cpp
@@ -49,7 +49,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc);
     }
 
-    Result FootpathRemoveAction::Query(GameState_t& gameState) const
+    Result FootpathRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.cost = 0;
@@ -77,7 +77,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result FootpathRemoveAction::Execute(GameState_t& gameState) const
+    Result FootpathRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.cost = 0;

--- a/src/openrct2/actions/footpath/FootpathRemoveAction.h
+++ b/src/openrct2/actions/footpath/FootpathRemoveAction.h
@@ -28,8 +28,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         TileElement* GetFootpathElement() const;

--- a/src/openrct2/actions/general/BalloonPressAction.cpp
+++ b/src/openrct2/actions/general/BalloonPressAction.cpp
@@ -38,7 +38,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteIndex);
     }
 
-    Result BalloonPressAction::Query(GameState_t& gameState) const
+    Result BalloonPressAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto balloon = gameState.entities.TryGetEntity<Balloon>(_spriteIndex);
         if (balloon == nullptr)
@@ -49,7 +49,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result BalloonPressAction::Execute(GameState_t& gameState) const
+    Result BalloonPressAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto balloon = gameState.entities.TryGetEntity<Balloon>(_spriteIndex);
         if (balloon == nullptr)

--- a/src/openrct2/actions/general/BalloonPressAction.h
+++ b/src/openrct2/actions/general/BalloonPressAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/general/CustomAction.cpp
+++ b/src/openrct2/actions/general/CustomAction.cpp
@@ -48,13 +48,13 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_id) << DS_TAG(_json);
     }
 
-    Result CustomAction::Query(GameState_t& gameState) const
+    Result CustomAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto& scriptingEngine = GetContext()->GetScriptEngine();
         return scriptingEngine.QueryOrExecuteCustomGameAction(*this, false);
     }
 
-    Result CustomAction::Execute(GameState_t& gameState) const
+    Result CustomAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto& scriptingEngine = GetContext()->GetScriptEngine();
         return scriptingEngine.QueryOrExecuteCustomGameAction(*this, true);

--- a/src/openrct2/actions/general/CustomAction.h
+++ b/src/openrct2/actions/general/CustomAction.h
@@ -33,8 +33,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions
 

--- a/src/openrct2/actions/general/GameSetSpeedAction.cpp
+++ b/src/openrct2/actions/general/GameSetSpeedAction.cpp
@@ -38,7 +38,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_speed);
     }
 
-    Result GameSetSpeedAction::Query(GameState_t& gameState) const
+    Result GameSetSpeedAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
 
@@ -51,7 +51,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result GameSetSpeedAction::Execute(GameState_t& gameState) const
+    Result GameSetSpeedAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
 

--- a/src/openrct2/actions/general/GameSetSpeedAction.h
+++ b/src/openrct2/actions/general/GameSetSpeedAction.h
@@ -27,8 +27,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         bool IsValidSpeed(uint8_t speed) const;

--- a/src/openrct2/actions/general/LoadOrQuitAction.cpp
+++ b/src/openrct2/actions/general/LoadOrQuitAction.cpp
@@ -40,12 +40,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_mode) << DS_TAG(_savePromptMode);
     }
 
-    Result LoadOrQuitAction::Query(GameState_t& gameState) const
+    Result LoadOrQuitAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return Result();
     }
 
-    Result LoadOrQuitAction::Execute(GameState_t& gameState) const
+    Result LoadOrQuitAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto mode = static_cast<LoadOrQuitModes>(_mode);
         switch (mode)

--- a/src/openrct2/actions/general/LoadOrQuitAction.h
+++ b/src/openrct2/actions/general/LoadOrQuitAction.h
@@ -35,7 +35,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/general/MapChangeSizeAction.cpp
+++ b/src/openrct2/actions/general/MapChangeSizeAction.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_shift);
     }
 
-    Result MapChangeSizeAction::Query(GameState_t& gameState) const
+    Result MapChangeSizeAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_targetSize.x > kMaximumMapSizeTechnical || _targetSize.y > kMaximumMapSizeTechnical)
         {
@@ -56,7 +56,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result MapChangeSizeAction::Execute(GameState_t& gameState) const
+    Result MapChangeSizeAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         // Expand map
         while (_targetSize.x > gameState.mapSize.x)
@@ -84,7 +84,6 @@ namespace OpenRCT2::GameActions
         auto& uiContext = ctx->GetUiContext();
         auto* windowManager = uiContext.GetWindowManager();
 
-        auto& park = gameState.park;
         Park::UpdateSize(park);
 
         windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));

--- a/src/openrct2/actions/general/MapChangeSizeAction.h
+++ b/src/openrct2/actions/general/MapChangeSizeAction.h
@@ -25,8 +25,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         TileCoordsXY _targetSize;

--- a/src/openrct2/actions/general/PauseToggleAction.cpp
+++ b/src/openrct2/actions/general/PauseToggleAction.cpp
@@ -18,12 +18,12 @@ namespace OpenRCT2::GameActions
         return GameAction::GetActionFlags() | Flags::AllowWhilePaused | Flags::IgnoreForReplays;
     }
 
-    Result PauseToggleAction::Query(GameState_t& gameState) const
+    Result PauseToggleAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return Result();
     }
 
-    Result PauseToggleAction::Execute(GameState_t& gameState) const
+    Result PauseToggleAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         PauseToggle();
         return Result();

--- a/src/openrct2/actions/general/PauseToggleAction.h
+++ b/src/openrct2/actions/general/PauseToggleAction.h
@@ -20,8 +20,8 @@ namespace OpenRCT2::GameActions
 
         uint16_t GetActionFlags() const override;
 
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
     // clang-format on
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/general/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/general/ScenarioSetSettingAction.cpp
@@ -33,7 +33,7 @@ namespace OpenRCT2::GameActions
         visitor.Visit("value", _value);
     }
 
-    Result ScenarioSetSettingAction::Query(GameState_t& gameState) const
+    Result ScenarioSetSettingAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_setting >= ScenarioSetSetting::Count)
         {
@@ -44,7 +44,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ScenarioSetSettingAction::Execute(GameState_t& gameState) const
+    Result ScenarioSetSettingAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* windowMgr = Ui::GetWindowManager();
 

--- a/src/openrct2/actions/general/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/general/ScenarioSetSettingAction.cpp
@@ -55,22 +55,22 @@ namespace OpenRCT2::GameActions
                 {
                     if (_value != 0)
                     {
-                        gameState.park.flags |= PARK_FLAGS_NO_MONEY;
+                        park.flags |= PARK_FLAGS_NO_MONEY;
                     }
                     else
                     {
-                        gameState.park.flags &= ~PARK_FLAGS_NO_MONEY;
+                        park.flags &= ~PARK_FLAGS_NO_MONEY;
                     }
                 }
                 else
                 {
                     if (_value != 0)
                     {
-                        gameState.park.flags |= PARK_FLAGS_NO_MONEY;
+                        park.flags |= PARK_FLAGS_NO_MONEY;
                     }
                     else
                     {
-                        gameState.park.flags &= ~PARK_FLAGS_NO_MONEY;
+                        park.flags &= ~PARK_FLAGS_NO_MONEY;
                     }
                     // Invalidate all windows that have anything to do with finance
                     windowMgr->InvalidateByClass(WindowClass::ride);
@@ -83,32 +83,32 @@ namespace OpenRCT2::GameActions
                 break;
             case ScenarioSetSetting::InitialCash:
                 gameState.scenarioOptions.initialCash = std::clamp<money64>(_value, 0.00_GBP, 1000000.00_GBP);
-                gameState.park.cash = gameState.scenarioOptions.initialCash;
+                park.cash = gameState.scenarioOptions.initialCash;
                 windowMgr->InvalidateByClass(WindowClass::finances);
                 windowMgr->InvalidateByClass(WindowClass::bottomToolbar);
                 break;
             case ScenarioSetSetting::InitialLoan:
-                gameState.park.bankLoan = std::clamp<money64>(_value, 0.00_GBP, 5000000.00_GBP);
-                gameState.park.maxBankLoan = std::max(gameState.park.bankLoan, gameState.park.maxBankLoan);
+                park.bankLoan = std::clamp<money64>(_value, 0.00_GBP, 5000000.00_GBP);
+                park.maxBankLoan = std::max(park.bankLoan, park.maxBankLoan);
                 windowMgr->InvalidateByClass(WindowClass::finances);
                 break;
             case ScenarioSetSetting::MaximumLoanSize:
-                gameState.park.maxBankLoan = std::clamp<money64>(_value, 0.00_GBP, 5000000.00_GBP);
-                gameState.park.bankLoan = std::min(gameState.park.bankLoan, gameState.park.maxBankLoan);
+                park.maxBankLoan = std::clamp<money64>(_value, 0.00_GBP, 5000000.00_GBP);
+                park.bankLoan = std::min(park.bankLoan, park.maxBankLoan);
                 windowMgr->InvalidateByClass(WindowClass::finances);
                 break;
             case ScenarioSetSetting::AnnualInterestRate:
-                gameState.park.bankLoanInterestRate = std::clamp<uint8_t>(_value, 0, kMaxBankLoanInterestRate);
+                park.bankLoanInterestRate = std::clamp<uint8_t>(_value, 0, kMaxBankLoanInterestRate);
                 windowMgr->InvalidateByClass(WindowClass::finances);
                 break;
             case ScenarioSetSetting::ForbidMarketingCampaigns:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
+                    park.flags |= PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
+                    park.flags &= ~PARK_FLAGS_FORBID_MARKETING_CAMPAIGN;
                 }
                 break;
             case ScenarioSetSetting::AverageCashPerGuest:
@@ -126,21 +126,21 @@ namespace OpenRCT2::GameActions
             case ScenarioSetSetting::GuestsPreferLessIntenseRides:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                    park.flags |= PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
+                    park.flags &= ~PARK_FLAGS_PREF_LESS_INTENSE_RIDES;
                 }
                 break;
             case ScenarioSetSetting::GuestsPreferMoreIntenseRides:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                    park.flags |= PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
+                    park.flags &= ~PARK_FLAGS_PREF_MORE_INTENSE_RIDES;
                 }
                 break;
             case ScenarioSetSetting::CostToBuyLand:
@@ -154,96 +154,96 @@ namespace OpenRCT2::GameActions
                 {
                     if (_value == 0)
                     {
-                        gameState.park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                        gameState.park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
-                        gameState.park.entranceFee = 0.00_GBP;
+                        park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                        park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                        park.entranceFee = 0.00_GBP;
                     }
                     else if (_value == 1)
                     {
-                        gameState.park.flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                        gameState.park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
-                        gameState.park.entranceFee = 10.00_GBP;
+                        park.flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                        park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                        park.entranceFee = 10.00_GBP;
                     }
                     else
                     {
-                        gameState.park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                        gameState.park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
-                        gameState.park.entranceFee = 10.00_GBP;
+                        park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                        park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                        park.entranceFee = 10.00_GBP;
                     }
                 }
                 else
                 {
                     if (_value == 0)
                     {
-                        gameState.park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                        gameState.park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                        park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                        park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                     }
                     else if (_value == 1)
                     {
-                        gameState.park.flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
-                        gameState.park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
+                        park.flags &= ~PARK_FLAGS_PARK_FREE_ENTRY;
+                        park.flags &= ~PARK_FLAGS_UNLOCK_ALL_PRICES;
                     }
                     else
                     {
-                        gameState.park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
-                        gameState.park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
+                        park.flags |= PARK_FLAGS_PARK_FREE_ENTRY;
+                        park.flags |= PARK_FLAGS_UNLOCK_ALL_PRICES;
                     }
                     windowMgr->InvalidateByClass(WindowClass::parkInformation);
                     windowMgr->InvalidateByClass(WindowClass::ride);
                 }
                 break;
             case ScenarioSetSetting::ParkChargeEntryFee:
-                gameState.park.entranceFee = std::clamp<money64>(_value, 0.00_GBP, kMaxEntranceFee);
+                park.entranceFee = std::clamp<money64>(_value, 0.00_GBP, kMaxEntranceFee);
                 windowMgr->InvalidateByClass(WindowClass::parkInformation);
                 break;
             case ScenarioSetSetting::ForbidTreeRemoval:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_FORBID_TREE_REMOVAL;
+                    park.flags |= PARK_FLAGS_FORBID_TREE_REMOVAL;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_FORBID_TREE_REMOVAL;
+                    park.flags &= ~PARK_FLAGS_FORBID_TREE_REMOVAL;
                 }
                 break;
             case ScenarioSetSetting::ForbidLandscapeChanges:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
+                    park.flags |= PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
+                    park.flags &= ~PARK_FLAGS_FORBID_LANDSCAPE_CHANGES;
                 }
                 break;
             case ScenarioSetSetting::ForbidHighConstruction:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+                    park.flags |= PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
+                    park.flags &= ~PARK_FLAGS_FORBID_HIGH_CONSTRUCTION;
                 }
                 break;
             case ScenarioSetSetting::ParkRatingHigherDifficultyLevel:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_DIFFICULT_PARK_RATING;
+                    park.flags |= PARK_FLAGS_DIFFICULT_PARK_RATING;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_DIFFICULT_PARK_RATING;
+                    park.flags &= ~PARK_FLAGS_DIFFICULT_PARK_RATING;
                 }
                 break;
             case ScenarioSetSetting::GuestGenerationHigherDifficultyLevel:
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
+                    park.flags |= PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
+                    park.flags &= ~PARK_FLAGS_DIFFICULT_GUEST_GENERATION;
                 }
                 break;
             case ScenarioSetSetting::AllowEarlyCompletion:
@@ -253,11 +253,11 @@ namespace OpenRCT2::GameActions
             {
                 if (_value != 0)
                 {
-                    gameState.park.flags |= PARK_FLAGS_RCT1_INTEREST;
+                    park.flags |= PARK_FLAGS_RCT1_INTEREST;
                 }
                 else
                 {
-                    gameState.park.flags &= ~PARK_FLAGS_RCT1_INTEREST;
+                    park.flags &= ~PARK_FLAGS_RCT1_INTEREST;
                 }
                 break;
             }

--- a/src/openrct2/actions/general/ScenarioSetSettingAction.h
+++ b/src/openrct2/actions/general/ScenarioSetSettingAction.h
@@ -63,7 +63,7 @@ namespace OpenRCT2::GameActions
         }
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/general/TileModifyAction.cpp
+++ b/src/openrct2/actions/general/TileModifyAction.cpp
@@ -49,12 +49,12 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_pasteBanner);
     }
 
-    Result TileModifyAction::Query(GameState_t& gameState) const
+    Result TileModifyAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(false);
     }
 
-    Result TileModifyAction::Execute(GameState_t& gameState) const
+    Result TileModifyAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(true);
     }

--- a/src/openrct2/actions/general/TileModifyAction.h
+++ b/src/openrct2/actions/general/TileModifyAction.h
@@ -65,8 +65,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(bool isExecuting) const;

--- a/src/openrct2/actions/network/NetworkModifyGroupAction.cpp
+++ b/src/openrct2/actions/network/NetworkModifyGroupAction.cpp
@@ -45,12 +45,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_type) << DS_TAG(_groupId) << DS_TAG(_name) << DS_TAG(_permissionIndex) << DS_TAG(_permissionState);
     }
 
-    Result NetworkModifyGroupAction::Query(GameState_t& gameState) const
+    Result NetworkModifyGroupAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return Network::ModifyGroups(GetPlayer(), _type, _groupId, _name, _permissionIndex, _permissionState, false);
     }
 
-    Result NetworkModifyGroupAction::Execute(GameState_t& gameState) const
+    Result NetworkModifyGroupAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return Network::ModifyGroups(GetPlayer(), _type, _groupId, _name, _permissionIndex, _permissionState, true);
     }

--- a/src/openrct2/actions/network/NetworkModifyGroupAction.h
+++ b/src/openrct2/actions/network/NetworkModifyGroupAction.h
@@ -51,7 +51,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/network/PlayerKickAction.cpp
+++ b/src/openrct2/actions/network/PlayerKickAction.cpp
@@ -34,12 +34,12 @@ namespace OpenRCT2::GameActions
 
         stream << DS_TAG(_playerId);
     }
-    Result PlayerKickAction::Query(GameState_t& gameState) const
+    Result PlayerKickAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return Network::KickPlayer(_playerId, false);
     }
 
-    Result PlayerKickAction::Execute(GameState_t& gameState) const
+    Result PlayerKickAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return Network::KickPlayer(_playerId, true);
     }

--- a/src/openrct2/actions/network/PlayerKickAction.h
+++ b/src/openrct2/actions/network/PlayerKickAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/network/PlayerSetGroupAction.cpp
+++ b/src/openrct2/actions/network/PlayerSetGroupAction.cpp
@@ -36,12 +36,12 @@ namespace OpenRCT2::GameActions
 
         stream << DS_TAG(_playerId) << DS_TAG(_groupId);
     }
-    Result PlayerSetGroupAction::Query(GameState_t& gameState) const
+    Result PlayerSetGroupAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return Network::SetPlayerGroup(GetPlayer(), _playerId, _groupId, false);
     }
 
-    Result PlayerSetGroupAction::Execute(GameState_t& gameState) const
+    Result PlayerSetGroupAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return Network::SetPlayerGroup(GetPlayer(), _playerId, _groupId, true);
     }

--- a/src/openrct2/actions/network/PlayerSetGroupAction.h
+++ b/src/openrct2/actions/network/PlayerSetGroupAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/park/LandBuyRightsAction.cpp
+++ b/src/openrct2/actions/park/LandBuyRightsAction.cpp
@@ -57,12 +57,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_range) << DS_TAG(_setting);
     }
 
-    Result LandBuyRightsAction::Query(GameState_t& gameState) const
+    Result LandBuyRightsAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result LandBuyRightsAction::Execute(GameState_t& gameState) const
+    Result LandBuyRightsAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/park/LandBuyRightsAction.h
+++ b/src/openrct2/actions/park/LandBuyRightsAction.h
@@ -41,8 +41,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/park/LandSetRightsAction.cpp
+++ b/src/openrct2/actions/park/LandSetRightsAction.cpp
@@ -64,12 +64,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_range) << DS_TAG(_setting) << DS_TAG(_ownership);
     }
 
-    Result LandSetRightsAction::Query(GameState_t& gameState) const
+    Result LandSetRightsAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result LandSetRightsAction::Execute(GameState_t& gameState) const
+    Result LandSetRightsAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/park/LandSetRightsAction.h
+++ b/src/openrct2/actions/park/LandSetRightsAction.h
@@ -40,8 +40,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/park/ParkEntrancePlaceAction.cpp
+++ b/src/openrct2/actions/park/ParkEntrancePlaceAction.cpp
@@ -82,7 +82,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::noFreeElements, STR_CANT_BUILD_THIS_HERE, STR_ERR_LANDSCAPE_DATA_AREA_FULL);
         }
 
-        if (gameState.park.entrances.size() >= Limits::kMaxParkEntrances)
+        if (park.entrances.size() >= Limits::kMaxParkEntrances)
         {
             return Result(Status::invalidParameters, STR_CANT_BUILD_THIS_HERE, STR_ERR_TOO_MANY_PARK_ENTRANCES);
         }
@@ -127,7 +127,7 @@ namespace OpenRCT2::GameActions
 
         auto flags = GetFlags();
 
-        gameState.park.entrances.push_back(_loc);
+        park.entrances.push_back(_loc);
 
         auto zLow = _loc.z;
         auto zHigh = zLow + ParkEntranceHeight;

--- a/src/openrct2/actions/park/ParkEntrancePlaceAction.cpp
+++ b/src/openrct2/actions/park/ParkEntrancePlaceAction.cpp
@@ -59,7 +59,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_pathTypeIsLegacy);
     }
 
-    Result ParkEntrancePlaceAction::Query(GameState_t& gameState) const
+    Result ParkEntrancePlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (!isInEditorMode() && !gameState.cheats.sandboxMode)
         {
@@ -119,7 +119,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result ParkEntrancePlaceAction::Execute(GameState_t& gameState) const
+    Result ParkEntrancePlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landPurchase;

--- a/src/openrct2/actions/park/ParkEntrancePlaceAction.h
+++ b/src/openrct2/actions/park/ParkEntrancePlaceAction.h
@@ -31,8 +31,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         bool CheckMapCapacity(int16_t numTiles) const;

--- a/src/openrct2/actions/park/ParkEntranceRemoveAction.cpp
+++ b/src/openrct2/actions/park/ParkEntranceRemoveAction.cpp
@@ -42,7 +42,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc);
     }
 
-    Result ParkEntranceRemoveAction::Query(GameState_t& gameState) const
+    Result ParkEntranceRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (!isInEditorMode() && !gameState.cheats.sandboxMode)
         {
@@ -66,7 +66,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result ParkEntranceRemoveAction::Execute(GameState_t& gameState) const
+    Result ParkEntranceRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landPurchase;
@@ -80,7 +80,6 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
 
-        auto& park = gameState.park;
         auto direction = (park.entrances[entranceIndex].direction - 1) & 3;
 
         // Centre (sign)

--- a/src/openrct2/actions/park/ParkEntranceRemoveAction.h
+++ b/src/openrct2/actions/park/ParkEntranceRemoveAction.h
@@ -27,8 +27,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         void ParkEntranceRemoveSegment(const CoordsXYZ& loc) const;

--- a/src/openrct2/actions/park/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/park/ParkMarketingAction.cpp
@@ -54,7 +54,7 @@ namespace OpenRCT2::GameActions
         {
             return Result(Status::invalidParameters, STR_CANT_START_MARKETING_CAMPAIGN, STR_ERR_VALUE_OUT_OF_RANGE);
         }
-        if (gameState.park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN)
+        if (park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN)
         {
             return Result(
                 Status::disallowed, STR_CANT_START_MARKETING_CAMPAIGN, STR_MARKETING_CAMPAIGNS_FORBIDDEN_BY_LOCAL_AUTHORITY);

--- a/src/openrct2/actions/park/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/park/ParkMarketingAction.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_type) << DS_TAG(_item) << DS_TAG(_numWeeks);
     }
 
-    Result ParkMarketingAction::Query(GameState_t& gameState) const
+    Result ParkMarketingAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (static_cast<size_t>(_type) >= std::size(AdvertisingCampaignPricePerWeek) || _numWeeks >= 256)
         {
@@ -63,7 +63,7 @@ namespace OpenRCT2::GameActions
         return CreateResult();
     }
 
-    Result ParkMarketingAction::Execute(GameState_t& gameState) const
+    Result ParkMarketingAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         MarketingCampaign campaign{};
         campaign.Type = _type;

--- a/src/openrct2/actions/park/ParkMarketingAction.h
+++ b/src/openrct2/actions/park/ParkMarketingAction.h
@@ -29,8 +29,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result CreateResult() const;

--- a/src/openrct2/actions/park/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/park/ParkSetDateAction.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_year) << DS_TAG(_month) << DS_TAG(_day);
     }
 
-    Result ParkSetDateAction::Query(GameState_t& gameState) const
+    Result ParkSetDateAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_year < 0 || _year >= kMaxYear)
         {
@@ -66,7 +66,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ParkSetDateAction::Execute(GameState_t& gameState) const
+    Result ParkSetDateAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         gameState.date = Date::FromYMD(_year, _month, _day);
         return Result();

--- a/src/openrct2/actions/park/ParkSetDateAction.h
+++ b/src/openrct2/actions/park/ParkSetDateAction.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/park/ParkSetEntranceFeeAction.cpp
+++ b/src/openrct2/actions/park/ParkSetEntranceFeeAction.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::GameActions
 
     Result ParkSetEntranceFeeAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
-        if ((gameState.park.flags & PARK_FLAGS_NO_MONEY) != 0)
+        if ((park.flags & PARK_FLAGS_NO_MONEY) != 0)
         {
             LOG_ERROR("Can't set park entrance fee because the park has no money");
             return Result(Status::disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, kStringIdNone);
@@ -64,7 +64,7 @@ namespace OpenRCT2::GameActions
 
     Result ParkSetEntranceFeeAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
-        gameState.park.entranceFee = _fee;
+        park.entranceFee = _fee;
 
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByClass(WindowClass::parkInformation);

--- a/src/openrct2/actions/park/ParkSetEntranceFeeAction.cpp
+++ b/src/openrct2/actions/park/ParkSetEntranceFeeAction.cpp
@@ -41,7 +41,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_fee);
     }
 
-    Result ParkSetEntranceFeeAction::Query(GameState_t& gameState) const
+    Result ParkSetEntranceFeeAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if ((gameState.park.flags & PARK_FLAGS_NO_MONEY) != 0)
         {
@@ -62,7 +62,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ParkSetEntranceFeeAction::Execute(GameState_t& gameState) const
+    Result ParkSetEntranceFeeAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         gameState.park.entranceFee = _fee;
 

--- a/src/openrct2/actions/park/ParkSetEntranceFeeAction.cpp
+++ b/src/openrct2/actions/park/ParkSetEntranceFeeAction.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2::GameActions
             LOG_ERROR("Can't set park entrance fee because the park has no money");
             return Result(Status::disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, kStringIdNone);
         }
-        else if (!Park::EntranceFeeUnlocked())
+        else if (!Park::EntranceFeeUnlocked(park))
         {
             LOG_ERROR("Park entrance fee is locked");
             return Result(Status::disallowed, STR_ERR_CANT_CHANGE_PARK_ENTRANCE_FEE, kStringIdNone);

--- a/src/openrct2/actions/park/ParkSetEntranceFeeAction.h
+++ b/src/openrct2/actions/park/ParkSetEntranceFeeAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/park/ParkSetLoanAction.cpp
+++ b/src/openrct2/actions/park/ParkSetLoanAction.cpp
@@ -40,9 +40,8 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_value);
     }
 
-    Result ParkSetLoanAction::Query(GameState_t& gameState) const
+    Result ParkSetLoanAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
-        auto& park = gameState.park;
         if (_value > park.bankLoan && _value > park.maxBankLoan)
         {
             return Result(Status::disallowed, STR_CANT_BORROW_ANY_MORE_MONEY, STR_BANK_REFUSES_TO_INCREASE_LOAN);
@@ -61,10 +60,8 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ParkSetLoanAction::Execute(GameState_t& gameState) const
+    Result ParkSetLoanAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
-        auto& park = gameState.park;
-
         park.cash -= (park.bankLoan - _value);
         park.bankLoan = _value;
 

--- a/src/openrct2/actions/park/ParkSetLoanAction.h
+++ b/src/openrct2/actions/park/ParkSetLoanAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/park/ParkSetNameAction.cpp
+++ b/src/openrct2/actions/park/ParkSetNameAction.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_name);
     }
 
-    Result ParkSetNameAction::Query(GameState_t& gameState) const
+    Result ParkSetNameAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_name.empty())
         {
@@ -53,10 +53,9 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ParkSetNameAction::Execute(GameState_t& gameState) const
+    Result ParkSetNameAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         // Do a no-op if new name is the same as the current name is the same
-        auto& park = gameState.park;
         if (_name != park.name)
         {
             park.name = _name;

--- a/src/openrct2/actions/park/ParkSetNameAction.h
+++ b/src/openrct2/actions/park/ParkSetNameAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/park/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/park/ParkSetParameterAction.cpp
@@ -41,7 +41,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_parameter) << DS_TAG(_value);
     }
 
-    Result ParkSetParameterAction::Query(GameState_t& gameState) const
+    Result ParkSetParameterAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_parameter >= ParkParameter::Count)
         {
@@ -54,9 +54,8 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result ParkSetParameterAction::Execute(GameState_t& gameState) const
+    Result ParkSetParameterAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
-        auto& park = gameState.park;
         auto* windowMgr = Ui::GetWindowManager();
 
         switch (_parameter)

--- a/src/openrct2/actions/park/ParkSetParameterAction.h
+++ b/src/openrct2/actions/park/ParkSetParameterAction.h
@@ -43,7 +43,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/park/ParkSetResearchFundingAction.cpp
+++ b/src/openrct2/actions/park/ParkSetResearchFundingAction.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_priorities) << DS_TAG(_fundingAmount);
     }
 
-    Result ParkSetResearchFundingAction::Query(GameState_t& gameState) const
+    Result ParkSetResearchFundingAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_fundingAmount >= RESEARCH_FUNDING_COUNT)
         {
@@ -53,7 +53,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ParkSetResearchFundingAction::Execute(GameState_t& gameState) const
+    Result ParkSetResearchFundingAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         gameState.researchPriorities = _priorities;
         gameState.researchFundingLevel = _fundingAmount;

--- a/src/openrct2/actions/park/ParkSetResearchFundingAction.h
+++ b/src/openrct2/actions/park/ParkSetResearchFundingAction.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/GuestSetFlagsAction.cpp
+++ b/src/openrct2/actions/peep/GuestSetFlagsAction.cpp
@@ -41,7 +41,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_peepId) << DS_TAG(_newFlags);
     }
 
-    Result GuestSetFlagsAction::Query(GameState_t& gameState) const
+    Result GuestSetFlagsAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* peep = gameState.entities.TryGetEntity<Guest>(_peepId);
         if (peep == nullptr)
@@ -52,7 +52,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result GuestSetFlagsAction::Execute(GameState_t& gameState) const
+    Result GuestSetFlagsAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* peep = gameState.entities.TryGetEntity<Guest>(_peepId);
         if (peep == nullptr)

--- a/src/openrct2/actions/peep/GuestSetFlagsAction.h
+++ b/src/openrct2/actions/peep/GuestSetFlagsAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/GuestSetNameAction.cpp
+++ b/src/openrct2/actions/peep/GuestSetNameAction.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteIndex) << DS_TAG(_name);
     }
 
-    Result GuestSetNameAction::Query(GameState_t& gameState) const
+    Result GuestSetNameAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
@@ -73,7 +73,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result GuestSetNameAction::Execute(GameState_t& gameState) const
+    Result GuestSetNameAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto guest = gameState.entities.TryGetEntity<Guest>(_spriteIndex);
         if (guest == nullptr)

--- a/src/openrct2/actions/peep/GuestSetNameAction.h
+++ b/src/openrct2/actions/peep/GuestSetNameAction.h
@@ -31,7 +31,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/PeepPickupAction.cpp
+++ b/src/openrct2/actions/peep/PeepPickupAction.cpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_type) << DS_TAG(_entityId) << DS_TAG(_loc) << DS_TAG(_owner);
     }
 
-    Result PeepPickupAction::Query(GameState_t& gameState) const
+    Result PeepPickupAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_entityId.ToUnderlying() >= kMaxEntities || _entityId.IsNull())
         {
@@ -116,7 +116,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result PeepPickupAction::Execute(GameState_t& gameState) const
+    Result PeepPickupAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Peep* const peep = gameState.entities.TryGetEntity<Peep>(_entityId);
         if (peep == nullptr)

--- a/src/openrct2/actions/peep/PeepPickupAction.h
+++ b/src/openrct2/actions/peep/PeepPickupAction.h
@@ -39,8 +39,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         void CancelConcurrentPickups(Peep* pickedPeep) const;

--- a/src/openrct2/actions/peep/PeepSpawnPlaceAction.cpp
+++ b/src/openrct2/actions/peep/PeepSpawnPlaceAction.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_location.x) << DS_TAG(_location.y) << DS_TAG(_location.z) << DS_TAG(_location.direction);
     }
 
-    Result PeepSpawnPlaceAction::Query(GameState_t& gameState) const
+    Result PeepSpawnPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (!isInEditorMode() && !gameState.cheats.sandboxMode)
         {
@@ -84,7 +84,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result PeepSpawnPlaceAction::Execute(GameState_t& gameState) const
+    Result PeepSpawnPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landPurchase;

--- a/src/openrct2/actions/peep/PeepSpawnPlaceAction.h
+++ b/src/openrct2/actions/peep/PeepSpawnPlaceAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffFireAction.cpp
+++ b/src/openrct2/actions/peep/StaffFireAction.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteId);
     }
 
-    Result StaffFireAction::Query(GameState_t& gameState) const
+    Result StaffFireAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_spriteId.ToUnderlying() >= kMaxEntities || _spriteId.IsNull())
         {
@@ -66,7 +66,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result StaffFireAction::Execute(GameState_t& gameState) const
+    Result StaffFireAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto staff = gameState.entities.TryGetEntity<Staff>(_spriteId);
         if (staff == nullptr)

--- a/src/openrct2/actions/peep/StaffFireAction.h
+++ b/src/openrct2/actions/peep/StaffFireAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/peep/StaffHireNewAction.cpp
@@ -62,17 +62,17 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_autoPosition) << DS_TAG(_staffType) << DS_TAG(_costumeIndex) << DS_TAG(_staffOrders);
     }
 
-    Result StaffHireNewAction::Query(GameState_t& gameState) const
+    Result StaffHireNewAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
-        return QueryExecute(gameState, false);
+        return QueryExecute(gameState, park, false);
     }
 
-    Result StaffHireNewAction::Execute(GameState_t& gameState) const
+    Result StaffHireNewAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
-        return QueryExecute(gameState, true);
+        return QueryExecute(gameState, park, true);
     }
 
-    Result StaffHireNewAction::QueryExecute(GameState_t& gameState, bool execute) const
+    Result StaffHireNewAction::QueryExecute(GameState_t& gameState, Park::ParkData& park, bool execute) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::wages;
@@ -171,7 +171,7 @@ namespace OpenRCT2::GameActions
 
             if (_autoPosition)
             {
-                AutoPositionNewStaff(gameState, newPeep);
+                AutoPositionNewStaff(gameState, park, newPeep);
             }
             else
             {
@@ -221,7 +221,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    void StaffHireNewAction::AutoPositionNewStaff(GameState_t& gameState, Peep* newPeep) const
+    void StaffHireNewAction::AutoPositionNewStaff(GameState_t& gameState, Park::ParkData& park, Peep* newPeep) const
     {
         // Find a location to place new staff member
         newPeep->State = PeepState::falling;
@@ -281,7 +281,6 @@ namespace OpenRCT2::GameActions
         else
         {
             // No walking guests; pick random park entrance
-            const auto& park = gameState.park;
             if (!park.entrances.empty())
             {
                 auto rand = ScenarioRandMax(static_cast<uint32_t>(park.entrances.size()));

--- a/src/openrct2/actions/peep/StaffHireNewAction.h
+++ b/src/openrct2/actions/peep/StaffHireNewAction.h
@@ -36,11 +36,11 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
-        Result QueryExecute(GameState_t& gameState, bool execute) const;
-        void AutoPositionNewStaff(GameState_t& gameState, Peep* newPeep) const;
+        Result QueryExecute(GameState_t& gameState, Park::ParkData& park, bool execute) const;
+        void AutoPositionNewStaff(GameState_t& gameState, Park::ParkData& park, Peep* newPeep) const;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffSetColourAction.cpp
+++ b/src/openrct2/actions/peep/StaffSetColourAction.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_staffType) << DS_TAG(_colour);
     }
 
-    Result StaffSetColourAction::Query(GameState_t& gameState) const
+    Result StaffSetColourAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto staffType = static_cast<StaffType>(_staffType);
         if (staffType != StaffType::handyman && staffType != StaffType::mechanic && staffType != StaffType::security)
@@ -55,7 +55,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result StaffSetColourAction::Execute(GameState_t& gameState) const
+    Result StaffSetColourAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         // Update global uniform colour property
         auto res = StaffSetColour(static_cast<StaffType>(_staffType), _colour);

--- a/src/openrct2/actions/peep/StaffSetColourAction.h
+++ b/src/openrct2/actions/peep/StaffSetColourAction.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffSetCostumeAction.cpp
+++ b/src/openrct2/actions/peep/StaffSetCostumeAction.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteIndex) << DS_TAG(_costume);
     }
 
-    Result StaffSetCostumeAction::Query(GameState_t& gameState) const
+    Result StaffSetCostumeAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
@@ -72,7 +72,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result StaffSetCostumeAction::Execute(GameState_t& gameState) const
+    Result StaffSetCostumeAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* staff = gameState.entities.TryGetEntity<Staff>(_spriteIndex);
         if (staff == nullptr)

--- a/src/openrct2/actions/peep/StaffSetCostumeAction.h
+++ b/src/openrct2/actions/peep/StaffSetCostumeAction.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffSetNameAction.cpp
+++ b/src/openrct2/actions/peep/StaffSetNameAction.cpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteIndex) << DS_TAG(_name);
     }
 
-    Result StaffSetNameAction::Query(GameState_t& gameState) const
+    Result StaffSetNameAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
@@ -65,7 +65,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result StaffSetNameAction::Execute(GameState_t& gameState) const
+    Result StaffSetNameAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto staff = gameState.entities.TryGetEntity<Staff>(_spriteIndex);
         if (staff == nullptr)

--- a/src/openrct2/actions/peep/StaffSetNameAction.h
+++ b/src/openrct2/actions/peep/StaffSetNameAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
 
         uint16_t GetActionFlags() const override;
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffSetOrdersAction.cpp
+++ b/src/openrct2/actions/peep/StaffSetOrdersAction.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteIndex) << DS_TAG(_ordersId);
     }
 
-    Result StaffSetOrdersAction::Query(GameState_t& gameState) const
+    Result StaffSetOrdersAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_spriteIndex.ToUnderlying() >= kMaxEntities || _spriteIndex.IsNull())
         {
@@ -63,7 +63,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result StaffSetOrdersAction::Execute(GameState_t& gameState) const
+    Result StaffSetOrdersAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto* staff = gameState.entities.TryGetEntity<Staff>(_spriteIndex);
         if (staff == nullptr)

--- a/src/openrct2/actions/peep/StaffSetOrdersAction.h
+++ b/src/openrct2/actions/peep/StaffSetOrdersAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/peep/StaffSetPatrolAreaAction.cpp
+++ b/src/openrct2/actions/peep/StaffSetPatrolAreaAction.cpp
@@ -46,12 +46,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_spriteId) << DS_TAG(_range) << DS_TAG(_mode);
     }
 
-    Result StaffSetPatrolAreaAction::Query(GameState_t& gameState) const
+    Result StaffSetPatrolAreaAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result StaffSetPatrolAreaAction::Execute(GameState_t& gameState) const
+    Result StaffSetPatrolAreaAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/peep/StaffSetPatrolAreaAction.h
+++ b/src/openrct2/actions/peep/StaffSetPatrolAreaAction.h
@@ -37,7 +37,7 @@ namespace OpenRCT2::GameActions
 
         void AcceptParameters(GameActionParameterVisitor&) final;
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/ride/MazePlaceTrackAction.cpp
@@ -49,7 +49,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_rideIndex) << DS_TAG(_mazeEntry);
     }
 
-    Result MazePlaceTrackAction::Query(GameState_t& gameState) const
+    Result MazePlaceTrackAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 
@@ -147,7 +147,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result MazePlaceTrackAction::Execute(GameState_t& gameState) const
+    Result MazePlaceTrackAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 

--- a/src/openrct2/actions/ride/MazePlaceTrackAction.h
+++ b/src/openrct2/actions/ride/MazePlaceTrackAction.h
@@ -26,7 +26,7 @@ namespace OpenRCT2::GameActions
 
         void AcceptParameters(GameActionParameterVisitor&) final;
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/ride/MazeSetTrackAction.cpp
@@ -83,7 +83,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_loc.direction) << DS_TAG(_initialPlacement) << DS_TAG(_rideIndex) << DS_TAG(_mode);
     }
 
-    Result MazeSetTrackAction::Query(GameState_t& gameState) const
+    Result MazeSetTrackAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 
@@ -193,7 +193,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result MazeSetTrackAction::Execute(GameState_t& gameState) const
+    Result MazeSetTrackAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 

--- a/src/openrct2/actions/ride/MazeSetTrackAction.h
+++ b/src/openrct2/actions/ride/MazeSetTrackAction.h
@@ -34,8 +34,8 @@ namespace OpenRCT2::GameActions
 
         void AcceptParameters(GameActionParameterVisitor&) final;
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         uint8_t MazeGetSegmentBit(const CoordsXY&) const;

--- a/src/openrct2/actions/ride/RideCreateAction.cpp
+++ b/src/openrct2/actions/ride/RideCreateAction.cpp
@@ -75,7 +75,7 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_vehicleColourPreset) << DS_TAG(_inspectionInterval);
     }
 
-    Result RideCreateAction::Query(GameState_t& gameState) const
+    Result RideCreateAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_inspectionInterval > RideInspection::never)
         {
@@ -129,7 +129,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result RideCreateAction::Execute(GameState_t& gameState) const
+    Result RideCreateAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 

--- a/src/openrct2/actions/ride/RideCreateAction.cpp
+++ b/src/openrct2/actions/ride/RideCreateAction.cpp
@@ -206,7 +206,7 @@ namespace OpenRCT2::GameActions
 
         ride->ratings.setNull();
 
-        if (!(gameState.park.flags & PARK_FLAGS_NO_MONEY))
+        if (!(park.flags & PARK_FLAGS_NO_MONEY))
         {
             for (auto i = 0; i < RCT2::ObjectLimits::kMaxShopItemsPerRideEntry; i++)
             {
@@ -215,7 +215,7 @@ namespace OpenRCT2::GameActions
 
             if (rideEntry->shop_item[0] == ShopItem::none)
             {
-                if (!Park::RidePricesUnlocked() || gameState.park.entranceFee > 0)
+                if (!Park::RidePricesUnlocked(park) || park.entranceFee > 0)
                 {
                     ride->price[0] = 0;
                 }

--- a/src/openrct2/actions/ride/RideCreateAction.h
+++ b/src/openrct2/actions/ride/RideCreateAction.h
@@ -36,7 +36,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideDemolishAction.cpp
+++ b/src/openrct2/actions/ride/RideDemolishAction.cpp
@@ -58,7 +58,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_modifyType);
     }
 
-    Result RideDemolishAction::Query(GameState_t& gameState) const
+    Result RideDemolishAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -102,7 +102,7 @@ namespace OpenRCT2::GameActions
         return result;
     }
 
-    Result RideDemolishAction::Execute(GameState_t& gameState) const
+    Result RideDemolishAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -114,16 +114,16 @@ namespace OpenRCT2::GameActions
         switch (_modifyType)
         {
             case RideModifyType::demolish:
-                return DemolishRide(gameState, *ride);
+                return DemolishRide(gameState, park, *ride);
             case RideModifyType::renew:
-                return RefurbishRide(gameState, *ride);
+                return RefurbishRide(gameState, park, *ride);
             default:
                 LOG_ERROR("Unknown ride demolish type %d", _modifyType);
                 return Result(Status::invalidParameters, STR_CANT_DO_THIS, STR_ERR_VALUE_OUT_OF_RANGE);
         }
     }
 
-    Result RideDemolishAction::DemolishRide(GameState_t& gameState, Ride& ride) const
+    Result RideDemolishAction::DemolishRide(GameState_t& gameState, Park::ParkData& park, Ride& ride) const
     {
         money64 refundPrice = DemolishTracks(gameState);
 
@@ -158,7 +158,6 @@ namespace OpenRCT2::GameActions
         }
 
         ride.remove();
-        auto& park = gameState.park;
         park.value = Park::CalculateParkValue(park, gameState);
 
         // Close windows related to the demolished ride
@@ -270,7 +269,7 @@ namespace OpenRCT2::GameActions
         return refundPrice;
     }
 
-    Result RideDemolishAction::RefurbishRide(GameState_t& gameState, Ride& ride) const
+    Result RideDemolishAction::RefurbishRide(GameState_t& gameState, Park::ParkData& park, Ride& ride) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::rideConstruction;

--- a/src/openrct2/actions/ride/RideDemolishAction.h
+++ b/src/openrct2/actions/ride/RideDemolishAction.h
@@ -34,14 +34,14 @@ namespace OpenRCT2::GameActions
         uint32_t GetCooldownTime() const final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
-        Result DemolishRide(GameState_t& gameState, Ride& ride) const;
+        Result DemolishRide(GameState_t& gameState, Park::ParkData& park, Ride& ride) const;
         money64 MazeRemoveTrack(GameState_t& gameState, const CoordsXYZD& coords) const;
         money64 DemolishTracks(GameState_t& gameState) const;
-        Result RefurbishRide(GameState_t& gameState, Ride& ride) const;
+        Result RefurbishRide(GameState_t& gameState, Park::ParkData& park, Ride& ride) const;
         money64 GetRefurbishPrice(const Ride& ride) const;
         money64 GetRefundPrice(const Ride& ride) const;
     };

--- a/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
@@ -58,7 +58,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_direction) << DS_TAG(_rideIndex) << DS_TAG(_stationNum) << DS_TAG(_isExit);
     }
 
-    Result RideEntranceExitPlaceAction::Query(GameState_t& gameState) const
+    Result RideEntranceExitPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         const auto errorTitle = _isExit ? STR_CANT_BUILD_MOVE_EXIT_FOR_THIS_RIDE_ATTRACTION
                                         : STR_CANT_BUILD_MOVE_ENTRANCE_FOR_THIS_RIDE_ATTRACTION;
@@ -143,7 +143,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result RideEntranceExitPlaceAction::Execute(GameState_t& gameState) const
+    Result RideEntranceExitPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         // Remember when in unknown station num mode rideIndex is unknown and z is set
         // When in known station num mode rideIndex is known and z is unknown

--- a/src/openrct2/actions/ride/RideEntranceExitPlaceAction.h
+++ b/src/openrct2/actions/ride/RideEntranceExitPlaceAction.h
@@ -33,8 +33,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
         static Result TrackPlaceQuery(GameState_t& gameState, const CoordsXYZ& loc, bool isExit);
     };

--- a/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
@@ -67,7 +67,7 @@ namespace OpenRCT2::GameActions
         return nullptr;
     }
 
-    Result RideEntranceExitRemoveAction::Query(GameState_t& gameState) const
+    Result RideEntranceExitRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -110,7 +110,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideEntranceExitRemoveAction::Execute(GameState_t& gameState) const
+    Result RideEntranceExitRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)

--- a/src/openrct2/actions/ride/RideEntranceExitRemoveAction.h
+++ b/src/openrct2/actions/ride/RideEntranceExitRemoveAction.h
@@ -30,7 +30,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideFreezeRatingAction.cpp
+++ b/src/openrct2/actions/ride/RideFreezeRatingAction.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_type) << DS_TAG(_value);
     }
 
-    Result RideFreezeRatingAction::Query(GameState_t& gameState) const
+    Result RideFreezeRatingAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -52,7 +52,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideFreezeRatingAction::Execute(GameState_t& gameState) const
+    Result RideFreezeRatingAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
 

--- a/src/openrct2/actions/ride/RideFreezeRatingAction.h
+++ b/src/openrct2/actions/ride/RideFreezeRatingAction.h
@@ -34,7 +34,7 @@ namespace OpenRCT2::GameActions
         void AcceptParameters(GameActionParameterVisitor&) final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideSetAppearanceAction.cpp
+++ b/src/openrct2/actions/ride/RideSetAppearanceAction.cpp
@@ -50,7 +50,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_type) << DS_TAG(_value) << DS_TAG(_index);
     }
 
-    Result RideSetAppearanceAction::Query(GameState_t& gameState) const
+    Result RideSetAppearanceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -91,7 +91,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetAppearanceAction::Execute(GameState_t& gameState) const
+    Result RideSetAppearanceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)

--- a/src/openrct2/actions/ride/RideSetAppearanceAction.h
+++ b/src/openrct2/actions/ride/RideSetAppearanceAction.h
@@ -44,7 +44,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideSetColourSchemeAction.cpp
+++ b/src/openrct2/actions/ride/RideSetColourSchemeAction.cpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_trackType) << DS_TAG(_newColourScheme);
     }
 
-    Result RideSetColourSchemeAction::Query(GameState_t& gameState) const
+    Result RideSetColourSchemeAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (!LocationValid(_loc))
         {
@@ -70,7 +70,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetColourSchemeAction::Execute(GameState_t& gameState) const
+    Result RideSetColourSchemeAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
         res.expenditure = ExpenditureType::rideConstruction;

--- a/src/openrct2/actions/ride/RideSetColourSchemeAction.h
+++ b/src/openrct2/actions/ride/RideSetColourSchemeAction.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideSetNameAction.cpp
+++ b/src/openrct2/actions/ride/RideSetNameAction.cpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_name);
     }
 
-    Result RideSetNameAction::Query(GameState_t& gameState) const
+    Result RideSetNameAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -64,7 +64,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetNameAction::Execute(GameState_t& gameState) const
+    Result RideSetNameAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)

--- a/src/openrct2/actions/ride/RideSetNameAction.h
+++ b/src/openrct2/actions/ride/RideSetNameAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/ride/RideSetPriceAction.cpp
@@ -50,7 +50,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_price) << DS_TAG(_primaryPrice);
     }
 
-    Result RideSetPriceAction::Query(GameState_t& gameState) const
+    Result RideSetPriceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -75,7 +75,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetPriceAction::Execute(GameState_t& gameState) const
+    Result RideSetPriceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
         res.expenditure = ExpenditureType::parkRideTickets;

--- a/src/openrct2/actions/ride/RideSetPriceAction.h
+++ b/src/openrct2/actions/ride/RideSetPriceAction.h
@@ -29,8 +29,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         void RideSetCommonPrice(GameState_t& gameState, ShopItem shopItem) const;

--- a/src/openrct2/actions/ride/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/ride/RideSetSettingAction.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_setting) << DS_TAG(_value);
     }
 
-    Result RideSetSettingAction::Query(GameState_t& gameState) const
+    Result RideSetSettingAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -155,7 +155,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetSettingAction::Execute(GameState_t& gameState) const
+    Result RideSetSettingAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)

--- a/src/openrct2/actions/ride/RideSetSettingAction.h
+++ b/src/openrct2/actions/ride/RideSetSettingAction.h
@@ -44,8 +44,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         bool RideIsModeValid(const Ride& ride) const;

--- a/src/openrct2/actions/ride/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/ride/RideSetStatusAction.cpp
@@ -54,7 +54,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_status);
     }
 
-    Result RideSetStatusAction::Query(GameState_t& gameState) const
+    Result RideSetStatusAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
 
@@ -117,7 +117,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetStatusAction::Execute(GameState_t& gameState) const
+    Result RideSetStatusAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
         res.expenditure = ExpenditureType::rideRunningCosts;

--- a/src/openrct2/actions/ride/RideSetStatusAction.h
+++ b/src/openrct2/actions/ride/RideSetStatusAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/ride/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.cpp
@@ -61,7 +61,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_type) << DS_TAG(_value) << DS_TAG(_colour);
     }
 
-    Result RideSetVehicleAction::Query(GameState_t& gameState) const
+    Result RideSetVehicleAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (_type >= RideSetVehicleType::Count)
         {
@@ -124,7 +124,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetVehicleAction::Execute(GameState_t& gameState) const
+    Result RideSetVehicleAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto errTitle = kSetVehicleTypeErrorTitle[EnumValue(_type)];
         auto ride = GetRide(_rideIndex);

--- a/src/openrct2/actions/ride/RideSetVehicleAction.h
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.h
@@ -39,8 +39,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         bool RideIsVehicleTypeValid(GameState_t& gameState, const Ride& ride) const;

--- a/src/openrct2/actions/ride/RideSetVisibilityAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVisibilityAction.cpp
@@ -40,7 +40,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_rideIndex) << DS_TAG(_visibility);
     }
 
-    Result RideSetVisibilityAction::Query(GameState_t& gameState) const
+    Result RideSetVisibilityAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (EnumValue(_visibility) >= 2)
         {
@@ -51,7 +51,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result RideSetVisibilityAction::Execute(GameState_t& gameState) const
+    Result RideSetVisibilityAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         for (int32_t y = 1; y <= gameState.mapSize.y; y++)
         {

--- a/src/openrct2/actions/ride/RideSetVisibilityAction.h
+++ b/src/openrct2/actions/ride/RideSetVisibilityAction.h
@@ -34,7 +34,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/BannerPlaceAction.cpp
@@ -52,7 +52,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_bannerType) << DS_TAG(_primaryColour);
     }
 
-    Result BannerPlaceAction::Query(GameState_t& gameState) const
+    Result BannerPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position.x = _loc.x + 16;
@@ -109,7 +109,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result BannerPlaceAction::Execute(GameState_t& gameState) const
+    Result BannerPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position.x = _loc.x + 16;

--- a/src/openrct2/actions/scenery/BannerPlaceAction.h
+++ b/src/openrct2/actions/scenery/BannerPlaceAction.h
@@ -39,8 +39,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         PathElement* GetValidPathElement() const;

--- a/src/openrct2/actions/scenery/BannerRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/BannerRemoveAction.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc);
     }
 
-    Result BannerRemoveAction::Query(GameState_t& gameState) const
+    Result BannerRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landscaping;
@@ -93,7 +93,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result BannerRemoveAction::Execute(GameState_t& gameState) const
+    Result BannerRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landscaping;

--- a/src/openrct2/actions/scenery/BannerRemoveAction.h
+++ b/src/openrct2/actions/scenery/BannerRemoveAction.h
@@ -27,8 +27,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         BannerElement* GetBannerElementAt() const;

--- a/src/openrct2/actions/scenery/BannerSetColourAction.cpp
+++ b/src/openrct2/actions/scenery/BannerSetColourAction.cpp
@@ -44,12 +44,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_primaryColour);
     }
 
-    Result BannerSetColourAction::Query(GameState_t& gameState) const
+    Result BannerSetColourAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(false);
     }
 
-    Result BannerSetColourAction::Execute(GameState_t& gameState) const
+    Result BannerSetColourAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(true);
     }

--- a/src/openrct2/actions/scenery/BannerSetColourAction.h
+++ b/src/openrct2/actions/scenery/BannerSetColourAction.h
@@ -33,8 +33,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(bool isExecuting) const;

--- a/src/openrct2/actions/scenery/BannerSetNameAction.cpp
+++ b/src/openrct2/actions/scenery/BannerSetNameAction.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_bannerIndex) << DS_TAG(_name);
     }
 
-    Result BannerSetNameAction::Query(GameState_t& gameState) const
+    Result BannerSetNameAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
@@ -78,7 +78,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result BannerSetNameAction::Execute(GameState_t& gameState) const
+    Result BannerSetNameAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)

--- a/src/openrct2/actions/scenery/BannerSetNameAction.h
+++ b/src/openrct2/actions/scenery/BannerSetNameAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/BannerSetStyleAction.cpp
+++ b/src/openrct2/actions/scenery/BannerSetStyleAction.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_type) << DS_TAG(_bannerIndex) << DS_TAG(_parameter);
     }
 
-    Result BannerSetStyleAction::Query(GameState_t& gameState) const
+    Result BannerSetStyleAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         StringId errorTitle = STR_CANT_REPAINT_THIS;
         if (_type == BannerSetStyleType::NoEntry)
@@ -120,7 +120,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result BannerSetStyleAction::Execute(GameState_t& gameState) const
+    Result BannerSetStyleAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 

--- a/src/openrct2/actions/scenery/BannerSetStyleAction.h
+++ b/src/openrct2/actions/scenery/BannerSetStyleAction.h
@@ -39,7 +39,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/LargeSceneryPlaceAction.cpp
@@ -65,7 +65,7 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_tertiaryColour);
     }
 
-    Result LargeSceneryPlaceAction::Query(GameState_t& gameState) const
+    Result LargeSceneryPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_POSITION_THIS_HERE;
@@ -193,7 +193,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result LargeSceneryPlaceAction::Execute(GameState_t& gameState) const
+    Result LargeSceneryPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_POSITION_THIS_HERE;

--- a/src/openrct2/actions/scenery/LargeSceneryPlaceAction.h
+++ b/src/openrct2/actions/scenery/LargeSceneryPlaceAction.h
@@ -47,8 +47,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         bool CheckMapCapacity(std::span<const LargeSceneryTile> tiles, size_t numTiles) const;

--- a/src/openrct2/actions/scenery/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/LargeSceneryRemoveAction.cpp
@@ -49,7 +49,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_tileIndex);
     }
 
-    Result LargeSceneryRemoveAction::Query(GameState_t& gameState) const
+    Result LargeSceneryRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 
@@ -129,7 +129,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result LargeSceneryRemoveAction::Execute(GameState_t& gameState) const
+    Result LargeSceneryRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
 

--- a/src/openrct2/actions/scenery/LargeSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/LargeSceneryRemoveAction.cpp
@@ -90,7 +90,7 @@ namespace OpenRCT2::GameActions
 
             if (gLegacyScene != LegacyScene::scenarioEditor && !gameState.cheats.sandboxMode)
             {
-                if (gameState.park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+                if (park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
                 {
                     if (sceneryEntry->flags.has(LargeSceneryFlag::isTree))
                     {

--- a/src/openrct2/actions/scenery/LargeSceneryRemoveAction.h
+++ b/src/openrct2/actions/scenery/LargeSceneryRemoveAction.h
@@ -28,8 +28,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         TileElement* FindLargeSceneryElement(const CoordsXYZ& pos, int32_t sequenceIndex) const;

--- a/src/openrct2/actions/scenery/LargeScenerySetColourAction.cpp
+++ b/src/openrct2/actions/scenery/LargeScenerySetColourAction.cpp
@@ -53,12 +53,12 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_tertiaryColour);
     }
 
-    Result LargeScenerySetColourAction::Query(GameState_t& gameState) const
+    Result LargeScenerySetColourAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result LargeScenerySetColourAction::Execute(GameState_t& gameState) const
+    Result LargeScenerySetColourAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/scenery/LargeScenerySetColourAction.h
+++ b/src/openrct2/actions/scenery/LargeScenerySetColourAction.h
@@ -33,8 +33,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/scenery/ScenerySetRestrictedAction.cpp
+++ b/src/openrct2/actions/scenery/ScenerySetRestrictedAction.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2::GameActions
         return GameAction::GetActionFlags() | Flags::AllowWhilePaused;
     }
 
-    Result ScenerySetRestrictedAction::Query(GameState_t& gameState) const
+    Result ScenerySetRestrictedAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (!ObjectTypeCanBeRestricted(_objectType))
         {
@@ -49,7 +49,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result ScenerySetRestrictedAction::Execute(GameState_t& gameState) const
+    Result ScenerySetRestrictedAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto sceneryType = GetSceneryTypeFromObjectType(_objectType);
         SetSceneryItemRestricted({ sceneryType, _objectIndex }, _isRestricted);

--- a/src/openrct2/actions/scenery/ScenerySetRestrictedAction.h
+++ b/src/openrct2/actions/scenery/ScenerySetRestrictedAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/SignSetNameAction.cpp
+++ b/src/openrct2/actions/scenery/SignSetNameAction.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_bannerIndex) << DS_TAG(_name);
     }
 
-    Result SignSetNameAction::Query(GameState_t& gameState) const
+    Result SignSetNameAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
@@ -76,7 +76,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result SignSetNameAction::Execute(GameState_t& gameState) const
+    Result SignSetNameAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)

--- a/src/openrct2/actions/scenery/SignSetNameAction.h
+++ b/src/openrct2/actions/scenery/SignSetNameAction.h
@@ -28,7 +28,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/SignSetStyleAction.cpp
+++ b/src/openrct2/actions/scenery/SignSetStyleAction.cpp
@@ -51,7 +51,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_bannerIndex) << DS_TAG(_mainColour) << DS_TAG(_textColour) << DS_TAG(_isLarge);
     }
 
-    Result SignSetStyleAction::Query(GameState_t& gameState) const
+    Result SignSetStyleAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)
@@ -103,7 +103,7 @@ namespace OpenRCT2::GameActions
         return Result();
     }
 
-    Result SignSetStyleAction::Execute(GameState_t& gameState) const
+    Result SignSetStyleAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto banner = GetBanner(_bannerIndex);
         if (banner == nullptr)

--- a/src/openrct2/actions/scenery/SignSetStyleAction.h
+++ b/src/openrct2/actions/scenery/SignSetStyleAction.h
@@ -30,7 +30,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
@@ -78,7 +78,7 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_secondaryColour) << DS_TAG(_tertiaryColour);
     }
 
-    Result SmallSceneryPlaceAction::Query(GameState_t& gameState) const
+    Result SmallSceneryPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         bool isOnWater = false;
         bool supportsRequired = false;
@@ -287,7 +287,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result SmallSceneryPlaceAction::Execute(GameState_t& gameState) const
+    Result SmallSceneryPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         bool supportsRequired = false;
         if (_loc.z != 0)

--- a/src/openrct2/actions/scenery/SmallSceneryPlaceAction.h
+++ b/src/openrct2/actions/scenery/SmallSceneryPlaceAction.h
@@ -42,7 +42,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/scenery/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryRemoveAction.cpp
@@ -54,7 +54,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_quadrant) << DS_TAG(_sceneryType);
     }
 
-    Result SmallSceneryRemoveAction::Query(GameState_t& gameState) const
+    Result SmallSceneryRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
 
@@ -106,7 +106,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result SmallSceneryRemoveAction::Execute(GameState_t& gameState) const
+    Result SmallSceneryRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
 

--- a/src/openrct2/actions/scenery/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryRemoveAction.cpp
@@ -76,7 +76,7 @@ namespace OpenRCT2::GameActions
         if (gLegacyScene != LegacyScene::scenarioEditor && !GetFlags().has(CommandFlag::ghost) && !gameState.cheats.sandboxMode)
         {
             // Check if allowed to remove item
-            if (gameState.park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+            if (park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
             {
                 if (entry->flags.has(SmallSceneryFlag::isTree))
                 {

--- a/src/openrct2/actions/scenery/SmallSceneryRemoveAction.h
+++ b/src/openrct2/actions/scenery/SmallSceneryRemoveAction.h
@@ -29,8 +29,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         TileElement* FindSceneryElement() const;

--- a/src/openrct2/actions/scenery/SmallScenerySetColourAction.cpp
+++ b/src/openrct2/actions/scenery/SmallScenerySetColourAction.cpp
@@ -59,12 +59,12 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_secondaryColour) << DS_TAG(_tertiaryColour);
     }
 
-    Result SmallScenerySetColourAction::Query(GameState_t& gameState) const
+    Result SmallScenerySetColourAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result SmallScenerySetColourAction::Execute(GameState_t& gameState) const
+    Result SmallScenerySetColourAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/scenery/SmallScenerySetColourAction.h
+++ b/src/openrct2/actions/scenery/SmallScenerySetColourAction.h
@@ -34,8 +34,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/scenery/WallPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/WallPlaceAction.cpp
@@ -74,7 +74,7 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_tertiaryColour);
     }
 
-    Result WallPlaceAction::Query(GameState_t& gameState) const
+    Result WallPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_BUILD_THIS_HERE;
@@ -276,7 +276,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result WallPlaceAction::Execute(GameState_t& gameState) const
+    Result WallPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_BUILD_THIS_HERE;

--- a/src/openrct2/actions/scenery/WallPlaceAction.h
+++ b/src/openrct2/actions/scenery/WallPlaceAction.h
@@ -49,8 +49,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         /**

--- a/src/openrct2/actions/scenery/WallRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/WallRemoveAction.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc);
     }
 
-    Result WallRemoveAction::Query(GameState_t& gameState) const
+    Result WallRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
         res.cost = 0;
@@ -67,7 +67,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result WallRemoveAction::Execute(GameState_t& gameState) const
+    Result WallRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         Result res = Result();
         res.cost = 0;

--- a/src/openrct2/actions/scenery/WallRemoveAction.h
+++ b/src/openrct2/actions/scenery/WallRemoveAction.h
@@ -24,8 +24,8 @@ namespace OpenRCT2::GameActions
 
         void AcceptParameters(GameActionParameterVisitor&) final;
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         TileElement* GetFirstWallElementAt(const CoordsXYZD& location, bool isGhost) const;

--- a/src/openrct2/actions/scenery/WallSetColourAction.cpp
+++ b/src/openrct2/actions/scenery/WallSetColourAction.cpp
@@ -51,7 +51,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_primaryColour) << DS_TAG(_secondaryColour) << DS_TAG(_tertiaryColour);
     }
 
-    Result WallSetColourAction::Query(GameState_t& gameState) const
+    Result WallSetColourAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_REPAINT_THIS;
@@ -115,7 +115,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result WallSetColourAction::Execute(GameState_t& gameState) const
+    Result WallSetColourAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_REPAINT_THIS;

--- a/src/openrct2/actions/scenery/WallSetColourAction.h
+++ b/src/openrct2/actions/scenery/WallSetColourAction.h
@@ -32,7 +32,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/terraform/ClearAction.cpp
+++ b/src/openrct2/actions/terraform/ClearAction.cpp
@@ -52,12 +52,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_range) << DS_TAG(_itemsToClear);
     }
 
-    Result ClearAction::Query(GameState_t& gameState) const
+    Result ClearAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result ClearAction::Execute(GameState_t& gameState) const
+    Result ClearAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/terraform/ClearAction.h
+++ b/src/openrct2/actions/terraform/ClearAction.h
@@ -39,8 +39,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result CreateResult() const;

--- a/src/openrct2/actions/terraform/LandLowerAction.cpp
+++ b/src/openrct2/actions/terraform/LandLowerAction.cpp
@@ -56,12 +56,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_coords) << DS_TAG(_range) << DS_TAG(_selectionType);
     }
 
-    Result LandLowerAction::Query(GameState_t& gameState) const
+    Result LandLowerAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result LandLowerAction::Execute(GameState_t& gameState) const
+    Result LandLowerAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/terraform/LandLowerAction.h
+++ b/src/openrct2/actions/terraform/LandLowerAction.h
@@ -31,8 +31,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/terraform/LandRaiseAction.cpp
+++ b/src/openrct2/actions/terraform/LandRaiseAction.cpp
@@ -57,12 +57,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_coords) << DS_TAG(_range) << DS_TAG(_selectionType);
     }
 
-    Result LandRaiseAction::Query(GameState_t& gameState) const
+    Result LandRaiseAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result LandRaiseAction::Execute(GameState_t& gameState) const
+    Result LandRaiseAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/terraform/LandRaiseAction.h
+++ b/src/openrct2/actions/terraform/LandRaiseAction.h
@@ -31,8 +31,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/terraform/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/LandSetHeightAction.cpp
@@ -59,7 +59,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_coords) << DS_TAG(_height) << DS_TAG(_style);
     }
 
-    Result LandSetHeightAction::Query(GameState_t& gameState) const
+    Result LandSetHeightAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         if (gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
         {
@@ -155,7 +155,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result LandSetHeightAction::Execute(GameState_t& gameState) const
+    Result LandSetHeightAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         money64 cost = 0.00_GBP;
         auto surfaceHeight = TileElementHeight(_coords);

--- a/src/openrct2/actions/terraform/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/LandSetHeightAction.cpp
@@ -61,7 +61,7 @@ namespace OpenRCT2::GameActions
 
     Result LandSetHeightAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
-        if (gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
+        if (park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
         {
             return Result(Status::disallowed, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY, kStringIdNone);
         }
@@ -83,7 +83,7 @@ namespace OpenRCT2::GameActions
         money64 sceneryRemovalCost = 0;
         if (!gameState.cheats.disableClearanceChecks)
         {
-            if (gameState.park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
+            if (park.flags & PARK_FLAGS_FORBID_TREE_REMOVAL)
             {
                 // Check for obstructing large trees
                 TileElement* tileElement = CheckTreeObstructions();

--- a/src/openrct2/actions/terraform/LandSetHeightAction.h
+++ b/src/openrct2/actions/terraform/LandSetHeightAction.h
@@ -29,8 +29,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         StringId CheckParameters() const;

--- a/src/openrct2/actions/terraform/LandSmoothAction.cpp
+++ b/src/openrct2/actions/terraform/LandSmoothAction.cpp
@@ -61,12 +61,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_coords) << DS_TAG(_range) << DS_TAG(_selectionType) << DS_TAG(_isLowering);
     }
 
-    Result LandSmoothAction::Query(GameState_t& gameState) const
+    Result LandSmoothAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return SmoothLand(gameState, false);
     }
 
-    Result LandSmoothAction::Execute(GameState_t& gameState) const
+    Result LandSmoothAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return SmoothLand(gameState, true);
     }

--- a/src/openrct2/actions/terraform/LandSmoothAction.h
+++ b/src/openrct2/actions/terraform/LandSmoothAction.h
@@ -37,8 +37,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result SmoothLandTile(

--- a/src/openrct2/actions/terraform/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/terraform/SurfaceSetStyleAction.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_range) << DS_TAG(_surfaceStyle) << DS_TAG(_edgeStyle);
     }
 
-    Result SurfaceSetStyleAction::Query(GameState_t& gameState) const
+    Result SurfaceSetStyleAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_CHANGE_LAND_TYPE;
@@ -142,7 +142,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result SurfaceSetStyleAction::Execute(GameState_t& gameState) const
+    Result SurfaceSetStyleAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.errorTitle = STR_CANT_CHANGE_LAND_TYPE;

--- a/src/openrct2/actions/terraform/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/terraform/SurfaceSetStyleAction.cpp
@@ -85,7 +85,7 @@ namespace OpenRCT2::GameActions
 
         // Do nothing if not in editor, sandbox mode or landscaping is forbidden
         if (gLegacyScene != LegacyScene::scenarioEditor && !gameState.cheats.sandboxMode
-            && (gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES))
+            && (park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES))
         {
             return Result(Status::disallowed, STR_CANT_CHANGE_LAND_TYPE, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY);
         }

--- a/src/openrct2/actions/terraform/SurfaceSetStyleAction.h
+++ b/src/openrct2/actions/terraform/SurfaceSetStyleAction.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::GameActions
         void AcceptParameters(GameActionParameterVisitor&) final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/terraform/WaterLowerAction.cpp
+++ b/src/openrct2/actions/terraform/WaterLowerAction.cpp
@@ -42,12 +42,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_range);
     }
 
-    Result WaterLowerAction::Query(GameState_t& gameState) const
+    Result WaterLowerAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result WaterLowerAction::Execute(GameState_t& gameState) const
+    Result WaterLowerAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/terraform/WaterLowerAction.h
+++ b/src/openrct2/actions/terraform/WaterLowerAction.h
@@ -27,8 +27,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/terraform/WaterRaiseAction.cpp
+++ b/src/openrct2/actions/terraform/WaterRaiseAction.cpp
@@ -42,12 +42,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_range);
     }
 
-    Result WaterRaiseAction::Query(GameState_t& gameState) const
+    Result WaterRaiseAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, false);
     }
 
-    Result WaterRaiseAction::Execute(GameState_t& gameState) const
+    Result WaterRaiseAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(gameState, true);
     }

--- a/src/openrct2/actions/terraform/WaterRaiseAction.h
+++ b/src/openrct2/actions/terraform/WaterRaiseAction.h
@@ -27,8 +27,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(GameState_t& gameState, bool isExecuting) const;

--- a/src/openrct2/actions/terraform/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/WaterSetHeightAction.cpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_coords) << DS_TAG(_height);
     }
 
-    Result WaterSetHeightAction::Query(GameState_t& gameState) const
+    Result WaterSetHeightAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landscaping;
@@ -112,7 +112,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result WaterSetHeightAction::Execute(GameState_t& gameState) const
+    Result WaterSetHeightAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.expenditure = ExpenditureType::landscaping;

--- a/src/openrct2/actions/terraform/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/WaterSetHeightAction.cpp
@@ -54,7 +54,7 @@ namespace OpenRCT2::GameActions
         res.position = { _coords, _height * kCoordsZStep };
 
         if (gLegacyScene != LegacyScene::scenarioEditor && !gameState.cheats.sandboxMode
-            && gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
+            && park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES)
         {
             return Result(Status::disallowed, kStringIdNone, STR_FORBIDDEN_BY_THE_LOCAL_AUTHORITY);
         }

--- a/src/openrct2/actions/terraform/WaterSetHeightAction.h
+++ b/src/openrct2/actions/terraform/WaterSetHeightAction.h
@@ -28,8 +28,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const override;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         StringId CheckParameters() const;

--- a/src/openrct2/actions/track/TrackDesignAction.cpp
+++ b/src/openrct2/actions/track/TrackDesignAction.cpp
@@ -58,7 +58,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_inspectionInterval);
     }
 
-    Result TrackDesignAction::Query(GameState_t& gameState) const
+    Result TrackDesignAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position.x = _loc.x + 16;
@@ -140,7 +140,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result TrackDesignAction::Execute(GameState_t& gameState) const
+    Result TrackDesignAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position.x = _loc.x + 16;

--- a/src/openrct2/actions/track/TrackDesignAction.h
+++ b/src/openrct2/actions/track/TrackDesignAction.h
@@ -33,7 +33,7 @@ namespace OpenRCT2::GameActions
 
         void Serialise(DataSerialiser& stream) override;
 
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/track/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/track/TrackPlaceAction.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::GameActions
                << DS_TAG(_colour) << DS_TAG(_seatRotation) << DS_TAG(_trackPlaceFlags.holder);
     }
 
-    Result TrackPlaceAction::Query(GameState_t& gameState) const
+    Result TrackPlaceAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)
@@ -413,7 +413,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result TrackPlaceAction::Execute(GameState_t& gameState) const
+    Result TrackPlaceAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto ride = GetRide(_rideIndex);
         if (ride == nullptr)

--- a/src/openrct2/actions/track/TrackPlaceAction.h
+++ b/src/openrct2/actions/track/TrackPlaceAction.h
@@ -43,8 +43,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         bool CheckMapCapacity(int16_t numTiles) const;

--- a/src/openrct2/actions/track/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/track/TrackRemoveAction.cpp
@@ -68,7 +68,7 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_trackType) << DS_TAG(_sequence) << DS_TAG(_origin);
     }
 
-    Result TrackRemoveAction::Query(GameState_t& gameState) const
+    Result TrackRemoveAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position.x = _origin.x + 16;
@@ -252,7 +252,7 @@ namespace OpenRCT2::GameActions
         return res;
     }
 
-    Result TrackRemoveAction::Execute(GameState_t& gameState) const
+    Result TrackRemoveAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         auto res = Result();
         res.position.x = _origin.x + 16;

--- a/src/openrct2/actions/track/TrackRemoveAction.h
+++ b/src/openrct2/actions/track/TrackRemoveAction.h
@@ -29,7 +29,7 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
     };
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/track/TrackSetBrakeSpeedAction.cpp
+++ b/src/openrct2/actions/track/TrackSetBrakeSpeedAction.cpp
@@ -43,12 +43,12 @@ namespace OpenRCT2::GameActions
         stream << DS_TAG(_loc) << DS_TAG(_trackType) << DS_TAG(_brakeSpeed);
     }
 
-    Result TrackSetBrakeSpeedAction::Query(GameState_t& gameState) const
+    Result TrackSetBrakeSpeedAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(false);
     }
 
-    Result TrackSetBrakeSpeedAction::Execute(GameState_t& gameState) const
+    Result TrackSetBrakeSpeedAction::Execute(GameState_t& gameState, Park::ParkData& park) const
     {
         return QueryExecute(true);
     }

--- a/src/openrct2/actions/track/TrackSetBrakeSpeedAction.h
+++ b/src/openrct2/actions/track/TrackSetBrakeSpeedAction.h
@@ -29,8 +29,8 @@ namespace OpenRCT2::GameActions
         uint16_t GetActionFlags() const final;
 
         void Serialise(DataSerialiser& stream) override;
-        Result Query(GameState_t& gameState) const override;
-        Result Execute(GameState_t& gameState) const override;
+        Result Query(GameState_t& gameState, Park::ParkData& park) const override;
+        Result Execute(GameState_t& gameState, Park::ParkData& park) const override;
 
     private:
         Result QueryExecute(bool isExecuting) const;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1886,7 +1886,7 @@ namespace OpenRCT2
                 return true;
             }
 
-            auto entranceFee = Park::GetEntranceFee();
+            auto entranceFee = Park::GetEntranceFee(gameState.park);
             if (entranceFee != 0)
             {
                 if (guest->HasItem(ShopItem::voucher))

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -84,7 +84,7 @@ StringId AwardGetNews(AwardType type)
 #pragma region Award checks
 
 /** More than 1/16 of the total guests must be thinking untidy thoughts. */
-static bool AwardIsDeservedMostUntidy(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedMostUntidy(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::mostBeautiful))
         return false;
@@ -110,11 +110,11 @@ static bool AwardIsDeservedMostUntidy(GameState_t& gameState, int32_t activeAwar
         }
     }
 
-    return (negativeCount > gameState.park.numGuestsInPark / 16);
+    return (negativeCount > park.numGuestsInPark / 16);
 }
 
 /** More than 1/64 of the total guests must be thinking tidy thoughts and less than 6 guests thinking untidy thoughts. */
-static bool AwardIsDeservedMostTidy(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedMostTidy(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::mostUntidy))
         return false;
@@ -142,11 +142,12 @@ static bool AwardIsDeservedMostTidy(GameState_t& gameState, int32_t activeAwardT
         }
     }
 
-    return (negativeCount <= 5 && positiveCount > gameState.park.numGuestsInPark / 64);
+    return (negativeCount <= 5 && positiveCount > park.numGuestsInPark / 64);
 }
 
 /** At least 6 open roller coasters. */
-static bool AwardIsDeservedBestRollercoasters(GameState_t& gameState, [[maybe_unused]] int32_t activeAwardTypes)
+static bool AwardIsDeservedBestRollercoasters(
+    GameState_t& gameState, Park::ParkData& park, [[maybe_unused]] int32_t activeAwardTypes)
 {
     auto rollerCoasters = 0;
     for (const auto& ride : RideManager(gameState))
@@ -173,10 +174,8 @@ static bool AwardIsDeservedBestRollercoasters(GameState_t& gameState, [[maybe_un
 }
 
 /** Entrance fee is 0.10 less than half of the total ride value. */
-static bool AwardIsDeservedBestValue(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedBestValue(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
-    auto& park = gameState.park;
-
     if (activeAwardTypes & EnumToFlag(AwardType::worstValue))
         return false;
 
@@ -196,7 +195,7 @@ static bool AwardIsDeservedBestValue(GameState_t& gameState, int32_t activeAward
 }
 
 /** More than 1/128 of the total guests must be thinking scenic thoughts and fewer than 16 untidy thoughts. */
-static bool AwardIsDeservedMostBeautiful(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedMostBeautiful(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::mostUntidy))
         return false;
@@ -229,10 +228,8 @@ static bool AwardIsDeservedMostBeautiful(GameState_t& gameState, int32_t activeA
 }
 
 /** Entrance fee is more than total ride value. */
-static bool AwardIsDeservedWorstValue(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedWorstValue(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
-    auto& park = gameState.park;
-
     if (activeAwardTypes & EnumToFlag(AwardType::bestValue))
         return false;
     if (park.flags & PARK_FLAGS_NO_MONEY)
@@ -247,7 +244,7 @@ static bool AwardIsDeservedWorstValue(GameState_t& gameState, int32_t activeAwar
 }
 
 /** No more than 2 people who think the vandalism is bad and no crashes. */
-static bool AwardIsDeservedSafest(GameState_t& gameState, [[maybe_unused]] int32_t activeAwardTypes)
+static bool AwardIsDeservedSafest(GameState_t& gameState, Park::ParkData& park, [[maybe_unused]] int32_t activeAwardTypes)
 {
     auto peepsWhoDislikeVandalism = 0;
     for (auto peep : EntityList<Guest>())
@@ -276,7 +273,7 @@ static bool AwardIsDeservedSafest(GameState_t& gameState, [[maybe_unused]] int32
 }
 
 /** All staff types, at least 20 staff, one staff per 32 peeps. */
-static bool AwardIsDeservedBestStaff(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedBestStaff(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::mostUntidy))
         return false;
@@ -288,7 +285,7 @@ static bool AwardIsDeservedBestStaff(GameState_t& gameState, int32_t activeAward
 }
 
 /** At least 7 shops, 4 unique, one shop per 128 guests and no more than 12 hungry guests. */
-static bool AwardIsDeservedBestFood(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedBestFood(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::worstFood))
         return false;
@@ -333,7 +330,7 @@ static bool AwardIsDeservedBestFood(GameState_t& gameState, int32_t activeAwardT
 }
 
 /** No more than 2 unique shops, less than one shop per 256 guests and more than 15 hungry guests. */
-static bool AwardIsDeservedWorstFood(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedWorstFood(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::bestFood))
         return false;
@@ -378,7 +375,7 @@ static bool AwardIsDeservedWorstFood(GameState_t& gameState, int32_t activeAward
 }
 
 /** At least 4 toilets, 1 toilet per 128 guests and no more than 16 guests who think they need the toilet. */
-static bool AwardIsDeservedBestToilets(GameState_t& gameState, [[maybe_unused]] int32_t activeAwardTypes)
+static bool AwardIsDeservedBestToilets(GameState_t& gameState, Park::ParkData& park, [[maybe_unused]] int32_t activeAwardTypes)
 {
     // Count open toilets
     const auto& rideManager = RideManager(gameState);
@@ -410,11 +407,11 @@ static bool AwardIsDeservedBestToilets(GameState_t& gameState, [[maybe_unused]] 
 }
 
 /** More than half of the rides have satisfaction <= 6 and park rating <= 650. */
-static bool AwardIsDeservedMostDisappointing(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedMostDisappointing(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::bestValue))
         return false;
-    if (gameState.park.rating > 650)
+    if (park.rating > 650)
         return false;
 
     // Count the number of disappointing rides
@@ -437,7 +434,8 @@ static bool AwardIsDeservedMostDisappointing(GameState_t& gameState, int32_t act
 }
 
 /** At least 6 open water rides. */
-static bool AwardIsDeservedBestWaterRides(GameState_t& gameState, [[maybe_unused]] int32_t activeAwardTypes)
+static bool AwardIsDeservedBestWaterRides(
+    GameState_t& gameState, Park::ParkData& park, [[maybe_unused]] int32_t activeAwardTypes)
 {
     auto waterRides = 0;
     for (const auto& ride : RideManager(gameState))
@@ -465,7 +463,7 @@ static bool AwardIsDeservedBestWaterRides(GameState_t& gameState, [[maybe_unused
 }
 
 /** At least 6 custom designed rides. */
-static bool AwardIsDeservedBestCustomDesignedRides(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedBestCustomDesignedRides(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     if (activeAwardTypes & EnumToFlag(AwardType::mostDisappointing))
         return false;
@@ -488,7 +486,7 @@ static bool AwardIsDeservedBestCustomDesignedRides(GameState_t& gameState, int32
     return (customDesignedRides >= 6);
 }
 
-static bool AwardIsDeservedMostDazzlingRideColours(GameState_t& gameState, int32_t activeAwardTypes)
+static bool AwardIsDeservedMostDazzlingRideColours(GameState_t& gameState, Park::ParkData& park, int32_t activeAwardTypes)
 {
     /** At least 5 colourful rides and more than half of the rides are colourful. */
     static constexpr OpenRCT2::Drawing::Colour dazzling_ride_colours[] = {
@@ -525,7 +523,8 @@ static bool AwardIsDeservedMostDazzlingRideColours(GameState_t& gameState, int32
 }
 
 /** At least 10 peeps and more than 1/64 of total guests are lost or can't find something. */
-static bool AwardIsDeservedMostConfusingLayout(GameState_t& gameState, [[maybe_unused]] int32_t activeAwardTypes)
+static bool AwardIsDeservedMostConfusingLayout(
+    GameState_t& gameState, Park::ParkData& park, [[maybe_unused]] int32_t activeAwardTypes)
 {
     uint32_t peepsCounted = 0;
     uint32_t peepsLost = 0;
@@ -544,7 +543,8 @@ static bool AwardIsDeservedMostConfusingLayout(GameState_t& gameState, [[maybe_u
 }
 
 /** At least 10 open gentle rides. */
-static bool AwardIsDeservedBestGentleRides(GameState_t& gameState, [[maybe_unused]] int32_t activeAwardTypes)
+static bool AwardIsDeservedBestGentleRides(
+    GameState_t& gameState, Park::ParkData& park, [[maybe_unused]] int32_t activeAwardTypes)
 {
     auto gentleRides = 0;
     for (const auto& ride : RideManager(gameState))
@@ -571,7 +571,7 @@ static bool AwardIsDeservedBestGentleRides(GameState_t& gameState, [[maybe_unuse
     return (gentleRides >= 10);
 }
 
-using award_deserved_check = bool (*)(GameState_t& gameState, int32_t);
+using award_deserved_check = bool (*)(GameState_t& gameState, Park::ParkData& park, int32_t);
 
 static constexpr award_deserved_check _awardChecks[] = {
     AwardIsDeservedMostUntidy,
@@ -593,9 +593,9 @@ static constexpr award_deserved_check _awardChecks[] = {
     AwardIsDeservedBestGentleRides,
 };
 
-static bool AwardIsDeserved(GameState_t& gameState, AwardType awardType, int32_t activeAwardTypes)
+static bool AwardIsDeserved(GameState_t& gameState, Park::ParkData& park, AwardType awardType, int32_t activeAwardTypes)
 {
-    return _awardChecks[EnumValue(awardType)](gameState, activeAwardTypes);
+    return _awardChecks[EnumValue(awardType)](gameState, park, activeAwardTypes);
 }
 
 #pragma endregion
@@ -643,7 +643,9 @@ void AwardUpdateAll()
 
     // Only add new awards if park is open
     auto& gameState = getGameState();
-    if (gameState.park.flags & PARK_FLAGS_PARK_OPEN)
+    auto& park = gameState.park;
+
+    if (park.flags & PARK_FLAGS_PARK_OPEN)
     {
         // Set active award types as flags
         int32_t activeAwardTypes = 0;
@@ -663,7 +665,7 @@ void AwardUpdateAll()
             } while (activeAwardTypes & (1 << EnumValue(awardType)));
 
             // Check if award is deserved
-            if (AwardIsDeserved(gameState, awardType, activeAwardTypes))
+            if (AwardIsDeserved(gameState, park, awardType, activeAwardTypes))
             {
                 AwardAdd(awardType);
             }

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -183,13 +183,13 @@ static bool AwardIsDeservedBestValue(GameState_t& gameState, int32_t activeAward
     if (activeAwardTypes & EnumToFlag(AwardType::mostDisappointing))
         return false;
 
-    if ((park.flags & PARK_FLAGS_NO_MONEY) || !Park::EntranceFeeUnlocked())
+    if ((park.flags & PARK_FLAGS_NO_MONEY) || !Park::EntranceFeeUnlocked(park))
         return false;
 
     if (park.totalRideValueForMoney < 10.00_GBP)
         return false;
 
-    if (Park::GetEntranceFee() + 0.10_GBP >= park.totalRideValueForMoney / 2)
+    if (Park::GetEntranceFee(park) + 0.10_GBP >= park.totalRideValueForMoney / 2)
         return false;
 
     return true;
@@ -238,7 +238,7 @@ static bool AwardIsDeservedWorstValue(GameState_t& gameState, int32_t activeAwar
     if (park.flags & PARK_FLAGS_NO_MONEY)
         return false;
 
-    const auto parkEntranceFee = Park::GetEntranceFee();
+    const auto parkEntranceFee = Park::GetEntranceFee(park);
     if (parkEntranceFee == 0.00_GBP)
         return false;
     if (parkEntranceFee <= park.totalRideValueForMoney)

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -57,16 +57,18 @@ uint16_t MarketingGetCampaignGuestGenerationProbability(int32_t campaignType)
     if (campaign == nullptr)
         return 0;
 
+    auto& park = getGameState().park;
+
     // Lower probability of guest generation if price was already low
     auto probability = AdvertisingCampaignGuestGenerationProbabilities[campaign->Type];
     switch (campaign->Type)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
-            if (Park::GetEntranceFee() < 4.00_GBP)
+            if (Park::GetEntranceFee(park) < 4.00_GBP)
                 probability /= 8;
             break;
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
-            if (Park::GetEntranceFee() < 6.00_GBP)
+            if (Park::GetEntranceFee(park) < 6.00_GBP)
                 probability /= 8;
             break;
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
@@ -186,17 +188,18 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaignType)
 bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 {
     auto& gameState = getGameState();
+    auto& park = gameState.park;
 
     switch (campaignType)
     {
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_FREE:
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
-            if (!Park::EntranceFeeUnlocked())
+            if (!Park::EntranceFeeUnlocked(park))
                 return false;
             return true;
 
         case ADVERTISING_CAMPAIGN_RIDE_FREE:
-            if (!Park::RidePricesUnlocked())
+            if (!Park::RidePricesUnlocked(park))
                 return false;
 
             [[fallthrough]];

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2830,7 +2830,8 @@ namespace OpenRCT2::Network
             auto loadOrQuitAction = GameActions::LoadOrQuitAction(
                 GameActions::LoadOrQuitModes::OpenSavePrompt, PromptMode::saveBeforeQuit);
 
-            loadOrQuitAction.Execute(getGameState());
+            auto& gameState = getGameState();
+            loadOrQuitAction.Execute(gameState, gameState.park);
         }
     }
 

--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -661,7 +661,7 @@ static void ApplyPathFixes(const json_t& scenarioPatch)
             auto footpathPlaceAction = GameActions::FootpathPlaceAction(
                 coordinate.ToCoordsXYZ(), slope, surfaceObjIndex, railingsObjIndex, direction, constructionFlags);
             auto& gameState = getGameState();
-            auto result = footpathPlaceAction.Execute(gameState);
+            auto result = footpathPlaceAction.Execute(gameState, gameState.park);
             if (result.error != GameActions::Status::ok)
             {
                 Guard::Assert(false, "Could not patch path");

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5074,11 +5074,12 @@ bool Ride::isRide() const
 
 money64 RideGetPrice(const Ride& ride)
 {
-    if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
+    auto& park = getGameState().park;
+    if (park.flags & PARK_FLAGS_NO_MONEY)
         return 0;
     if (ride.isRide())
     {
-        if (!Park::RidePricesUnlocked())
+        if (!Park::RidePricesUnlocked(park))
         {
             return 0;
         }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -226,7 +226,7 @@ static void ScenarioCheckEntranceFeeTooHigh()
     const auto& park = getGameState().park;
     const auto max_fee = AddClamp(park.totalRideValueForMoney, park.totalRideValueForMoney / 2);
 
-    if ((park.flags & PARK_FLAGS_PARK_OPEN) && Park::GetEntranceFee() > max_fee)
+    if ((park.flags & PARK_FLAGS_PARK_OPEN) && Park::GetEntranceFee(park) > max_fee)
     {
         if (!park.entrances.empty())
         {

--- a/src/openrct2/scripting/bindings/game/ScCheats.hpp
+++ b/src/openrct2/scripting/bindings/game/ScCheats.hpp
@@ -404,8 +404,13 @@ namespace OpenRCT2::Scripting
             JS_UNPACK_INT32(valueInt, ctx, value);
             JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
             int32_t adjusted = std::max(-1, std::min(valueInt, 999));
-            getGameState().cheats.forcedParkRating = adjusted;
-            Park::SetForcedRating(adjusted);
+
+            auto& gameState = getGameState();
+            auto& park = gameState.park;
+
+            gameState.cheats.forcedParkRating = adjusted;
+
+            Park::SetForcedRating(park, adjusted);
 
             return JS_UNDEFINED;
         }

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::Park
     static money64 calculateTotalRideValueForMoney(const ParkData& park, const GameState_t& gameState)
     {
         money64 totalRideValue = 0;
-        bool ridePricesUnlocked = RidePricesUnlocked() && !(gameState.park.flags & PARK_FLAGS_NO_MONEY);
+        bool ridePricesUnlocked = RidePricesUnlocked(park) && !(gameState.park.flags & PARK_FLAGS_NO_MONEY);
         for (auto& ride : RideManager(gameState))
         {
             if (ride.status != RideStatus::open)
@@ -190,7 +190,7 @@ namespace OpenRCT2::Park
         }
 
         // Penalty for overpriced entrance fee relative to total ride value
-        auto entranceFee = GetEntranceFee();
+        auto entranceFee = GetEntranceFee(park);
         if (entranceFee > park.totalRideValueForMoney)
         {
             probability /= 4;
@@ -263,10 +263,8 @@ namespace OpenRCT2::Park
         history[0] = newItem;
     }
 
-    void Initialise(GameState_t& gameState)
+    void Initialise(ParkData& park, GameState_t& gameState)
     {
-        auto& park = gameState.park;
-
         park.name = LanguageGetString(STR_UNNAMED_PARK);
         gameState.pluginStorage = {};
         park.staffHandymanColour = Drawing::Colour::brightRed;
@@ -627,7 +625,7 @@ namespace OpenRCT2::Park
         return tiles;
     }
 
-    void SetOpen(bool open)
+    void SetOpen(const ParkData& park, bool open)
     {
         auto parkSetParameter = GameActions::ParkSetParameterAction(
             open ? GameActions::ParkParameter::Open : GameActions::ParkParameter::Close);
@@ -713,12 +711,11 @@ namespace OpenRCT2::Park
         UpdateFences({ coords.x, coords.y - kCoordsXYStep });
     }
 
-    void SetForcedRating(int32_t rating)
+    void SetForcedRating(ParkData& park, int32_t rating)
     {
         auto& gameState = getGameState();
         gameState.cheats.forcedParkRating = rating;
 
-        auto& park = gameState.park;
         park.rating = CalculateParkRating(park, gameState);
 
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
@@ -730,16 +727,13 @@ namespace OpenRCT2::Park
         return getGameState().cheats.forcedParkRating;
     }
 
-    money64 GetEntranceFee()
+    money64 GetEntranceFee(const ParkData& park)
     {
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
-
         if (park.flags & PARK_FLAGS_NO_MONEY)
         {
             return 0;
         }
-        if (!EntranceFeeUnlocked())
+        if (!EntranceFeeUnlocked(park))
         {
             return 0;
         }
@@ -747,11 +741,8 @@ namespace OpenRCT2::Park
         return park.entranceFee;
     }
 
-    bool RidePricesUnlocked()
+    bool RidePricesUnlocked(const ParkData& park)
     {
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
-
         if (park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
         {
             return true;
@@ -763,11 +754,8 @@ namespace OpenRCT2::Park
         return false;
     }
 
-    bool EntranceFeeUnlocked()
+    bool EntranceFeeUnlocked(const ParkData& park)
     {
-        // TODO: pass park by ref
-        auto& park = getGameState().park;
-
         if (park.flags & PARK_FLAGS_UNLOCK_ALL_PRICES)
         {
             return true;

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -22,7 +22,7 @@ namespace OpenRCT2::Park
 {
     struct ParkData;
 
-    void Initialise(GameState_t& gameState);
+    void Initialise(ParkData& park, GameState_t& gameState);
     void Update(ParkData& park, GameState_t& gameState);
 
     uint32_t CalculateParkSize(ParkData& park);
@@ -34,7 +34,7 @@ namespace OpenRCT2::Park
 
     void ResetHistories(ParkData& park);
     void UpdateHistories(ParkData& park);
-    void SetForcedRating(int32_t rating);
+    void SetForcedRating(ParkData& park, int32_t rating);
     int32_t GetForcedRating();
 
     uint32_t UpdateSize(ParkData& park);
@@ -45,9 +45,9 @@ namespace OpenRCT2::Park
     uint8_t CalculateGuestInitialHappiness(uint8_t percentage);
 
     bool IsOpen(const ParkData& park);
-    void SetOpen(bool open);
-    money64 GetEntranceFee();
+    void SetOpen(const ParkData& park, bool open);
+    money64 GetEntranceFee(const ParkData& park);
 
-    bool RidePricesUnlocked();
-    bool EntranceFeeUnlocked();
+    bool RidePricesUnlocked(const ParkData& park);
+    bool EntranceFeeUnlocked(const ParkData& park);
 } // namespace OpenRCT2::Park

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -242,7 +242,7 @@ void SceneryRemoveGhostToolPlacement()
         auto removeSceneryAction = GameActions::SmallSceneryRemoveAction(
             gSceneryGhostPosition, gSceneryQuadrant, gSceneryPlaceObject.EntryIndex);
         removeSceneryAction.SetFlags({ CommandFlag::allowDuringPaused, CommandFlag::noSpend, CommandFlag::ghost });
-        removeSceneryAction.Execute(gameState);
+        GameActions::Execute(&removeSceneryAction, gameState);
     }
 
     if (gSceneryGhostType & SCENERY_GHOST_FLAG_1)
@@ -275,7 +275,7 @@ void SceneryRemoveGhostToolPlacement()
         CoordsXYZD wallLocation = { gSceneryGhostPosition, gSceneryGhostWallRotation };
         auto wallRemoveAction = GameActions::WallRemoveAction(wallLocation);
         wallRemoveAction.SetFlags({ CommandFlag::allowDuringPaused, CommandFlag::noSpend, CommandFlag::ghost });
-        wallRemoveAction.Execute(gameState);
+        GameActions::Execute(&wallRemoveAction, gameState);
     }
 
     if (gSceneryGhostType & SCENERY_GHOST_FLAG_3)
@@ -284,7 +284,7 @@ void SceneryRemoveGhostToolPlacement()
 
         auto removeSceneryAction = GameActions::LargeSceneryRemoveAction({ gSceneryGhostPosition, gSceneryPlaceRotation }, 0);
         removeSceneryAction.SetFlags({ CommandFlag::allowDuringPaused, CommandFlag::noSpend, CommandFlag::ghost });
-        removeSceneryAction.Execute(gameState);
+        GameActions::Execute(&removeSceneryAction, gameState);
     }
 
     if (gSceneryGhostType & SCENERY_GHOST_FLAG_4)


### PR DESCRIPTION
This passes a ref to the current `ParkData` struct down to game actions as they're being executed. To make this less cumbersome, I've opted to pass these down from the game action runner.

In the future, what `ParkData` struct to pass down will depend on what park the player is controlling -- doubly so in competitive multiplayer situations. This is a step towards making that possible.

I expect no differences in behaviour, but it doesn't hurt to do a quick test.