### PR TITLE
Refactor StationObject image indices

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4981,13 +4981,14 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             auto trackColour = ride->trackColours[0];
-            auto imageId = ImageId(stationObj->entranceBackIndex, trackColour.main, trackColour.additional);
 
             // Back
-            GfxDrawSprite(rt, imageId, { 34, 20 });
+            auto backImageId = ImageId(stationObj->entranceBackIndex, trackColour.main, trackColour.additional);
+            GfxDrawSprite(rt, backImageId, { 34, 20 });
 
             // Front
-            GfxDrawSprite(rt, imageId.WithIndexOffset(kNumOrthogonalDirections), { 34, 20 });
+            auto frontImageId = ImageId(stationObj->entranceFrontIndex, trackColour.main, trackColour.additional);
+            GfxDrawSprite(rt, frontImageId, { 34, 20 });
 
             // Glass
             if (stationObj->Flags & StationObjectFlags::isTransparent)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4977,22 +4977,22 @@ namespace OpenRCT2::Ui::Windows
         void ColourOnDrawEntrancePreview(RenderTarget& rt, const Ride* ride, const Widget& widget)
         {
             auto stationObj = ride->getStationObject();
-            if (stationObj == nullptr && stationObj->BaseImageId == kImageIndexUndefined)
+            if (stationObj == nullptr && stationObj->entranceBackIndex == kImageIndexUndefined)
                 return;
 
             auto trackColour = ride->trackColours[0];
-            auto imageId = ImageId(stationObj->BaseImageId, trackColour.main, trackColour.additional);
+            auto imageId = ImageId(stationObj->entranceBackIndex, trackColour.main, trackColour.additional);
 
             // Back
             GfxDrawSprite(rt, imageId, { 34, 20 });
 
             // Front
-            GfxDrawSprite(rt, imageId.WithIndexOffset(4), { 34, 20 });
+            GfxDrawSprite(rt, imageId.WithIndexOffset(kNumOrthogonalDirections), { 34, 20 });
 
             // Glass
             if (stationObj->Flags & StationObjectFlags::isTransparent)
             {
-                auto glassImageId = ImageId(stationObj->BaseImageId + 20).WithTransparency(trackColour.main);
+                auto glassImageId = ImageId(stationObj->entranceFrontGlassIndex).WithTransparency(trackColour.main);
                 GfxDrawSprite(rt, glassImageId, { 34, 20 });
             }
         }

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -50,10 +50,10 @@ namespace OpenRCT2
         exitFrontGlassIndex = entranceBackIndex + 28;
 
         if (numImages > 32)
-        {
             shelterIndex = entranceBackIndex + 32;
+
+        if (numImages > 44)
             shelterGlassIndex = entranceBackIndex + 44;
-        }
     }
 
     void StationObject::Unload()

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -37,7 +37,9 @@ namespace OpenRCT2
 
         if (!(Flags & StationObjectFlags::isTransparent))
         {
-            shelterIndex = baseImageIndex + 16;
+            if (numImages > 16)
+                shelterIndex = baseImageIndex + 16;
+
             return;
         }
 
@@ -47,8 +49,11 @@ namespace OpenRCT2
         exitBackGlassIndex = baseImageIndex + 24;
         exitFrontGlassIndex = baseImageIndex + 28;
 
-        shelterIndex = baseImageIndex + 32;
-        shelterGlassIndex = baseImageIndex + 44;
+        if (numImages > 32)
+        {
+            shelterIndex = baseImageIndex + 32;
+            shelterGlassIndex = baseImageIndex + 44;
+        }
     }
 
     void StationObject::Unload()

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -58,7 +58,19 @@ namespace OpenRCT2
 
         NameStringId = 0;
         baseImageIndex = kImageIndexUndefined;
+
+        entranceBackIndex = kImageIndexUndefined;
+        entranceFrontIndex = kImageIndexUndefined;
+        exitBackIndex = kImageIndexUndefined;
+        exitFrontIndex = kImageIndexUndefined;
+
+        entranceBackGlassIndex = kImageIndexUndefined;
+        entranceFrontGlassIndex = kImageIndexUndefined;
+        exitBackGlassIndex = kImageIndexUndefined;
+        exitFrontGlassIndex = kImageIndexUndefined;
+
         shelterIndex = kImageIndexUndefined;
+        shelterGlassIndex = kImageIndexUndefined;
     }
 
     void StationObject::DrawPreview(Drawing::RenderTarget& rt, int32_t width, int32_t height) const

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -30,29 +30,29 @@ namespace OpenRCT2
         baseImageIndex = LoadImages();
 
         entranceBackIndex = baseImageIndex;
