### PR TITLE
Fix selecting elements in tile inspector list and all track tiles invalidation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#25954] Guests display hats, balloons, and umbrellas while puking.
 - Fix: [#25978] Frozen peeps start clapping when the scenario is won.
 - Fix: [#25999] Scenery picker tool does not pick the tertiary colour of large scenery correctly.
+- Fix: [#26037] Selecting elements in the tile inspector list and changing all tiles of a track piece does not redraw correctly.
 
 0.4.31 (2026-02-01)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1849,6 +1849,7 @@ static uint64_t PageDisabledWidgets[] = {
                 windowTileInspectorSelectedIndex = index;
             }
             invalidate();
+            MapInvalidateTileFull(_toolMap);
         }
 
         void LoadTile(TileElement* elementToSelect)

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -769,6 +769,8 @@ namespace OpenRCT2::TileInspector
 
                 nextTrackElement->BaseHeight += offset;
                 nextTrackElement->ClearanceHeight += offset;
+
+                MapInvalidateTileFull(elem);
             }
         }
 

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -855,6 +855,8 @@ namespace OpenRCT2::TileInspector
                 {
                     nextTrackElement->AsTrack()->SetHasChain(setChain);
                 }
+
+                MapInvalidateTileFull(elem);
             }
         }
 


### PR DESCRIPTION
This invalidates tiles when selecting elements in the list, and changing all tiles of a track piece with the tile inspector.

Video of current behavior:

https://github.com/user-attachments/assets/92106862-41c6-4731-bc8f-6111fd4b3af8

