### PR TITLE
Add readability-container-size-empty check to clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
     modernize-use-bool-literals,
     modernize-use-nullptr,
     modernize-use-override,
+    readability-container-size-empty,
     readability-redundant-typename,
     readability-uppercase-literal-suffix
 CheckOptions:


### PR DESCRIPTION
This was addressed in a previous pr https://github.com/OpenRCT2/OpenRCT2/pull/25950 Since this improves readability and there were many cases of this already in the code I think it would be good to add this rule