-        entranceFrontIndex = baseImageIndex + 4;
+        entranceFrontIndex = entranceBackIndex + 4;
 
-        exitBackIndex = baseImageIndex + 8;
-        exitFrontIndex = baseImageIndex + 12;
+        exitBackIndex = entranceBackIndex + 8;
+        exitFrontIndex = entranceBackIndex + 12;
 
         if (!(Flags & StationObjectFlags::isTransparent))
         {
             if (numImages > 16)
-                shelterIndex = baseImageIndex + 16;
+                shelterIndex = entranceBackIndex + 16;
 
             return;
         }
 
-        entranceBackGlassIndex = baseImageIndex + 16;
-        entranceFrontGlassIndex = baseImageIndex + 20;
+        entranceBackGlassIndex = entranceBackIndex + 16;
+        entranceFrontGlassIndex = entranceBackIndex + 20;
 
-        exitBackGlassIndex = baseImageIndex + 24;
-        exitFrontGlassIndex = baseImageIndex + 28;
+        exitBackGlassIndex = entranceBackIndex + 24;
+        exitFrontGlassIndex = entranceBackIndex + 28;
 
         if (numImages > 32)
         {
-            shelterIndex = baseImageIndex + 32;
-            shelterGlassIndex = baseImageIndex + 44;
+            shelterIndex = entranceBackIndex + 32;
+            shelterGlassIndex = entranceBackIndex + 44;
         }
     }
 

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -69,29 +69,22 @@ namespace OpenRCT2
         auto colour1 = Drawing::Colour::bordeauxRed;
         auto tcolour0 = colour0;
 
-        auto imageId = ImageId(entranceBackIndex);
-        auto tImageId = ImageId(entranceBackGlassIndex).WithTransparency(tcolour0);
-        if (Flags & StationObjectFlags::hasPrimaryColour)
-        {
-            imageId = imageId.WithPrimary(colour0);
-        }
-        if (Flags & StationObjectFlags::hasSecondaryColour)
-        {
-            imageId = imageId.WithSecondary(colour1);
-        }
-
         // Draw back sprite
-        GfxDrawSprite(rt, imageId, screenCoords);
+        auto backImageId = ImageId(entranceBackIndex, colour0, colour1);
+        GfxDrawSprite(rt, backImageId, screenCoords);
         if (Flags & StationObjectFlags::isTransparent)
         {
+            auto tImageId = ImageId(entranceBackGlassIndex).WithTransparency(tcolour0);
             GfxDrawSprite(rt, tImageId, screenCoords);
         }
 
         // Draw front sprite
-        GfxDrawSprite(rt, imageId.WithIndexOffset(kNumOrthogonalDirections), screenCoords);
+        auto frontImageId = ImageId(entranceFrontIndex, colour0, colour1);
+        GfxDrawSprite(rt, frontImageId, screenCoords);
         if (Flags & StationObjectFlags::isTransparent)
         {
-            GfxDrawSprite(rt, tImageId.WithIndexOffset(kNumOrthogonalDirections), screenCoords);
+            auto frontGlassImageId = ImageId(entranceFrontGlassIndex).WithTransparency(tcolour0);
+            GfxDrawSprite(rt, frontGlassImageId, screenCoords);
         }
     }
 

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -24,31 +24,31 @@ namespace OpenRCT2
         NameStringId = LanguageAllocateObjectString(GetName());
 
         auto numImages = GetImageTable().GetCount();
-        if (numImages != 0)
+        if (numImages == 0)
+            return;
+
+        baseImageIndex = LoadImages();
+
+        entranceBackIndex = baseImageIndex;
+        entranceFrontIndex = baseImageIndex + 4;
+
+        exitBackIndex = baseImageIndex + 8;
+        exitFrontIndex = baseImageIndex + 12;
+
+        if (!(Flags & StationObjectFlags::isTransparent))
         {
-            baseImageIndex = LoadImages();
-
-            entranceBackIndex = baseImageIndex;
-            entranceFrontIndex = baseImageIndex + 4;
-
-            exitBackIndex = baseImageIndex + 8;
-            exitFrontIndex = baseImageIndex + 12;
-
-            if (!(Flags & StationObjectFlags::isTransparent))
-            {
-                shelterIndex = baseImageIndex + 16;
-                return;
-            }
-
-            entranceBackGlassIndex = baseImageIndex + 16;
-            entranceFrontGlassIndex = baseImageIndex + 20;
-
-            exitBackGlassIndex = baseImageIndex + 24;
-            exitFrontGlassIndex = baseImageIndex + 28;
-
-            shelterIndex = baseImageIndex + 32;
-            shelterGlassIndex = baseImageIndex + 44;
+            shelterIndex = baseImageIndex + 16;
+            return;
         }
