### PR TITLE
Fix #26083: Only allow food marketing for open stalls

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#25941] The command line sprite build command is now faster.
 - Improved: [#26002] Rides with newer track elements (like the zero G roll or diagonal brakes) can now be saved as track designs.
 - Improved: [#26050] Add Danish translation to Windows installer.
+- Improved: [#26091] When all rides are closed, the marketing window will no longer show the ride advertisement campaign.
 - Change: [#26011] Audio resampling no longer depends on the third-party library libspeexdsp.
 - Change: [#26049] Guest generation now starts slowing down above 52000 guests instead of 7000.
 - Fix: [#14686, #23996, #25981] Preview images from different windows overwrite each other when using OpenGL.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#26037] Selecting elements in the tile inspector list and changing all tiles of a track piece does not redraw correctly.
 - Fix: [#26057] In the scrolling intro, the Infogrames logo is taken off the screen before it reaches the bottom (original bug).
 - Fix: [#26058] RCT Classic scenarios with packed objects missing from scenario index.
+- Fix: [#26083] You can advertise for closed food & drink stalls.
 
 0.4.31 (2026-02-01)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -117,7 +117,7 @@ namespace OpenRCT2::Ui::Windows
             for (auto& curRide : RideManager(gameState))
             {
                 auto rideEntry = curRide.getRideEntry();
-                if (rideEntry != nullptr)
+                if (rideEntry != nullptr && curRide.status == RideStatus::open)
                 {
                     for (const auto itemType : rideEntry->shop_item)
                     {
@@ -209,21 +209,18 @@ namespace OpenRCT2::Ui::Windows
                     if (Campaign.campaign_type == ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE)
                     {
                         GetShopItems();
-                        if (!ShopItems.empty())
+                        int32_t numItems = 0;
+                        int32_t maxSize = std::min(Dropdown::kItemsMaxSize, static_cast<int32_t>(ShopItems.size()));
+                        for (int32_t i = 0; i < maxSize; i++)
                         {
-                            int32_t numItems = 0;
-                            int32_t maxSize = std::min(Dropdown::kItemsMaxSize, static_cast<int32_t>(ShopItems.size()));
-                            for (int32_t i = 0; i < maxSize; i++)
-                            {
-                                gDropdown.items[i] = Dropdown::MenuLabel(GetShopItemDescriptor(ShopItems[i]).Naming.Plural);
-                                numItems++;
-                            }
-
-                            WindowDropdownShowTextCustomWidth(
-                                { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top },
-                                dropdownWidget->height(), colours[1], 0, Dropdown::Flag::StayOpen, numItems,
-                                dropdownWidget->width() - 4);
+                            gDropdown.items[i] = Dropdown::MenuLabel(GetShopItemDescriptor(ShopItems[i]).Naming.Plural);
+                            numItems++;
                         }
+
+                        WindowDropdownShowTextCustomWidth(
+                            { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top },
+                            dropdownWidget->height(), colours[1], 0, Dropdown::Flag::StayOpen, numItems,
+                            dropdownWidget->width() - 4);
                     }
                     else
                     {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -218,9 +218,8 @@ namespace OpenRCT2::Ui::Windows
                         }
 
                         WindowDropdownShowTextCustomWidth(
-                            { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top },
-                            dropdownWidget->height(), colours[1], 0, Dropdown::Flag::StayOpen, numItems,
-                            dropdownWidget->width() - 4);
+                            { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height(),
+                            colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 4);
                     }
                     else
                     {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -209,17 +209,21 @@ namespace OpenRCT2::Ui::Windows
                     if (Campaign.campaign_type == ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE)
                     {
                         GetShopItems();
-                        int32_t numItems = 0;
-                        int32_t maxSize = std::min(Dropdown::kItemsMaxSize, static_cast<int32_t>(ShopItems.size()));
-                        for (int32_t i = 0; i < maxSize; i++)
+                        if (!ShopItems.empty())
                         {
-                            gDropdown.items[i] = Dropdown::MenuLabel(GetShopItemDescriptor(ShopItems[i]).Naming.Plural);
-                            numItems++;
-                        }
+                            int32_t numItems = 0;
+                            int32_t maxSize = std::min(Dropdown::kItemsMaxSize, static_cast<int32_t>(ShopItems.size()));
+                            for (int32_t i = 0; i < maxSize; i++)
+                            {
+                                gDropdown.items[i] = Dropdown::MenuLabel(GetShopItemDescriptor(ShopItems[i]).Naming.Plural);
+                                numItems++;
+                            }
 
-                        WindowDropdownShowTextCustomWidth(
-                            { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height(),
-                            colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 4);
+                            WindowDropdownShowTextCustomWidth(
+                                { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top },
+                                dropdownWidget->height(), colours[1], 0, Dropdown::Flag::StayOpen, numItems,
+                                dropdownWidget->width() - 4);
+                        }
                     }
                     else
                     {

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -201,10 +201,10 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
 
             [[fallthrough]];
         case ADVERTISING_CAMPAIGN_RIDE:
-            // Check if any rides exist
+            // Check if any rides exist and are open
             for (auto& ride : RideManager(gameState))
             {
-                if (ride.isRide())
+                if (ride.isRide() && ride.status == RideStatus::open)
                 {
                     return true;
                 }
@@ -216,7 +216,7 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
             for (auto& ride : RideManager(gameState))
             {
                 auto rideEntry = ride.getRideEntry();
-                if (rideEntry != nullptr)
+                if (rideEntry != nullptr && ride.status == RideStatus::open)
                 {
                     for (auto& item : rideEntry->shop_item)
                     {


### PR DESCRIPTION
Fixes #26083 

This PR fixes several issues:
- Food/drink campaign shows up even when all stalls are closed.
- You can select food/drink from closed stalls and advertise it.
- Ride campaigns show up even when all rides are closed.

I also changed it so that if you close all your food stalls while the new campaign window is open, it shows a dropdown with a single empty bar instead of no dropdown at all (see image). The ride campaigns already have this behaviour and I find it more intuitive than not having a dropdown at all, which might lead the user to believe it's not working properly.

<img width="787" height="250" alt="image" src="https://github.com/user-attachments/assets/be5d4f56-37ac-4e6f-94eb-e0bbe015918a" />

The marketing window does now have issues with redrawing when you close/open rides/stalls and there is a change in which campaigns are available. For a brief time it looks like this, and I don't have the knowledge how to fix that.

<img width="1185" height="381" alt="image" src="https://github.com/user-attachments/assets/edac6d7b-e879-4c1c-b9d7-049817033d3b" />
