### PR TITLE
Refactor IntroScene

### DIFF
--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -89,26 +89,9 @@ namespace OpenRCT2
         return _introState != IntroState::None;
     }
 
-    IntroScene::IntroScene(IContext& context)
-        : Scene(context)
-        , _impl(std::make_shared<IntroSceneImpl>())
-    {
-        introSceneImplementation = _impl;
-    }
-
-    void IntroScene::Load()
-    {
-        _impl->Load();
-    }
-
     void IntroSceneImpl::Load()
     {
         _introState = IntroState::PublisherBegin;
-    }
-
-    void IntroScene::Stop()
-    {
-        _impl->Stop();
     }
 
     void IntroSceneImpl::Stop()
@@ -118,12 +101,6 @@ namespace OpenRCT2
     }
 
     // rct2: 0x0068E966
-    void IntroScene::Tick()
-    {
-        auto& sceneContext = GetContext();
-        _impl->Tick(sceneContext);
-    }
-
     void IntroSceneImpl::Tick(IContext& sceneContext)
     {
         ScreenIntroProcessMouseInput();
@@ -389,5 +366,28 @@ namespace OpenRCT2
         GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
         GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
         GfxDrawSprite(rt, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
+    }
+
+    IntroScene::IntroScene(IContext& context)
+        : Scene(context)
+        , _impl(std::make_shared<IntroSceneImpl>())
+    {
+        introSceneImplementation = _impl;
+    }
+
+    void IntroScene::Load()
+    {
+        _impl->Load();
+    }
+
+    void IntroScene::Stop()
+    {
+        _impl->Stop();
+    }
+
+    void IntroScene::Tick()
+    {
+        auto& sceneContext = GetContext();
+        _impl->Tick(sceneContext);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -19,27 +19,13 @@
 #include "../../drawing/Drawing.h"
 #include "../../drawing/Rectangle.h"
 
-#include <memory>
+#include <cstdint>
 
 using OpenRCT2::Audio::SoundId;
 using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2
 {
-    enum class IntroState : uint8_t
-    {
-        None,
-        PublisherBegin,
-        PublisherScroll,
-        DeveloperBegin,
-        DeveloperScroll,
-        LogoFadeIn,
-        LogoWait,
-        LogoFadeOut,
-        Clear = 254,
-        Finish = 255,
-    };
-
     static constexpr PaletteIndex kBackgroundColourDark = PaletteIndex::pi10;
     static constexpr PaletteIndex kBackgroundColourLogo = PaletteIndex::primaryRemap2;
     static constexpr PaletteIndex kBorderColourPublisher = PaletteIndex::pi129;
@@ -47,37 +33,98 @@ namespace OpenRCT2
     static constexpr ImageIndex kPaletteChrisSawyerLogo = 23217;
     static constexpr ImageIndex kPaletteRCT2Logo = 23224;
 
-    static IntroState _introState;
+    static std::weak_ptr<IntroSceneImpl> introSceneImplementation;
 
-    // Used mainly for timing but also for Y coordinate and fading.
-    static int32_t _introStateCounter;
+    class IntroSceneImpl
+    {
+    public:
+        bool IntroIsPlaying();
+        void IntroDraw(Drawing::RenderTarget& rt);
+        void Load();
+        void Stop();
+        void Tick(IContext& sceneContext);
 
-    static std::shared_ptr<Audio::IAudioChannel> _soundChannel = nullptr;
-    static bool _chainLiftFinished;
+    private:
+        void ScreenIntroProcessMouseInput();
+        void ScreenIntroProcessKeyboardInput();
+        void ScreenIntroSkipPart();
+        void ScreenIntroDrawLogo(RenderTarget& rt);
+
+    private:
+        enum class IntroState : uint8_t
+        {
+            None,
+            PublisherBegin,
+            PublisherScroll,
+            DeveloperBegin,
+            DeveloperScroll,
+            LogoFadeIn,
+            LogoWait,
+            LogoFadeOut,
+            Clear = 254,
+            Finish = 255,
+        };
+
+        IntroState _introState;
+
+        // Used mainly for timing but also for Y coordinate and fading.
+        int32_t _introStateCounter;
+
+        std::shared_ptr<Audio::IAudioChannel> _soundChannel = nullptr;
+        bool _chainLiftFinished;
+    };
 
     bool IntroIsPlaying()
+    {
+        if (auto impl = introSceneImplementation.lock())
+        {
+            return impl->IntroIsPlaying();
+        }
+
+        return false;
+    }
+
+    bool IntroSceneImpl::IntroIsPlaying()
     {
         return _introState != IntroState::None;
     }
 
+    IntroScene::IntroScene(IContext& context)
+        : Scene(context)
+        , _impl(std::make_shared<IntroSceneImpl>())
+    {
+        introSceneImplementation = _impl;
+    }
+
     void IntroScene::Load()
+    {
+        _impl->Load();
+    }
+
+    void IntroSceneImpl::Load()
     {
         _introState = IntroState::PublisherBegin;
     }
 
     void IntroScene::Stop()
     {
+        _impl->Stop();
+    }
+
+    void IntroSceneImpl::Stop()
+    {
         _introState = IntroState::None;
         LoadPalette();
     }
 
-    static void ScreenIntroProcessMouseInput();
-    static void ScreenIntroProcessKeyboardInput();
-    static void ScreenIntroSkipPart();
-    static void ScreenIntroDrawLogo(RenderTarget& rt);
-
     // rct2: 0x0068E966
     void IntroScene::Tick()
+    {
+        auto& sceneContext = GetContext();
+        _impl->Tick(sceneContext);
+    }
+
+    void IntroSceneImpl::Tick(IContext& sceneContext)
     {
         ScreenIntroProcessMouseInput();
         ScreenIntroProcessKeyboardInput();
@@ -195,8 +242,7 @@ namespace OpenRCT2
                 break;
             case IntroState::Finish:
             {
-                auto& context = GetContext();
-                context.SetActiveScene(context.GetTitleScene());
+                sceneContext.SetActiveScene(sceneContext.GetTitleScene());
                 break;
             }
             default:
@@ -205,6 +251,14 @@ namespace OpenRCT2
     }
 
     void IntroDraw(RenderTarget& rt)
+    {
+        if (auto impl = introSceneImplementation.lock())
+        {
+            impl->IntroDraw(rt);
+        }
+    }
+
+    void IntroSceneImpl::IntroDraw(RenderTarget& rt)
     {
         int32_t screenWidth = ContextGetWidth();
 
@@ -278,7 +332,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ScreenIntroProcessMouseInput()
+    void IntroSceneImpl::ScreenIntroProcessMouseInput()
     {
         if (ContextGetCursorState()->any & CURSOR_DOWN)
         {
@@ -290,7 +344,7 @@ namespace OpenRCT2
      *
      *  rct2: 0x006E3AEC
      */
-    static void ScreenIntroProcessKeyboardInput()
+    void IntroSceneImpl::ScreenIntroProcessKeyboardInput()
     {
         const uint8_t* keys = ContextGetKeysState();
         for (int i = 0; i < 256; i++)
@@ -303,7 +357,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ScreenIntroSkipPart()
+    void IntroSceneImpl::ScreenIntroSkipPart()
     {
         switch (_introState)
         {
@@ -315,7 +369,7 @@ namespace OpenRCT2
         }
     }
 
-    static void ScreenIntroDrawLogo(RenderTarget& rt)
+    void IntroSceneImpl::ScreenIntroDrawLogo(RenderTarget& rt)
     {
         int32_t screenWidth = ContextGetWidth();
         int32_t imageWidth = 640;

--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -26,6 +26,20 @@ using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2
 {
+    enum class IntroState : uint8_t
+    {
+        None,
+        PublisherBegin,
+        PublisherScroll,
+        DeveloperBegin,
+        DeveloperScroll,
+        LogoFadeIn,
+        LogoWait,
+        LogoFadeOut,
+        Clear = 254,
+        Finish = 255,
+    };
+
     static constexpr PaletteIndex kBackgroundColourDark = PaletteIndex::pi10;
     static constexpr PaletteIndex kBackgroundColourLogo = PaletteIndex::primaryRemap2;
     static constexpr PaletteIndex kBorderColourPublisher = PaletteIndex::pi129;

--- a/src/openrct2/scenes/intro/IntroScene.h
+++ b/src/openrct2/scenes/intro/IntroScene.h
@@ -11,7 +11,7 @@
 
 #include "../Scene.h"
 
-#include <cstdint>
+#include <memory>
 
 namespace OpenRCT2::Drawing
 {
@@ -20,14 +20,21 @@ namespace OpenRCT2::Drawing
 
 namespace OpenRCT2
 {
+    class IntroSceneImpl;
+
     class IntroScene final : public Scene
     {
     public:
         using Scene::Scene;
 
+        IntroScene(IContext& context);
+
         void Load() override;
         void Tick() override;
         void Stop() override;
+
+    private:
+        std::shared_ptr<IntroSceneImpl> _impl;
     };
 
     bool IntroIsPlaying();

--- a/src/openrct2/scenes/intro/IntroScene.h
+++ b/src/openrct2/scenes/intro/IntroScene.h
@@ -20,20 +20,6 @@ namespace OpenRCT2::Drawing
 
 namespace OpenRCT2
 {
-    enum class IntroState : uint8_t
-    {
-        None,
-        PublisherBegin,
-        PublisherScroll,
-        DeveloperBegin,
-        DeveloperScroll,
-        LogoFadeIn,
-        LogoWait,
-        LogoFadeOut,
-        Clear = 254,
-        Finish = 255,
-    };
-
     class IntroScene final : public Scene
     {
     public:

--- a/src/openrct2/scenes/intro/IntroScene.h
+++ b/src/openrct2/scenes/intro/IntroScene.h
@@ -31,6 +31,5 @@ namespace OpenRCT2
     };
 
     bool IntroIsPlaying();
-    void IntroUpdate();
     void IntroDraw(Drawing::RenderTarget& rt);
 } // namespace OpenRCT2


### PR DESCRIPTION
The goal of this PR is mostly to make the class stand more on its own, to not rely on static globals, and move implementation details out of the header. I went for a shared_ptr to the implementation instead of a unique_ptr, because there are some free functions that need to refer the class, and for that I needed a weak pointer too. Once that is refactored later on, it can be replaced with a unique_ptr.

Gymnasiast mentioned that he also refactored a bit here and there, so I kept it as uninvasive as possible.