+
+        entranceBackGlassIndex = baseImageIndex + 16;
+        entranceFrontGlassIndex = baseImageIndex + 20;
+
+        exitBackGlassIndex = baseImageIndex + 24;
+        exitFrontGlassIndex = baseImageIndex + 28;
+
+        shelterIndex = baseImageIndex + 32;
+        shelterGlassIndex = baseImageIndex + 44;
     }
 
     void StationObject::Unload()

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -26,13 +26,28 @@ namespace OpenRCT2
         auto numImages = GetImageTable().GetCount();
         if (numImages != 0)
         {
-            BaseImageId = LoadImages();
+            baseImageIndex = LoadImages();
 
-            uint32_t shelterOffset = (Flags & StationObjectFlags::isTransparent) ? 32 : 16;
-            if (numImages > shelterOffset)
+            entranceBackIndex = baseImageIndex;
+            entranceFrontIndex = baseImageIndex + 4;
+
+            exitBackIndex = baseImageIndex + 8;
+            exitFrontIndex = baseImageIndex + 12;
+
+            if (!(Flags & StationObjectFlags::isTransparent))
             {
-                ShelterImageId = BaseImageId + shelterOffset;
+                shelterIndex = baseImageIndex + 16;
+                return;
             }
+
+            entranceBackGlassIndex = baseImageIndex + 16;
+            entranceFrontGlassIndex = baseImageIndex + 20;
+
+            exitBackGlassIndex = baseImageIndex + 24;
+            exitFrontGlassIndex = baseImageIndex + 28;
+
+            shelterIndex = baseImageIndex + 32;
+            shelterGlassIndex = baseImageIndex + 44;
         }
     }
 
@@ -42,8 +57,8 @@ namespace OpenRCT2
         UnloadImages();
 
         NameStringId = 0;
-        BaseImageId = kImageIndexUndefined;
-        ShelterImageId = kImageIndexUndefined;
+        baseImageIndex = kImageIndexUndefined;
+        shelterIndex = kImageIndexUndefined;
     }
 
     void StationObject::DrawPreview(Drawing::RenderTarget& rt, int32_t width, int32_t height) const
@@ -54,8 +69,8 @@ namespace OpenRCT2
         auto colour1 = Drawing::Colour::bordeauxRed;
         auto tcolour0 = colour0;
 
-        auto imageId = ImageId(BaseImageId);
-        auto tImageId = ImageId(BaseImageId + 16).WithTransparency(tcolour0);
+        auto imageId = ImageId(entranceBackIndex);
+        auto tImageId = ImageId(entranceBackGlassIndex).WithTransparency(tcolour0);
         if (Flags & StationObjectFlags::hasPrimaryColour)
         {
             imageId = imageId.WithPrimary(colour0);
@@ -65,16 +80,18 @@ namespace OpenRCT2
             imageId = imageId.WithSecondary(colour1);
         }
 
+        // Draw back sprite
         GfxDrawSprite(rt, imageId, screenCoords);
         if (Flags & StationObjectFlags::isTransparent)
         {
             GfxDrawSprite(rt, tImageId, screenCoords);
         }
 
-        GfxDrawSprite(rt, imageId.WithIndexOffset(4), screenCoords);
+        // Draw front sprite
+        GfxDrawSprite(rt, imageId.WithIndexOffset(kNumOrthogonalDirections), screenCoords);
         if (Flags & StationObjectFlags::isTransparent)
         {
-            GfxDrawSprite(rt, tImageId.WithIndexOffset(4), screenCoords);
+            GfxDrawSprite(rt, tImageId.WithIndexOffset(kNumOrthogonalDirections), screenCoords);
         }
     }
 

--- a/src/openrct2/object/StationObject.h
+++ b/src/openrct2/object/StationObject.h
@@ -20,8 +20,19 @@ namespace OpenRCT2
         const uint32_t hasSecondaryColour = 1 << 1;
         const uint32_t isTransparent = 1 << 2;
         const uint32_t noPlatforms = 1 << 3;
-        const uint32_t hasShelter = (1 << 4);
+        const uint32_t hasShelter = 1 << 4;
     } // namespace StationObjectFlags
