### PR TITLE
Refactor ride window's vehicle draw routines

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3001,13 +3001,12 @@ namespace OpenRCT2::Ui::Windows
             int32_t startY = widget->height() - 5;
 
             bool isReversed = ride->flags.has(RideFlag::reversedTrains);
-            int32_t carIndex = (isReversed) ? ride->numCarsPerTrain - 1 : 0;
-
+            const int32_t firstCarIndex = (isReversed) ? ride->numCarsPerTrain - 1 : 0;
             const auto& firstCarEntry = rideEntry->Cars[RideEntryGetVehicleAtPosition(
-                ride->subtype, ride->numCarsPerTrain, carIndex)];
+                ride->subtype, ride->numCarsPerTrain, firstCarIndex)];
             startY += firstCarEntry.tab_height;
 
-            // For each train
+            // Prepare and draw each train
             for (int32_t i = 0; i < ride->numTrains; i++)
             {
                 VehicleDrawInfo trainCarImages[Limits::kMaxCarsPerTrain];
@@ -3015,11 +3014,12 @@ namespace OpenRCT2::Ui::Windows
                 int32_t x = startX;
                 int32_t y = startY;
 
-                // For each car in train
                 static_assert(std::numeric_limits<decltype(ride->numCarsPerTrain)>::max() <= std::size(trainCarImages));
+
+                // Prepare each car in train for drawing
                 for (int32_t j = 0; j < ride->numCarsPerTrain; j++)
                 {
-                    carIndex = (isReversed) ? (ride->numCarsPerTrain - 1) - j : j;
+                    const auto carIndex = (isReversed) ? (ride->numCarsPerTrain - 1) - j : j;
 
                     const auto& carEntry = rideEntry->Cars[RideEntryGetVehicleAtPosition(
                         ride->subtype, ride->numCarsPerTrain, carIndex)];
@@ -3073,6 +3073,7 @@ namespace OpenRCT2::Ui::Windows
                     *(nextImageToDraw - 2) = tmp;
                 }
 
+                // Draw each car in the train
                 VehicleDrawInfo* current = nextImageToDraw;
                 while (--current >= trainCarImages)
                     GfxDrawSprite(rt, current->imageId, { current->x, current->y });

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3011,7 +3011,7 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t i = 0; i < ride->numTrains; i++)
             {
                 VehicleDrawInfo trainCarImages[Limits::kMaxCarsPerTrain];
-                VehicleDrawInfo* nextSpriteToDraw = trainCarImages;
+                VehicleDrawInfo* nextImageToDraw = trainCarImages;
                 int32_t x = startX;
                 int32_t y = startY;
 
@@ -3056,24 +3056,24 @@ namespace OpenRCT2::Ui::Windows
 
                     auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
 
-                    nextSpriteToDraw->x = x;
-                    nextSpriteToDraw->y = y;
-                    nextSpriteToDraw->imageId = imageId;
-                    nextSpriteToDraw++;
+                    nextImageToDraw->x = x;
+                    nextImageToDraw->y = y;
+                    nextImageToDraw->imageId = imageId;
+                    nextImageToDraw++;
 
                     x += carEntry.spacing / 17432;
                     y -= (carEntry.spacing / 2) / 17432;
                 }
 
                 if (ride->getRideTypeDescriptor().flags.has(RtdFlag::layeredVehiclePreview)
-                    && (nextSpriteToDraw - trainCarImages) >= 2)
+                    && (nextImageToDraw - trainCarImages) >= 2)
                 {
-                    VehicleDrawInfo tmp = *(nextSpriteToDraw - 1);
-                    *(nextSpriteToDraw - 1) = *(nextSpriteToDraw - 2);
-                    *(nextSpriteToDraw - 2) = tmp;
+                    VehicleDrawInfo tmp = *(nextImageToDraw - 1);
+                    *(nextImageToDraw - 1) = *(nextImageToDraw - 2);
+                    *(nextImageToDraw - 2) = tmp;
                 }
 
-                VehicleDrawInfo* current = nextSpriteToDraw;
+                VehicleDrawInfo* current = nextImageToDraw;
                 while (--current >= trainCarImages)
                     GfxDrawSprite(rt, current->imageId, { current->x, current->y });
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2978,13 +2978,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        struct VehicleDrawInfo
-        {
-            int16_t x;
-            int16_t y;
-            ImageId imageId;
-        };
-
         static ImageId getVehiclePreviewImageId(
             const Ride& ride, const RideObjectEntry& rideEntry, const CarEntry& carEntry, int32_t trainIndex, int32_t carIndex,
             bool isReversed)
