### PR TITLE
Android: add support for bundled assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,10 +176,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: Build graphics .dat files
         run: |
-          gxc build g2.dat OpenRCT2/resources/g2/sprites.json
-          gxc build palettes.dat OpenRCT2/resources/palettes/sprites.json
-          gxc build fonts.dat OpenRCT2/resources/fonts/sprites.json
-          gxc build tracks.dat OpenRCT2/resources/tracks/sprites.json
+          OpenRCT2/scripts/build-graphics-dat "$PWD"
       - name: Upload graphics .dat files
         uses: actions/upload-artifact@v6
         with:
@@ -648,14 +645,18 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ hashFiles('src/openrct2-android/gradle.properties') }}
+          # The cache key needs to occasionally be updated as the cache itself is immutable, otherwise it can grow stale. The easiest way to force this is to include the tag, which changes every month.
+          # Keep in sync with the cache key used in the `android` job.
+          key: gradle-${{ runner.os }}-${{ needs.build_variables.outputs.tag }}-android-${{ hashFiles('src/openrct2-android/build.gradle', 'src/openrct2-android/settings.gradle', 'src/openrct2-android/app/build.gradle', 'src/openrct2-android/gradle.properties', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ needs.build_variables.outputs.tag }}-android-
       - name: Install GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build Native Libs
         run: |
           . scripts/setenv
           pushd src/openrct2-android
-          ./gradlew app:externalNativeBuildRelease -PabiFilter=${{ matrix.arch }}
+          ./gradlew app:externalNativeBuildRelease -PabiFilter=${{ matrix.arch }} -PskipAssets -PskipJava
           popd
       - name: Upload Native Libs
         uses: actions/upload-artifact@v6
@@ -667,8 +668,8 @@ jobs:
   android:
     name: Android
     runs-on: ubuntu-latest
-    needs: [android-libs, build_variables]
-    container: openrct2/openrct2-build:25-android
+    needs: [android-libs, build_variables, g2dat]
+    container: ghcr.io/openrct2/openrct2-build:26-android
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -678,7 +679,10 @@ jobs:
           # The gradle cache is by default ~/.gradle/caches, but ~ gets resolved by GitHub Actions to the runner's
           # home directory (/home/github), not the user inside the container (/root). Name the path explicitly.
           path: /root/.gradle/caches
-          key: gradle-${{ hashFiles('src/openrct2-android/gradle.properties') }}
+          # Keep in sync with the cache key used in the `android-libs` job.
+          key: gradle-${{ runner.os }}-${{ needs.build_variables.outputs.tag }}-android-${{ hashFiles('src/openrct2-android/build.gradle', 'src/openrct2-android/settings.gradle', 'src/openrct2-android/app/build.gradle', 'src/openrct2-android/gradle.properties', 'src/openrct2-android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ needs.build_variables.outputs.tag }}-android-
       - name: Setup keystore
         run: |
           echo "${{ secrets.OPENRCT2_KEYSTORE_CONTENTS }}" | base64 -d > keystore.jks
@@ -700,9 +704,15 @@ jobs:
               echo "::warning title=Missing libraries::Warning: No libs found for $arch"
             fi
           done
+      - name: Download graphics .dat files
+        uses: actions/download-artifact@v7
+        with:
+          name: graphics-${{ needs.build_variables.outputs.name }}
+          path: bin/data
       - name: Build OpenRCT2
         run: |
           . scripts/setenv
+          export OPENRCT2_DAT_DIR="$GITHUB_WORKSPACE/bin/data"
           pushd src/openrct2-android
           ./gradlew app:assembleRelease -PskipNativeBuild
           popd

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#26178] Port of the Spinning Cars from RollerCoaster Tycoon 1.
 - Improved: [#25314] Add unbanked and banked quarter helices to the Alpine, Corkscrew, Giga, Hybrid, Looping, Mine Ride, Mini, Multi-Dimension, Single Rail, Stand Up and Twister tracks.
+- Improved: [#26044] Simplify Android installation by bundling OpenRCT2 assets in APK.
 - Change: [#25962] The station style dropdown now shows entrance icons next to the labels for easier selection.
 - Change: [#26178] Symmetric spinning trains and legacy ‘pre-reversed’ trains can no longer be reversed.
 - Fix: [#10616] Quarter-tile trees cannot be placed on dry portions of half-water tiles.

--- a/scripts/build-graphics-dat
+++ b/scripts/build-graphics-dat
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-}"
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    echo "Usage: $(basename "$0") <output-dir>" >&2
+    exit 2
+fi
+
+if ! command -v gxc >/dev/null 2>&1; then
+    echo "ERROR: gxc not found in PATH." >&2
+    echo "Download gxc from https://github.com/OpenRCT2/libsawyer/releases" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+gxc build "$OUTPUT_DIR/g2.dat" "$ROOT_DIR/resources/g2/sprites.json"
+gxc build "$OUTPUT_DIR/palettes.dat" "$ROOT_DIR/resources/palettes/sprites.json"
+gxc build "$OUTPUT_DIR/fonts.dat" "$ROOT_DIR/resources/fonts/sprites.json"
+gxc build "$OUTPUT_DIR/tracks.dat" "$ROOT_DIR/resources/tracks/sprites.json"

--- a/scripts/prepare-android-assets
+++ b/scripts/prepare-android-assets
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ASSETS_DIR="$ROOT_DIR/src/openrct2-android/app/src/main/assets/openrct2"
+DATA_DIR="$ASSETS_DIR/data"
+
+mkdir -p "$DATA_DIR"
+
+DAT_DIR="${OPENRCT2_DAT_DIR:-}"
+if [[ -n "$DAT_DIR" && -f "$DAT_DIR/g2.dat" ]]; then
+    cp "$DAT_DIR"/*.dat "$DATA_DIR/"
+else
+    TMP_DIR="$(mktemp -d)"
+    "$ROOT_DIR/scripts/build-graphics-dat" "$TMP_DIR"
+    cp "$TMP_DIR"/*.dat "$DATA_DIR/"
+    rm -rf "$TMP_DIR"
+fi
+
+cp -r "$ROOT_DIR/data/language" "$DATA_DIR/"
+cp -r "$ROOT_DIR/data/shaders" "$DATA_DIR/"
+cp -r "$ROOT_DIR/data/scenario_patches" "$DATA_DIR/"
+cp "$ROOT_DIR/distribution/changelog.txt" "$DATA_DIR/"
+cp "$ROOT_DIR/contributors.md" "$DATA_DIR/"
+
+OBJECTS_URL=$(jq -r '.objects.url' "$ROOT_DIR/assets.json")
+TS_URL=$(jq -r '."title-sequences".url' "$ROOT_DIR/assets.json")
+
+curl -fL "$OBJECTS_URL" -o "$DATA_DIR/objects.zip"
+mkdir -p "$DATA_DIR/object"
+unzip -q "$DATA_DIR/objects.zip" -d "$DATA_DIR/object"
+rm -f "$DATA_DIR/objects.zip"
+
+curl -fL "$TS_URL" -o "$DATA_DIR/title-sequences.zip"
+mkdir -p "$DATA_DIR/sequence"
+unzip -q "$DATA_DIR/title-sequences.zip" -d "$DATA_DIR/sequence"
+rm -f "$DATA_DIR/title-sequences.zip"
+
+pushd "$ROOT_DIR/src/openrct2-android/app/src/main/assets" >/dev/null
+find openrct2 -type f ! -name manifest.txt -printf "%p|%s\n" > openrct2/manifest.txt
+popd >/dev/null

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -68,6 +68,52 @@ android {
     lintOptions {
         abortOnError = false
     }
+
+    androidResources {
+        noCompress 'parkseq', 'zip', 'dat', 'parkobj'
+    }
+}
+
+def prepareAndroidAssetsScript = "${rootProject.projectDir}/../../scripts/prepare-android-assets"
+tasks.register('prepareOpenRCT2Assets', Exec) {
+    workingDir rootProject.projectDir
+    commandLine 'bash', prepareAndroidAssetsScript
+    inputs.file(prepareAndroidAssetsScript)
+    inputs.file("${rootProject.projectDir}/../../assets.json")
+    inputs.file("${rootProject.projectDir}/../../contributors.md")
+    inputs.file("${rootProject.projectDir}/../../distribution/changelog.txt")
+    inputs.file("${rootProject.projectDir}/../../resources/fonts/sprites.json")
+    inputs.file("${rootProject.projectDir}/../../resources/g2/sprites.json")
+    inputs.file("${rootProject.projectDir}/../../resources/palettes/sprites.json")
+    inputs.file("${rootProject.projectDir}/../../resources/tracks/sprites.json")
+    inputs.dir("${rootProject.projectDir}/../../data/language")
+    inputs.dir("${rootProject.projectDir}/../../data/shaders")
+    inputs.dir("${rootProject.projectDir}/../../data/scenario_patches")
+    outputs.dir("${projectDir}/src/main/assets/openrct2")
+}
+
+if (!project.hasProperty('skipAssets')) {
+    preBuild.dependsOn(tasks.named('prepareOpenRCT2Assets'))
+}
+
+// When the `skipJava` property is set, skip all Java-related tasks.
+// This is used in CI so native libraries can be built in separate jobs for each ABI to speed up our builds.
+if (project.hasProperty('skipJava')) {
+    tasks.withType(JavaCompile).configureEach {
+        enabled = false
+    }
+    def skippablePrefixes = ["process", "merge", "generate", "compile", "lint", "check"]
+    def skippableKeywords = ["Java", "Resources", "Manifest", "Asset", "Lint", "Runtime"]
+    tasks.configureEach { task ->
+        def name = task.name
+        def hasPrefix = skippablePrefixes.any { name.startsWith(it) }
+        def hasKeyword = skippableKeywords.any { name.contains(it) }
+        if (hasPrefix && hasKeyword) {
+            if (!name.contains("externalNativeBuild") && !name.contains("CMake") && !name.contains("Ninja")) {
+                task.enabled = false
+            }
+        }
+    }
 }
 
 dependencies {

--- a/src/openrct2-android/app/src/main/java/io/openrct2/MainActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/MainActivity.java
@@ -32,7 +32,6 @@ import java.io.InputStream;
 public class MainActivity extends AppCompatActivity {
 
     public static final String TAG = "OpenRCT2";
-    private boolean assetsCopied = false;
 
     @Override
     public void onRequestPermissionsResult(
@@ -144,7 +143,6 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void startGame() {
-        copyAssets(); // TODO Don't copy/enumerate assets on every startup
         Intent intent = new Intent(this, GameActivity.class);
         if (getIntent().hasExtra("commandLineArgs")) {
             intent.putExtra("commandLineArgs", getIntent().getStringArrayExtra("commandLineArgs"));
@@ -152,50 +150,4 @@ public class MainActivity extends AppCompatActivity {
         startActivity(intent);
         finish();
     }
-
-    // TODO Don't copy/enumerate assets on every startup
-    // When building, ensure OpenRCT2 assets are inside their own directory within the APK assets,
-    // so that we do not attempt to copy files out of the standard Android asset folders - webkit, etc.
-    private void copyAssets() {
-        File dataDir = new File(Environment.getExternalStorageDirectory().toString()
-            + File.separator + "openrct2" + File.separator);
-
-        try {
-            copyAsset(getAssets(), "openrct2", dataDir, "");
-        } catch (IOException e) {
-            Log.e(TAG, "Error extracting files", e);
-            return;
-        }
-
-        assetsCopied = true;
-    }
-
-    // srcPath cannot be the empty string
-    private void copyAsset(AssetManager assets, String srcPath, File dataDir, String destPath) throws IOException {
-        String[] list = assets.list(srcPath);
-
-        if (list.length == 0) {
-            InputStream input = assets.open(srcPath);
-            File extractedFile = new File(dataDir, destPath);
-            File parentFile = extractedFile.getParentFile();
-            if (!parentFile.exists()) {
-                boolean success = parentFile.mkdirs();
-                if (!success) {
-                    Log.d(TAG, String.format("Error creating folder '%s'", parentFile));
-                }
-            }
-            FileOutputStream output = new FileOutputStream(extractedFile);
-            IOUtils.copyLarge(input, output);
-            output.close();
-            input.close();
-            return;
-        }
-
-        for (String fileName : list) {
-            // This ternary expression makes sure that this string does not begin with a slash
-            String destination = destPath + (destPath.isEmpty() ? "" : File.separator) + fileName;
-            copyAsset(assets, srcPath + File.separator + fileName, dataDir, destination);
-        }
-    }
-
 }

--- a/src/openrct2-android/app/src/main/java/io/openrct2/PlatformConstants.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/PlatformConstants.java
@@ -1,0 +1,24 @@
+package io.openrct2;
+
+/**
+ * Platform constants exposed from C++ via JNI.
+ * These constants are defined in the native code and exposed to Java to ensure
+ * the same definitions are used in both languages.
+ */
+public class PlatformConstants {
+    static {
+        System.loadLibrary("openrct2");
+    }
+
+    /**
+     * Android asset path prefix.
+     * This constant is retrieved from the native C++ code to ensure consistency.
+     */
+    public static final String ANDROID_ASSET_PATH_PREFIX = getAndroidAssetPathPrefix();
+
+    /**
+     * Native method to get the Android asset path prefix from C++.
+     * Defined in src/openrct2/platform/Platform.Android.cpp
+     */
+    private static native String getAndroidAssetPathPrefix();
+}

--- a/src/openrct2-android/app/src/main/java/io/openrct2/ZipArchive.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/ZipArchive.java
@@ -1,36 +1,75 @@
 package io.openrct2;
 
+import android.content.Context;
+import android.content.res.AssetManager;
 import android.util.Log;
 
 import org.apache.commons.io.IOUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 public class ZipArchive {
+    private ZipFile _zipArchive;
+    private List<String> _entryNames = new ArrayList<>();
+    private Map<String, byte[]> _entries = new HashMap<>();
 
-    private final ZipFile _zipArchive;
-
-    public ZipArchive(String path) throws IOException {
-        _zipArchive = new ZipFile(path);
+    public ZipArchive(Context context, String path) throws IOException {
+        if (path.startsWith(PlatformConstants.ANDROID_ASSET_PATH_PREFIX))
+        {
+            String assetPath = path.substring(PlatformConstants.ANDROID_ASSET_PATH_PREFIX.length());
+            AssetManager assetManager = context.getAssets();
+            try (InputStream is = assetManager.open(assetPath); ZipInputStream zis = new ZipInputStream(is)) {
+                _entryNames = new ArrayList<>();
+                _entries = new HashMap<>();
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null)
+                {
+                    byte[] data = IOUtils.toByteArray(zis);
+                    _entryNames.add(entry.getName());
+                    _entries.put(entry.getName().toLowerCase(), data);
+                    zis.closeEntry();
+                }
+            }
+        } else {
+            _zipArchive = new ZipFile(path);
+        }
     }
 
     public void close() {
         try {
-            _zipArchive.close();
+            if (_zipArchive != null) {
+                _zipArchive.close();
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }
+        _entries.clear();
+        _entryNames.clear();
     }
 
     public int getNumFiles() {
-        return _zipArchive.size();
+        if (_zipArchive != null) {
+            return _zipArchive.size();
+        }
+        return _entryNames.size();
     }
 
     private ZipEntry getZipEntry(int index) {
+        if (_zipArchive == null) {
+            return null;
+        }
         Enumeration<? extends ZipEntry> entries = _zipArchive.entries();
 
         int i = 0;
@@ -47,61 +86,93 @@ public class ZipArchive {
     }
 
     public String getFileName(int index) {
-        ZipEntry entry = getZipEntry(index);
-
-        if (entry != null) {
-            return entry.getName();
+        if (_zipArchive != null) {
+            ZipEntry entry = getZipEntry(index);
+            if (entry != null) {
+                return entry.getName();
+            }
+        } else {
+            if (index >= 0 && index < _entryNames.size()) {
+                return _entryNames.get(index);
+            }
         }
 
         return null;
     }
 
     public long getFileSize(int index) {
-        ZipEntry entry = getZipEntry(index);
-
-        if (entry != null) {
-            return entry.getSize();
+        if (_zipArchive != null) {
+            ZipEntry entry = getZipEntry(index);
+            if (entry != null) {
+                return entry.getSize();
+            }
+        } else {
+            if (index >= 0 && index < _entryNames.size()) {
+                byte[] data = _entries.get(_entryNames.get(index).toLowerCase());
+                return data != null ? data.length : 0;
+            }
         }
 
         return -1;
     }
 
     public int getFileIndex(String path) {
-        Enumeration<? extends ZipEntry> entries = _zipArchive.entries();
+        if (_zipArchive != null) {
+            Enumeration<? extends ZipEntry> entries = _zipArchive.entries();
 
-        int i = 0;
-        while (entries.hasMoreElements()) {
-            ZipEntry entry = entries.nextElement();
-            if (entry.getName().equalsIgnoreCase(path)) {
-                return i;
+            int i = 0;
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                if (entry.getName().equalsIgnoreCase(path)) {
+                    return i;
+                }
+
+                i++;
             }
-
-            i++;
+        } else {
+            for (int i = 0; i < _entryNames.size(); i++) {
+                if (_entryNames.get(i).equalsIgnoreCase(path)) {
+                    return i;
+                }
+            }
         }
 
         return -1;
     }
 
-    public long getFile(int index) throws IOException {
-        ZipEntry entry = getZipEntry(index);
+    public byte[] getFile(int index) throws IOException {
+        if (_zipArchive != null) {
+            ZipEntry entry = getZipEntry(index);
 
-        if (entry == null) {
-            return 0;
+            if (entry == null) {
+                return null;
+            }
+
+            try (InputStream inputStream = _zipArchive.getInputStream(entry)) {
+                long numBytesToRead = entry.getSize();
+                if (numBytesToRead == -1) {
+                    Log.e("ZipArchive", "Unknown length for zip entry");
+                    return null;
+                }
+
+                // Validate that the entry size fits in memory
+                if (numBytesToRead > Integer.MAX_VALUE) {
+                    Log.e("ZipArchive", "Entry too large: " + entry.getName() + " (" + numBytesToRead + " bytes exceeds max " + Integer.MAX_VALUE + ")");
+                    throw new IOException("Zip entry exceeds maximum size: " + entry.getName());
+                }
+
+                // Use IOUtils.toByteArray to safely read without preallocation concerns
+                byte[] data = IOUtils.toByteArray(inputStream);
+                if (data.length != (int)numBytesToRead) {
+                    Log.w("ZipArchive", "Truncated zip entry: " + entry.getName() + ", expected " + numBytesToRead + ", got " + data.length);
+                }
+                return data;
+            }
+        } else {
+            if (index >= 0 && index < _entryNames.size()) {
+                return _entries.get(_entryNames.get(index).toLowerCase());
+            }
         }
-
-        InputStream inputStream = _zipArchive.getInputStream(entry);
-
-        int numBytesToRead = (int) entry.getSize();
-        if (numBytesToRead == -1) {
-            Log.e("ZipArchive", "Unknown length for zip entry");
-            return 0;
-        }
-
-        byte[] inBuffer = new byte[numBytesToRead];
-        IOUtils.read(inputStream, inBuffer);
-
-        return allocBytes(inBuffer, numBytesToRead);
+        return null;
     }
-
-    native static long allocBytes(byte[] input, int size);
 }

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -7,13 +7,13 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <fstream>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/PlatformEnvironment.h>
 #include <openrct2/Version.h>
+#include <openrct2/core/File.h>
 #include <openrct2/core/FileSystem.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
@@ -65,18 +65,7 @@ namespace OpenRCT2::Ui::Windows
         {
             auto& env = GetContext()->GetPlatformEnvironment();
             auto path = env.GetFilePath(pathId);
-            auto fs = std::ifstream(fs::u8path(path), std::ios::in);
-            if (!fs.is_open())
-            {
-                throw std::runtime_error("Unable to open " + path);
-            }
-            fs.seekg(0, fs.end);
-            auto length = fs.tellg();
-            fs.seekg(0, fs.beg);
-            std::unique_ptr<char[]> buffer = std::make_unique<char[]>(length);
-            fs.read(buffer.get(), length);
-            auto result = std::string(buffer.get(), buffer.get() + length);
-            return result;
+            return File::ReadAllText(path);
         }
 
         /**

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -145,6 +145,17 @@ public:
         auto dirbase = GetDefaultBaseDirectory(pathid);
         auto basePath = GetDirectoryPath(dirbase);
         auto fileName = kFileNames[EnumValue(pathid)];
+
+        auto assetPath = Platform::GetAssetPath();
+        if (!assetPath.empty())
+        {
+            auto combinedAssetPath = Path::Combine(assetPath, basePath, fileName);
+            if (File::Exists(combinedAssetPath))
+            {
+                return combinedAssetPath;
+            }
+        }
+
         return Path::Combine(basePath, fileName);
     }
 

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -28,8 +28,20 @@ namespace OpenRCT2::File
 {
     bool Exists(u8string_view path)
     {
-        fs::path file = fs::u8path(path);
         LOG_VERBOSE("Checking if file exists: %s", u8string(path).c_str());
+        auto assetCheckResult = Platform::CheckAssetExists(path);
+        switch (assetCheckResult)
+        {
+            case Platform::AssetCheckResult::Found:
+                return true;
+            case Platform::AssetCheckResult::NotFound:
+                return false;
+            case Platform::AssetCheckResult::NotApplicable:
+            default:
+                break;
+        }
+
+        fs::path file = fs::u8path(path);
         std::error_code ec;
         const auto result = fs::exists(file, ec);
         return result && ec.value() == 0;
@@ -64,14 +76,9 @@ namespace OpenRCT2::File
 
     std::vector<uint8_t> ReadAllBytes(u8string_view path)
     {
-        std::ifstream fs(fs::u8path(u8string(path)), std::ios::in | std::ios::binary);
-        if (!fs.is_open())
-        {
-            throw IOException("Unable to open " + u8string(path));
-        }
-
+        FileStream fstream(path, FileMode::open);
         std::vector<uint8_t> result;
-        auto fsize = Platform::GetFileSize(path);
+        auto fsize = fstream.GetLength();
         if (fsize > SIZE_MAX)
         {
             u8string message = String::stdFormat(
@@ -80,9 +87,8 @@ namespace OpenRCT2::File
         }
         else
         {
-            result.resize(fsize);
-            fs.read(reinterpret_cast<char*>(result.data()), result.size());
-            fs.exceptions(fs.failbit);
+            result.resize(static_cast<size_t>(fsize));
+            fstream.Read(result.data(), result.size());
         }
         return result;
     }
@@ -127,8 +133,8 @@ namespace OpenRCT2::File
 
     void WriteAllBytes(u8string_view path, const void* buffer, size_t length)
     {
-        auto fs = FileStream(path, FileMode::write);
-        fs.Write(buffer, length);
+        auto fstream = FileStream(path, FileMode::write);
+        fstream.Write(buffer, length);
     }
 
     uint64_t GetLastModified(u8string_view path)

--- a/src/openrct2/core/FileScanner.cpp
+++ b/src/openrct2/core/FileScanner.cpp
@@ -12,13 +12,14 @@
         #define WIN32_LEAN_AND_MEAN
     #endif
     #include <windows.h>
-#elif defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))
+#elif defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__ANDROID__)
     #include <dirent.h>
     #include <sys/stat.h>
     #include <sys/types.h>
     #include <unistd.h>
 #endif
 
+#include "../platform/Platform.h"
 #include "FileScanner.h"
 #include "Memory.hpp"
 #include "Numerics.hpp"
@@ -26,6 +27,7 @@
 #include "String.hpp"
 
 #include <memory>
+#include <set>
 #include <stack>
 #include <string>
 #include <vector>
@@ -251,6 +253,63 @@ private:
 
 #endif // _WIN32
 
+#ifdef __ANDROID__
+
+class FileScannerAndroidAssets final : public FileScannerBase
+{
+public:
+    FileScannerAndroidAssets(u8string_view pattern, bool recurse)
+        : FileScannerBase(pattern, recurse)
+    {
+    }
+
+    void GetDirectoryChildren(std::vector<DirectoryChild>& children, const std::string& path) override
+    {
+        const auto& assetList = Platform::GetAssetList();
+        std::string prefix = path.substr(Platform::kAndroidAssetPathPrefix.length());
+        if (!prefix.empty() && prefix.back() != '/')
+        {
+            prefix += '/';
+        }
+
+        std::set<std::string> seen;
+
+        for (const auto& entry : assetList)
+        {
+            if (entry.Path.size() > prefix.size() && String::startsWith(entry.Path, prefix))
+            {
+                std::string_view relative = std::string_view(entry.Path).substr(prefix.size());
+                auto slashPos = relative.find('/');
+                if (slashPos != std::string_view::npos)
+                {
+                    std::string dirName = std::string(relative.substr(0, slashPos));
+                    if (seen.insert(dirName).second)
+                    {
+                        DirectoryChild child;
+                        child.Name = dirName;
+                        child.Type = DirectoryChildType::directory;
+                        children.push_back(child);
+                    }
+                }
+                else
+                {
+                    std::string fileName = std::string(relative);
+                    if (seen.insert(fileName).second)
+                    {
+                        DirectoryChild child;
+                        child.Name = fileName;
+                        child.Type = DirectoryChildType::file;
+                        child.Size = entry.Size;
+
+                        children.push_back(child);
+                    }
+                }
+            }
+        }
+    }
+};
+#endif // __ANDROID__
+
 #if defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))
 
 class FileScannerUnix final : public FileScannerBase
@@ -328,6 +387,12 @@ private:
 
 std::unique_ptr<IFileScanner> Path::ScanDirectory(const std::string& pattern, bool recurse)
 {
+#ifdef __ANDROID__
+    if (String::startsWith(pattern, Platform::kAndroidAssetPathPrefix))
+    {
+        return std::make_unique<FileScannerAndroidAssets>(pattern, recurse);
+    }
+#endif
 #ifdef _WIN32
     return std::make_unique<FileScannerWindows>(pattern, recurse);
 #elif defined(__unix__) || defined(__HAIKU__) || (defined(__APPLE__) && defined(__MACH__))

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -9,6 +9,7 @@
 
 #include "FileStream.h"
 
+#include "../platform/Platform.h"
 #include "Path.hpp"
 #include "String.hpp"
 
@@ -44,6 +45,20 @@ namespace OpenRCT2
 
     FileStream::FileStream(const utf8* path, FileMode fileMode)
     {
+        if (fileMode == FileMode::open)
+        {
+            auto assetOpen = Platform::OpenAssetFile(path);
+            if (assetOpen.result == Platform::AssetCheckResult::Found)
+            {
+                _asset = assetOpen.handle;
+                _fileSize = assetOpen.size;
+                _canRead = true;
+                _canWrite = false;
+                _ownsFilePtr = true;
+                return;
+            }
+        }
+
         const char* mode;
         switch (fileMode)
         {
@@ -117,7 +132,17 @@ namespace OpenRCT2
             _disposed = true;
             if (_ownsFilePtr)
             {
-                fclose(_file);
+                if (_asset != nullptr)
+                {
+                    Platform::CloseAssetFile(_asset);
+                }
+                else
+                {
+                    if (_file != nullptr)
+                    {
+                        fclose(_file);
+                    }
+                }
             }
         }
     }
@@ -139,6 +164,10 @@ namespace OpenRCT2
 
     uint64_t FileStream::GetPosition() const
     {
+        if (_asset != nullptr)
+        {
+            return Platform::GetAssetPosition(_asset);
+        }
         return ftello(_file);
     }
 
@@ -149,6 +178,11 @@ namespace OpenRCT2
 
     void FileStream::Seek(int64_t offset, int32_t origin)
     {
+        if (_asset != nullptr)
+        {
+            Platform::SeekAsset(_asset, offset, origin);
+            return;
+        }
         switch (origin)
         {
             case STREAM_SEEK_BEGIN:
@@ -165,6 +199,14 @@ namespace OpenRCT2
 
     void FileStream::Read(void* buffer, uint64_t length)
     {
+        if (_asset != nullptr)
+        {
+            if (Platform::ReadAsset(_asset, buffer, length) == length)
+            {
+                return;
+            }
+            throw IOException("Attempted to read past end of file.");
+        }
         if (fread(buffer, 1, static_cast<size_t>(length), _file) == length)
         {
             return;
@@ -174,6 +216,10 @@ namespace OpenRCT2
 
     void FileStream::Write(const void* buffer, uint64_t length)
     {
+        if (_canWrite == false)
+        {
+            throw IOException("Cannot write to a read-only stream.");
+        }
         if (length == 0)
         {
             return;
@@ -191,6 +237,10 @@ namespace OpenRCT2
 
     uint64_t FileStream::TryRead(void* buffer, uint64_t length)
     {
+        if (_asset != nullptr)
+        {
+            return Platform::TryReadAsset(_asset, buffer, length);
+        }
         size_t readBytes = fread(buffer, 1, static_cast<size_t>(length), _file);
         return readBytes;
     }

--- a/src/openrct2/core/FileStream.h
+++ b/src/openrct2/core/FileStream.h
@@ -28,6 +28,7 @@ namespace OpenRCT2
     {
     private:
         FILE* _file = nullptr;
+        void* _asset = nullptr;
         bool _ownsFilePtr = false;
         bool _canRead = false;
         bool _canWrite = false;

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -60,6 +60,18 @@ namespace OpenRCT2::Path
 
     bool DirectoryExists(u8string_view path)
     {
+        auto assetCheckResult = Platform::CheckAssetDirectoryExists(path);
+        switch (assetCheckResult)
+        {
+            case Platform::AssetCheckResult::Found:
+                return true;
+            case Platform::AssetCheckResult::NotFound:
+                return false;
+            case Platform::AssetCheckResult::NotApplicable:
+            default:
+                break;
+        }
+
         std::error_code ec;
         const auto result = fs::is_directory(fs::u8path(path), ec);
         return result && ec.value() == 0;

--- a/src/openrct2/core/ZipAndroid.cpp
+++ b/src/openrct2/core/ZipAndroid.cpp
@@ -34,18 +34,36 @@ public:
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
         jclass jniClass = Platform::AndroidFindClass(env, "io/openrct2/ZipArchive");
-        jmethodID constructor = env->GetMethodID(jniClass, "<init>", "(Ljava/lang/String;)V");
+        jmethodID constructor = env->GetMethodID(jniClass, "<init>", "(Landroid/content/Context;Ljava/lang/String;)V");
 
-        jstring jniPath = env->NewStringUTF(path.data());
+        jobject activity = (jobject)SDL_AndroidGetActivity();
+        jstring jniPath = env->NewStringUTF(std::string(path).c_str());
 
-        // TODO: Catch exceptions. Should probably be done on Java side, and just return null from a static method
-        jobject zip = env->NewObject(jniClass, constructor, jniPath);
+        jobject zip = env->NewObject(jniClass, constructor, activity, jniPath);
+        if (env->ExceptionCheck())
+        {
+            env->ExceptionClear();
+            env->DeleteLocalRef(jniClass);
+            env->DeleteLocalRef(jniPath);
+            env->DeleteLocalRef(activity);
+            throw std::runtime_error("Failed to open zip archive: " + std::string(path));
+        }
 
         _zip = env->NewGlobalRef(zip);
+
+        env->DeleteLocalRef(zip);
+        env->DeleteLocalRef(jniClass);
+        env->DeleteLocalRef(jniPath);
+        env->DeleteLocalRef(activity);
     }
 
     ~ZipArchive() override
     {
+        if (_zip == nullptr)
+        {
+            return;
+        }
+
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
@@ -53,23 +71,47 @@ public:
         jmethodID closeMethod = env->GetMethodID(zipClass, "close", "()V");
 
         env->CallVoidMethod(_zip, closeMethod);
+        if (env->ExceptionCheck())
+        {
+            env->ExceptionClear();
+        }
 
+        env->DeleteLocalRef(zipClass);
         env->DeleteGlobalRef(_zip);
     }
 
     size_t GetNumFiles() const override
     {
+        if (_zip == nullptr)
+        {
+            return 0;
+        }
+
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
         jclass zipClass = env->GetObjectClass(_zip);
         jmethodID fileCountMethod = env->GetMethodID(zipClass, "getNumFiles", "()I");
 
-        return static_cast<size_t>(env->CallIntMethod(_zip, fileCountMethod));
+        jint count = env->CallIntMethod(_zip, fileCountMethod);
+        if (env->ExceptionCheck())
+        {
+            env->ExceptionClear();
+            count = 0;
+        }
+
+        env->DeleteLocalRef(zipClass);
+
+        return static_cast<size_t>(count);
     }
 
     std::string GetFileName(size_t index) const override
     {
+        if (_zip == nullptr)
+        {
+            return std::string();
+        }
+
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
@@ -77,42 +119,96 @@ public:
         jmethodID fileNameMethod = env->GetMethodID(zipClass, "getFileName", "(I)Ljava/lang/String;");
 
         jstring jniString = (jstring)env->CallObjectMethod(_zip, fileNameMethod, (jint)index);
+        if (env->ExceptionCheck())
+        {
+            env->ExceptionClear();
+            env->DeleteLocalRef(zipClass);
+            return std::string();
+        }
 
-        const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
-        std::string string = jniChars;
-        env->ReleaseStringUTFChars(jniString, jniChars);
+        std::string string;
+        if (jniString != nullptr)
+        {
+            const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
+            string = jniChars;
+            env->ReleaseStringUTFChars(jniString, jniChars);
+            env->DeleteLocalRef(jniString);
+        }
+
+        env->DeleteLocalRef(zipClass);
 
         return string;
     }
 
     uint64_t GetFileSize(size_t index) const override
     {
+        if (_zip == nullptr)
+        {
+            return 0;
+        }
+
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
         jclass zipClass = env->GetObjectClass(_zip);
         jmethodID fileSizeMethod = env->GetMethodID(zipClass, "getFileSize", "(I)J");
 
-        return (size_t)env->CallLongMethod(_zip, fileSizeMethod, (jint)index);
+        jlong size = env->CallLongMethod(_zip, fileSizeMethod, (jint)index);
+        if (env->ExceptionCheck())
+        {
+            env->ExceptionClear();
+            size = 0;
+        }
+
+        env->DeleteLocalRef(zipClass);
+
+        return static_cast<uint64_t>(size);
     }
 
     std::vector<uint8_t> GetFileData(std::string_view path) const override
     {
+        if (_zip == nullptr)
+        {
+            return {};
+        }
+
         // retrieve the JNI environment.
         JNIEnv* env = (JNIEnv*)SDL_AndroidGetJNIEnv();
 
         jclass zipClass = env->GetObjectClass(_zip);
-        jstring javaPath = env->NewStringUTF(path.data());
+        jstring javaPath = env->NewStringUTF(std::string(path).c_str());
         jmethodID indexMethod = env->GetMethodID(zipClass, "getFileIndex", "(Ljava/lang/String;)I");
         jint index = env->CallIntMethod(_zip, indexMethod, javaPath);
+        if (env->ExceptionCheck())
+        {
+            env->ExceptionClear();
+            index = -1;
+        }
 
-        jmethodID fileMethod = env->GetMethodID(zipClass, "getFile", "(I)J");
-        jlong ptr = env->CallLongMethod(_zip, fileMethod, index);
+        std::vector<uint8_t> result;
+        if (index != -1)
+        {
+            jmethodID fileMethod = env->GetMethodID(zipClass, "getFile", "(I)[B");
+            jbyteArray array = (jbyteArray)env->CallObjectMethod(_zip, fileMethod, index);
+            if (env->ExceptionCheck())
+            {
+                env->ExceptionClear();
+                array = nullptr;
+            }
 
-        auto dataPtr = reinterpret_cast<uint8_t*>(ptr);
-        auto dataSize = this->GetFileSize(index);
+            if (array != nullptr)
+            {
+                jsize len = env->GetArrayLength(array);
+                result.resize(len);
+                env->GetByteArrayRegion(array, 0, len, reinterpret_cast<jbyte*>(result.data()));
+                env->DeleteLocalRef(array);
+            }
+        }
 
-        return std::vector<uint8_t>(dataPtr, dataPtr + dataSize);
+        env->DeleteLocalRef(javaPath);
+        env->DeleteLocalRef(zipClass);
+
+        return result;
     }
 
     std::unique_ptr<IStream> GetFileStream(std::string_view path) const override
@@ -157,21 +253,5 @@ namespace OpenRCT2::Zip
         return result;
     }
 } // namespace OpenRCT2::Zip
-
-extern "C" {
-JNIEXPORT jlong JNICALL Java_io_openrct2_ZipArchive_allocBytes(JNIEnv* env, jclass, jbyteArray input, jint numBytes);
-}
-
-JNIEXPORT jlong JNICALL Java_io_openrct2_ZipArchive_allocBytes(JNIEnv* env, jclass, jbyteArray input, jint numBytes)
-{
-    jbyte* bufferPtr = env->GetByteArrayElements(input, nullptr);
-
-    void* data = Memory::Allocate<void>((size_t)numBytes);
-    std::memcpy(data, bufferPtr, numBytes);
-
-    env->ReleaseByteArrayElements(input, bufferPtr, 0);
-
-    return reinterpret_cast<uintptr_t>(data);
-}
 
 #endif // __ANDROID__

--- a/src/openrct2/core/ZipAndroid.cpp
+++ b/src/openrct2/core/ZipAndroid.cpp
@@ -42,6 +42,8 @@ public:
         jobject zip = env->NewObject(jniClass, constructor, activity, jniPath);
         if (env->ExceptionCheck())
         {
+            LOG_ERROR("JNI exception occurred while opening zip archive '%s':", std::string(path).c_str());
+            env->ExceptionDescribe();
             env->ExceptionClear();
             env->DeleteLocalRef(jniClass);
             env->DeleteLocalRef(jniPath);
@@ -73,6 +75,8 @@ public:
         env->CallVoidMethod(_zip, closeMethod);
         if (env->ExceptionCheck())
         {
+            LOG_ERROR("JNI exception occurred while closing zip archive:");
+            env->ExceptionDescribe();
             env->ExceptionClear();
         }
 
@@ -96,6 +100,8 @@ public:
         jint count = env->CallIntMethod(_zip, fileCountMethod);
         if (env->ExceptionCheck())
         {
+            LOG_ERROR("JNI exception occurred while getting file count:");
+            env->ExceptionDescribe();
             env->ExceptionClear();
             count = 0;
         }
@@ -121,6 +127,8 @@ public:
         jstring jniString = (jstring)env->CallObjectMethod(_zip, fileNameMethod, (jint)index);
         if (env->ExceptionCheck())
         {
+            LOG_ERROR("JNI exception occurred while getting file name at index %zu:", index);
+            env->ExceptionDescribe();
             env->ExceptionClear();
             env->DeleteLocalRef(zipClass);
             return std::string();
@@ -156,6 +164,8 @@ public:
         jlong size = env->CallLongMethod(_zip, fileSizeMethod, (jint)index);
         if (env->ExceptionCheck())
         {
+            LOG_ERROR("JNI exception occurred while getting file size at index %zu:", index);
+            env->ExceptionDescribe();
             env->ExceptionClear();
             size = 0;
         }
@@ -181,6 +191,8 @@ public:
         jint index = env->CallIntMethod(_zip, indexMethod, javaPath);
         if (env->ExceptionCheck())
         {
+            LOG_ERROR("JNI exception occurred while getting file index for path: %s", std::string(path).c_str());
+            env->ExceptionDescribe();
             env->ExceptionClear();
             index = -1;
         }
@@ -192,6 +204,8 @@ public:
             jbyteArray array = (jbyteArray)env->CallObjectMethod(_zip, fileMethod, index);
             if (env->ExceptionCheck())
             {
+                LOG_ERROR("JNI exception occurred while getting file data at index %d:", index);
+                env->ExceptionDescribe();
                 env->ExceptionClear();
                 array = nullptr;
             }

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -14,11 +14,18 @@
     #include "../Diagnostic.h"
     #include "../core/File.h"
     #include "../core/Guard.hpp"
+    #include "../core/IStream.hpp"
+    #include "../core/String.hpp"
     #include "../localisation/Language.h"
 
     #include <SDL.h>
+    #include <algorithm>
+    #include <android/asset_manager.h>
+    #include <android/asset_manager_jni.h>
     #include <jni.h>
     #include <memory>
+    #include <mutex>
+    #include <sys/stat.h>
 
 AndroidClassLoader::~AndroidClassLoader()
 {
@@ -28,6 +35,10 @@ AndroidClassLoader::~AndroidClassLoader()
 
 jobject AndroidClassLoader::_classLoader;
 jmethodID AndroidClassLoader::_findClassMethod;
+static AAssetManager* _assetManager;
+static std::vector<OpenRCT2::Platform::AssetInfo> _assetList;
+static std::once_flag _assetManagerInitialized;
+static std::once_flag _assetListInitialized;
 
 // Initialized in JNI_OnLoad. Cannot be initialized here as JVM is not
 // available until after JNI_OnLoad is called.
@@ -57,7 +68,14 @@ namespace OpenRCT2::Platform
 
     std::string GetInstallPath()
     {
-        return "/sdcard/openrct2";
+        // If assets are bundled, use them as install path
+        if (File::Exists(std::string(Platform::kAndroidAssetPathPrefix) + "openrct2/data/g2.dat"))
+        {
+            return std::string(Platform::kAndroidAssetPathPrefix) + "openrct2/data";
+        }
+
+        // Fallback to external storage for backward compatibility
+        return GetFolderPath(SpecialFolder::userData);
     }
 
     std::string GetCurrentExecutablePath()
@@ -153,6 +171,51 @@ namespace OpenRCT2::Platform
         return {};
     }
 
+    uint64_t GetLastModified(std::string_view path)
+    {
+        if (String::startsWith(path, Platform::kAndroidAssetPathPrefix))
+        {
+            // Assets don't have a modification time in the traditional sense.
+            return 0;
+        }
+
+        uint64_t lastModified = 0;
+        struct stat statInfo{};
+        if (stat(std::string(path).c_str(), &statInfo) == 0)
+        {
+            lastModified = statInfo.st_mtime;
+        }
+        return lastModified;
+    }
+
+    uint64_t GetFileSize(std::string_view path)
+    {
+        if (String::startsWith(path, Platform::kAndroidAssetPathPrefix))
+        {
+            auto assetManager = static_cast<AAssetManager*>(GetAssetManager());
+            if (assetManager != nullptr)
+            {
+                std::string assetPath = std::string(path).substr(Platform::kAndroidAssetPathPrefix.length());
+                auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_UNKNOWN);
+                if (asset != nullptr)
+                {
+                    auto size = AAsset_getLength64(asset);
+                    AAsset_close(asset);
+                    return size;
+                }
+            }
+            return 0;
+        }
+
+        uint64_t size = 0;
+        struct stat statInfo{};
+        if (stat(std::string(path).c_str(), &statInfo) == 0)
+        {
+            size = statInfo.st_size;
+        }
+        return size;
+    }
+
     #ifndef DISABLE_TTF
     std::string GetFontPath(const TTFFontDescriptor& font)
     {
@@ -189,6 +252,225 @@ namespace OpenRCT2::Platform
             env->NewStringUTF(std::string(name).c_str())));
     }
 
+    void* GetAssetManager()
+    {
+        std::call_once(_assetManagerInitialized, []() {
+            JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
+            jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+            jclass activityClass = env->GetObjectClass(activity);
+            jmethodID getAssetsMethod = env->GetMethodID(activityClass, "getAssets", "()Landroid/content/res/AssetManager;");
+            jobject assetManagerObj = env->CallObjectMethod(activity, getAssetsMethod);
+            _assetManager = AAssetManager_fromJava(env, assetManagerObj);
+
+            env->DeleteLocalRef(assetManagerObj);
+            env->DeleteLocalRef(activityClass);
+            env->DeleteLocalRef(activity);
+        });
+
+        return _assetManager;
+    }
+
+    static AssetCheckResult CheckAssetExistsInList(u8string_view path, bool directoryOnly)
+    {
+        if (!String::startsWith(path, Platform::kAndroidAssetPathPrefix))
+        {
+            return AssetCheckResult::NotApplicable;
+        }
+
+        const auto& assetList = GetAssetList();
+        std::string assetPath = std::string(path.substr(Platform::kAndroidAssetPathPrefix.length()));
+        if (assetPath.empty())
+        {
+            return assetList.empty() ? AssetCheckResult::NotFound : AssetCheckResult::Found;
+        }
+
+        if (!directoryOnly)
+        {
+            auto it = std::lower_bound(
+                assetList.begin(), assetList.end(), assetPath,
+                [](const AssetInfo& a, const std::string& b) { return a.Path < b; });
+            if (it != assetList.end() && it->Path == assetPath)
+            {
+                return AssetCheckResult::Found;
+            }
+            return AssetCheckResult::NotFound;
+        }
+
+        // Only check for directory/prefix matches if directoryOnly is true
+        std::string prefix = assetPath;
+        if (!prefix.empty() && prefix.back() != '/')
+        {
+            prefix += '/';
+        }
+
+        auto it = std::lower_bound(
+            assetList.begin(), assetList.end(), prefix, [](const AssetInfo& a, const std::string& b) { return a.Path < b; });
+        if (it != assetList.end() && String::startsWith(it->Path, prefix))
+        {
+            return AssetCheckResult::Found;
+        }
+
+        return AssetCheckResult::NotFound;
+    }
+
+    AssetCheckResult CheckAssetDirectoryExists(u8string_view path)
+    {
+        return CheckAssetExistsInList(path, true);
+    }
+
+    AssetCheckResult CheckAssetExists(u8string_view path)
+    {
+        return CheckAssetExistsInList(path, false);
+    }
+
+    AssetFileOpenResult OpenAssetFile(u8string_view path)
+    {
+        if (!String::startsWith(path, Platform::kAndroidAssetPathPrefix))
+        {
+            return AssetFileOpenResult{ AssetCheckResult::NotApplicable, nullptr, 0 };
+        }
+
+        auto assetManager = static_cast<AAssetManager*>(GetAssetManager());
+        if (assetManager == nullptr)
+        {
+            return AssetFileOpenResult{ AssetCheckResult::NotFound, nullptr, 0 };
+        }
+
+        std::string assetPath = std::string(path.substr(Platform::kAndroidAssetPathPrefix.length()));
+        auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_RANDOM);
+        if (asset == nullptr)
+        {
+            return AssetFileOpenResult{ AssetCheckResult::NotFound, nullptr, 0 };
+        }
+
+        uint64_t assetSize = AAsset_getLength64(asset);
+        return AssetFileOpenResult{ AssetCheckResult::Found, asset, assetSize };
+    }
+
+    void CloseAssetFile(void* handle)
+    {
+        if (handle != nullptr)
+        {
+            AAsset_close(static_cast<AAsset*>(handle));
+        }
+    }
+
+    uint64_t GetAssetPosition(void* handle)
+    {
+        if (handle == nullptr)
+        {
+            return 0;
+        }
+        return static_cast<uint64_t>(AAsset_seek64(static_cast<AAsset*>(handle), 0, SEEK_CUR));
+    }
+
+    void SeekAsset(void* handle, int64_t offset, int32_t origin)
+    {
+        if (handle == nullptr)
+        {
+            return;
+        }
+
+        int whence;
+        switch (origin)
+        {
+            case STREAM_SEEK_BEGIN:
+                whence = SEEK_SET;
+                break;
+            case STREAM_SEEK_CURRENT:
+                whence = SEEK_CUR;
+                break;
+            case STREAM_SEEK_END:
+                whence = SEEK_END;
+                break;
+            default:
+                return;
+        }
+        AAsset_seek64(static_cast<AAsset*>(handle), static_cast<off64_t>(offset), whence);
+    }
+
+    uint64_t ReadAsset(void* handle, void* buffer, uint64_t length)
+    {
+        if (handle == nullptr)
+        {
+            return 0;
+        }
+        int readBytes = AAsset_read(static_cast<AAsset*>(handle), buffer, static_cast<size_t>(length));
+        if (readBytes < 0)
+        {
+            return 0;
+        }
+        return static_cast<uint64_t>(readBytes);
+    }
+
+    uint64_t TryReadAsset(void* handle, void* buffer, uint64_t length)
+    {
+        return ReadAsset(handle, buffer, length);
+    }
+
+    u8string GetAssetPath()
+    {
+        return std::string(Platform::kAndroidAssetPathPrefix);
+    }
+
+    const std::vector<AssetInfo>& GetAssetList()
+    {
+        std::call_once(_assetListInitialized, []() {
+            AAssetManager* am = static_cast<AAssetManager*>(GetAssetManager());
+            if (am != nullptr)
+            {
+                AAsset* asset = AAssetManager_open(am, "openrct2/manifest.txt", AASSET_MODE_BUFFER);
+                if (asset != nullptr)
+                {
+                    size_t size = AAsset_getLength64(asset);
+                    std::string content;
+                    content.resize(size);
+                    AAsset_read(asset, content.data(), size);
+                    AAsset_close(asset);
+
+                    auto processLine = [](std::string line) {
+                        if (!line.empty() && line.back() == '\r')
+                        {
+                            line.pop_back();
+                        }
+                        if (!line.empty())
+                        {
+                            auto sep = line.find('|');
+                            if (sep != std::string::npos)
+                            {
+                                try
+                                {
+                                    AssetInfo info;
+                                    info.Path = line.substr(0, sep);
+                                    info.Size = std::stoull(line.substr(sep + 1));
+                                    _assetList.push_back(std::move(info));
+                                }
+                                catch (const std::exception&)
+                                {
+                                    LOG_WARNING("Failed to parse asset entry: %s", line.c_str());
+                                }
+                            }
+                        }
+                    };
+
+                    size_t start = 0;
+                    size_t end = content.find('\n');
+                    while (end != std::string::npos)
+                    {
+                        processLine(content.substr(start, end - start));
+                        start = end + 1;
+                        end = content.find('\n', start);
+                    }
+                    processLine(content.substr(start));
+                    std::sort(_assetList.begin(), _assetList.end(), [](const AssetInfo& a, const AssetInfo& b) {
+                        return a.Path < b.Path;
+                    });
+                }
+            }
+        });
+        return _assetList;
+    }
+
     std::vector<std::string_view> GetSearchablePathsRCT1()
     {
         return { "/sdcard/rct1" };
@@ -197,6 +479,11 @@ namespace OpenRCT2::Platform
     std::vector<std::string_view> GetSearchablePathsRCT2()
     {
         return { "/sdcard/rct2" };
+    }
+
+    time_t FileGetModifiedTime(u8string_view path)
+    {
+        return static_cast<time_t>(GetLastModified(path));
     }
 } // namespace OpenRCT2::Platform
 

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -347,7 +347,7 @@ namespace OpenRCT2::Platform
         return AssetFileOpenResult{ AssetCheckResult::Found, asset, assetSize };
     }
 
-    void CloseAssetFile(void* handle)
+    void CloseAssetFile(AssetHandle handle)
     {
         if (handle != nullptr)
         {
@@ -355,7 +355,7 @@ namespace OpenRCT2::Platform
         }
     }
 
-    uint64_t GetAssetPosition(void* handle)
+    uint64_t GetAssetPosition(AssetHandle handle)
     {
         if (handle == nullptr)
         {
@@ -364,7 +364,7 @@ namespace OpenRCT2::Platform
         return static_cast<uint64_t>(AAsset_seek64(static_cast<AAsset*>(handle), 0, SEEK_CUR));
     }
 
-    void SeekAsset(void* handle, int64_t offset, int32_t origin)
+    void SeekAsset(AssetHandle handle, int64_t offset, int32_t origin)
     {
         if (handle == nullptr)
         {
@@ -389,7 +389,7 @@ namespace OpenRCT2::Platform
         AAsset_seek64(static_cast<AAsset*>(handle), static_cast<off64_t>(offset), whence);
     }
 
-    uint64_t ReadAsset(void* handle, void* buffer, uint64_t length)
+    uint64_t ReadAsset(AssetHandle handle, void* buffer, uint64_t length)
     {
         if (handle == nullptr)
         {
@@ -403,7 +403,7 @@ namespace OpenRCT2::Platform
         return static_cast<uint64_t>(readBytes);
     }
 
-    uint64_t TryReadAsset(void* handle, void* buffer, uint64_t length)
+    uint64_t TryReadAsset(AssetHandle handle, void* buffer, uint64_t length)
     {
         return ReadAsset(handle, buffer, length);
     }

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -487,6 +487,16 @@ namespace OpenRCT2::Platform
     }
 } // namespace OpenRCT2::Platform
 
+/**
+ * JNI function to expose the Android asset path prefix constant to Java.
+ * Called from io.openrct2.PlatformConstants.getAndroidAssetPathPrefix()
+ */
+extern "C" JNIEXPORT jstring JNICALL
+    Java_io_openrct2_PlatformConstants_getAndroidAssetPathPrefix(JNIEnv* env, jclass /* clazz */)
+{
+    return env->NewStringUTF(std::string(OpenRCT2::Platform::kAndroidAssetPathPrefix).c_str());
+}
+
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* pjvm, void* reserved)
 {
     // Due to an issue where JNI_OnLoad could be called multiple times, we need

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -91,6 +91,7 @@ namespace OpenRCT2::Platform
         return outTime;
     }
 
+#ifndef __ANDROID__
     AssetCheckResult CheckAssetDirectoryExists([[maybe_unused]] u8string_view path)
     {
         return AssetCheckResult::NotApplicable;
@@ -133,6 +134,7 @@ namespace OpenRCT2::Platform
     {
         return {};
     }
+#endif
 
     std::optional<RCT2Variant> classifyGamePath(std::string_view path)
     {

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -91,6 +91,49 @@ namespace OpenRCT2::Platform
         return outTime;
     }
 
+    AssetCheckResult CheckAssetDirectoryExists([[maybe_unused]] u8string_view path)
+    {
+        return AssetCheckResult::NotApplicable;
+    }
+
+    AssetCheckResult CheckAssetExists([[maybe_unused]] u8string_view path)
+    {
+        return AssetCheckResult::NotApplicable;
+    }
+
+    AssetFileOpenResult OpenAssetFile([[maybe_unused]] u8string_view path)
+    {
+        return AssetFileOpenResult{ AssetCheckResult::NotApplicable, nullptr, 0 };
+    }
+
+    void CloseAssetFile([[maybe_unused]] void* handle)
+    {
+    }
+
+    uint64_t GetAssetPosition([[maybe_unused]] void* handle)
+    {
+        return 0;
+    }
+
+    void SeekAsset([[maybe_unused]] void* handle, [[maybe_unused]] int64_t offset, [[maybe_unused]] int32_t origin)
+    {
+    }
+
+    uint64_t ReadAsset([[maybe_unused]] void* handle, [[maybe_unused]] void* buffer, [[maybe_unused]] uint64_t length)
+    {
+        return 0;
+    }
+
+    uint64_t TryReadAsset([[maybe_unused]] void* handle, [[maybe_unused]] void* buffer, [[maybe_unused]] uint64_t length)
+    {
+        return 0;
+    }
+
+    u8string GetAssetPath()
+    {
+        return {};
+    }
+
     std::optional<RCT2Variant> classifyGamePath(std::string_view path)
     {
         auto combinedPath = Path::ResolveCasing(Path::Combine(path, u8"Data", u8"g1.dat"));

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -214,6 +214,7 @@ namespace OpenRCT2::Platform
     #endif // __EMSCRIPTEN__
     }
 
+    #ifndef __ANDROID__
     uint64_t GetLastModified(std::string_view path)
     {
         uint64_t lastModified = 0;
@@ -235,6 +236,7 @@ namespace OpenRCT2::Platform
         }
         return size;
     }
+    #endif
 
     bool ShouldIgnoreCase()
     {
@@ -390,6 +392,7 @@ namespace OpenRCT2::Platform
         return 0;
     }
 
+    #ifndef __ANDROID__
     time_t FileGetModifiedTime(u8string_view path)
     {
         struct stat buf;
@@ -399,6 +402,7 @@ namespace OpenRCT2::Platform
         }
         return 100;
     }
+    #endif
 
     datetime64 GetDatetimeNowUTC()
     {

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -61,6 +61,13 @@ struct TTFFontDescriptor;
 
 namespace OpenRCT2::Platform
 {
+    enum class AssetCheckResult
+    {
+        NotApplicable,
+        Found,
+        NotFound,
+    };
+
     struct SteamGameData
     {
         u8string nativeFolder;
@@ -112,6 +119,13 @@ namespace OpenRCT2::Platform
         u8"RCT Classic+.app" PATH_SEPARATOR "Contents" PATH_SEPARATOR "Resources";
     // clang-format on
 
+    struct AssetFileOpenResult
+    {
+        AssetCheckResult result;
+        void* handle;
+        uint64_t size;
+    };
+
     std::string GetEnvironmentVariable(std::string_view name);
     std::string GetFolderPath(SpecialFolder folder);
     std::string GetInstallPath();
@@ -125,6 +139,15 @@ namespace OpenRCT2::Platform
     std::string ResolveCasing(std::string_view path, bool fileExists);
     std::string SanitiseFilename(std::string_view originalName);
     bool IsFilenameValid(u8string_view fileName);
+    AssetCheckResult CheckAssetDirectoryExists(u8string_view path);
+    AssetCheckResult CheckAssetExists(u8string_view path);
+    AssetFileOpenResult OpenAssetFile(u8string_view path);
+    void CloseAssetFile(void* handle);
+    uint64_t GetAssetPosition(void* handle);
+    void SeekAsset(void* handle, int64_t offset, int32_t origin);
+    uint64_t ReadAsset(void* handle, void* buffer, uint64_t length);
+    uint64_t TryReadAsset(void* handle, void* buffer, uint64_t length);
+    u8string GetAssetPath();
 
     uint16_t GetLocaleLanguage();
     CurrencyType GetLocaleCurrency();

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -119,6 +119,13 @@ namespace OpenRCT2::Platform
         u8"RCT Classic+.app" PATH_SEPARATOR "Contents" PATH_SEPARATOR "Resources";
     // clang-format on
 
+#ifdef __ANDROID__
+    // Android asset path prefix
+    constexpr u8string_view kAndroidAssetPathPrefix = u8"/android_asset/";
+    // Android asset path must end with slash
+    static_assert(kAndroidAssetPathPrefix.back() == '/', "kAndroidAssetPathPrefix must end with a slash");
+#endif // __ANDROID__
+
     struct AssetFileOpenResult
     {
         AssetCheckResult result;
@@ -192,7 +199,14 @@ namespace OpenRCT2::Platform
     bool SetupUriProtocol();
 #endif
 #ifdef __ANDROID__
+    struct AssetInfo
+    {
+        std::string Path;
+        uint64_t Size;
+    };
     jclass AndroidFindClass(JNIEnv* env, std::string_view name);
+    void* GetAssetManager();
+    const std::vector<AssetInfo>& GetAssetList();
 #endif
 
     bool IsRunningInWine();

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -68,6 +68,8 @@ namespace OpenRCT2::Platform
         NotFound,
     };
 
+    using AssetHandle = void*;
+
     struct SteamGameData
     {
         u8string nativeFolder;
@@ -129,7 +131,7 @@ namespace OpenRCT2::Platform
     struct AssetFileOpenResult
     {
         AssetCheckResult result;
-        void* handle;
+        AssetHandle handle;
         uint64_t size;
     };
 
@@ -149,11 +151,11 @@ namespace OpenRCT2::Platform
     AssetCheckResult CheckAssetDirectoryExists(u8string_view path);
     AssetCheckResult CheckAssetExists(u8string_view path);
     AssetFileOpenResult OpenAssetFile(u8string_view path);
-    void CloseAssetFile(void* handle);
-    uint64_t GetAssetPosition(void* handle);
-    void SeekAsset(void* handle, int64_t offset, int32_t origin);
-    uint64_t ReadAsset(void* handle, void* buffer, uint64_t length);
-    uint64_t TryReadAsset(void* handle, void* buffer, uint64_t length);
+    void CloseAssetFile(AssetHandle handle);
+    uint64_t GetAssetPosition(AssetHandle handle);
+    void SeekAsset(AssetHandle handle, int64_t offset, int32_t origin);
+    uint64_t ReadAsset(AssetHandle handle, void* buffer, uint64_t length);
+    uint64_t TryReadAsset(AssetHandle handle, void* buffer, uint64_t length);
     u8string GetAssetPath();
 
     uint16_t GetLocaleLanguage();


### PR DESCRIPTION
This PR reworks how Android handles the OpenRCT2 assets (g2.dat, title sequences, etc.) by embedding them inside the apk itself.

Copying data to some predefined location on your phone from other builds is no longer necessary. As a consequence, updating the builds is much easier now as well.

<details>
<summary>The internals of apk look like this now (abridged)</summary>

```
assets
├── dexopt
│   ├── baseline.prof
│   └── baseline.profm
└── openrct2
    ├── data
    │   ├── changelog.txt
    │   ├── contributors.md
    │   ├── fonts.dat
    │   ├── g2.dat
    │   ├── language  [28 entries exceeds filelimit, not opening dir]
    │   ├── object
    │   │   ├── official
    │   │   │   ├── footpath_item
    │   │   │   │   └── rct2dlc.footpath_item.litterpa.parkobj
    │   │   │   ├── footpath_railings
    │   │   │   │   └── openrct2.footpath_railings.invisible.json
    │   │   │   ├── footpath_surface
    │   │   │   │   ├── openrct2.footpath_surface.invisible.json
    │   │   │   │   └── openrct2.footpath_surface.queue_invisible.parkobj
    │   │   │   ├── ride
    │   │   │   │   ├── openrct2.ride.alpine_coaster.parkobj
    │   │   │   │   ├── openrct2.ride.hybrid_coaster.parkobj
    │   │   │   │   ├── openrct2.ride.modern_twister.parkobj
    │   │   │   │   ├── openrct2.ride.single_rail_coaster.parkobj
    │   │   │   │   └── rct2dlc.ride.zpanda.parkobj
    │   │   │   ├── scenario_meta  [37 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_group
    │   │   │   │   └── rct2dlc.scenery_group.scgpanda.parkobj
    │   │   │   ├── scenery_small  [25 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_wall
    │   │   │   │   ├── couger.scenery_wall.acww33.parkobj
    │   │   │   │   ├── couger.scenery_wall.acwwf32.parkobj
    │   │   │   │   ├── mamabear.scenery_wall.mg-prar.parkobj
    │   │   │   │   ├── official.scenery_wall.post_flipped.json
    │   │   │   │   ├── official.scenery_wall.support_structure_full.parkobj
    │   │   │   │   └── official.scenery_wall.support_structure_half.parkobj
    │   │   │   ├── station
    │   │   │   │   ├── openrct2.station.noentrance.json
    │   │   │   │   └── openrct2.station.noplatformnoentrance.json
    │   │   │   ├── terrain_edge
    │   │   │   │   ├── official.terrain_edge.void.parkobj
    │   │   │   │   ├── rct1beta.terrain_edge.brick.parkobj
    │   │   │   │   └── rct1beta.terrain_edge.rock.parkobj
    │   │   │   ├── terrain_surface
    │   │   │   │   ├── openrct2.terrain_surface.void.parkobj
    │   │   │   │   └── rct1beta.terrain_surface.wildflowers.parkobj
    │   │   │   └── water
    │   │   │       └── rct2dlc.water.wtrpink.json
    │   │   ├── rct1
    │   │   │   ├── audio
    │   │   │   │   └── rct1.audio.title.json
    │   │   │   ├── footpath_railings
    │   │   │   │   ├── rct1ll.footpath_railings.bamboo.parkobj
    │   │   │   │   └── rct1ll.footpath_railings.space.parkobj
    │   │   │   ├── footpath_surface
    │   │   │   │   ├── rct1aa.footpath_surface.ash.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.queue_green.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.queue_red.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.queue_yellow.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.tarmac_brown.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.tarmac_green.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.tarmac_red.parkobj
    │   │   │   │   ├── rct1aa.footpath_surface.tiles_grey.parkobj
    │   │   │   │   ├── rct1.footpath_surface.crazy_paving.parkobj
    │   │   │   │   ├── rct1.footpath_surface.dirt.parkobj
    │   │   │   │   ├── rct1.footpath_surface.queue_blue.parkobj
    │   │   │   │   ├── rct1.footpath_surface.road.parkobj
    │   │   │   │   ├── rct1.footpath_surface.tarmac.parkobj
    │   │   │   │   ├── rct1.footpath_surface.tiles_brown.parkobj
    │   │   │   │   ├── rct1ll.footpath_surface.tiles_green.parkobj
    │   │   │   │   └── rct1ll.footpath_surface.tiles_red.parkobj
    │   │   │   ├── ride  [67 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenario_meta  [85 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_wall
    │   │   │   │   ├── rct1aa.scenery_wall.glass_wall.parkobj
    │   │   │   │   ├── rct1aa.scenery_wall.wooden_post_wall_1.json
    │   │   │   │   ├── rct1aa.scenery_wall.wooden_post_wall_2.json
    │   │   │   │   ├── rct1ll.scenery_wall.medieval_wooden_fence.json
    │   │   │   │   ├── rct1ll.scenery_wall.wooden_fence_brown_snow.json
    │   │   │   │   ├── rct1.scenery_wall.playing_card_wall_1.json
    │   │   │   │   ├── rct1.scenery_wall.playing_card_wall_2.json
    │   │   │   │   ├── rct1.scenery_wall.roman_column_wall.json
    │   │   │   │   ├── rct1.scenery_wall.wooden_fence_brown_gate.json
    │   │   │   │   ├── rct1.scenery_wall.wooden_fence_brown.json
    │   │   │   │   ├── rct1.scenery_wall.wooden_fence_red.json
    │   │   │   │   └── rct1.scenery_wall.wooden_fence_white.json
    │   │   │   ├── terrain_edge
    │   │   │   │   ├── rct1aa.terrain_edge.grey.parkobj
    │   │   │   │   ├── rct1aa.terrain_edge.red.parkobj
    │   │   │   │   ├── rct1aa.terrain_edge.yellow.parkobj
    │   │   │   │   ├── rct1ll.terrain_edge.green.parkobj
    │   │   │   │   ├── rct1ll.terrain_edge.purple.parkobj
    │   │   │   │   ├── rct1ll.terrain_edge.skyscraper_a.parkobj
    │   │   │   │   ├── rct1ll.terrain_edge.skyscraper_b.parkobj
    │   │   │   │   ├── rct1ll.terrain_edge.stone_brown.parkobj
    │   │   │   │   ├── rct1ll.terrain_edge.stone_grey.parkobj
    │   │   │   │   ├── rct1.terrain_edge.brick.parkobj
    │   │   │   │   └── rct1.terrain_edge.iron.parkobj
    │   │   │   └── terrain_surface
    │   │   │       ├── rct1aa.terrain_surface.roof_red.parkobj
    │   │   │       ├── rct1ll.terrain_surface.roof_grey.parkobj
    │   │   │       ├── rct1ll.terrain_surface.rust.parkobj
    │   │   │       └── rct1ll.terrain_surface.wood.parkobj
    │   │   ├── rct2
    │   │   │   ├── audio
    │   │   │   │   ├── rct2.audio.base.rct2.json
    │   │   │   │   ├── rct2.audio.base.rctc.json
    │   │   │   │   ├── rct2.audio.circus.json
    │   │   │   │   └── rct2.audio.title.json
    │   │   │   ├── climate
    │   │   │   │   ├── rct2.climate.cold.json
    │   │   │   │   ├── rct2.climate.cool_and_wet.json
    │   │   │   │   ├── rct2.climate.hot_and_dry.json
    │   │   │   │   └── rct2.climate.warm.json
    │   │   │   ├── footpath_banner
    │   │   │   │   ├── rct2.footpath_banner.bn1.json
    │   │   │   │   ├── rct2.footpath_banner.bn2.json
    │   │   │   │   ├── rct2.footpath_banner.bn3.json
    │   │   │   │   ├── rct2.footpath_banner.bn4.json
    │   │   │   │   ├── rct2.footpath_banner.bn5.json
    │   │   │   │   ├── rct2.footpath_banner.bn6.json
    │   │   │   │   ├── rct2.footpath_banner.bn7.json
    │   │   │   │   ├── rct2.footpath_banner.bn8.json
    │   │   │   │   └── rct2.footpath_banner.bn9.json
    │   │   │   ├── footpath_item
    │   │   │   │   ├── rct2.footpath_item.bench1.json
    │   │   │   │   ├── rct2.footpath_item.benchlog.json
    │   │   │   │   ├── rct2.footpath_item.benchpl.json
    │   │   │   │   ├── rct2.footpath_item.benchspc.json
    │   │   │   │   ├── rct2.footpath_item.benchstn.json
    │   │   │   │   ├── rct2.footpath_item.jumpfnt1.json
    │   │   │   │   ├── rct2.footpath_item.jumpsnw1.json
    │   │   │   │   ├── rct2.footpath_item.lamp1.json
    │   │   │   │   ├── rct2.footpath_item.lamp2.json
    │   │   │   │   ├── rct2.footpath_item.lamp3.json
    │   │   │   │   ├── rct2.footpath_item.lamp4.json
    │   │   │   │   ├── rct2.footpath_item.lampdsy.json
    │   │   │   │   ├── rct2.footpath_item.lamppir.json
    │   │   │   │   ├── rct2.footpath_item.litter1.json
    │   │   │   │   ├── rct2.footpath_item.littermn.json
    │   │   │   │   ├── rct2.footpath_item.littersp.json
    │   │   │   │   ├── rct2.footpath_item.litterww.json
    │   │   │   │   └── rct2.footpath_item.qtv1.json
    │   │   │   ├── footpath_railings
    │   │   │   │   ├── rct2.footpath_railings.bamboo_black.parkobj
    │   │   │   │   ├── rct2.footpath_railings.bamboo_brown.parkobj
    │   │   │   │   ├── rct2.footpath_railings.concrete_green.parkobj
    │   │   │   │   ├── rct2.footpath_railings.concrete.parkobj
    │   │   │   │   ├── rct2.footpath_railings.space.parkobj
    │   │   │   │   └── rct2.footpath_railings.wood.parkobj
    │   │   │   ├── footpath_surface
    │   │   │   │   ├── rct2.footpath_surface.ash.parkobj
    │   │   │   │   ├── rct2.footpath_surface.crazy_paving.parkobj
    │   │   │   │   ├── rct2.footpath_surface.dirt.parkobj
    │   │   │   │   ├── rct2.footpath_surface.queue_blue.parkobj
    │   │   │   │   ├── rct2.footpath_surface.queue_green.parkobj
    │   │   │   │   ├── rct2.footpath_surface.queue_red.parkobj
    │   │   │   │   ├── rct2.footpath_surface.queue_yellow.parkobj
    │   │   │   │   ├── rct2.footpath_surface.road.parkobj
    │   │   │   │   ├── rct2.footpath_surface.tarmac_brown.parkobj
    │   │   │   │   ├── rct2.footpath_surface.tarmac_green.parkobj
    │   │   │   │   ├── rct2.footpath_surface.tarmac.parkobj
    │   │   │   │   └── rct2.footpath_surface.tarmac_red.parkobj
    │   │   │   ├── music  [32 entries exceeds filelimit, not opening dir]
    │   │   │   ├── park_entrance
    │   │   │   │   ├── rct2.park_entrance.pkemm.json
    │   │   │   │   ├── rct2.park_entrance.pkent1.json
    │   │   │   │   └── rct2.park_entrance.pkesfh.json
    │   │   │   ├── peep_animations
    │   │   │   │   ├── rct2.peep_animations.entertainer_astronaut.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_bandit.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_elephant.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_gorilla.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_knight.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_panda.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_pirate.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_roman.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_sheriff.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_snowman.json
    │   │   │   │   ├── rct2.peep_animations.entertainer_tiger.json
    │   │   │   │   ├── rct2.peep_animations.guest.json
    │   │   │   │   ├── rct2.peep_animations.handyman.json
    │   │   │   │   ├── rct2.peep_animations.mechanic.json
    │   │   │   │   └── rct2.peep_animations.security.json
    │   │   │   ├── peep_names
    │   │   │   │   └── rct2.peep_names.original.json
    │   │   │   ├── ride  [155 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenario_meta  [27 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_group  [29 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_large  [48 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_small  [333 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_wall  [126 entries exceeds filelimit, not opening dir]
    │   │   │   ├── station
    │   │   │   │   ├── rct2.station.abstract.json
    │   │   │   │   ├── rct2.station.canvas_tent.json
    │   │   │   │   ├── rct2.station.castle_brown.json
    │   │   │   │   ├── rct2.station.castle_grey.json
    │   │   │   │   ├── rct2.station.classical.json
    │   │   │   │   ├── rct2.station.jungle.json
    │   │   │   │   ├── rct2.station.log.json
    │   │   │   │   ├── rct2.station.pagoda.json
    │   │   │   │   ├── rct2.station.plain.json
    │   │   │   │   ├── rct2.station.snow.json
    │   │   │   │   ├── rct2.station.space.json
    │   │   │   │   └── rct2.station.wooden.json
    │   │   │   ├── terrain_edge
    │   │   │   │   ├── rct2.terrain_edge.ice.parkobj
    │   │   │   │   ├── rct2.terrain_edge.rock.parkobj
    │   │   │   │   ├── rct2.terrain_edge.wood_black.parkobj
    │   │   │   │   └── rct2.terrain_edge.wood_red.parkobj
    │   │   │   ├── terrain_surface
    │   │   │   │   ├── rct2.terrain_surface.chequerboard.json
    │   │   │   │   ├── rct2.terrain_surface.dirt.json
    │   │   │   │   ├── rct2.terrain_surface.grass_clumps.json
    │   │   │   │   ├── rct2.terrain_surface.grass.json
    │   │   │   │   ├── rct2.terrain_surface.grid_green.json
    │   │   │   │   ├── rct2.terrain_surface.grid_purple.json
    │   │   │   │   ├── rct2.terrain_surface.grid_red.json
    │   │   │   │   ├── rct2.terrain_surface.grid_yellow.json
    │   │   │   │   ├── rct2.terrain_surface.ice.json
    │   │   │   │   ├── rct2.terrain_surface.martian.json
    │   │   │   │   ├── rct2.terrain_surface.rock.json
    │   │   │   │   ├── rct2.terrain_surface.sand_brown.json
    │   │   │   │   ├── rct2.terrain_surface.sand.json
    │   │   │   │   └── rct2.terrain_surface.sand_red.json
    │   │   │   └── water
    │   │   │       ├── rct2.water.wtrcyan.json
    │   │   │       ├── rct2.water.wtrgreen.json
    │   │   │       ├── rct2.water.wtrgrn.json
    │   │   │       └── rct2.water.wtrorng.json
    │   │   ├── rct2tt
    │   │   │   ├── footpath_item
    │   │   │   │   ├── rct2tt.footpath_item.firhydrt.json
    │   │   │   │   └── rct2tt.footpath_item.medbench.json
    │   │   │   ├── footpath_railings
    │   │   │   │   ├── rct2tt.footpath_railings.balustrade.parkobj
    │   │   │   │   ├── rct2tt.footpath_railings.circuitboard_invisible.parkobj
    │   │   │   │   ├── rct2tt.footpath_railings.circuitboard.parkobj
    │   │   │   │   ├── rct2tt.footpath_railings.medieval.parkobj
    │   │   │   │   ├── rct2tt.footpath_railings.pavement.parkobj
    │   │   │   │   ├── rct2tt.footpath_railings.rainbow.parkobj
    │   │   │   │   └── rct2tt.footpath_railings.rocky.parkobj
    │   │   │   ├── footpath_surface
    │   │   │   │   ├── rct2tt.footpath_surface.circuitboard.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.medieval.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.mosaic.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.pavement.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.queue_circuitboard.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.queue_pavement.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.queue_rainbow.parkobj
    │   │   │   │   ├── rct2tt.footpath_surface.rainbow.parkobj
    │   │   │   │   └── rct2tt.footpath_surface.rocky.parkobj
    │   │   │   ├── park_entrance
    │   │   │   │   ├── rct2tt.park_entrance.1920sent.json
    │   │   │   │   ├── rct2tt.park_entrance.futurent.json
    │   │   │   │   ├── rct2tt.park_entrance.gldyrent.json
    │   │   │   │   ├── rct2tt.park_entrance.jurasent.json
    │   │   │   │   ├── rct2tt.park_entrance.medientr.json
    │   │   │   │   └── rct2tt.park_entrance.mythentr.json
    │   │   │   ├── ride  [56 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenario_meta
    │   │   │   │   ├── rct2tt.scenario_meta.alcatraz.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.animatronic_antics.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.cliffside_castle.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.coastersaurus.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.crater_carnage.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.extraterrestrial_extravaganza.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.gemini_city.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.metropolis.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.mythological_madness.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.rock_n_roll_revival.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.rocky_rambles.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.schneider_shores.parkobj
    │   │   │   │   ├── rct2tt.scenario_meta.sherwood_forest.parkobj
    │   │   │   │   └── rct2tt.scenario_meta.woodstock.parkobj
    │   │   │   ├── scenery_group
    │   │   │   │   ├── rct2tt.scenery_group.scg1920s.json
    │   │   │   │   ├── rct2tt.scenery_group.scg1920w.json
    │   │   │   │   ├── rct2tt.scenery_group.scg1960s.json
    │   │   │   │   ├── rct2tt.scenery_group.scgfutur.json
    │   │   │   │   ├── rct2tt.scenery_group.scgjurra.json
    │   │   │   │   ├── rct2tt.scenery_group.scgmediv.json
    │   │   │   │   └── rct2tt.scenery_group.scgmytho.json
    │   │   │   ├── scenery_large  [114 entries exceeds filelimit, not opening dir]
    │   │   │   ├── scenery_small  [430 entries exceeds filelimit, not opening dir]
    │   │   │   └── scenery_wall
    │   │   │       ├── rct2tt.scenery_wall.jailxx19.json
    │   │   │       └── rct2tt.scenery_wall.mspkwa01.json
    │   │   └── rct2ww
    │   │       ├── park_entrance
    │   │       │   ├── rct2ww.park_entrance.africent.json
    │   │       │   ├── rct2ww.park_entrance.euroent.json
    │   │       │   ├── rct2ww.park_entrance.iceent.json
    │   │       │   ├── rct2ww.park_entrance.japent.json
    │   │       │   ├── rct2ww.park_entrance.naent.json
    │   │       │   ├── rct2ww.park_entrance.ozentran.json
    │   │       │   └── rct2ww.park_entrance.samerent.json
    │   │       ├── ride  [56 entries exceeds filelimit, not opening dir]
    │   │       ├── scenario_meta
    │   │       │   ├── rct2ww.scenario_meta.ayers_adventure.parkobj
    │   │       │   ├── rct2ww.scenario_meta.beach_barbecue_blast.parkobj
    │   │       │   ├── rct2ww.scenario_meta.canyon_calamities.parkobj
    │   │       │   ├── rct2ww.scenario_meta.european_extravaganza.parkobj
    │   │       │   ├── rct2ww.scenario_meta.from_the_ashes.parkobj
    │   │       │   ├── rct2ww.scenario_meta.great_wall_of_china.parkobj
    │   │       │   ├── rct2ww.scenario_meta.icy_adventures.parkobj
    │   │       │   ├── rct2ww.scenario_meta.lost_city_founder.parkobj
    │   │       │   ├── rct2ww.scenario_meta.mines_of_africa.parkobj
    │   │       │   ├── rct2ww.scenario_meta.mirage_madness.parkobj
    │   │       │   ├── rct2ww.scenario_meta.okinawa_coast.parkobj
    │   │       │   ├── rct2ww.scenario_meta.over_the_edge.parkobj
    │   │       │   ├── rct2ww.scenario_meta.park_maharaja.parkobj
    │   │       │   ├── rct2ww.scenario_meta.rainforest_romp.parkobj
    │   │       │   ├── rct2ww.scenario_meta.rollercoaster_heaven.parkobj
    │   │       │   ├── rct2ww.scenario_meta.sugarloaf_shores.parkobj
    │   │       │   └── rct2ww.scenario_meta.wacky_waikiki.parkobj
    │   │       ├── scenery_group
    │   │       │   ├── rct2ww.scenery_group.scgafric.json
    │   │       │   ├── rct2ww.scenery_group.scgartic.json
    │   │       │   ├── rct2ww.scenery_group.scgasia.json
    │   │       │   ├── rct2ww.scenery_group.scgaustr.json
    │   │       │   ├── rct2ww.scenery_group.scgeurop.json
    │   │       │   ├── rct2ww.scenery_group.scgnamrc.json
    │   │       │   └── rct2ww.scenery_group.scgsamer.json
    │   │       ├── scenery_large  [87 entries exceeds filelimit, not opening dir]
    │   │       ├── scenery_small  [354 entries exceeds filelimit, not opening dir]
    │   │       └── scenery_wall  [185 entries exceeds filelimit, not opening dir]
    │   ├── palettes.dat
    │   ├── scenario_patches  [115 entries exceeds filelimit, not opening dir]
    │   ├── sequence
    │   │   ├── openrct2.parkseq
    │   │   ├── rct1aall.parkseq
    │   │   ├── rct1aa.parkseq
    │   │   ├── rct1.parkseq
    │   │   └── rct2.parkseq
    │   ├── shaders
    │   │   ├── applypalette.frag
    │   │   ├── applypalette.vert
    │   │   ├── applytransparency.frag
    │   │   ├── applytransparency.vert
    │   │   ├── copyrect.frag
    │   │   ├── copyrect.vert
    │   │   ├── drawline.frag
    │   │   ├── drawline.vert
    │   │   ├── drawrect.frag
    │   │   └── drawrect.vert
    │   └── tracks.dat
    └── manifest.txt
```

</details>

with the `manifest.txt` being the most important one, as it defines contents of the bundled assets. This is used as an optimization technique.
Random sampling of `manifest.txt` contents, each line consisting of `<file path>|<size>`
```
openrct2/data/object/rct2/scenery_large/rct2.scenery_large.ssk1.json|1614
openrct2/data/object/rct2ww/scenery_small/rct2ww.scenery_small.sbwind05.json|1868
openrct2/data/object/rct2tt/scenery_large/rct2tt.scenery_large.rdmeto02.json|1941
openrct2/data/object/rct2ww/scenery_small/rct2ww.scenery_small.wgeorg09.json|1778
openrct2/data/scenario_patches/47e5512.parkpatch|706
openrct2/data/object/rct2tt/scenery_large/rct2tt.scenery_large.majoroak.json|2568
openrct2/data/object/rct2/scenery_small/rct2.scenery_small.tmm1.json|1536
openrct2/data/object/rct2ww/scenery_large/rct2ww.scenery_large.rdrab02.json|1988
openrct2/data/object/rct2ww/scenery_wall/rct2ww.scenery_wall.wmarbpl4.json|1296
openrct2/data/object/rct2/ride/rct2.ride.gtc.json|6882
```
The file is generated on the fly by CI.

The path to bundled assets is defined with a prefix in `src/openrct/platform/Platform.h`.

The implementation uses an established pattern of defining generic functions in `Platform.Common.cpp` and the specializing them in `Platform.Android.cpp`

There are no changes to how RCT2 assets are obtained or to UI.

If testing builds from CI, keep in mind the certificate is only enabled for builds on branches in this repo, which is why I've decided to submit PR from within and not my fork. Use the `CI / Android (push)` to get the apk with matching signature - otherwise the signature is ephemeral.