+
+    enum
+    {
+        SPR_STATION_COVER_OFFSET_NE_SW_BACK_0 = 0,
+        SPR_STATION_COVER_OFFSET_NE_SW_BACK_1,
+        SPR_STATION_COVER_OFFSET_NE_SW_FRONT,
+        SPR_STATION_COVER_OFFSET_SE_NW_BACK_0,
+        SPR_STATION_COVER_OFFSET_SE_NW_BACK_1,
+        SPR_STATION_COVER_OFFSET_SE_NW_FRONT,
+        SPR_STATION_COVER_OFFSET_TALL
+    };
 
     class StationObject final : public Object
     {
@@ -29,8 +40,22 @@ namespace OpenRCT2
         static constexpr ObjectType kObjectType = ObjectType::station;
 
         StringId NameStringId{};
-        ImageIndex BaseImageId = kImageIndexUndefined;
-        ImageIndex ShelterImageId = kImageIndexUndefined;
+
+        ImageIndex baseImageIndex = kImageIndexUndefined;
+
+        ImageIndex entranceBackIndex = kImageIndexUndefined;
+        ImageIndex entranceFrontIndex = kImageIndexUndefined;
+        ImageIndex exitBackIndex = kImageIndexUndefined;
+        ImageIndex exitFrontIndex = kImageIndexUndefined;
+
+        ImageIndex entranceBackGlassIndex = kImageIndexUndefined;
+        ImageIndex entranceFrontGlassIndex = kImageIndexUndefined;
+        ImageIndex exitBackGlassIndex = kImageIndexUndefined;
+        ImageIndex exitFrontGlassIndex = kImageIndexUndefined;
+
+        ImageIndex shelterIndex = kImageIndexUndefined;
+        ImageIndex shelterGlassIndex = kImageIndexUndefined;
+
         uint32_t Flags{};
         int32_t Height{};
         uint8_t ScrollingMode{};

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -167,27 +167,30 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
     auto isExit = entranceEl.GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT;
 
     // Back
-    ImageIndex imageIndex = (isExit ? stationObj->exitBackIndex : stationObj->entranceBackIndex) + direction;
-    ImageIndex glassImageIndex = (isExit ? stationObj->exitBackGlassIndex : stationObj->entranceBackGlassIndex) + direction;
+    ImageIndex backImageIndex = (isExit ? stationObj->exitBackIndex : stationObj->entranceBackIndex) + direction;
     PaintAddImageAsParentRotated(
-        session, direction, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height }, { 28, 8, 30 } });
+        session, direction, imageTemplate.WithIndex(backImageIndex), { 0, 0, height }, { { 2, 2, height }, { 28, 8, 30 } });
     if (hasGlass)
     {
+        ImageIndex backGlassImageIndex = (isExit ? stationObj->exitBackGlassIndex : stationObj->entranceBackGlassIndex)
+            + direction;
         PaintAddImageAsChildRotated(
-            session, direction, glassImageTemplate.WithIndex(glassImageIndex), { 0, 0, height },
+            session, direction, glassImageTemplate.WithIndex(backGlassImageIndex), { 0, 0, height },
             { { 2, 2, height }, { 28, 8, 30 } });
     }
 
     // Front
     const auto frontBoundBoxZ = isExit ? 1 : 17;
-    imageIndex += kNumOrthogonalDirections;
+    ImageIndex frontImageIndex = (isExit ? stationObj->exitFrontIndex : stationObj->entranceFrontIndex) + direction;
     PaintAddImageAsParent(
-        session, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });
+        session, imageTemplate.WithIndex(frontImageIndex), { 0, 0, height },
+        { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });
     if (hasGlass)
     {
-        glassImageIndex += kNumOrthogonalDirections;
+        ImageIndex frontGlassImageIndex = (isExit ? stationObj->exitFrontGlassIndex : stationObj->entranceFrontGlassIndex)
+            + direction;
         PaintAddImageAsChild(
-            session, glassImageTemplate.WithIndex(glassImageIndex), { 0, 0, height },
+            session, glassImageTemplate.WithIndex(frontGlassImageIndex), { 0, 0, height },
             { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });
     }
 

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -119,7 +119,7 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
     }
 
     auto stationObj = ride->getStationObject();
-    if (stationObj == nullptr || stationObj->BaseImageId == kImageIndexUndefined)
+    if (stationObj == nullptr || stationObj->baseImageIndex == kImageIndexUndefined)
     {
         return;
     }
@@ -167,8 +167,8 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
     auto isExit = entranceEl.GetEntranceType() == ENTRANCE_TYPE_RIDE_EXIT;
 
     // Back