@@ -3024,11 +3017,20 @@ namespace OpenRCT2::Ui::Windows
             return ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
         }
 
-        static VehicleDrawInfo* prepareTrainCarImages(
-            const Ride& ride, const RideObjectEntry& rideEntry, int32_t trainIndex, bool isReversed, int32_t x, int32_t y,
-            VehicleDrawInfo* out)
+        struct VehicleDrawInfo
         {
-            for (int32_t j = 0; j < ride.numCarsPerTrain; j++)
+            int16_t x;
+            int16_t y;
+            ImageId imageId;
+        };
+
+        static size_t prepareTrainCarImages(
+            const Ride& ride, const RideObjectEntry& rideEntry, int32_t trainIndex, bool isReversed, int32_t x, int32_t y,
+            std::span<VehicleDrawInfo> out)
+        {
+            size_t count = 0;
+
+            for (int32_t j = 0; j < ride.numCarsPerTrain; ++j)
             {
                 const int32_t carIndex = isReversed ? (ride.numCarsPerTrain - 1 - j) : j;
 
@@ -3041,17 +3043,17 @@ namespace OpenRCT2::Ui::Windows
                 x += dx;
                 y -= dy;
 
-                out->x = x;
-                out->y = y;
-                out->imageId = getVehiclePreviewImageId(ride, rideEntry, carEntry, trainIndex, carIndex, isReversed);
+                auto imageId = getVehiclePreviewImageId(ride, rideEntry, carEntry, trainIndex, carIndex, isReversed);
 
-                ++out;
+                out[count++] = VehicleDrawInfo{ .x = static_cast<int16_t>(x),
+                                                .y = static_cast<int16_t>(y),
+                                                .imageId = imageId };
 
                 x += dx;
                 y -= dy;
             }
 
-            return out;
+            return count;
         }
 
         void VehicleOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)
@@ -3080,20 +3082,19 @@ namespace OpenRCT2::Ui::Windows
             {
                 VehicleDrawInfo trainCarImages[Limits::kMaxCarsPerTrain];
 
-                auto* nextImageToDraw = prepareTrainCarImages(*ride, *rideEntry, i, isReversed, startX, startY, trainCarImages);
+                std::span images(trainCarImages);
+                auto count = prepareTrainCarImages(*ride, *rideEntry, i, isReversed, startX, startY, images);
 
-                if (ride->getRideTypeDescriptor().flags.has(RtdFlag::layeredVehiclePreview)
-                    && (nextImageToDraw - trainCarImages) >= 2)
+                if (ride->getRideTypeDescriptor().flags.has(RtdFlag::layeredVehiclePreview) && count >= 2)
                 {
-                    VehicleDrawInfo tmp = *(nextImageToDraw - 1);
-                    *(nextImageToDraw - 1) = *(nextImageToDraw - 2);
-                    *(nextImageToDraw - 2) = tmp;
+                    std::swap(images[count - 1], images[count - 2]);
                 }
 
                 // Draw each car in the train
-                VehicleDrawInfo* current = nextImageToDraw;
-                while (--current >= trainCarImages)
-                    GfxDrawSprite(rt, current->imageId, { current->x, current->y });
+                for (auto& image : std::views::reverse(images.first(count)))
+                {
+                    GfxDrawSprite(rt, image.imageId, { image.x, image.y });
+                }
 
                 startX += 36;
             }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2985,62 +2985,73 @@ namespace OpenRCT2::Ui::Windows
             ImageId imageId;
         };
 
