### PR TITLE
Increase the threshold for the guest generation penalty for having a high guest count from 7000 to 52000

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#25941] The command line sprite build command is now faster.
 - Improved: [#26002] Rides with newer track elements (like the zero G roll or diagonal brakes) can now be saved as track designs.
 - Change: [#26011] Audio resampling no longer depends on the third-party library libspeexdsp.
+- Change: [#26049] Increase the threshold for the guest generation penalty for having a high guest count from 7000 to 52000.
 - Fix: [#14686, #23996, #25981] Preview images from different windows overwrite each other when using OpenGL.
 - Fix: [#15128, #15626, #16331, #17443, #18626, #21597, #24175, #24971, #25963] Crash when loading corrupted RCT2/RCT1 save files with duplicate entity indices.
 - Fix: [#25237] Wrong colours on the Knight costume.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,7 +6,7 @@
 - Improved: [#25941] The command line sprite build command is now faster.
 - Improved: [#26002] Rides with newer track elements (like the zero G roll or diagonal brakes) can now be saved as track designs.
 - Change: [#26011] Audio resampling no longer depends on the third-party library libspeexdsp.
-- Change: [#26049] Increase the threshold for the guest generation penalty for having a high guest count from 7000 to 52000.
+- Change: [#26049] Guest generation now starts slowing down above 52000 guests instead of 7000.
 - Fix: [#14686, #23996, #25981] Preview images from different windows overwrite each other when using OpenGL.
 - Fix: [#15128, #15626, #16331, #17443, #18626, #21597, #24175, #24971, #25963] Crash when loading corrupted RCT2/RCT1 save files with duplicate entity indices.
 - Fix: [#25237] Wrong colours on the Knight costume.

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -186,8 +186,8 @@ namespace OpenRCT2::Park
             }
         }
 
-        // Reduces chance for any more than 7000 guests
-        if (numGuests > 7000)
+        // Reduces chance for any more than 52000 guests
+        if (numGuests > 52000)
         {
             probability /= 4;
         }


### PR DESCRIPTION
This limit was originally there probably both to prevent lag from having a lot of guests and to prevent people from reaching the entity limit. With much better hardware and a higher entity limit of about 65k this limit should be a lot higher.