-    ImageIndex imageIndex = isExit ? stationObj->BaseImageId + direction + 8 : stationObj->BaseImageId + direction;
-    ImageIndex glassImageIndex = isExit ? stationObj->BaseImageId + direction + 24 : stationObj->BaseImageId + direction + 16;
+    ImageIndex imageIndex = (isExit ? stationObj->exitBackIndex : stationObj->entranceBackIndex) + direction;
+    ImageIndex glassImageIndex = (isExit ? stationObj->exitBackGlassIndex : stationObj->entranceBackGlassIndex) + direction;
     PaintAddImageAsParentRotated(
         session, direction, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height }, { 28, 8, 30 } });
     if (hasGlass)
@@ -180,12 +180,12 @@ static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int3
 
     // Front
     const auto frontBoundBoxZ = isExit ? 1 : 17;
-    imageIndex += 4;
+    imageIndex += kNumOrthogonalDirections;
     PaintAddImageAsParent(
         session, imageTemplate.WithIndex(imageIndex), { 0, 0, height }, { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });
     if (hasGlass)
     {
-        glassImageIndex += 4;
+        glassImageIndex += kNumOrthogonalDirections;
         PaintAddImageAsChild(
             session, glassImageTemplate.WithIndex(glassImageIndex), { 0, 0, height },
             { { 2, 2, height + 30 }, { 28, 28, frontBoundBoxZ } });

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -85,17 +85,6 @@ static constexpr uint32_t trackSpritesGhostTrainSpinningTunnel[2][2][4] = {
     },
 };
 
-enum
-{
-    SPR_STATION_COVER_OFFSET_NE_SW_BACK_0 = 0,
-    SPR_STATION_COVER_OFFSET_NE_SW_BACK_1,
-    SPR_STATION_COVER_OFFSET_NE_SW_FRONT,
-    SPR_STATION_COVER_OFFSET_SE_NW_BACK_0,
-    SPR_STATION_COVER_OFFSET_SE_NW_BACK_1,
-    SPR_STATION_COVER_OFFSET_SE_NW_FRONT,
-    SPR_STATION_COVER_OFFSET_TALL
-};
-
 bool TrackPaintUtilHasFence(
     enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride, uint8_t rotation)
 {
@@ -670,8 +659,8 @@ bool TrackPaintUtilDrawStationCovers2(
         return false;
     }
 
-    auto baseImageIndex = stationObject->ShelterImageId;
-    if (baseImageIndex == kImageIndexUndefined)
+    auto shelterImageIndex = stationObject->shelterIndex;
+    if (shelterImageIndex == kImageIndexUndefined)
         return false;
 
     static constexpr int16_t heights[][2] = {
@@ -708,10 +697,10 @@ bool TrackPaintUtilDrawStationCovers2(
         imageOffset += SPR_STATION_COVER_OFFSET_TALL;
     }
 
-    auto imageId = session.TrackColours.WithIndex(baseImageIndex + imageOffset);
+    auto imageId = session.TrackColours.WithIndex(shelterImageIndex + imageOffset);
     if (!session.TrackColours.IsRemap())
     {
-        imageId = ImageId(baseImageIndex + imageOffset);
+        imageId = ImageId(shelterImageIndex + imageOffset);
         if (stationObject->Flags & StationObjectFlags::hasPrimaryColour)
             imageId = imageId.WithPrimary(session.TrackColours.GetPrimary());
         if (stationObject->Flags & StationObjectFlags::hasSecondaryColour)
@@ -723,7 +712,8 @@ bool TrackPaintUtilDrawStationCovers2(
     // Glass
     if (colour == TrackStationColour && (stationObject->Flags & StationObjectFlags::isTransparent))
     {
-        imageId = ImageId(baseImageIndex + imageOffset + 12).WithTransparency(session.TrackColours.GetPrimary());
+        auto shelterGlassImageIndex = stationObject->shelterGlassIndex;
+        imageId = ImageId(shelterGlassImageIndex + imageOffset).WithTransparency(session.TrackColours.GetPrimary());
         PaintAddImageAsChild(session, imageId, offset, boundBox);
     }
     return true;
@@ -737,6 +727,7 @@ bool TrackPaintUtilDrawNarrowStationPlatform(
     const auto* stationObj = ride.getStationObject();
     if (stationObj != nullptr && stationObj->Flags & StationObjectFlags::noPlatforms)
         return false;
+
     auto colour = GetStationColourScheme(session, trackElement);
     if (direction & 1)
     {


### PR DESCRIPTION
This reworks handling of `StationObject` to rely less on magic numbers. This is done by providing the necessary image offsets for entrances, exits, and shelters directly from the object.

Added benefit of this refactor is that it becomes easier to append more images to the objects' image table in the near future, e.g. icons for entrance/icon/shelter selection.