+        static ImageId getVehiclePreviewImageId(
+            const Ride& ride, const RideObjectEntry& rideEntry, const CarEntry& carEntry, int32_t trainIndex, int32_t carIndex,
+            bool isReversed)
+        {
+            int32_t vehicleColourIndex = 0;
+
+            switch (ride.vehicleColourSettings)
+            {
+                case VehicleColourSettings::same:
+                    vehicleColourIndex = 0;
+                    break;
+
+                case VehicleColourSettings::perTrain:
+                    vehicleColourIndex = trainIndex;
+                    break;
+
+                case VehicleColourSettings::perCar:
+                    vehicleColourIndex = carIndex;
+                    break;
+            }
+
+            VehicleColour vehicleColour = RideGetVehicleColour(ride, vehicleColourIndex);
+
+            ImageIndex imageIndex = carEntry.SpriteByYaw(Entity::Yaw::kBaseRotation / 2, SpriteGroupType::SlopeFlat);
+
+            if (isReversed)
+            {
+                auto baseRotation = carEntry.NumRotationSprites(SpriteGroupType::SlopeFlat);
+                imageIndex = carEntry.SpriteByYaw(
+                    (imageIndex + (baseRotation / 2)) & (baseRotation - 1), SpriteGroupType::SlopeFlat);
+            }
+
+            imageIndex &= carEntry.TabRotationMask;
+            imageIndex *= carEntry.base_num_frames;
+            imageIndex += carEntry.base_image_id;
+
+            return ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
+        }
+
         static VehicleDrawInfo* prepareTrainCarImages(
             const Ride& ride, const RideObjectEntry& rideEntry, int32_t trainIndex, bool isReversed, int32_t x, int32_t y,
             VehicleDrawInfo* out)
         {
-            auto nextImageToDraw = out;
-
             for (int32_t j = 0; j < ride.numCarsPerTrain; j++)
             {
-                const auto carIndex = (isReversed) ? (ride.numCarsPerTrain - 1) - j : j;
+                const int32_t carIndex = isReversed ? (ride.numCarsPerTrain - 1 - j) : j;
+
                 const auto vehicleIndex = RideEntryGetVehicleAtPosition(ride.subtype, ride.numCarsPerTrain, carIndex);
-
                 const auto& carEntry = rideEntry.Cars[vehicleIndex];
-                x += carEntry.spacing / 17432;
-                y -= (carEntry.spacing / 2) / 17432;
 
-                int32_t vehicleColourIndex = 0;
-                switch (ride.vehicleColourSettings)
-                {
-                    case VehicleColourSettings::same:
-                        vehicleColourIndex = 0;
-                        break;
-                    case VehicleColourSettings::perTrain:
-                        vehicleColourIndex = trainIndex;
-                        break;
-                    case VehicleColourSettings::perCar:
-                        vehicleColourIndex = carIndex;
-                        break;
-                }
+                const int32_t dx = carEntry.spacing / 17432;
+                const int32_t dy = (carEntry.spacing / 2) / 17432;
 
-                VehicleColour vehicleColour = RideGetVehicleColour(ride, vehicleColourIndex);
+                x += dx;
+                y -= dy;
 
-                ImageIndex imageIndex = carEntry.SpriteByYaw(Entity::Yaw::kBaseRotation / 2, SpriteGroupType::SlopeFlat);
+                out->x = x;
+                out->y = y;
+                out->imageId = getVehiclePreviewImageId(ride, rideEntry, carEntry, trainIndex, carIndex, isReversed);
 
-                if (isReversed)
-                {
-                    auto baseRotation = carEntry.NumRotationSprites(SpriteGroupType::SlopeFlat);
-                    imageIndex = carEntry.SpriteByYaw(
-                        (imageIndex + (baseRotation / 2)) & (baseRotation - 1), SpriteGroupType::SlopeFlat);
-                }
+                ++out;
 
-                imageIndex &= carEntry.TabRotationMask;
-                imageIndex *= carEntry.base_num_frames;
-                imageIndex += carEntry.base_image_id;
-
-                auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
-
-                nextImageToDraw->x = x;
-                nextImageToDraw->y = y;
-                nextImageToDraw->imageId = imageId;
-                nextImageToDraw++;
-
-                x += carEntry.spacing / 17432;
-                y -= (carEntry.spacing / 2) / 17432;
+                x += dx;
+                y -= dy;
             }
 
-            return nextImageToDraw;
+            return out;
         }
 
         void VehicleOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2996,9 +2996,9 @@ namespace OpenRCT2::Ui::Windows
             // Background
             Rectangle::fill(rt, { { rt.x, rt.y }, { rt.x + rt.width, rt.y + rt.height } }, PaletteIndex::pi12);
 
-            Widget* widget = &widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
-            int32_t startX = std::max(2, (widget->width() - 1 - ((ride->numTrains - 1) * 36)) / 2 - 25);
-            int32_t startY = widget->height() - 5;
+            const Widget& widget = widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
+            int32_t startX = std::max(2, (widget.width() - 1 - ((ride->numTrains - 1) * 36)) / 2 - 25);
+            int32_t startY = widget.height() - 5;
 
             bool isReversed = ride->flags.has(RideFlag::reversedTrains);
             const int32_t firstCarIndex = (isReversed) ? ride->numCarsPerTrain - 1 : 0;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2985,6 +2985,64 @@ namespace OpenRCT2::Ui::Windows
             ImageId imageId;
         };
 
+        static VehicleDrawInfo* prepareTrainCarImages(
+            const Ride& ride, const RideObjectEntry& rideEntry, int32_t trainIndex, bool isReversed, int32_t x, int32_t y,
+            VehicleDrawInfo* out)
+        {
+            auto nextImageToDraw = out;
+
+            for (int32_t j = 0; j < ride.numCarsPerTrain; j++)
+            {
+                const auto carIndex = (isReversed) ? (ride.numCarsPerTrain - 1) - j : j;
+                const auto vehicleIndex = RideEntryGetVehicleAtPosition(ride.subtype, ride.numCarsPerTrain, carIndex);
+
+                const auto& carEntry = rideEntry.Cars[vehicleIndex];
+                x += carEntry.spacing / 17432;
+                y -= (carEntry.spacing / 2) / 17432;
+
+                int32_t vehicleColourIndex = 0;
+                switch (ride.vehicleColourSettings)
+                {
+                    case VehicleColourSettings::same:
+                        vehicleColourIndex = 0;
+                        break;
+                    case VehicleColourSettings::perTrain:
+                        vehicleColourIndex = trainIndex;
+                        break;
+                    case VehicleColourSettings::perCar:
+                        vehicleColourIndex = carIndex;
+                        break;
+                }
+
+                VehicleColour vehicleColour = RideGetVehicleColour(ride, vehicleColourIndex);
+
+                ImageIndex imageIndex = carEntry.SpriteByYaw(Entity::Yaw::kBaseRotation / 2, SpriteGroupType::SlopeFlat);
+
+                if (isReversed)
+                {
+                    auto baseRotation = carEntry.NumRotationSprites(SpriteGroupType::SlopeFlat);
+                    imageIndex = carEntry.SpriteByYaw(
+                        (imageIndex + (baseRotation / 2)) & (baseRotation - 1), SpriteGroupType::SlopeFlat);
+                }
+
+                imageIndex &= carEntry.TabRotationMask;
+                imageIndex *= carEntry.base_num_frames;
+                imageIndex += carEntry.base_image_id;
+
+                auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
+
+                nextImageToDraw->x = x;
+                nextImageToDraw->y = y;
+                nextImageToDraw->imageId = imageId;
+                nextImageToDraw++;
+
+                x += carEntry.spacing / 17432;
+                y -= (carEntry.spacing / 2) / 17432;
+            }
+
+            return nextImageToDraw;
+        }
+
         void VehicleOnScrollDraw(RenderTarget& rt, int32_t scrollIndex)
         {
             auto ride = GetRide(rideId);
@@ -3010,60 +3068,8 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t i = 0; i < ride->numTrains; i++)
             {
                 VehicleDrawInfo trainCarImages[Limits::kMaxCarsPerTrain];
-                VehicleDrawInfo* nextImageToDraw = trainCarImages;
-                int32_t x = startX;
-                int32_t y = startY;
 
-                static_assert(std::numeric_limits<decltype(ride->numCarsPerTrain)>::max() <= std::size(trainCarImages));
-
-                // Prepare each car in train for drawing
-                for (int32_t j = 0; j < ride->numCarsPerTrain; j++)
-                {
-                    const auto carIndex = (isReversed) ? (ride->numCarsPerTrain - 1) - j : j;
-
-                    const auto& carEntry = rideEntry->Cars[RideEntryGetVehicleAtPosition(
-                        ride->subtype, ride->numCarsPerTrain, carIndex)];
-                    x += carEntry.spacing / 17432;
-                    y -= (carEntry.spacing / 2) / 17432;
-
-                    // Get colour of vehicle
-                    int32_t vehicleColourIndex = 0;
-                    switch (ride->vehicleColourSettings)
-                    {
-                        case VehicleColourSettings::same:
-                            vehicleColourIndex = 0;
-                            break;
-                        case VehicleColourSettings::perTrain:
-                            vehicleColourIndex = i;
-                            break;
-                        case VehicleColourSettings::perCar:
-                            vehicleColourIndex = carIndex;
-                            break;
-                    }
-                    VehicleColour vehicleColour = RideGetVehicleColour(*ride, vehicleColourIndex);
-
-                    ImageIndex imageIndex = carEntry.SpriteByYaw(Entity::Yaw::kBaseRotation / 2, SpriteGroupType::SlopeFlat);
-                    if (isReversed)
-                    {
-                        auto baseRotation = carEntry.NumRotationSprites(SpriteGroupType::SlopeFlat);
-                        imageIndex = carEntry.SpriteByYaw(
-                            (imageIndex + (baseRotation / 2)) & (baseRotation - 1), SpriteGroupType::SlopeFlat);
-                    }
-
-                    imageIndex &= carEntry.TabRotationMask;
-                    imageIndex *= carEntry.base_num_frames;
-                    imageIndex += carEntry.base_image_id;
-
-                    auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
-
-                    nextImageToDraw->x = x;
-                    nextImageToDraw->y = y;
-                    nextImageToDraw->imageId = imageId;
-                    nextImageToDraw++;
-
-                    x += carEntry.spacing / 17432;
-                    y -= (carEntry.spacing / 2) / 17432;
-                }
+                auto* nextImageToDraw = prepareTrainCarImages(*ride, *rideEntry, i, isReversed, startX, startY, trainCarImages);
 
                 if (ride->getRideTypeDescriptor().flags.has(RtdFlag::layeredVehiclePreview)
                     && (nextImageToDraw - trainCarImages) >= 2)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4454,11 +4454,10 @@ void RideUpdateVehicleColours(const Ride& ride)
     for (int32_t i = 0; i <= Limits::kMaxTrainsPerRide; i++)
     {
         int32_t carIndex = 0;
-        VehicleColour colours = {};
-
         for (Vehicle* vehicle = entities.GetEntity<Vehicle>(ride.vehicles[i]); vehicle != nullptr;
              vehicle = entities.GetEntity<Vehicle>(vehicle->next_vehicle_on_train))
         {
+            VehicleColour colours = {};
             switch (ride.vehicleColourSettings)
             {
                 case VehicleColourSettings::same:

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4450,13 +4450,14 @@ void RideUpdateVehicleColours(const Ride& ride)
         GfxInvalidateScreen();
     }
 
+    auto& entities = getGameState().entities;
     for (int32_t i = 0; i <= Limits::kMaxTrainsPerRide; i++)
     {
         int32_t carIndex = 0;
         VehicleColour colours = {};
 
-        for (Vehicle* vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[i]); vehicle != nullptr;
-             vehicle = getGameState().entities.GetEntity<Vehicle>(vehicle->next_vehicle_on_train))
+        for (Vehicle* vehicle = entities.GetEntity<Vehicle>(ride.vehicles[i]); vehicle != nullptr;
+             vehicle = entities.GetEntity<Vehicle>(vehicle->next_vehicle_on_train))
         {
             switch (ride.vehicleColourSettings)
             {
@@ -4467,16 +4468,12 @@ void RideUpdateVehicleColours(const Ride& ride)
                     colours = ride.vehicleColours[i];
                     break;
                 case VehicleColourSettings::perCar:
-                    if (vehicle->flags.has(VehicleFlag::carIsReversed))
-                    {
-                        colours = ride.vehicleColours[std::min(
-                            (ride.numCarsPerTrain - 1) - carIndex, Limits::kMaxCarsPerTrain - 1)];
-                    }
-                    else
-                    {
-                        colours = ride.vehicleColours[std::min(carIndex, Limits::kMaxCarsPerTrain - 1)];
-                    }
+                {
+                    const bool isReversed = vehicle->flags.has(VehicleFlag::carIsReversed);
+                    const auto colourIndex = isReversed ? (ride.numCarsPerTrain - 1) - carIndex : carIndex;
+                    colours = ride.vehicleColours[std::min(colourIndex, Limits::kMaxCarsPerTrain - 1)];
                     break;
+                }
             }
 
             vehicle->colours = colours;


### PR DESCRIPTION
This rewrites the ride window's vehicle preview draw routines. Previously, this was one function, `VehicleOnScrollDraw`. Instead, the drawing is now prepared in a new function `prepareTrainCarImages`, which in turn calls `getVehiclePreviewImageId`.

The resulting `VehicleOnScrollDraw` function is much shorter. Furthermore, by using `std::span`, we can avoid relatively complicated pointer arithmetic. Similarly, we can now simply use `std::swap` in the edge case recently covered by #25970.

Finally, the reverse while loop is replaced with a `std::views::reverse` iterator working on the same `std::span`.

I realise the new code is marginally longer, but I think the added guardrails are worth it.