### PR TITLE
Refactor lifecycleFlags to FlagHolder

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2308,6 +2308,12 @@ declare global {
         /**
          * Various flags related to the operation of the ride.
          */
+        flags: number;
+
+        /**
+         * Old name of ‘flags’ property
+         * @deprecated
+         */
         lifecycleFlags: number;
 
         /**

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -2288,7 +2288,7 @@ namespace OpenRCT2::Ui::Windows
             auto* currentRide = GetRide(_rideableRides[i]);
             if (currentRide != nullptr)
             {
-                currentRide->lifecycleFlags ^= RIDE_LIFECYCLE_INDESTRUCTIBLE;
+                currentRide->lifecycleFlags.flip(RideFlag::indestructible);
             }
             invalidate();
         }
@@ -2366,7 +2366,7 @@ namespace OpenRCT2::Ui::Windows
                 auto* currentRide = GetRide(_rideableRides[i]);
                 if (currentRide != nullptr)
                 {
-                    if (currentRide->lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
+                    if (currentRide->lifecycleFlags.has(RideFlag::indestructible))
                     {
                         auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::extraDark : TextDarkness::dark;
                         DrawText(

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -2288,7 +2288,7 @@ namespace OpenRCT2::Ui::Windows
             auto* currentRide = GetRide(_rideableRides[i]);
             if (currentRide != nullptr)
             {
-                currentRide->lifecycleFlags.flip(RideFlag::indestructible);
+                currentRide->flags.flip(RideFlag::indestructible);
             }
             invalidate();
         }
@@ -2366,7 +2366,7 @@ namespace OpenRCT2::Ui::Windows
                 auto* currentRide = GetRide(_rideableRides[i]);
                 if (currentRide != nullptr)
                 {
-                    if (currentRide->lifecycleFlags.has(RideFlag::indestructible))
+                    if (currentRide->flags.has(RideFlag::indestructible))
                     {
                         auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::extraDark : TextDarkness::dark;
                         DrawText(

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1525,8 +1525,7 @@ namespace OpenRCT2::Ui::Windows
 
             std::optional<Focus> newFocus;
 
-            if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->numTrains
-                && ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+            if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->numTrains && ride->lifecycleFlags.has(RideFlag::onTrack))
             {
                 auto vehId = ride->vehicles[viewSelectionIndex];
                 const auto* rideEntry = ride->getRideEntry();
@@ -1755,7 +1754,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool TrainMustBeHidden(const Ride& ride, int32_t trainIndex) const
         {
-            if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+            if (!ride.lifecycleFlags.has(RideFlag::onTrack))
                 return true;
 
             const auto* rideEntry = ride.getRideEntry();
@@ -1827,12 +1826,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 default:
                 case RideStatus::closed:
-                    if ((ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED)
-                        || (ride.lifecycleFlags & RIDE_LIFECYCLE_HAS_STALLED_VEHICLE))
+                    if (ride.lifecycleFlags.hasAny(RideFlag::crashed, RideFlag::hasStalledVehicle))
                     {
                         return RideStatus::closed;
                     }
-                    if (ride.supportsStatus(RideStatus::testing) && !(ride.lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+                    if (ride.supportsStatus(RideStatus::testing) && !ride.lifecycleFlags.has(RideFlag::tested))
                     {
                         return RideStatus::testing;
                     }
@@ -1840,7 +1838,7 @@ namespace OpenRCT2::Ui::Windows
                 case RideStatus::simulating:
                     return RideStatus::testing;
                 case RideStatus::testing:
-                    return (ride.lifecycleFlags & RIDE_LIFECYCLE_TESTED) ? RideStatus::open : RideStatus::closed;
+                    return ride.lifecycleFlags.has(RideFlag::tested) ? RideStatus::open : RideStatus::closed;
                 case RideStatus::open:
                     return RideStatus::closed;
             }
@@ -2205,7 +2203,7 @@ namespace OpenRCT2::Ui::Windows
                         if (ride != nullptr)
                         {
                             if (dropdownIndex != 0 && dropdownIndex <= ride->numTrains
-                                && !(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+                                && !ride->lifecycleFlags.has(RideFlag::onTrack))
                             {
                                 dropdownIndex = ride->numTrains + 1;
                             }
@@ -2341,7 +2339,7 @@ namespace OpenRCT2::Ui::Windows
 
             const auto& gameState = getGameState();
             disabledWidgets &= ~((1uLL << WIDX_DEMOLISH) | (1uLL << WIDX_CONSTRUCTION));
-            if (ride->lifecycleFlags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+            if (ride->lifecycleFlags.hasAny(RideFlag::indestructible, RideFlag::indestructibleTrack)
                 && !gameState.cheats.makeAllDestructible)
                 disabledWidgets |= (1uLL << WIDX_DEMOLISH);
 
@@ -2475,7 +2473,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 ride->formatStatusTo(ft);
                 stringId = STR_BLACK_STRING;
-                if ((ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN) || (ride->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+                if (ride->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                 {
                     stringId = STR_RED_OUTLINED_STRING;
                 }
@@ -2588,7 +2586,7 @@ namespace OpenRCT2::Ui::Windows
                 return GetStatusOverallView(ft);
             if (ride != nullptr && _viewIndex <= ride->numTrains)
                 return GetStatusVehicle(ft);
-            if (ride != nullptr && ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+            if (ride != nullptr && ride->lifecycleFlags.has(RideFlag::brokenDown))
                 return GetStatusOverallView(ft);
             return GetStatusStation(ft);
         }
@@ -2688,7 +2686,7 @@ namespace OpenRCT2::Ui::Windows
                     ShowVehicleTypeDropdown(&widgets[widgetIndex]);
                     break;
                 case WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX:
-                    ride->setReversedTrains(!ride->hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS));
+                    ride->setReversedTrains(!ride->lifecycleFlags.has(RideFlag::reversedTrains));
                     break;
                 case WIDX_VEHICLE_TRAINS_INCREASE:
                     if (ride->numTrains < Limits::kMaxTrainsPerRide)
@@ -2840,7 +2838,7 @@ namespace OpenRCT2::Ui::Windows
                 || (gameState.cheats.disableTrainLengthLimit && !ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide)))
             {
                 widgets[WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX].type = WidgetType::checkbox;
-                if (ride->hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS))
+                if (ride->lifecycleFlags.has(RideFlag::reversedTrains))
                 {
                     pressedWidgets |= (1uLL << WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX);
                 }
@@ -2984,7 +2982,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t startX = std::max(2, (widget->width() - 1 - ((ride->numTrains - 1) * 36)) / 2 - 25);
             int32_t startY = widget->height() - 5;
 
-            bool isReversed = ride->hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS);
+            bool isReversed = ride->lifecycleFlags.has(RideFlag::reversedTrains);
             int32_t carIndex = (isReversed) ? ride->numCarsPerTrain - 1 : 0;
 
             const auto& firstCarEntry = rideEntry->Cars[RideEntryGetVehicleAtPosition(
@@ -3857,7 +3855,7 @@ namespace OpenRCT2::Ui::Windows
 
                         numItems = 1;
                         int32_t breakdownReason = ride->breakdownReasonPending;
-                        if (breakdownReason != BREAKDOWN_NONE && (ride->lifecycleFlags & RIDE_LIFECYCLE_BREAKDOWN_PENDING))
+                        if (breakdownReason != BREAKDOWN_NONE && ride->lifecycleFlags.has(RideFlag::breakdownPending))
                         {
                             for (int32_t i = 0; i < 8; i++)
                             {
@@ -3880,7 +3878,7 @@ namespace OpenRCT2::Ui::Windows
                             }
                         }
 
-                        if ((ride->lifecycleFlags & RIDE_LIFECYCLE_BREAKDOWN_PENDING) == 0)
+                        if (!ride->lifecycleFlags.has(RideFlag::breakdownPending))
                         {
                             gDropdown.items[0].setDisabled(true);
                         }
@@ -3915,7 +3913,7 @@ namespace OpenRCT2::Ui::Windows
                         switch (ride->breakdownReasonPending)
                         {
                             case BREAKDOWN_SAFETY_CUT_OUT:
-                                if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+                                if (!ride->lifecycleFlags.has(RideFlag::onTrack))
                                     break;
                                 for (int32_t i = 0; i < ride->numTrains; ++i)
                                 {
@@ -3947,14 +3945,13 @@ namespace OpenRCT2::Ui::Windows
                                 }
                                 break;
                         }
-                        ride->lifecycleFlags &= ~(RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN);
+                        ride->lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown);
 
                         auto* windowMgr = GetWindowManager();
                         windowMgr->InvalidateByNumber(WindowClass::ride, number);
                         break;
                     }
-                    if (ride->lifecycleFlags
-                        & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+                    if (ride->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
                     {
                         ContextShowError(STR_DEBUG_CANT_FORCE_BREAKDOWN, STR_DEBUG_RIDE_ALREADY_BROKEN, {});
                     }
@@ -4032,8 +4029,7 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_FORCE_BREAKDOWN].type = WidgetType::empty;
             }
 
-            if (ride->getRideTypeDescriptor().AvailableBreakdowns == 0
-                || !(ride->lifecycleFlags & RIDE_LIFECYCLE_EVER_BEEN_OPENED))
+            if (ride->getRideTypeDescriptor().AvailableBreakdowns == 0 || !ride->lifecycleFlags.has(RideFlag::everBeenOpened))
             {
                 disabledWidgets |= (1uLL << WIDX_REFURBISH_RIDE);
                 widgets[WIDX_REFURBISH_RIDE].tooltip = STR_CANT_REFURBISH_NOT_NEEDED;
@@ -4103,14 +4099,14 @@ namespace OpenRCT2::Ui::Windows
             if (ride->breakdownReason == BREAKDOWN_NONE)
                 return;
 
-            stringId = (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
+            stringId = ride->lifecycleFlags.has(RideFlag::brokenDown) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
             ft = Formatter();
             ft.Add<StringId>(RideBreakdownReasonNames[ride->breakdownReason]);
             DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += 12;
 
             // Mechanic status
-            if (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+            if (ride->lifecycleFlags.has(RideFlag::brokenDown))
             {
                 switch (ride->mechanicStatus)
                 {
@@ -4247,7 +4243,7 @@ namespace OpenRCT2::Ui::Windows
                     auto ride = GetRide(rideId);
                     if (ride != nullptr)
                     {
-                        const bool currentlyEnabled = ride->hasLifecycleFlag(RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS);
+                        const bool currentlyEnabled = ride->lifecycleFlags.has(RideFlag::randomShopColours);
                         auto rideSetAppearanceAction = GameActions::RideSetAppearanceAction(
                             rideId, GameActions::RideSetAppearanceType::SellingItemColourIsRandom, currentlyEnabled ? 0 : 1, 0);
                         GameActions::Execute(&rideSetAppearanceAction, gameState);
@@ -4667,7 +4663,7 @@ namespace OpenRCT2::Ui::Windows
             if (ride->hasRecolourableShopItems())
             {
                 widgets[WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX].type = WidgetType::checkbox;
-                if (ride->hasLifecycleFlag(RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS))
+                if (ride->lifecycleFlags.has(RideFlag::randomShopColours))
                 {
                     pressedWidgets |= (1uLL << WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX);
                 }
@@ -4927,7 +4923,7 @@ namespace OpenRCT2::Ui::Windows
             RenderTarget& rt, const Ride* ride, const ShopItemDescriptor& shopItem, const Widget& widget)
         {
             Colour spriteColour = ride->trackColours[0].main;
-            if (ride->hasLifecycleFlag(RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS))
+            if (ride->lifecycleFlags.has(RideFlag::randomShopColours))
                 spriteColour = Colour((getGameState().currentTicks / 32) % kColourNumNormal);
 
             auto* image = GfxGetG1Element(shopItem.Image);
@@ -5047,7 +5043,7 @@ namespace OpenRCT2::Ui::Windows
             auto ride = GetRide(rideId);
             if (ride != nullptr)
             {
-                int32_t activateMusic = (ride->lifecycleFlags & RIDE_LIFECYCLE_MUSIC) ? 0 : 1;
+                int32_t activateMusic = ride->lifecycleFlags.has(RideFlag::music) ? 0 : 1;
                 SetOperatingSetting(rideId, GameActions::RideSetSetting::Music, activateMusic);
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::music);
             }
@@ -5087,7 +5083,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // Expand the window when music is playing
-            auto isMusicActivated = (ride->lifecycleFlags & RIDE_LIFECYCLE_MUSIC) != 0;
+            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
             auto standardHeight = widgets[WIDX_MUSIC_DROPDOWN].bottom + 6;
             auto newMinHeight = isMusicActivated ? standardHeight + 133 : standardHeight;
             auto newMaxHeight = isMusicActivated ? standardHeight + 369 : standardHeight;
@@ -5272,7 +5268,7 @@ namespace OpenRCT2::Ui::Windows
             }
             widgets[WIDX_MUSIC].text = musicName;
 
-            auto isMusicActivated = (ride->lifecycleFlags & RIDE_LIFECYCLE_MUSIC) != 0;
+            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
             bool hasPreviewImage = musicObj != nullptr && musicObj->HasPreview();
 
             widgetSetVisible(*this, WIDX_MUSIC_DATA, isMusicActivated);
@@ -5315,7 +5311,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // Draw music data only when music is activated
-            auto isMusicActivated = (ride->lifecycleFlags & RIDE_LIFECYCLE_MUSIC) != 0;
+            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
             if (!isMusicActivated)
                 return;
 
@@ -5350,7 +5346,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // only draw track listing when music is activated
-            auto isMusicActivated = (ride->lifecycleFlags & RIDE_LIFECYCLE_MUSIC) != 0;
+            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
             if (!isMusicActivated)
                 return;
 
@@ -5672,7 +5668,7 @@ namespace OpenRCT2::Ui::Windows
 
                 widgets[WIDX_SAVE_TRACK_DESIGN].type = WidgetType::flatBtn;
                 disabledWidgets |= (1uLL << WIDX_SAVE_TRACK_DESIGN);
-                if (ride->lifecycleFlags & RIDE_LIFECYCLE_TESTED)
+                if (ride->lifecycleFlags.has(RideFlag::tested))
                 {
                     if (!ride->ratings.isNull())
                     {
@@ -5712,7 +5708,7 @@ namespace OpenRCT2::Ui::Windows
                 auto screenCoords = windowPos
                     + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-                if (ride->lifecycleFlags & RIDE_LIFECYCLE_TESTED)
+                if (ride->lifecycleFlags.has(RideFlag::tested))
                 {
                     // Excitement
                     StringId ratingName = GetRatingName(ride->ratings.excitement);
@@ -5753,7 +5749,7 @@ namespace OpenRCT2::Ui::Windows
                         rt, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, colours[1],
                         Rectangle::BorderStyle::inset);
 
-                    if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_NO_RAW_STATS))
+                    if (!ride->lifecycleFlags.has(RideFlag::noRawStats))
                     {
                         if (ride->getRideTypeDescriptor().specialType == RtdSpecialType::miniGolf)
                         {
@@ -6647,7 +6643,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Get secondary item
             auto secondaryItem = ride->getRideTypeDescriptor().PhotoItem;
-            if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO))
+            if (!ride->lifecycleFlags.has(RideFlag::onRidePhoto))
             {
                 if ((secondaryItem = rideEntry->shop_item[1]) != ShopItem::none)
                 {
@@ -6733,7 +6729,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Secondary item profit / loss per item sold
             secondaryItem = ride->getRideTypeDescriptor().PhotoItem;
-            if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO))
+            if (!ride->lifecycleFlags.has(RideFlag::onRidePhoto))
                 secondaryItem = rideEntry->shop_item[1];
 
             if (secondaryItem != ShopItem::none)
@@ -6975,8 +6971,8 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Secondary shop items sold / on-ride photos sold
-            shopItem = (ride->lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO) ? ride->getRideTypeDescriptor().PhotoItem
-                                                                             : ride->getRideEntry()->shop_item[1];
+            shopItem = ride->lifecycleFlags.has(RideFlag::onRidePhoto) ? ride->getRideTypeDescriptor().PhotoItem
+                                                                       : ride->getRideEntry()->shop_item[1];
             if (shopItem != ShopItem::none)
             {
                 ft = Formatter();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1525,7 +1525,7 @@ namespace OpenRCT2::Ui::Windows
 
             std::optional<Focus> newFocus;
 
-            if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->numTrains && ride->lifecycleFlags.has(RideFlag::onTrack))
+            if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->numTrains && ride->flags.has(RideFlag::onTrack))
             {
                 auto vehId = ride->vehicles[viewSelectionIndex];
                 const auto* rideEntry = ride->getRideEntry();
@@ -1754,7 +1754,7 @@ namespace OpenRCT2::Ui::Windows
 
         bool TrainMustBeHidden(const Ride& ride, int32_t trainIndex) const
         {
-            if (!ride.lifecycleFlags.has(RideFlag::onTrack))
+            if (!ride.flags.has(RideFlag::onTrack))
                 return true;
 
             const auto* rideEntry = ride.getRideEntry();
@@ -1826,11 +1826,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 default:
                 case RideStatus::closed:
-                    if (ride.lifecycleFlags.hasAny(RideFlag::crashed, RideFlag::hasStalledVehicle))
+                    if (ride.flags.hasAny(RideFlag::crashed, RideFlag::hasStalledVehicle))
                     {
                         return RideStatus::closed;
                     }
-                    if (ride.supportsStatus(RideStatus::testing) && !ride.lifecycleFlags.has(RideFlag::tested))
+                    if (ride.supportsStatus(RideStatus::testing) && !ride.flags.has(RideFlag::tested))
                     {
                         return RideStatus::testing;
                     }
@@ -1838,7 +1838,7 @@ namespace OpenRCT2::Ui::Windows
                 case RideStatus::simulating:
                     return RideStatus::testing;
                 case RideStatus::testing:
-                    return ride.lifecycleFlags.has(RideFlag::tested) ? RideStatus::open : RideStatus::closed;
+                    return ride.flags.has(RideFlag::tested) ? RideStatus::open : RideStatus::closed;
                 case RideStatus::open:
                     return RideStatus::closed;
             }
@@ -2202,8 +2202,7 @@ namespace OpenRCT2::Ui::Windows
                         auto ride = GetRide(rideId);
                         if (ride != nullptr)
                         {
-                            if (dropdownIndex != 0 && dropdownIndex <= ride->numTrains
-                                && !ride->lifecycleFlags.has(RideFlag::onTrack))
+                            if (dropdownIndex != 0 && dropdownIndex <= ride->numTrains && !ride->flags.has(RideFlag::onTrack))
                             {
                                 dropdownIndex = ride->numTrains + 1;
                             }
@@ -2339,7 +2338,7 @@ namespace OpenRCT2::Ui::Windows
 
             const auto& gameState = getGameState();
             disabledWidgets &= ~((1uLL << WIDX_DEMOLISH) | (1uLL << WIDX_CONSTRUCTION));
-            if (ride->lifecycleFlags.hasAny(RideFlag::indestructible, RideFlag::indestructibleTrack)
+            if (ride->flags.hasAny(RideFlag::indestructible, RideFlag::indestructibleTrack)
                 && !gameState.cheats.makeAllDestructible)
                 disabledWidgets |= (1uLL << WIDX_DEMOLISH);
 
@@ -2473,7 +2472,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 ride->formatStatusTo(ft);
                 stringId = STR_BLACK_STRING;
-                if (ride->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+                if (ride->flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                 {
                     stringId = STR_RED_OUTLINED_STRING;
                 }
@@ -2586,7 +2585,7 @@ namespace OpenRCT2::Ui::Windows
                 return GetStatusOverallView(ft);
             if (ride != nullptr && _viewIndex <= ride->numTrains)
                 return GetStatusVehicle(ft);
-            if (ride != nullptr && ride->lifecycleFlags.has(RideFlag::brokenDown))
+            if (ride != nullptr && ride->flags.has(RideFlag::brokenDown))
                 return GetStatusOverallView(ft);
             return GetStatusStation(ft);
         }
@@ -2686,7 +2685,7 @@ namespace OpenRCT2::Ui::Windows
                     ShowVehicleTypeDropdown(&widgets[widgetIndex]);
                     break;
                 case WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX:
-                    ride->setReversedTrains(!ride->lifecycleFlags.has(RideFlag::reversedTrains));
+                    ride->setReversedTrains(!ride->flags.has(RideFlag::reversedTrains));
                     break;
                 case WIDX_VEHICLE_TRAINS_INCREASE:
                     if (ride->numTrains < Limits::kMaxTrainsPerRide)
@@ -2838,7 +2837,7 @@ namespace OpenRCT2::Ui::Windows
                 || (gameState.cheats.disableTrainLengthLimit && !ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide)))
             {
                 widgets[WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX].type = WidgetType::checkbox;
-                if (ride->lifecycleFlags.has(RideFlag::reversedTrains))
+                if (ride->flags.has(RideFlag::reversedTrains))
                 {
                     pressedWidgets |= (1uLL << WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX);
                 }
@@ -2982,7 +2981,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t startX = std::max(2, (widget->width() - 1 - ((ride->numTrains - 1) * 36)) / 2 - 25);
             int32_t startY = widget->height() - 5;
 
-            bool isReversed = ride->lifecycleFlags.has(RideFlag::reversedTrains);
+            bool isReversed = ride->flags.has(RideFlag::reversedTrains);
             int32_t carIndex = (isReversed) ? ride->numCarsPerTrain - 1 : 0;
 
             const auto& firstCarEntry = rideEntry->Cars[RideEntryGetVehicleAtPosition(
@@ -3855,7 +3854,7 @@ namespace OpenRCT2::Ui::Windows
 
                         numItems = 1;
                         int32_t breakdownReason = ride->breakdownReasonPending;
-                        if (breakdownReason != BREAKDOWN_NONE && ride->lifecycleFlags.has(RideFlag::breakdownPending))
+                        if (breakdownReason != BREAKDOWN_NONE && ride->flags.has(RideFlag::breakdownPending))
                         {
                             for (int32_t i = 0; i < 8; i++)
                             {
@@ -3878,7 +3877,7 @@ namespace OpenRCT2::Ui::Windows
                             }
                         }
 
-                        if (!ride->lifecycleFlags.has(RideFlag::breakdownPending))
+                        if (!ride->flags.has(RideFlag::breakdownPending))
                         {
                             gDropdown.items[0].setDisabled(true);
                         }
@@ -3913,7 +3912,7 @@ namespace OpenRCT2::Ui::Windows
                         switch (ride->breakdownReasonPending)
                         {
                             case BREAKDOWN_SAFETY_CUT_OUT:
-                                if (!ride->lifecycleFlags.has(RideFlag::onTrack))
+                                if (!ride->flags.has(RideFlag::onTrack))
                                     break;
                                 for (int32_t i = 0; i < ride->numTrains; ++i)
                                 {
@@ -3945,13 +3944,13 @@ namespace OpenRCT2::Ui::Windows
                                 }
                                 break;
                         }
-                        ride->lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown);
+                        ride->flags.unset(RideFlag::breakdownPending, RideFlag::brokenDown);
 
                         auto* windowMgr = GetWindowManager();
                         windowMgr->InvalidateByNumber(WindowClass::ride, number);
                         break;
                     }
-                    if (ride->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
+                    if (ride->flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
                     {
                         ContextShowError(STR_DEBUG_CANT_FORCE_BREAKDOWN, STR_DEBUG_RIDE_ALREADY_BROKEN, {});
                     }
@@ -4029,7 +4028,7 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_FORCE_BREAKDOWN].type = WidgetType::empty;
             }
 
-            if (ride->getRideTypeDescriptor().AvailableBreakdowns == 0 || !ride->lifecycleFlags.has(RideFlag::everBeenOpened))
+            if (ride->getRideTypeDescriptor().AvailableBreakdowns == 0 || !ride->flags.has(RideFlag::everBeenOpened))
             {
                 disabledWidgets |= (1uLL << WIDX_REFURBISH_RIDE);
                 widgets[WIDX_REFURBISH_RIDE].tooltip = STR_CANT_REFURBISH_NOT_NEEDED;
@@ -4099,14 +4098,14 @@ namespace OpenRCT2::Ui::Windows
             if (ride->breakdownReason == BREAKDOWN_NONE)
                 return;
 
-            stringId = ride->lifecycleFlags.has(RideFlag::brokenDown) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
+            stringId = ride->flags.has(RideFlag::brokenDown) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
             ft = Formatter();
             ft.Add<StringId>(RideBreakdownReasonNames[ride->breakdownReason]);
             DrawTextBasic(rt, screenCoords, stringId, ft);
             screenCoords.y += 12;
 
             // Mechanic status
-            if (ride->lifecycleFlags.has(RideFlag::brokenDown))
+            if (ride->flags.has(RideFlag::brokenDown))
             {
                 switch (ride->mechanicStatus)
                 {
@@ -4243,7 +4242,7 @@ namespace OpenRCT2::Ui::Windows
                     auto ride = GetRide(rideId);
                     if (ride != nullptr)
                     {
-                        const bool currentlyEnabled = ride->lifecycleFlags.has(RideFlag::randomShopColours);
+                        const bool currentlyEnabled = ride->flags.has(RideFlag::randomShopColours);
                         auto rideSetAppearanceAction = GameActions::RideSetAppearanceAction(
                             rideId, GameActions::RideSetAppearanceType::SellingItemColourIsRandom, currentlyEnabled ? 0 : 1, 0);
                         GameActions::Execute(&rideSetAppearanceAction, gameState);
@@ -4663,7 +4662,7 @@ namespace OpenRCT2::Ui::Windows
             if (ride->hasRecolourableShopItems())
             {
                 widgets[WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX].type = WidgetType::checkbox;
-                if (ride->lifecycleFlags.has(RideFlag::randomShopColours))
+                if (ride->flags.has(RideFlag::randomShopColours))
                 {
                     pressedWidgets |= (1uLL << WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX);
                 }
@@ -4923,7 +4922,7 @@ namespace OpenRCT2::Ui::Windows
             RenderTarget& rt, const Ride* ride, const ShopItemDescriptor& shopItem, const Widget& widget)
         {
             Colour spriteColour = ride->trackColours[0].main;
-            if (ride->lifecycleFlags.has(RideFlag::randomShopColours))
+            if (ride->flags.has(RideFlag::randomShopColours))
                 spriteColour = Colour((getGameState().currentTicks / 32) % kColourNumNormal);
 
             auto* image = GfxGetG1Element(shopItem.Image);
@@ -5043,7 +5042,7 @@ namespace OpenRCT2::Ui::Windows
             auto ride = GetRide(rideId);
             if (ride != nullptr)
             {
-                int32_t activateMusic = ride->lifecycleFlags.has(RideFlag::music) ? 0 : 1;
+                int32_t activateMusic = ride->flags.has(RideFlag::music) ? 0 : 1;
                 SetOperatingSetting(rideId, GameActions::RideSetSetting::Music, activateMusic);
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::music);
             }
@@ -5083,7 +5082,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // Expand the window when music is playing
-            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
+            auto isMusicActivated = ride->flags.has(RideFlag::music);
             auto standardHeight = widgets[WIDX_MUSIC_DROPDOWN].bottom + 6;
             auto newMinHeight = isMusicActivated ? standardHeight + 133 : standardHeight;
             auto newMaxHeight = isMusicActivated ? standardHeight + 369 : standardHeight;
@@ -5268,7 +5267,7 @@ namespace OpenRCT2::Ui::Windows
             }
             widgets[WIDX_MUSIC].text = musicName;
 
-            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
+            auto isMusicActivated = ride->flags.has(RideFlag::music);
             bool hasPreviewImage = musicObj != nullptr && musicObj->HasPreview();
 
             widgetSetVisible(*this, WIDX_MUSIC_DATA, isMusicActivated);
@@ -5311,7 +5310,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // Draw music data only when music is activated
-            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
+            auto isMusicActivated = ride->flags.has(RideFlag::music);
             if (!isMusicActivated)
                 return;
 
@@ -5346,7 +5345,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // only draw track listing when music is activated
-            auto isMusicActivated = ride->lifecycleFlags.has(RideFlag::music);
+            auto isMusicActivated = ride->flags.has(RideFlag::music);
             if (!isMusicActivated)
                 return;
 
@@ -5668,7 +5667,7 @@ namespace OpenRCT2::Ui::Windows
 
                 widgets[WIDX_SAVE_TRACK_DESIGN].type = WidgetType::flatBtn;
                 disabledWidgets |= (1uLL << WIDX_SAVE_TRACK_DESIGN);
-                if (ride->lifecycleFlags.has(RideFlag::tested))
+                if (ride->flags.has(RideFlag::tested))
                 {
                     if (!ride->ratings.isNull())
                     {
@@ -5708,7 +5707,7 @@ namespace OpenRCT2::Ui::Windows
                 auto screenCoords = windowPos
                     + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-                if (ride->lifecycleFlags.has(RideFlag::tested))
+                if (ride->flags.has(RideFlag::tested))
                 {
                     // Excitement
                     StringId ratingName = GetRatingName(ride->ratings.excitement);
@@ -5749,7 +5748,7 @@ namespace OpenRCT2::Ui::Windows
                         rt, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, colours[1],
                         Rectangle::BorderStyle::inset);
 
-                    if (!ride->lifecycleFlags.has(RideFlag::noRawStats))
+                    if (!ride->flags.has(RideFlag::noRawStats))
                     {
                         if (ride->getRideTypeDescriptor().specialType == RtdSpecialType::miniGolf)
                         {
@@ -6643,7 +6642,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Get secondary item
             auto secondaryItem = ride->getRideTypeDescriptor().PhotoItem;
-            if (!ride->lifecycleFlags.has(RideFlag::onRidePhoto))
+            if (!ride->flags.has(RideFlag::onRidePhoto))
             {
                 if ((secondaryItem = rideEntry->shop_item[1]) != ShopItem::none)
                 {
@@ -6729,7 +6728,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Secondary item profit / loss per item sold
             secondaryItem = ride->getRideTypeDescriptor().PhotoItem;
-            if (!ride->lifecycleFlags.has(RideFlag::onRidePhoto))
+            if (!ride->flags.has(RideFlag::onRidePhoto))
                 secondaryItem = rideEntry->shop_item[1];
 
             if (secondaryItem != ShopItem::none)
@@ -6971,8 +6970,8 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Secondary shop items sold / on-ride photos sold
-            shopItem = ride->lifecycleFlags.has(RideFlag::onRidePhoto) ? ride->getRideTypeDescriptor().PhotoItem
-                                                                       : ride->getRideEntry()->shop_item[1];
+            shopItem = ride->flags.has(RideFlag::onRidePhoto) ? ride->getRideTypeDescriptor().PhotoItem
+                                                              : ride->getRideEntry()->shop_item[1];
             if (shopItem != ShopItem::none)
             {
                 ft = Formatter();

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -675,7 +675,7 @@ namespace OpenRCT2::Ui::Windows
                         ridePtr->formatStatusTo(ft);
 
                         // Make test red and bold if broken down or crashed
-                        if (ridePtr->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+                        if (ridePtr->flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                         {
                             format = STR_RED_OUTLINED_STRING;
                         }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -675,8 +675,7 @@ namespace OpenRCT2::Ui::Windows
                         ridePtr->formatStatusTo(ft);
 
                         // Make test red and bold if broken down or crashed
-                        if ((ridePtr->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
-                            || (ridePtr->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+                        if (ridePtr->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                         {
                             format = STR_RED_OUTLINED_STRING;
                         }

--- a/src/openrct2/actions/cheats/CheatSetAction.cpp
+++ b/src/openrct2/actions/cheats/CheatSetAction.cpp
@@ -522,7 +522,7 @@ namespace OpenRCT2::GameActions
     {
         for (auto& ride : RideManager(gameState))
         {
-            if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
+            if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
             {
                 auto mechanic = RideGetAssignedMechanic(ride);
 
@@ -559,7 +559,7 @@ namespace OpenRCT2::GameActions
         for (auto& ride : RideManager(gameState))
         {
             // Reset crash status and history
-            ride.lifecycleFlags &= ~RIDE_LIFECYCLE_CRASHED;
+            ride.lifecycleFlags.unset(RideFlag::crashed);
             ride.lastCrashType = RIDE_CRASH_TYPE_NONE;
         }
         auto* windowMgr = Ui::GetWindowManager();

--- a/src/openrct2/actions/cheats/CheatSetAction.cpp
+++ b/src/openrct2/actions/cheats/CheatSetAction.cpp
@@ -522,7 +522,7 @@ namespace OpenRCT2::GameActions
     {
         for (auto& ride : RideManager(gameState))
         {
-            if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
+            if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
             {
                 auto mechanic = RideGetAssignedMechanic(ride);
 
@@ -559,7 +559,7 @@ namespace OpenRCT2::GameActions
         for (auto& ride : RideManager(gameState))
         {
             // Reset crash status and history
-            ride.lifecycleFlags.unset(RideFlag::crashed);
+            ride.flags.unset(RideFlag::crashed);
             ride.lastCrashType = RIDE_CRASH_TYPE_NONE;
         }
         auto* windowMgr = Ui::GetWindowManager();

--- a/src/openrct2/actions/ride/RideCreateAction.cpp
+++ b/src/openrct2/actions/ride/RideCreateAction.cpp
@@ -194,7 +194,7 @@ namespace OpenRCT2::GameActions
             {
                 if (rtd.flags.has(RtdFlag::hasMusicByDefault))
                 {
-                    ride->lifecycleFlags |= RIDE_LIFECYCLE_MUSIC;
+                    ride->lifecycleFlags.set(RideFlag::music);
                 }
             }
         }

--- a/src/openrct2/actions/ride/RideCreateAction.cpp
+++ b/src/openrct2/actions/ride/RideCreateAction.cpp
@@ -194,7 +194,7 @@ namespace OpenRCT2::GameActions
             {
                 if (rtd.flags.has(RtdFlag::hasMusicByDefault))
                 {
-                    ride->lifecycleFlags.set(RideFlag::music);
+                    ride->flags.set(RideFlag::music);
                 }
             }
         }

--- a/src/openrct2/actions/ride/RideDemolishAction.cpp
+++ b/src/openrct2/actions/ride/RideDemolishAction.cpp
@@ -67,7 +67,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_DEMOLISH_RIDE, STR_ERR_RIDE_NOT_FOUND);
         }
 
-        if ((ride->lifecycleFlags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+        if ((ride->lifecycleFlags.hasAny(RideFlag::indestructible, RideFlag::indestructibleTrack)
              && _modifyType == RideModifyType::demolish)
             && !gameState.cheats.makeAllDestructible)
         {
@@ -90,8 +90,7 @@ namespace OpenRCT2::GameActions
                 return Result(Status::disallowed, STR_CANT_REFURBISH_RIDE, STR_RIDE_NOT_YET_EMPTY);
             }
 
-            if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
-                || ride->getRideTypeDescriptor().AvailableBreakdowns == 0)
+            if (!ride->lifecycleFlags.has(RideFlag::everBeenOpened) || ride->getRideTypeDescriptor().AvailableBreakdowns == 0)
             {
                 return Result(Status::disallowed, STR_CANT_REFURBISH_RIDE, STR_CANT_REFURBISH_NOT_NEEDED);
             }
@@ -279,7 +278,7 @@ namespace OpenRCT2::GameActions
 
         ride.renew();
 
-        ride.lifecycleFlags &= ~RIDE_LIFECYCLE_EVER_BEEN_OPENED;
+        ride.lifecycleFlags.unset(RideFlag::everBeenOpened);
         ride.lastCrashType = RIDE_CRASH_TYPE_NONE;
 
         ride.windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::customers);

--- a/src/openrct2/actions/ride/RideDemolishAction.cpp
+++ b/src/openrct2/actions/ride/RideDemolishAction.cpp
@@ -67,7 +67,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_DEMOLISH_RIDE, STR_ERR_RIDE_NOT_FOUND);
         }
 
-        if ((ride->lifecycleFlags.hasAny(RideFlag::indestructible, RideFlag::indestructibleTrack)
+        if ((ride->flags.hasAny(RideFlag::indestructible, RideFlag::indestructibleTrack)
              && _modifyType == RideModifyType::demolish)
             && !gameState.cheats.makeAllDestructible)
         {
@@ -90,7 +90,7 @@ namespace OpenRCT2::GameActions
                 return Result(Status::disallowed, STR_CANT_REFURBISH_RIDE, STR_RIDE_NOT_YET_EMPTY);
             }
 
-            if (!ride->lifecycleFlags.has(RideFlag::everBeenOpened) || ride->getRideTypeDescriptor().AvailableBreakdowns == 0)
+            if (!ride->flags.has(RideFlag::everBeenOpened) || ride->getRideTypeDescriptor().AvailableBreakdowns == 0)
             {
                 return Result(Status::disallowed, STR_CANT_REFURBISH_RIDE, STR_CANT_REFURBISH_NOT_NEEDED);
             }
@@ -278,7 +278,7 @@ namespace OpenRCT2::GameActions
 
         ride.renew();
 
-        ride.lifecycleFlags.unset(RideFlag::everBeenOpened);
+        ride.flags.unset(RideFlag::everBeenOpened);
         ride.lastCrashType = RIDE_CRASH_TYPE_NONE;
 
         ride.windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::customers);

--- a/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
@@ -80,7 +80,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::notClosed, errorTitle, STR_MUST_BE_CLOSED_FIRST);
         }
 
-        if (ride->lifecycleFlags.has(RideFlag::indestructibleTrack))
+        if (ride->flags.has(RideFlag::indestructibleTrack))
         {
             return Result(Status::disallowed, errorTitle, STR_NOT_ALLOWED_TO_MODIFY_STATION);
         }

--- a/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
@@ -80,7 +80,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::notClosed, errorTitle, STR_MUST_BE_CLOSED_FIRST);
         }
 
-        if (ride->lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+        if (ride->lifecycleFlags.has(RideFlag::indestructibleTrack))
         {
             return Result(Status::disallowed, errorTitle, STR_NOT_ALLOWED_TO_MODIFY_STATION);
         }

--- a/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_MUST_BE_CLOSED_FIRST, kStringIdNone);
         }
 
-        if (ride->lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+        if (ride->lifecycleFlags.has(RideFlag::indestructibleTrack))
         {
             return Result(Status::invalidParameters, STR_NOT_ALLOWED_TO_MODIFY_STATION, kStringIdNone);
         }

--- a/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
@@ -81,7 +81,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_MUST_BE_CLOSED_FIRST, kStringIdNone);
         }
 
-        if (ride->lifecycleFlags.has(RideFlag::indestructibleTrack))
+        if (ride->flags.has(RideFlag::indestructibleTrack))
         {
             return Result(Status::invalidParameters, STR_NOT_ALLOWED_TO_MODIFY_STATION, kStringIdNone);
         }

--- a/src/openrct2/actions/ride/RideFreezeRatingAction.cpp
+++ b/src/openrct2/actions/ride/RideFreezeRatingAction.cpp
@@ -69,7 +69,7 @@ namespace OpenRCT2::GameActions
                 break;
         }
 
-        ride->lifecycleFlags.set(RideFlag::fixedRatings);
+        ride->flags.set(RideFlag::fixedRatings);
 
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByNumber(WindowClass::ride, _rideIndex.ToUnderlying());

--- a/src/openrct2/actions/ride/RideFreezeRatingAction.cpp
+++ b/src/openrct2/actions/ride/RideFreezeRatingAction.cpp
@@ -69,7 +69,7 @@ namespace OpenRCT2::GameActions
                 break;
         }
 
-        ride->lifecycleFlags |= RIDE_LIFECYCLE_FIXED_RATINGS;
+        ride->lifecycleFlags.set(RideFlag::fixedRatings);
 
         auto* windowMgr = Ui::GetWindowManager();
         windowMgr->InvalidateByNumber(WindowClass::ride, _rideIndex.ToUnderlying());

--- a/src/openrct2/actions/ride/RideSetAppearanceAction.cpp
+++ b/src/openrct2/actions/ride/RideSetAppearanceAction.cpp
@@ -139,7 +139,7 @@ namespace OpenRCT2::GameActions
                 GfxInvalidateScreen();
                 break;
             case RideSetAppearanceType::SellingItemColourIsRandom:
-                ride->lifecycleFlags.set(RideFlag::randomShopColours, static_cast<bool>(_value));
+                ride->flags.set(RideFlag::randomShopColours, static_cast<bool>(_value));
                 break;
         }
 

--- a/src/openrct2/actions/ride/RideSetAppearanceAction.cpp
+++ b/src/openrct2/actions/ride/RideSetAppearanceAction.cpp
@@ -139,7 +139,7 @@ namespace OpenRCT2::GameActions
                 GfxInvalidateScreen();
                 break;
             case RideSetAppearanceType::SellingItemColourIsRandom:
-                ride->setLifecycleFlag(RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS, static_cast<bool>(_value));
+                ride->lifecycleFlags.set(RideFlag::randomShopColours, static_cast<bool>(_value));
                 break;
         }
 

--- a/src/openrct2/actions/ride/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/ride/RideSetPriceAction.cpp
@@ -138,7 +138,7 @@ namespace OpenRCT2::GameActions
             if (shopItem == ShopItem::none)
             {
                 shopItem = ride->getRideTypeDescriptor().PhotoItem;
-                if ((ride->lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO) == 0)
+                if (!ride->lifecycleFlags.has(RideFlag::onRidePhoto))
                 {
                     ride->price[1] = _price;
                     windowMgr->InvalidateByClass(WindowClass::ride);

--- a/src/openrct2/actions/ride/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/ride/RideSetPriceAction.cpp
@@ -138,7 +138,7 @@ namespace OpenRCT2::GameActions
             if (shopItem == ShopItem::none)
             {
                 shopItem = ride->getRideTypeDescriptor().PhotoItem;
-                if (!ride->lifecycleFlags.has(RideFlag::onRidePhoto))
+                if (!ride->flags.has(RideFlag::onRidePhoto))
                 {
                     ride->price[1] = _price;
                     windowMgr->InvalidateByClass(WindowClass::ride);

--- a/src/openrct2/actions/ride/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/ride/RideSetSettingAction.cpp
@@ -60,7 +60,7 @@ namespace OpenRCT2::GameActions
         switch (_setting)
         {
             case RideSetSetting::Mode:
-                if (ride->lifecycleFlags.has(RideFlag::brokenDown))
+                if (ride->flags.has(RideFlag::brokenDown))
                 {
                     return Result(Status::disallowed, STR_CANT_CHANGE_OPERATING_MODE, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING);
                 }
@@ -127,7 +127,7 @@ namespace OpenRCT2::GameActions
                 }
                 break;
             case RideSetSetting::NumCircuits:
-                if (ride->lifecycleFlags.has(RideFlag::cableLift) && _value > 1)
+                if (ride->flags.has(RideFlag::cableLift) && _value > 1)
                 {
                     return Result(
                         Status::invalidParameters, STR_CANT_CHANGE_OPERATING_MODE,
@@ -194,16 +194,16 @@ namespace OpenRCT2::GameActions
 
                 if (_value == EnumValue(RideInspection::never))
                 {
-                    ride->lifecycleFlags.unset(RideFlag::dueInspection);
+                    ride->flags.unset(RideFlag::dueInspection);
                 }
 
                 ride->inspectionInterval = static_cast<RideInspection>(_value);
                 break;
             case RideSetSetting::Music:
-                ride->lifecycleFlags.unset(RideFlag::music);
+                ride->flags.unset(RideFlag::music);
                 if (_value)
                 {
-                    ride->lifecycleFlags.set(RideFlag::music);
+                    ride->flags.set(RideFlag::music);
                 }
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::music);
                 break;

--- a/src/openrct2/actions/ride/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/ride/RideSetSettingAction.cpp
@@ -60,7 +60,7 @@ namespace OpenRCT2::GameActions
         switch (_setting)
         {
             case RideSetSetting::Mode:
-                if (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+                if (ride->lifecycleFlags.has(RideFlag::brokenDown))
                 {
                     return Result(Status::disallowed, STR_CANT_CHANGE_OPERATING_MODE, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING);
                 }
@@ -127,7 +127,7 @@ namespace OpenRCT2::GameActions
                 }
                 break;
             case RideSetSetting::NumCircuits:
-                if (ride->lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT && _value > 1)
+                if (ride->lifecycleFlags.has(RideFlag::cableLift) && _value > 1)
                 {
                     return Result(
                         Status::invalidParameters, STR_CANT_CHANGE_OPERATING_MODE,
@@ -194,16 +194,16 @@ namespace OpenRCT2::GameActions
 
                 if (_value == EnumValue(RideInspection::never))
                 {
-                    ride->lifecycleFlags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+                    ride->lifecycleFlags.unset(RideFlag::dueInspection);
                 }
 
                 ride->inspectionInterval = static_cast<RideInspection>(_value);
                 break;
             case RideSetSetting::Music:
-                ride->lifecycleFlags &= ~RIDE_LIFECYCLE_MUSIC;
+                ride->lifecycleFlags.unset(RideFlag::music);
                 if (_value)
                 {
-                    ride->lifecycleFlags |= RIDE_LIFECYCLE_MUSIC;
+                    ride->lifecycleFlags.set(RideFlag::music);
                 }
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::music);
                 break;

--- a/src/openrct2/actions/ride/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/ride/RideSetStatusAction.cpp
@@ -83,7 +83,7 @@ namespace OpenRCT2::GameActions
         ride->formatNameTo(ft);
         if (_status != ride->status)
         {
-            if (_status == RideStatus::simulating && ride->lifecycleFlags.has(RideFlag::brokenDown))
+            if (_status == RideStatus::simulating && ride->flags.has(RideFlag::brokenDown))
             {
                 // Simulating will force clear the track, so make sure player can't cheat around a break down
                 res.error = Status::disallowed;
@@ -150,23 +150,23 @@ namespace OpenRCT2::GameActions
             case RideStatus::closed:
                 if (ride->status == _status || ride->status == RideStatus::simulating)
                 {
-                    if (!ride->lifecycleFlags.has(RideFlag::brokenDown))
+                    if (!ride->flags.has(RideFlag::brokenDown))
                     {
-                        ride->lifecycleFlags.unset(RideFlag::crashed);
+                        ride->flags.unset(RideFlag::crashed);
                         RideClearForConstruction(*ride);
                         ride->removePeeps();
                     }
                 }
 
                 ride->status = RideStatus::closed;
-                ride->lifecycleFlags.unset(RideFlag::passStationNoStopping);
+                ride->flags.unset(RideFlag::passStationNoStopping);
                 ride->raceWinner = EntityId::GetNull();
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
                 windowMgr->InvalidateByNumber(WindowClass::ride, _rideIndex.ToUnderlying());
                 break;
             case RideStatus::simulating:
             {
-                ride->lifecycleFlags.unset(RideFlag::crashed);
+                ride->flags.unset(RideFlag::crashed);
                 RideClearForConstruction(*ride);
                 ride->removePeeps();
 
@@ -179,7 +179,7 @@ namespace OpenRCT2::GameActions
                 }
 
                 ride->status = _status;
-                ride->lifecycleFlags.unset(RideFlag::passStationNoStopping);
+                ride->flags.unset(RideFlag::passStationNoStopping);
                 ride->raceWinner = EntityId::GetNull();
                 ride->currentIssues = 0;
                 ride->lastIssueTime = 0;

--- a/src/openrct2/actions/ride/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/ride/RideSetStatusAction.cpp
@@ -83,7 +83,7 @@ namespace OpenRCT2::GameActions
         ride->formatNameTo(ft);
         if (_status != ride->status)
         {
-            if (_status == RideStatus::simulating && (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+            if (_status == RideStatus::simulating && ride->lifecycleFlags.has(RideFlag::brokenDown))
             {
                 // Simulating will force clear the track, so make sure player can't cheat around a break down
                 res.error = Status::disallowed;
@@ -150,23 +150,23 @@ namespace OpenRCT2::GameActions
             case RideStatus::closed:
                 if (ride->status == _status || ride->status == RideStatus::simulating)
                 {
-                    if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+                    if (!ride->lifecycleFlags.has(RideFlag::brokenDown))
                     {
-                        ride->lifecycleFlags &= ~RIDE_LIFECYCLE_CRASHED;
+                        ride->lifecycleFlags.unset(RideFlag::crashed);
                         RideClearForConstruction(*ride);
                         ride->removePeeps();
                     }
                 }
 
                 ride->status = RideStatus::closed;
-                ride->lifecycleFlags &= ~RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING;
+                ride->lifecycleFlags.unset(RideFlag::passStationNoStopping);
                 ride->raceWinner = EntityId::GetNull();
                 ride->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
                 windowMgr->InvalidateByNumber(WindowClass::ride, _rideIndex.ToUnderlying());
                 break;
             case RideStatus::simulating:
             {
-                ride->lifecycleFlags &= ~RIDE_LIFECYCLE_CRASHED;
+                ride->lifecycleFlags.unset(RideFlag::crashed);
                 RideClearForConstruction(*ride);
                 ride->removePeeps();
 
@@ -179,7 +179,7 @@ namespace OpenRCT2::GameActions
                 }
 
                 ride->status = _status;
-                ride->lifecycleFlags &= ~RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING;
+                ride->lifecycleFlags.unset(RideFlag::passStationNoStopping);
                 ride->raceWinner = EntityId::GetNull();
                 ride->currentIssues = 0;
                 ride->lastIssueTime = 0;

--- a/src/openrct2/actions/ride/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.cpp
@@ -76,7 +76,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, errTitle, STR_ERR_RIDE_NOT_FOUND);
         }
 
-        if (ride->lifecycleFlags.has(RideFlag::brokenDown))
+        if (ride->flags.has(RideFlag::brokenDown))
         {
             return Result(Status::broken, errTitle, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING);
         }
@@ -194,7 +194,7 @@ namespace OpenRCT2::GameActions
                 ride->removePeeps();
                 ride->vehicleChangeTimeout = 100;
 
-                ride->lifecycleFlags.set(RideFlag::reversedTrains, static_cast<bool>(_value));
+                ride->flags.set(RideFlag::reversedTrains, static_cast<bool>(_value));
                 break;
             }
 

--- a/src/openrct2/actions/ride/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.cpp
@@ -76,7 +76,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, errTitle, STR_ERR_RIDE_NOT_FOUND);
         }
 
-        if (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+        if (ride->lifecycleFlags.has(RideFlag::brokenDown))
         {
             return Result(Status::broken, errTitle, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING);
         }
@@ -194,7 +194,7 @@ namespace OpenRCT2::GameActions
                 ride->removePeeps();
                 ride->vehicleChangeTimeout = 100;
 
-                ride->setLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS, _value);
+                ride->lifecycleFlags.set(RideFlag::reversedTrains, static_cast<bool>(_value));
                 break;
             }
 

--- a/src/openrct2/actions/track/TrackDesignAction.cpp
+++ b/src/openrct2/actions/track/TrackDesignAction.cpp
@@ -247,7 +247,7 @@ namespace OpenRCT2::GameActions
         auto numCircuits = std::max<uint8_t>(1, _td.operation.numCircuits);
         SetOperatingSettingNested(ride->id, RideSetSetting::NumCircuits, numCircuits, flags);
 
-        ride->lifecycleFlags.set(RideFlag::notCustomDesign);
+        ride->flags.set(RideFlag::notCustomDesign);
         ride->vehicleColourSettings = _td.appearance.vehicleColourSettings;
 
         ride->entranceStyle = objManager.GetLoadedObjectEntryIndex(_td.appearance.stationObjectIdentifier);

--- a/src/openrct2/actions/track/TrackDesignAction.cpp
+++ b/src/openrct2/actions/track/TrackDesignAction.cpp
@@ -247,7 +247,7 @@ namespace OpenRCT2::GameActions
         auto numCircuits = std::max<uint8_t>(1, _td.operation.numCircuits);
         SetOperatingSettingNested(ride->id, RideSetSetting::NumCircuits, numCircuits, flags);
 
-        ride->lifecycleFlags |= RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN;
+        ride->lifecycleFlags.set(RideFlag::notCustomDesign);
         ride->vehicleColourSettings = _td.appearance.vehicleColourSettings;
 
         ride->entranceStyle = objManager.GetLoadedObjectEntryIndex(_td.appearance.stationObjectIdentifier);

--- a/src/openrct2/actions/track/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/track/TrackPlaceAction.cpp
@@ -130,7 +130,7 @@ namespace OpenRCT2::GameActions
 
         const auto& rtd = ride->getRideTypeDescriptor();
 
-        if ((ride->lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK) && _trackType == TrackElemType::endStation)
+        if (ride->lifecycleFlags.has(RideFlag::indestructibleTrack) && _trackType == TrackElemType::endStation)
         {
             return Result(
                 Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_NOT_ALLOWED_TO_MODIFY_STATION);
@@ -150,7 +150,7 @@ namespace OpenRCT2::GameActions
         {
             if (_trackType == TrackElemType::onRidePhoto)
             {
-                if (ride->lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO)
+                if (ride->lifecycleFlags.has(RideFlag::onRidePhoto))
                 {
                     return Result(
                         Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
@@ -159,7 +159,7 @@ namespace OpenRCT2::GameActions
             }
             else if (_trackType == TrackElemType::cableLiftHill)
             {
-                if (ride->lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED)
+                if (ride->lifecycleFlags.has(RideFlag::cableLiftHillComponentUsed))
                 {
                     return Result(
                         Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
@@ -674,11 +674,11 @@ namespace OpenRCT2::GameActions
             switch (_trackType)
             {
                 case TrackElemType::onRidePhoto:
-                    ride->lifecycleFlags |= RIDE_LIFECYCLE_ON_RIDE_PHOTO;
+                    ride->lifecycleFlags.set(RideFlag::onRidePhoto);
                     InvalidateTestResults(*ride);
                     break;
                 case TrackElemType::cableLiftHill:
-                    ride->lifecycleFlags |= RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
+                    ride->lifecycleFlags.set(RideFlag::cableLiftHillComponentUsed);
                     ride->cableLiftLoc = originLocation;
                     InvalidateTestResults(*ride);
                     break;

--- a/src/openrct2/actions/track/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/track/TrackPlaceAction.cpp
@@ -130,7 +130,7 @@ namespace OpenRCT2::GameActions
 
         const auto& rtd = ride->getRideTypeDescriptor();
 
-        if (ride->lifecycleFlags.has(RideFlag::indestructibleTrack) && _trackType == TrackElemType::endStation)
+        if (ride->flags.has(RideFlag::indestructibleTrack) && _trackType == TrackElemType::endStation)
         {
             return Result(
                 Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_NOT_ALLOWED_TO_MODIFY_STATION);
@@ -150,7 +150,7 @@ namespace OpenRCT2::GameActions
         {
             if (_trackType == TrackElemType::onRidePhoto)
             {
-                if (ride->lifecycleFlags.has(RideFlag::onRidePhoto))
+                if (ride->flags.has(RideFlag::onRidePhoto))
                 {
                     return Result(
                         Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
@@ -159,7 +159,7 @@ namespace OpenRCT2::GameActions
             }
             else if (_trackType == TrackElemType::cableLiftHill)
             {
-                if (ride->lifecycleFlags.has(RideFlag::cableLiftHillComponentUsed))
+                if (ride->flags.has(RideFlag::cableLiftHillComponentUsed))
                 {
                     return Result(
                         Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
@@ -674,11 +674,11 @@ namespace OpenRCT2::GameActions
             switch (_trackType)
             {
                 case TrackElemType::onRidePhoto:
-                    ride->lifecycleFlags.set(RideFlag::onRidePhoto);
+                    ride->flags.set(RideFlag::onRidePhoto);
                     InvalidateTestResults(*ride);
                     break;
                 case TrackElemType::cableLiftHill:
-                    ride->lifecycleFlags.set(RideFlag::cableLiftHillComponentUsed);
+                    ride->flags.set(RideFlag::cableLiftHillComponentUsed);
                     ride->cableLiftLoc = originLocation;
                     InvalidateTestResults(*ride);
                     break;

--- a/src/openrct2/actions/track/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/track/TrackRemoveAction.cpp
@@ -240,7 +240,7 @@ namespace OpenRCT2::GameActions
         price *= ted.priceModifier;
         price >>= 16;
         price = supportCosts + price;
-        if (ride->lifecycleFlags.has(RideFlag::everBeenOpened))
+        if (ride->flags.has(RideFlag::everBeenOpened))
         {
             // 70% modifier for opened rides
             price = (price * 45875) / 65536;
@@ -442,10 +442,10 @@ namespace OpenRCT2::GameActions
             switch (trackType)
             {
                 case TrackElemType::onRidePhoto:
-                    ride->lifecycleFlags.unset(RideFlag::onRidePhoto);
+                    ride->flags.unset(RideFlag::onRidePhoto);
                     break;
                 case TrackElemType::cableLiftHill:
-                    ride->lifecycleFlags.unset(RideFlag::cableLiftHillComponentUsed);
+                    ride->flags.unset(RideFlag::cableLiftHillComponentUsed);
                     break;
                 case TrackElemType::blockBrakes:
                 case TrackElemType::diagBlockBrakes:
@@ -499,7 +499,7 @@ namespace OpenRCT2::GameActions
         price *= ted.priceModifier;
         price >>= 16;
         price = supportCosts + price;
-        if (ride->lifecycleFlags.has(RideFlag::everBeenOpened))
+        if (ride->flags.has(RideFlag::everBeenOpened))
         {
             // 70% modifier for opened rides
             price = (price * 45875) / 65536;

--- a/src/openrct2/actions/track/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/track/TrackRemoveAction.cpp
@@ -240,7 +240,7 @@ namespace OpenRCT2::GameActions
         price *= ted.priceModifier;
         price >>= 16;
         price = supportCosts + price;
-        if (ride->lifecycleFlags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
+        if (ride->lifecycleFlags.has(RideFlag::everBeenOpened))
         {
             // 70% modifier for opened rides
             price = (price * 45875) / 65536;
@@ -442,10 +442,10 @@ namespace OpenRCT2::GameActions
             switch (trackType)
             {
                 case TrackElemType::onRidePhoto:
-                    ride->lifecycleFlags &= ~RIDE_LIFECYCLE_ON_RIDE_PHOTO;
+                    ride->lifecycleFlags.unset(RideFlag::onRidePhoto);
                     break;
                 case TrackElemType::cableLiftHill:
-                    ride->lifecycleFlags &= ~RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED;
+                    ride->lifecycleFlags.unset(RideFlag::cableLiftHillComponentUsed);
                     break;
                 case TrackElemType::blockBrakes:
                 case TrackElemType::diagBlockBrakes:
@@ -499,7 +499,7 @@ namespace OpenRCT2::GameActions
         price *= ted.priceModifier;
         price >>= 16;
         price = supportCosts + price;
-        if (ride->lifecycleFlags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
+        if (ride->lifecycleFlags.has(RideFlag::everBeenOpened))
         {
             // 70% modifier for opened rides
             price = (price * 45875) / 65536;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1667,7 +1667,7 @@ static bool GuestDecideAndBuyItem(Guest& guest, Ride& ride, const ShopItem shopI
     // The peep has now decided to buy the item (or, specifically, has not been
     // dissuaded so far).
     guest.GiveItem(shopItem);
-    const auto hasRandomShopColour = ride.hasLifecycleFlag(RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS);
+    const auto hasRandomShopColour = ride.lifecycleFlags.has(RideFlag::randomShopColours);
 
     switch (shopItem)
     {
@@ -1954,7 +1954,7 @@ static Ride* GuestFindBestRideToGoOn(Guest& guest)
         const auto rideIndex = ride.id.ToUnderlying();
         if (rideConsideration.size() > rideIndex && rideConsideration[rideIndex])
         {
-            if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_QUEUE_FULL))
+            if (!ride.lifecycleFlags.has(RideFlag::queueFull))
             {
                 if (guest.ShouldGoOnRide(ride, StationIndex::FromUnderlying(0), false, true) && RideHasRatings(ride))
                 {
@@ -1980,7 +1980,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
     // Indicates whether a peep is physically at the ride, or is just thinking about going on the ride.
     bool peepAtRide = !thinking;
 
-    if (ride.status == RideStatus::open && !(ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (ride.status == RideStatus::open && !ride.lifecycleFlags.has(RideFlag::brokenDown))
     {
         // Peeps that are leaving the park will refuse to go on any rides, with the exception of free transport rides.
         assert(ride.type < std::size(kRideTypeDescriptors));
@@ -2254,7 +2254,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
             GuestResetRideHeading(*this);
         }
 
-        ride.lifecycleFlags &= ~RIDE_LIFECYCLE_QUEUE_FULL;
+        ride.lifecycleFlags.unset(RideFlag::queueFull);
         return true;
     }
 
@@ -2456,7 +2456,7 @@ static bool GuestHasVoucherForFreeRide(Guest& guest, const Ride& ride)
  */
 static void GuestTriedToEnterFullQueue(Guest& guest, Ride& ride)
 {
-    ride.lifecycleFlags |= RIDE_LIFECYCLE_QUEUE_FULL;
+    ride.lifecycleFlags.set(RideFlag::queueFull);
     guest.PreviousRide = ride.id;
     guest.PreviousRideTimeOut = 0;
     // Change status "Heading to" to "Walking" if queue is full
@@ -2590,7 +2590,7 @@ static bool FindVehicleToEnter(
 
     if (ride.mode == RideMode::dodgems || ride.mode == RideMode::race)
     {
-        if (ride.lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+        if (ride.lifecycleFlags.has(RideFlag::passStationNoStopping))
             return false;
 
         for (int32_t i = 0; i < ride.numTrains; ++i)
@@ -3025,8 +3025,8 @@ static PeepThoughtType GuestAssessSurroundings(int16_t centre_x, int16_t centre_
                         if (ride == nullptr)
                             break;
 
-                        bool isPlayingMusic = ride->lifecycleFlags & RIDE_LIFECYCLE_MUSIC && ride->status != RideStatus::closed
-                            && !(ride->lifecycleFlags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED));
+                        bool isPlayingMusic = ride->lifecycleFlags.has(RideFlag::music) && ride->status != RideStatus::closed
+                            && !ride->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed);
                         if (!isPlayingMusic)
                             break;
 
@@ -3249,7 +3249,7 @@ static void PeepHeadForNearestRide(Guest& guest, bool considerOnlyCloseRides, T 
     {
         if (rideConsideration[ride.id.ToUnderlying()])
         {
-            if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_QUEUE_FULL))
+            if (!ride.lifecycleFlags.has(RideFlag::queueFull))
             {
                 if (guest.ShouldGoOnRide(ride, StationIndex::FromUnderlying(0), false, true))
                 {
@@ -3554,7 +3554,7 @@ void Guest::UpdateRideAtEntrance()
         return;
     }
 
-    if (ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (ride->lifecycleFlags.has(RideFlag::brokenDown))
         return;
 
     auto ridePrice = RideGetPrice(*ride);
@@ -4485,7 +4485,7 @@ void Guest::UpdateRideInExit()
         MoveTo({ loc.value(), z });
     }
 
-    if (ride->lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO)
+    if (ride->lifecycleFlags.has(RideFlag::onRidePhoto))
     {
         ShopItem secondaryItem = ride->getRideTypeDescriptor().PhotoItem;
         if (GuestDecideAndBuyItem(*this, *ride, secondaryItem, ride->price[1]))
@@ -4809,7 +4809,7 @@ void Guest::UpdateRideOnSpiralSlide()
 
                 return;
             case PeepSpiralSlideSubState::prepareToSlide:
-                if (ride->slideInUse || ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+                if (ride->slideInUse || ride->lifecycleFlags.has(RideFlag::brokenDown))
                     return;
 
                 ride->slideInUse = 1;
@@ -6466,7 +6466,7 @@ bool Loc690FD0(Guest& guest, RideId* rideToView, uint8_t* rideSeatToView, TileEl
     else
     {
         *rideSeatToView = 0;
-        if (ride->status == RideStatus::open && !(ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+        if (ride->status == RideStatus::open && !ride->lifecycleFlags.has(RideFlag::brokenDown))
         {
             if (tileElement->GetClearanceZ() > guest.NextLoc.z + (8 * kCoordsZStep))
             {

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1667,7 +1667,7 @@ static bool GuestDecideAndBuyItem(Guest& guest, Ride& ride, const ShopItem shopI
     // The peep has now decided to buy the item (or, specifically, has not been
     // dissuaded so far).
     guest.GiveItem(shopItem);
-    const auto hasRandomShopColour = ride.lifecycleFlags.has(RideFlag::randomShopColours);
+    const auto hasRandomShopColour = ride.flags.has(RideFlag::randomShopColours);
 
     switch (shopItem)
     {
@@ -1954,7 +1954,7 @@ static Ride* GuestFindBestRideToGoOn(Guest& guest)
         const auto rideIndex = ride.id.ToUnderlying();
         if (rideConsideration.size() > rideIndex && rideConsideration[rideIndex])
         {
-            if (!ride.lifecycleFlags.has(RideFlag::queueFull))
+            if (!ride.flags.has(RideFlag::queueFull))
             {
                 if (guest.ShouldGoOnRide(ride, StationIndex::FromUnderlying(0), false, true) && RideHasRatings(ride))
                 {
@@ -1980,7 +1980,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
     // Indicates whether a peep is physically at the ride, or is just thinking about going on the ride.
     bool peepAtRide = !thinking;
 
-    if (ride.status == RideStatus::open && !ride.lifecycleFlags.has(RideFlag::brokenDown))
+    if (ride.status == RideStatus::open && !ride.flags.has(RideFlag::brokenDown))
     {
         // Peeps that are leaving the park will refuse to go on any rides, with the exception of free transport rides.
         assert(ride.type < std::size(kRideTypeDescriptors));
@@ -2254,7 +2254,7 @@ bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, b
             GuestResetRideHeading(*this);
         }
 
-        ride.lifecycleFlags.unset(RideFlag::queueFull);
+        ride.flags.unset(RideFlag::queueFull);
         return true;
     }
 
@@ -2456,7 +2456,7 @@ static bool GuestHasVoucherForFreeRide(Guest& guest, const Ride& ride)
  */
 static void GuestTriedToEnterFullQueue(Guest& guest, Ride& ride)
 {
-    ride.lifecycleFlags.set(RideFlag::queueFull);
+    ride.flags.set(RideFlag::queueFull);
     guest.PreviousRide = ride.id;
     guest.PreviousRideTimeOut = 0;
     // Change status "Heading to" to "Walking" if queue is full
@@ -2590,7 +2590,7 @@ static bool FindVehicleToEnter(
 
     if (ride.mode == RideMode::dodgems || ride.mode == RideMode::race)
     {
-        if (ride.lifecycleFlags.has(RideFlag::passStationNoStopping))
+        if (ride.flags.has(RideFlag::passStationNoStopping))
             return false;
 
         for (int32_t i = 0; i < ride.numTrains; ++i)
@@ -3025,8 +3025,8 @@ static PeepThoughtType GuestAssessSurroundings(int16_t centre_x, int16_t centre_
                         if (ride == nullptr)
                             break;
 
-                        bool isPlayingMusic = ride->lifecycleFlags.has(RideFlag::music) && ride->status != RideStatus::closed
-                            && !ride->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed);
+                        bool isPlayingMusic = ride->flags.has(RideFlag::music) && ride->status != RideStatus::closed
+                            && !ride->flags.hasAny(RideFlag::brokenDown, RideFlag::crashed);
                         if (!isPlayingMusic)
                             break;
 
@@ -3249,7 +3249,7 @@ static void PeepHeadForNearestRide(Guest& guest, bool considerOnlyCloseRides, T 
     {
         if (rideConsideration[ride.id.ToUnderlying()])
         {
-            if (!ride.lifecycleFlags.has(RideFlag::queueFull))
+            if (!ride.flags.has(RideFlag::queueFull))
             {
                 if (guest.ShouldGoOnRide(ride, StationIndex::FromUnderlying(0), false, true))
                 {
@@ -3554,7 +3554,7 @@ void Guest::UpdateRideAtEntrance()
         return;
     }
 
-    if (ride->lifecycleFlags.has(RideFlag::brokenDown))
+    if (ride->flags.has(RideFlag::brokenDown))
         return;
 
     auto ridePrice = RideGetPrice(*ride);
@@ -4485,7 +4485,7 @@ void Guest::UpdateRideInExit()
         MoveTo({ loc.value(), z });
     }
 
-    if (ride->lifecycleFlags.has(RideFlag::onRidePhoto))
+    if (ride->flags.has(RideFlag::onRidePhoto))
     {
         ShopItem secondaryItem = ride->getRideTypeDescriptor().PhotoItem;
         if (GuestDecideAndBuyItem(*this, *ride, secondaryItem, ride->price[1]))
@@ -4809,7 +4809,7 @@ void Guest::UpdateRideOnSpiralSlide()
 
                 return;
             case PeepSpiralSlideSubState::prepareToSlide:
-                if (ride->slideInUse || ride->lifecycleFlags.has(RideFlag::brokenDown))
+                if (ride->slideInUse || ride->flags.has(RideFlag::brokenDown))
                     return;
 
                 ride->slideInUse = 1;
@@ -6466,7 +6466,7 @@ bool Loc690FD0(Guest& guest, RideId* rideToView, uint8_t* rideSeatToView, TileEl
     else
     {
         *rideSeatToView = 0;
-        if (ride->status == RideStatus::open && !ride->lifecycleFlags.has(RideFlag::brokenDown))
+        if (ride->status == RideStatus::open && !ride->flags.has(RideFlag::brokenDown))
         {
             if (tileElement->GetClearanceZ() > guest.NextLoc.z + (8 * kCoordsZStep))
             {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1244,12 +1244,12 @@ void Staff::UpdateHeadingToInspect()
 
     if (ride->getStation(CurrentRideStation).Exit.IsNull())
     {
-        ride->lifecycleFlags.unset(RideFlag::dueInspection);
+        ride->flags.unset(RideFlag::dueInspection);
         SetState(PeepState::falling);
         return;
     }
 
-    if (ride->mechanicStatus != MechanicStatus::heading || !ride->lifecycleFlags.has(RideFlag::dueInspection))
+    if (ride->mechanicStatus != MechanicStatus::heading || !ride->flags.has(RideFlag::dueInspection))
     {
         SetState(PeepState::falling);
         return;
@@ -1267,7 +1267,7 @@ void Staff::UpdateHeadingToInspect()
         MechanicTimeSinceCall++;
         if (MechanicTimeSinceCall > 2500)
         {
-            if (ride->lifecycleFlags.has(RideFlag::dueInspection) && ride->mechanicStatus == MechanicStatus::heading)
+            if (ride->flags.has(RideFlag::dueInspection) && ride->mechanicStatus == MechanicStatus::heading)
             {
                 ride->mechanicStatus = MechanicStatus::calling;
             }
@@ -1975,7 +1975,7 @@ void Staff::UpdateFixing(int32_t steps)
     bool progressToNextSubstate = true;
     bool firstRun = true;
 
-    if ((State == PeepState::inspecting) && (ride->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)))
+    if ((State == PeepState::inspecting) && (ride->flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)))
     {
         // Ride has broken down since Mechanic was called to inspect it.
         // Mechanic identifies the breakdown and switches to fixing it.
@@ -2597,7 +2597,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
     auto ride = GetRide(rideIndex);
     if (ride != nullptr)
     {
-        ride->lifecycleFlags.unset(RideFlag::dueInspection);
+        ride->flags.unset(RideFlag::dueInspection);
         ride->reliability += ((100 - ride->reliabilityPercentage) / 4) * (ScenarioRand() & 0xFF);
         ride->lastInspection = 0;
         ride->windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::main, RideInvalidateFlag::list);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1244,12 +1244,12 @@ void Staff::UpdateHeadingToInspect()
 
     if (ride->getStation(CurrentRideStation).Exit.IsNull())
     {
-        ride->lifecycleFlags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+        ride->lifecycleFlags.unset(RideFlag::dueInspection);
         SetState(PeepState::falling);
         return;
     }
 
-    if (ride->mechanicStatus != MechanicStatus::heading || !(ride->lifecycleFlags & RIDE_LIFECYCLE_DUE_INSPECTION))
+    if (ride->mechanicStatus != MechanicStatus::heading || !ride->lifecycleFlags.has(RideFlag::dueInspection))
     {
         SetState(PeepState::falling);
         return;
@@ -1267,7 +1267,7 @@ void Staff::UpdateHeadingToInspect()
         MechanicTimeSinceCall++;
         if (MechanicTimeSinceCall > 2500)
         {
-            if (ride->lifecycleFlags & RIDE_LIFECYCLE_DUE_INSPECTION && ride->mechanicStatus == MechanicStatus::heading)
+            if (ride->lifecycleFlags.has(RideFlag::dueInspection) && ride->mechanicStatus == MechanicStatus::heading)
             {
                 ride->mechanicStatus = MechanicStatus::calling;
             }
@@ -1975,8 +1975,7 @@ void Staff::UpdateFixing(int32_t steps)
     bool progressToNextSubstate = true;
     bool firstRun = true;
 
-    if ((State == PeepState::inspecting)
-        && (ride->lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)))
+    if ((State == PeepState::inspecting) && (ride->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)))
     {
         // Ride has broken down since Mechanic was called to inspect it.
         // Mechanic identifies the breakdown and switches to fixing it.
@@ -2598,7 +2597,7 @@ void Staff::UpdateRideInspected(RideId rideIndex)
     auto ride = GetRide(rideIndex);
     if (ride != nullptr)
     {
-        ride->lifecycleFlags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+        ride->lifecycleFlags.unset(RideFlag::dueInspection);
         ride->reliability += ((100 - ride->reliabilityPercentage) / 4) * (ScenarioRand() & 0xFF);
         ride->lastInspection = 0;
         ride->windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::main, RideInvalidateFlag::list);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -694,7 +694,7 @@ namespace OpenRCT2
             || (peep.State == PeepState::leavingRide && peep.x == kLocationNull))
         {
             auto ride = GetRide(peep.CurrentRide);
-            if (ride != nullptr && ride->lifecycleFlags.has(RideFlag::onTrack))
+            if (ride != nullptr && ride->flags.has(RideFlag::onTrack))
             {
                 auto train = getGameState().entities.GetEntity<Vehicle>(ride->vehicles[peep.CurrentTrain]);
                 if (train != nullptr)

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -694,7 +694,7 @@ namespace OpenRCT2
             || (peep.State == PeepState::leavingRide && peep.x == kLocationNull))
         {
             auto ride = GetRide(peep.CurrentRide);
-            if (ride != nullptr && (ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+            if (ride != nullptr && ride->lifecycleFlags.has(RideFlag::onTrack))
             {
                 auto train = getGameState().entities.GetEntity<Vehicle>(ride->vehicles[peep.CurrentTrain]);
                 if (train != nullptr)

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -157,7 +157,7 @@ static bool AwardIsDeservedBestRollercoasters(GameState_t& gameState, [[maybe_un
             continue;
         }
 
-        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
+        if (ride.status != RideStatus::open || ride.flags.has(RideFlag::crashed))
         {
             continue;
         }
@@ -448,7 +448,7 @@ static bool AwardIsDeservedBestWaterRides(GameState_t& gameState, [[maybe_unused
             continue;
         }
 
-        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
+        if (ride.status != RideStatus::open || ride.flags.has(RideFlag::crashed))
         {
             continue;
         }
@@ -475,11 +475,11 @@ static bool AwardIsDeservedBestCustomDesignedRides(GameState_t& gameState, int32
     {
         if (!ride.getRideTypeDescriptor().flags.has(RtdFlag::hasTrack))
             continue;
-        if (ride.lifecycleFlags.has(RideFlag::notCustomDesign))
+        if (ride.flags.has(RideFlag::notCustomDesign))
             continue;
         if (ride.ratings.excitement < RideRating::make(5, 50))
             continue;
-        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
+        if (ride.status != RideStatus::open || ride.flags.has(RideFlag::crashed))
             continue;
 
         customDesignedRides++;
@@ -555,7 +555,7 @@ static bool AwardIsDeservedBestGentleRides(GameState_t& gameState, [[maybe_unuse
             continue;
         }
 
-        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
+        if (ride.status != RideStatus::open || ride.flags.has(RideFlag::crashed))
         {
             continue;
         }

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -157,7 +157,7 @@ static bool AwardIsDeservedBestRollercoasters(GameState_t& gameState, [[maybe_un
             continue;
         }
 
-        if (ride.status != RideStatus::open || (ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
         {
             continue;
         }
@@ -448,7 +448,7 @@ static bool AwardIsDeservedBestWaterRides(GameState_t& gameState, [[maybe_unused
             continue;
         }
 
-        if (ride.status != RideStatus::open || (ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
         {
             continue;
         }
@@ -475,11 +475,11 @@ static bool AwardIsDeservedBestCustomDesignedRides(GameState_t& gameState, int32
     {
         if (!ride.getRideTypeDescriptor().flags.has(RtdFlag::hasTrack))
             continue;
-        if (ride.lifecycleFlags & RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN)
+        if (ride.lifecycleFlags.has(RideFlag::notCustomDesign))
             continue;
         if (ride.ratings.excitement < RideRating::make(5, 50))
             continue;
-        if (ride.status != RideStatus::open || (ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
             continue;
 
         customDesignedRides++;
@@ -555,7 +555,7 @@ static bool AwardIsDeservedBestGentleRides(GameState_t& gameState, [[maybe_unuse
             continue;
         }
 
-        if (ride.status != RideStatus::open || (ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+        if (ride.status != RideStatus::open || ride.lifecycleFlags.has(RideFlag::crashed))
         {
             continue;
         }

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -174,7 +174,7 @@ void FinancePayRideUpkeep()
     auto& gameState = getGameState();
     for (auto& ride : RideManager(gameState))
     {
-        if (!ride.lifecycleFlags.has(RideFlag::everBeenOpened))
+        if (!ride.flags.has(RideFlag::everBeenOpened))
         {
             ride.renew();
         }

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -174,7 +174,7 @@ void FinancePayRideUpkeep()
     auto& gameState = getGameState();
     for (auto& ride : RideManager(gameState))
     {
-        if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_EVER_BEEN_OPENED))
+        if (!ride.lifecycleFlags.has(RideFlag::everBeenOpened))
         {
             ride.renew();
         }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -246,7 +246,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(ItemType type, int32_t subject
 
             // Find which ride peep is on
             Ride* ride = GetRide(peep->CurrentRide);
-            if (ride == nullptr || !(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+            if (ride == nullptr || !ride->lifecycleFlags.has(RideFlag::onTrack))
             {
                 subjectLoc = std::nullopt;
                 break;

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -246,7 +246,7 @@ std::optional<CoordsXYZ> News::GetSubjectLocation(ItemType type, int32_t subject
 
             // Find which ride peep is on
             Ride* ride = GetRide(peep->CurrentRide);
-            if (ride == nullptr || !ride->lifecycleFlags.has(RideFlag::onTrack))
+            if (ride == nullptr || !ride->flags.has(RideFlag::onTrack))
             {
                 subjectLoc = std::nullopt;
                 break;

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -58,7 +58,7 @@ static void PaintRideEntranceExitScrollingText(
         return;
 
     u8string bannerText;
-    if (ride->status == RideStatus::open && !(ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (ride->status == RideStatus::open && !ride->lifecycleFlags.has(RideFlag::brokenDown))
     {
         bannerText = ScrollingText::kRideBannerColourPrefix + ride->getName();
     }

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -58,7 +58,7 @@ static void PaintRideEntranceExitScrollingText(
         return;
 
     u8string bannerText;
-    if (ride->status == RideStatus::open && !ride->lifecycleFlags.has(RideFlag::brokenDown))
+    if (ride->status == RideStatus::open && !ride->flags.has(RideFlag::brokenDown))
     {
         bannerText = ScrollingText::kRideBannerColourPrefix + ride->getName();
     }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -156,7 +156,7 @@ static void PathPaintQueueBanner(
         scrollingMode += direction;
 
         u8string bannerText;
-        if (ride->status == RideStatus::open && !ride->lifecycleFlags.has(RideFlag::brokenDown))
+        if (ride->status == RideStatus::open && !ride->flags.has(RideFlag::brokenDown))
         {
             bannerText = ScrollingText::kRideBannerColourPrefix + ride->getName();
         }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -156,7 +156,7 @@ static void PathPaintQueueBanner(
         scrollingMode += direction;
 
         u8string bannerText;
-        if (ride->status == RideStatus::open && !(ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+        if (ride->status == RideStatus::open && !ride->lifecycleFlags.has(RideFlag::brokenDown))
         {
             bannerText = ScrollingText::kRideBannerColourPrefix + ride->getName();
         }

--- a/src/openrct2/paint/track/gentle/Circus.cpp
+++ b/src/openrct2/paint/track/gentle/Circus.cpp
@@ -31,7 +31,7 @@ static void PaintCircusTent(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/Circus.cpp
+++ b/src/openrct2/paint/track/gentle/Circus.cpp
@@ -31,7 +31,7 @@ static void PaintCircusTent(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/CrookedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/CrookedHouse.cpp
@@ -68,7 +68,7 @@ static void PaintCrookedHouseStructure(
     if (rideEntry == nullptr)
         return;
 
-    if (ride->lifecycleFlags.has(RideFlag::onTrack))
+    if (ride->flags.has(RideFlag::onTrack))
     {
         auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride->vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/gentle/CrookedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/CrookedHouse.cpp
@@ -68,7 +68,7 @@ static void PaintCrookedHouseStructure(
     if (rideEntry == nullptr)
         return;
 
-    if (ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (ride->lifecycleFlags.has(RideFlag::onTrack))
     {
         auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride->vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/gentle/FerrisWheel.cpp
+++ b/src/openrct2/paint/track/gentle/FerrisWheel.cpp
@@ -71,7 +71,7 @@ static void PaintFerrisWheelStructure(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/FerrisWheel.cpp
+++ b/src/openrct2/paint/track/gentle/FerrisWheel.cpp
@@ -71,7 +71,7 @@ static void PaintFerrisWheelStructure(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/HauntedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/HauntedHouse.cpp
@@ -40,7 +40,7 @@ static void PaintHauntedHouseStructure(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/HauntedHouse.cpp
+++ b/src/openrct2/paint/track/gentle/HauntedHouse.cpp
@@ -40,7 +40,7 @@ static void PaintHauntedHouseStructure(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/MerryGoRound.cpp
+++ b/src/openrct2/paint/track/gentle/MerryGoRound.cpp
@@ -36,7 +36,7 @@ static void PaintRiders(
 {
     if (session.rt.zoom_level > ZoomLevel{ 0 })
         return;
-    if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+    if (!ride.lifecycleFlags.has(RideFlag::onTrack))
         return;
 
     for (int32_t peep = 0; peep <= 14; peep += 2)
@@ -66,12 +66,12 @@ static void PaintCarousel(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;
 
-        if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)
+        if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
             && ride.breakdownReasonPending == BREAKDOWN_CONTROL_FAILURE && ride.breakdownSoundModifier >= 128)
         {
             height += kMerryGoRoundBreakdownVibration[(vehicle->current_time >> 1) & 7];

--- a/src/openrct2/paint/track/gentle/MerryGoRound.cpp
+++ b/src/openrct2/paint/track/gentle/MerryGoRound.cpp
@@ -36,7 +36,7 @@ static void PaintRiders(
 {
     if (session.rt.zoom_level > ZoomLevel{ 0 })
         return;
-    if (!ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (!ride.flags.has(RideFlag::onTrack))
         return;
 
     for (int32_t peep = 0; peep <= 14; peep += 2)
@@ -66,12 +66,12 @@ static void PaintCarousel(
         return;
 
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;
 
-        if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
+        if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
             && ride.breakdownReasonPending == BREAKDOWN_CONTROL_FAILURE && ride.breakdownSoundModifier >= 128)
         {
             height += kMerryGoRoundBreakdownVibration[(vehicle->current_time >> 1) & 7];

--- a/src/openrct2/paint/track/gentle/SpaceRings.cpp
+++ b/src/openrct2/paint/track/gentle/SpaceRings.cpp
@@ -54,7 +54,7 @@ static void PaintSpaceRingsStructure(
     int32_t frameNum = direction;
     uint32_t baseImageId = rideEntry->Cars[0].base_image_id;
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[vehicleIndex]);
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/gentle/SpaceRings.cpp
+++ b/src/openrct2/paint/track/gentle/SpaceRings.cpp
@@ -54,7 +54,7 @@ static void PaintSpaceRingsStructure(
     int32_t frameNum = direction;
     uint32_t baseImageId = rideEntry->Cars[0].base_image_id;
     auto vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[vehicleIndex]);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/thrill/3dCinema.cpp
+++ b/src/openrct2/paint/track/thrill/3dCinema.cpp
@@ -30,7 +30,7 @@ static void Paint3dCinemaDome(
     if (rideEntry == nullptr)
         return;
 
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && !ride.vehicles[0].IsNull())
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);

--- a/src/openrct2/paint/track/thrill/3dCinema.cpp
+++ b/src/openrct2/paint/track/thrill/3dCinema.cpp
@@ -30,7 +30,7 @@ static void Paint3dCinemaDome(
     if (rideEntry == nullptr)
         return;
 
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
+    if (ride.flags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);

--- a/src/openrct2/paint/track/thrill/Enterprise.cpp
+++ b/src/openrct2/paint/track/thrill/Enterprise.cpp
@@ -56,7 +56,7 @@ static void PaintEnterpriseStructure(
         return;
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (ride.flags.has(RideFlag::onTrack))
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/thrill/Enterprise.cpp
+++ b/src/openrct2/paint/track/thrill/Enterprise.cpp
@@ -56,7 +56,7 @@ static void PaintEnterpriseStructure(
         return;
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack))
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/thrill/MagicCarpet.cpp
+++ b/src/openrct2/paint/track/thrill/MagicCarpet.cpp
@@ -94,7 +94,7 @@ static ImageIndex GetMagicCarpetPendulumImage(Plane plane, Direction direction, 
 
 static Vehicle* GetFirstVehicle(const Ride& ride)
 {
-    if (ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (ride.flags.has(RideFlag::onTrack))
     {
         return getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
     }

--- a/src/openrct2/paint/track/thrill/MagicCarpet.cpp
+++ b/src/openrct2/paint/track/thrill/MagicCarpet.cpp
@@ -94,7 +94,7 @@ static ImageIndex GetMagicCarpetPendulumImage(Plane plane, Direction direction, 
 
 static Vehicle* GetFirstVehicle(const Ride& ride)
 {
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack))
     {
         return getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
     }

--- a/src/openrct2/paint/track/thrill/MotionSimulator.cpp
+++ b/src/openrct2/paint/track/thrill/MotionSimulator.cpp
@@ -46,7 +46,7 @@ static void PaintMotionSimulatorVehicle(
     CoordsXYZ offset(offsetX, offsetY, height + 2);
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (ride.flags.has(RideFlag::onTrack))
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/thrill/MotionSimulator.cpp
+++ b/src/openrct2/paint/track/thrill/MotionSimulator.cpp
@@ -46,7 +46,7 @@ static void PaintMotionSimulatorVehicle(
     CoordsXYZ offset(offsetX, offsetY, height + 2);
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack))
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
@@ -75,7 +75,7 @@ static void PaintSwingingInverterShipStructure(
     BoundBoxXYZ bb = { { boundBox.offset, height }, { boundBox.length, 127 } };
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack))
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingInverterShip.cpp
@@ -75,7 +75,7 @@ static void PaintSwingingInverterShipStructure(
     BoundBoxXYZ bb = { { boundBox.offset, height }, { boundBox.length, 127 } };
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (ride.flags.has(RideFlag::onTrack))
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         if (vehicle != nullptr)

--- a/src/openrct2/paint/track/thrill/SwingingShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingShip.cpp
@@ -67,7 +67,7 @@ static void PaintSwingingShipRiders(
     if (session.rt.zoom_level > ZoomLevel{ 1 })
         return;
 
-    if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+    if (!ride.lifecycleFlags.has(RideFlag::onTrack))
         return;
 
     int32_t peep = 0;
@@ -96,7 +96,7 @@ static void PaintSwingingShipStructure(
         return;
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && !ride.vehicles[0].IsNull())
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         session.InteractionType = ViewportInteractionItem::entity;

--- a/src/openrct2/paint/track/thrill/SwingingShip.cpp
+++ b/src/openrct2/paint/track/thrill/SwingingShip.cpp
@@ -67,7 +67,7 @@ static void PaintSwingingShipRiders(
     if (session.rt.zoom_level > ZoomLevel{ 1 })
         return;
 
-    if (!ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (!ride.flags.has(RideFlag::onTrack))
         return;
 
     int32_t peep = 0;
@@ -96,7 +96,7 @@ static void PaintSwingingShipStructure(
         return;
 
     Vehicle* vehicle = nullptr;
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
+    if (ride.flags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
         session.InteractionType = ViewportInteractionItem::entity;

--- a/src/openrct2/paint/track/thrill/TopSpin.cpp
+++ b/src/openrct2/paint/track/thrill/TopSpin.cpp
@@ -130,7 +130,7 @@ static void PaintTopSpinVehicle(
     uint8_t seatRotation = 0;
     uint8_t armRotation = 0;
     auto* vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/thrill/TopSpin.cpp
+++ b/src/openrct2/paint/track/thrill/TopSpin.cpp
@@ -130,7 +130,7 @@ static void PaintTopSpinVehicle(
     uint8_t seatRotation = 0;
     uint8_t armRotation = 0;
     auto* vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         session.InteractionType = ViewportInteractionItem::entity;
         session.CurrentlyDrawnEntity = vehicle;

--- a/src/openrct2/paint/track/thrill/Twist.cpp
+++ b/src/openrct2/paint/track/thrill/Twist.cpp
@@ -38,7 +38,7 @@ static void PaintTwistStructure(
 
     height += 7;
 
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && !ride.vehicles[0].IsNull())
+    if (ride.lifecycleFlags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
 
@@ -69,7 +69,7 @@ static void PaintTwistStructure(
     };
     PaintAddImageAsParent(session, imageId, { xOffset, yOffset, height }, bb);
 
-    if (session.rt.zoom_level < ZoomLevel{ 1 } && ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (session.rt.zoom_level < ZoomLevel{ 1 } && ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         for (int32_t i = 0; i < vehicle->num_peeps; i += 2)
         {

--- a/src/openrct2/paint/track/thrill/Twist.cpp
+++ b/src/openrct2/paint/track/thrill/Twist.cpp
@@ -38,7 +38,7 @@ static void PaintTwistStructure(
 
     height += 7;
 
-    if (ride.lifecycleFlags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
+    if (ride.flags.has(RideFlag::onTrack) && !ride.vehicles[0].IsNull())
     {
         vehicle = getGameState().entities.GetEntity<Vehicle>(ride.vehicles[0]);
 
@@ -69,7 +69,7 @@ static void PaintTwistStructure(
     };
     PaintAddImageAsParent(session, imageId, { xOffset, yOffset, height }, bb);
 
-    if (session.rt.zoom_level < ZoomLevel{ 1 } && ride.lifecycleFlags.has(RideFlag::onTrack) && vehicle != nullptr)
+    if (session.rt.zoom_level < ZoomLevel{ 1 } && ride.flags.has(RideFlag::onTrack) && vehicle != nullptr)
     {
         for (int32_t i = 0; i < vehicle->num_peeps; i += 2)
         {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1429,7 +1429,7 @@ namespace OpenRCT2
                     cs.readWrite(ride.mode);
                     cs.readWrite(ride.status);
                     cs.readWrite(ride.departFlags);
-                    cs.readWrite(ride.lifecycleFlags.holder);
+                    cs.readWrite(ride.flags.holder);
 
                     // Meta
                     cs.readWrite(ride.customName);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1429,7 +1429,7 @@ namespace OpenRCT2
                     cs.readWrite(ride.mode);
                     cs.readWrite(ride.status);
                     cs.readWrite(ride.departFlags);
-                    cs.readWrite(ride.lifecycleFlags);
+                    cs.readWrite(ride.lifecycleFlags.holder);
 
                     // Meta
                     cs.readWrite(ride.customName);

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -248,7 +248,7 @@ namespace OpenRCT2::RCT1
     {
         RideType type;                               // 0x000
         RCT1::VehicleType vehicleType;               // 0x001
-        uint16_t lifecycleFlags;                     // 0x002
+        uint16_t flags;                              // 0x002
         uint8_t operatingMode;                       // 0x004
         VehicleColourSettings vehicleColourSettings; // 0x005
         struct

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -854,17 +854,15 @@ namespace OpenRCT2::RCT1
             dst->status = static_cast<RideStatus>(src->status);
 
             // Flags
-            dst->lifecycleFlags = src->lifecycleFlags;
+            dst->lifecycleFlags.holder = src->lifecycleFlags;
             // These flags were not in the base game
             if (_gameVersion == FILE_VERSION_RCT1)
             {
-                dst->lifecycleFlags &= ~RIDE_LIFECYCLE_MUSIC;
-                dst->lifecycleFlags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE;
-                dst->lifecycleFlags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK;
+                dst->lifecycleFlags.unset(RideFlag::music, RideFlag::indestructible, RideFlag::indestructibleTrack);
             }
             if (VehicleTypeIsReversed(src->vehicleType))
             {
-                dst->lifecycleFlags |= RIDE_LIFECYCLE_REVERSED_TRAINS;
+                dst->lifecycleFlags.set(RideFlag::reversedTrains);
             }
 
             // Station
@@ -978,7 +976,7 @@ namespace OpenRCT2::RCT1
                         if (src->departFlags & RCT1_RIDE_DEPART_PLAY_MUSIC)
                         {
                             dst->departFlags &= ~RCT1_RIDE_DEPART_PLAY_MUSIC;
-                            dst->lifecycleFlags |= RIDE_LIFECYCLE_MUSIC;
+                            dst->lifecycleFlags.set(RideFlag::music);
                         }
                     }
                 }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -854,15 +854,15 @@ namespace OpenRCT2::RCT1
             dst->status = static_cast<RideStatus>(src->status);
 
             // Flags
-            dst->lifecycleFlags.holder = src->lifecycleFlags;
+            dst->flags.holder = src->flags;
             // These flags were not in the base game
             if (_gameVersion == FILE_VERSION_RCT1)
             {
-                dst->lifecycleFlags.unset(RideFlag::music, RideFlag::indestructible, RideFlag::indestructibleTrack);
+                dst->flags.unset(RideFlag::music, RideFlag::indestructible, RideFlag::indestructibleTrack);
             }
             if (VehicleTypeIsReversed(src->vehicleType))
             {
-                dst->lifecycleFlags.set(RideFlag::reversedTrains);
+                dst->flags.set(RideFlag::reversedTrains);
             }
 
             // Station
@@ -976,7 +976,7 @@ namespace OpenRCT2::RCT1
                         if (src->departFlags & RCT1_RIDE_DEPART_PLAY_MUSIC)
                         {
                             dst->departFlags &= ~RCT1_RIDE_DEPART_PLAY_MUSIC;
-                            dst->lifecycleFlags.set(RideFlag::music);
+                            dst->flags.set(RideFlag::music);
                         }
                     }
                 }

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -287,7 +287,7 @@ namespace OpenRCT2::RCT2
         uint8_t numBlockBrakes;                                             // 0x1CC
         uint8_t liftHillSpeed;                                              // 0x1CD
         uint16_t guestsFavourite;                                           // 0x1CE
-        uint32_t lifecycleFlags;                                            // 0x1D0
+        uint32_t flags;                                                     // 0x1D0
         Drawing::Colour vehicleColoursExtended[Limits::kMaxVehicleColours]; // 0x1D4
         uint16_t totalAirTime;                                              // 0x1F4
         uint8_t currentTestStation;                                         // 0x1F6

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -999,7 +999,7 @@ namespace OpenRCT2::RCT2
             dst->numBlockBrakes = src->numBlockBrakes;
             dst->liftHillSpeed = src->liftHillSpeed;
             dst->guestsFavourite = src->guestsFavourite;
-            dst->lifecycleFlags.holder = src->lifecycleFlags;
+            dst->flags.holder = src->flags;
 
             for (uint8_t i = 0; i < Limits::kMaxTrainsPerRide; i++)
             {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -999,7 +999,7 @@ namespace OpenRCT2::RCT2
             dst->numBlockBrakes = src->numBlockBrakes;
             dst->liftHillSpeed = src->liftHillSpeed;
             dst->guestsFavourite = src->guestsFavourite;
-            dst->lifecycleFlags = src->lifecycleFlags;
+            dst->lifecycleFlags.holder = src->lifecycleFlags;
 
             for (uint8_t i = 0; i < Limits::kMaxTrainsPerRide; i++)
             {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -311,7 +311,7 @@ size_t Ride::getNumPrices() const
         auto rideEntry = getRideEntry();
         if (rideEntry != nullptr)
         {
-            if (lifecycleFlags.has(RideFlag::onRidePhoto))
+            if (flags.has(RideFlag::onRidePhoto))
             {
                 result++;
             }
@@ -440,7 +440,7 @@ money64 Ride::calculateIncomePerHour() const
         priceMinusCost -= GetShopItemDescriptor(currentShopItem).Cost;
     }
 
-    currentShopItem = lifecycleFlags.has(RideFlag::onRidePhoto) ? getRideTypeDescriptor().PhotoItem : entry->shop_item[1];
+    currentShopItem = flags.has(RideFlag::onRidePhoto) ? getRideTypeDescriptor().PhotoItem : entry->shop_item[1];
 
     if (currentShopItem != ShopItem::none)
     {
@@ -838,11 +838,11 @@ bool Ride::findTrackGap(const CoordsXYE& input, CoordsXYE* output) const
 
 void Ride::formatStatusTo(Formatter& ft) const
 {
-    if (lifecycleFlags.has(RideFlag::crashed))
+    if (flags.has(RideFlag::crashed))
     {
         ft.Add<StringId>(STR_CRASHED);
     }
-    else if (lifecycleFlags.has(RideFlag::brokenDown))
+    else if (flags.has(RideFlag::brokenDown))
     {
         ft.Add<StringId>(STR_BROKEN_DOWN);
     }
@@ -873,7 +873,7 @@ void Ride::formatStatusTo(Formatter& ft) const
     {
         ft.Add<StringId>(STR_TEST_RUN);
     }
-    else if (mode == RideMode::race && !lifecycleFlags.has(RideFlag::passStationNoStopping) && !raceWinner.IsNull())
+    else if (mode == RideMode::race && !flags.has(RideFlag::passStationNoStopping) && !raceWinner.IsNull())
     {
         auto peep = getGameState().entities.GetEntity<Guest>(raceWinner);
         if (peep != nullptr)
@@ -955,7 +955,7 @@ bool Ride::supportsStatus(RideStatus s) const
 
 bool Ride::hasFailingBrakes() const
 {
-    return lifecycleFlags.has(RideFlag::brokenDown) && breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
+    return flags.has(RideFlag::brokenDown) && breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
         && mechanicStatus != MechanicStatus::hasFixedStationBrakes;
 }
 
@@ -1039,7 +1039,7 @@ void Ride::updateAll()
 
 std::unique_ptr<TrackDesign> Ride::saveToTrackDesign(TrackDesignState& tds) const
 {
-    if (!lifecycleFlags.has(RideFlag::tested))
+    if (!flags.has(RideFlag::tested))
     {
         ContextShowError(STR_CANT_SAVE_TRACK_DESIGN, kStringIdNone, {});
         return nullptr;
@@ -1156,7 +1156,7 @@ void Ride::update()
     RideBreakdownUpdate(*this);
 
     // Various things include news messages
-    if (lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection))
+    if (flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection))
     {
         // Breakdown updates originally were performed when (id == (gCurrentTicks / 2) & 0xFF)
         // with the increased MAX_RIDES the update is tied to the first byte of the id this allows
@@ -1169,7 +1169,7 @@ void Ride::update()
     RideInspectionUpdate(*this);
 
     // If ride is simulating but crashed, reset the vehicles
-    if (status == RideStatus::simulating && lifecycleFlags.has(RideFlag::crashed))
+    if (status == RideStatus::simulating && flags.has(RideFlag::crashed))
     {
         // We require this to execute right away during the simulation, always ignore network and queue.
         auto gameAction = GameActions::RideSetStatusAction(id, RideStatus::simulating);
@@ -1183,9 +1183,9 @@ void Ride::update()
  */
 void updateChairlift(Ride& ride)
 {
-    if (!ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (!ride.flags.has(RideFlag::onTrack))
         return;
-    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed)
+    if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed)
         && ride.breakdownReasonPending == 0)
         return;
 
@@ -1346,7 +1346,7 @@ static void RideInspectionUpdate(Ride& ride)
     // An inspection interval of 0 minutes means the ride is set to never be inspected.
     if (inspectionIntervalMinutes == 0)
     {
-        ride.lifecycleFlags.unset(RideFlag::dueInspection);
+        ride.flags.unset(RideFlag::dueInspection);
         return;
     }
 
@@ -1356,12 +1356,11 @@ static void RideInspectionUpdate(Ride& ride)
     if (inspectionIntervalMinutes > ride.lastInspection)
         return;
 
-    if (ride.lifecycleFlags.hasAny(
-            RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection, RideFlag::crashed))
+    if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection, RideFlag::crashed))
         return;
 
     // Inspect the first station that has an exit
-    ride.lifecycleFlags.set(RideFlag::dueInspection);
+    ride.flags.set(RideFlag::dueInspection);
     ride.mechanicStatus = MechanicStatus::calling;
 
     auto stationIndex = RideGetFirstValidStationExit(ride);
@@ -1405,7 +1404,7 @@ static void RideBreakdownUpdate(Ride& ride)
     if (gLegacyScene == LegacyScene::trackDesigner)
         return;
 
-    if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+    if (ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
         ride.downtimeHistory[0]++;
 
     if (!(currentTicks & 8191))
@@ -1428,7 +1427,7 @@ static void RideBreakdownUpdate(Ride& ride)
         ride.windowInvalidateFlags.set(RideInvalidateFlag::maintenance);
     }
 
-    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
+    if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
         return;
     if (ride.status == RideStatus::closed || ride.status == RideStatus::simulating)
         return;
@@ -1556,10 +1555,10 @@ void RidePrepareBreakdown(Ride& ride, int32_t breakdownReason)
     StationIndex i;
     Vehicle* vehicle;
 
-    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
+    if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
         return;
 
-    ride.lifecycleFlags.set(RideFlag::breakdownPending);
+    ride.flags.set(RideFlag::breakdownPending);
 
     ride.breakdownReasonPending = breakdownReason;
     ride.breakdownSoundModifier = 0;
@@ -1645,7 +1644,7 @@ void RideBreakdownAddNewsItem(const Ride& ride)
 static void RideBreakdownStatusUpdate(Ride& ride)
 {
     // Warn player if ride hasn't been fixed for ages
-    if (ride.lifecycleFlags.has(RideFlag::brokenDown))
+    if (ride.flags.has(RideFlag::brokenDown))
     {
         ride.notFixedTimeout++;
         // When there has been a full 255 timeout ticks this
@@ -1678,13 +1677,13 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
     // Turn a pending breakdown into a breakdown.
     if ((mechanicStatus == MechanicStatus::undefined || mechanicStatus == MechanicStatus::calling
          || mechanicStatus == MechanicStatus::heading)
-        && ride.lifecycleFlags.has(RideFlag::breakdownPending) && !ride.lifecycleFlags.has(RideFlag::brokenDown))
+        && ride.flags.has(RideFlag::breakdownPending) && !ride.flags.has(RideFlag::brokenDown))
     {
         auto breakdownReason = ride.breakdownReasonPending;
         if (breakdownReason == BREAKDOWN_SAFETY_CUT_OUT || breakdownReason == BREAKDOWN_BRAKES_FAILURE
             || breakdownReason == BREAKDOWN_CONTROL_FAILURE)
         {
-            ride.lifecycleFlags.set(RideFlag::brokenDown);
+            ride.flags.set(RideFlag::brokenDown);
             ride.windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::list, RideInvalidateFlag::main);
             ride.breakdownReason = breakdownReason;
             RideBreakdownAddNewsItem(ride);
@@ -1693,7 +1692,7 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
     switch (mechanicStatus)
     {
         case MechanicStatus::undefined:
-            if (ride.lifecycleFlags.has(RideFlag::brokenDown))
+            if (ride.flags.has(RideFlag::brokenDown))
             {
                 ride.mechanicStatus = MechanicStatus::calling;
             }
@@ -1701,7 +1700,7 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
         case MechanicStatus::calling:
             if (ride.getRideTypeDescriptor().AvailableBreakdowns == 0)
             {
-                ride.lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection);
+                ride.flags.unset(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection);
                 break;
             }
 
@@ -1710,7 +1709,7 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
         case MechanicStatus::heading:
         {
             auto mechanic = RideGetMechanic(ride);
-            bool rideNeedsRepair = ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown);
+            bool rideNeedsRepair = ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown);
             if (mechanic == nullptr
                 || (mechanic->State != PeepState::headingToInspection && mechanic->State != PeepState::answering)
                 || mechanic->CurrentRide != ride.id)
@@ -1767,7 +1766,7 @@ static void RideCallMechanic(Ride& ride, Peep* mechanic, int32_t forInspection)
  */
 static void RideCallClosestMechanic(Ride& ride)
 {
-    auto forInspection = !ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown);
+    auto forInspection = !ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown);
     auto mechanic = RideFindClosestMechanic(ride, forInspection);
     if (mechanic != nullptr)
         RideCallMechanic(ride, mechanic, forInspection);
@@ -1863,7 +1862,7 @@ Staff* RideGetMechanic(const Ride& ride)
 
 Staff* RideGetAssignedMechanic(const Ride& ride)
 {
-    if (ride.lifecycleFlags.has(RideFlag::brokenDown))
+    if (ride.flags.has(RideFlag::brokenDown))
     {
         if (ride.mechanicStatus == MechanicStatus::heading || ride.mechanicStatus == MechanicStatus::fixing
             || ride.mechanicStatus == MechanicStatus::hasFixedStationBrakes)
@@ -1888,7 +1887,7 @@ static int32_t RideMusicSampleRate(const Ride& ride)
     int32_t sampleRate = 22050;
 
     // Alter sample rate for a power cut effect
-    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
+    if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
     {
         sampleRate = ride.breakdownSoundModifier * 70;
         if (ride.breakdownReasonPending != BREAKDOWN_CONTROL_FAILURE)
@@ -1906,7 +1905,7 @@ static int32_t RideMusicSampleRate(const Ride& ride)
 static bool RideMusicBreakdownEffect(Ride& ride)
 {
     // Oscillate parameters for a power cut effect when breaking down
-    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
+    if (ride.flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
     {
         if (ride.breakdownReasonPending == BREAKDOWN_CONTROL_FAILURE)
         {
@@ -1916,7 +1915,7 @@ static bool RideMusicBreakdownEffect(Ride& ride)
         }
         else
         {
-            if (ride.lifecycleFlags.has(RideFlag::brokenDown) || ride.breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
+            if (ride.flags.has(RideFlag::brokenDown) || ride.breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
                 || ride.breakdownReasonPending == BREAKDOWN_CONTROL_FAILURE)
             {
                 if (ride.breakdownSoundModifier != 255)
@@ -1965,7 +1964,7 @@ void CircusMusicUpdate(Ride& ride)
  */
 void DefaultMusicUpdate(Ride& ride)
 {
-    if (ride.status != RideStatus::open || !ride.lifecycleFlags.has(RideFlag::music))
+    if (ride.status != RideStatus::open || !ride.flags.has(RideFlag::music))
     {
         ride.musicTuneId = kTuneIDNull;
         return;
@@ -2104,7 +2103,7 @@ void RideMeasurementsUpdate()
     for (auto& ride : RideManager(gameState))
     {
         auto measurement = ride.measurement.get();
-        if (measurement != nullptr && ride.lifecycleFlags.has(RideFlag::onTrack) && ride.status != RideStatus::simulating)
+        if (measurement != nullptr && ride.flags.has(RideFlag::onTrack) && ride.status != RideStatus::simulating)
         {
             if (measurement->flags.has(RideMeasurementFlag::running))
             {
@@ -3205,7 +3204,7 @@ static void RideSetStartFinishPoints(RideId rideIndex, const CoordsXYE& startEle
     else if (rtd.specialType == RtdSpecialType::boatHire)
         RideSetBoatHireReturnPoint(*ride, startElement);
 
-    if (ride->isBlockSectioned() && !ride->lifecycleFlags.has(RideFlag::onTrack))
+    if (ride->isBlockSectioned() && !ride->flags.has(RideFlag::onTrack))
     {
         RideOpenBlockBrakes(startElement);
     }
@@ -3439,7 +3438,7 @@ static Vehicle* VehicleCreateCar(
         }
         vehicle->SetState(Vehicle::Status::movingToEndOfStation);
 
-        if (ride.lifecycleFlags.has(RideFlag::reversedTrains))
+        if (ride.flags.has(RideFlag::reversedTrains))
         {
             vehicle->SubType = carIndex == (ride.numCarsPerTrain - 1) ? Vehicle::Type::head : Vehicle::Type::tail;
             vehicle->flags.set(VehicleFlag::carIsReversed);
@@ -3461,7 +3460,7 @@ static TrainReference VehicleCreateTrain(
     Ride& ride, const CoordsXYZ& trainPos, int32_t vehicleIndex, int32_t* remainingDistance, TrackElement* trackElement)
 {
     TrainReference train = { nullptr, nullptr };
-    bool isReversed = ride.lifecycleFlags.has(RideFlag::reversedTrains);
+    bool isReversed = ride.flags.has(RideFlag::reversedTrains);
 
     for (int32_t carIndex = 0; carIndex < ride.numCarsPerTrain; carIndex++)
     {
@@ -3658,7 +3657,7 @@ ResultWithMessage Ride::createVehicles(const CoordsXYE& element, bool isApplying
     if (!VehicleCreateTrains(*this, vehiclePos, trackElement, numberOfTrains))
     {
         // This flag is needed for Ride::removeVehicles()
-        lifecycleFlags.set(RideFlag::onTrack);
+        flags.set(RideFlag::onTrack);
         removeVehicles();
         return { false, STR_UNABLE_TO_CREATE_ENOUGH_VEHICLES };
     }
@@ -3666,7 +3665,7 @@ ResultWithMessage Ride::createVehicles(const CoordsXYE& element, bool isApplying
 
     // Initialise station departs
     // 006DDDD0:
-    lifecycleFlags.set(RideFlag::onTrack);
+    flags.set(RideFlag::onTrack);
     for (int32_t i = 0; i < Limits::kMaxStationsPerRide; i++)
     {
         stations[i].Depart = (stations[i].Depart & kStationDepartFlag) | 1;
@@ -3718,7 +3717,7 @@ void Ride::moveTrainsToBlockBrakes(const CoordsXYZ& firstBlockPosition, TrackEle
     // If the ride has a cable lift, we don't want to fetch the cable lift element and the block preceding it
     TrackElement* cableLiftTileElement = nullptr;
     TrackElement* cableLiftPreviousBlock = nullptr;
-    if (lifecycleFlags.has(RideFlag::cableLiftHillComponentUsed))
+    if (flags.has(RideFlag::cableLiftHillComponentUsed))
     {
         cableLiftTileElement = MapGetTrackElementAt(cableLiftLoc);
         if (cableLiftTileElement != nullptr)
@@ -3957,7 +3956,7 @@ static ResultWithMessage RideCreateCableLift(RideId rideIndex, bool isApplying)
     head->prev_vehicle_on_ride = tail->Id;
     tail->next_vehicle_on_ride = head->Id;
 
-    ride->lifecycleFlags.set(RideFlag::cableLift);
+    ride->flags.set(RideFlag::cableLift);
     head->CableLiftUpdateTrackMotion();
     return { true };
 }
@@ -4177,7 +4176,7 @@ ResultWithMessage Ride::open(bool isApplying)
     if (isApplying)
     {
         chainQueues();
-        lifecycleFlags.set(RideFlag::everBeenOpened);
+        flags.set(RideFlag::everBeenOpened);
     }
 
     CoordsXYE trackElement = {};
@@ -4681,8 +4680,8 @@ void InvalidateTestResults(Ride& ride)
 {
     ride.measurement = {};
     ride.ratings.setNull();
-    ride.lifecycleFlags.unset(RideFlag::tested, RideFlag::testInProgress);
-    if (ride.lifecycleFlags.has(RideFlag::onTrack))
+    ride.flags.unset(RideFlag::tested, RideFlag::testInProgress);
+    if (ride.flags.has(RideFlag::onTrack))
     {
         for (int32_t i = 0; i < ride.numTrains; i++)
         {
@@ -4707,10 +4706,10 @@ void InvalidateTestResults(Ride& ride)
  */
 void RideFixBreakdown(Ride& ride, int32_t reliabilityIncreaseFactor)
 {
-    ride.lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection);
+    ride.flags.unset(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection);
     ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list, RideInvalidateFlag::maintenance);
 
-    if (ride.lifecycleFlags.has(RideFlag::onTrack))
+    if (ride.flags.has(RideFlag::onTrack))
     {
         for (int32_t i = 0; i < ride.numTrains; i++)
         {
@@ -6016,7 +6015,7 @@ ResultWithMessage Ride::changeStatusCreateVehicles(bool isApplying, const Coords
         RideSetStartFinishPoints(id, trackElement);
 
     const auto& rtd = getRideTypeDescriptor();
-    if (!rtd.flags.has(RtdFlag::noVehicles) && !lifecycleFlags.has(RideFlag::onTrack))
+    if (!rtd.flags.has(RtdFlag::noVehicles) && !flags.has(RideFlag::onTrack))
     {
         const auto createVehicleResult = createVehicles(trackElement, isApplying, isSimulating);
         if (!createVehicleResult.Successful)
@@ -6025,8 +6024,8 @@ ResultWithMessage Ride::changeStatusCreateVehicles(bool isApplying, const Coords
         }
     }
 
-    if (rtd.flags.has(RtdFlag::allowCableLiftHill) && lifecycleFlags.has(RideFlag::cableLiftHillComponentUsed)
-        && !lifecycleFlags.has(RideFlag::cableLift))
+    if (rtd.flags.has(RtdFlag::allowCableLiftHill) && flags.has(RideFlag::cableLiftHillComponentUsed)
+        && !flags.has(RideFlag::cableLift))
     {
         const auto createCableLiftResult = RideCreateCableLift(id, isApplying);
         if (!createCableLiftResult.Successful)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -311,7 +311,7 @@ size_t Ride::getNumPrices() const
         auto rideEntry = getRideEntry();
         if (rideEntry != nullptr)
         {
-            if (lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO)
+            if (lifecycleFlags.has(RideFlag::onRidePhoto))
             {
                 result++;
             }
@@ -440,7 +440,7 @@ money64 Ride::calculateIncomePerHour() const
         priceMinusCost -= GetShopItemDescriptor(currentShopItem).Cost;
     }
 
-    currentShopItem = (lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO) ? getRideTypeDescriptor().PhotoItem : entry->shop_item[1];
+    currentShopItem = lifecycleFlags.has(RideFlag::onRidePhoto) ? getRideTypeDescriptor().PhotoItem : entry->shop_item[1];
 
     if (currentShopItem != ShopItem::none)
     {
@@ -838,11 +838,11 @@ bool Ride::findTrackGap(const CoordsXYE& input, CoordsXYE* output) const
 
 void Ride::formatStatusTo(Formatter& ft) const
 {
-    if (lifecycleFlags & RIDE_LIFECYCLE_CRASHED)
+    if (lifecycleFlags.has(RideFlag::crashed))
     {
         ft.Add<StringId>(STR_CRASHED);
     }
-    else if (lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    else if (lifecycleFlags.has(RideFlag::brokenDown))
     {
         ft.Add<StringId>(STR_BROKEN_DOWN);
     }
@@ -873,7 +873,7 @@ void Ride::formatStatusTo(Formatter& ft) const
     {
         ft.Add<StringId>(STR_TEST_RUN);
     }
-    else if (mode == RideMode::race && !(lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING) && !raceWinner.IsNull())
+    else if (mode == RideMode::race && !lifecycleFlags.has(RideFlag::passStationNoStopping) && !raceWinner.IsNull())
     {
         auto peep = getGameState().entities.GetEntity<Guest>(raceWinner);
         if (peep != nullptr)
@@ -955,7 +955,7 @@ bool Ride::supportsStatus(RideStatus s) const
 
 bool Ride::hasFailingBrakes() const
 {
-    return lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN && breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
+    return lifecycleFlags.has(RideFlag::brokenDown) && breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
         && mechanicStatus != MechanicStatus::hasFixedStationBrakes;
 }
 
@@ -1039,7 +1039,7 @@ void Ride::updateAll()
 
 std::unique_ptr<TrackDesign> Ride::saveToTrackDesign(TrackDesignState& tds) const
 {
-    if (!(lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+    if (!lifecycleFlags.has(RideFlag::tested))
     {
         ContextShowError(STR_CANT_SAVE_TRACK_DESIGN, kStringIdNone, {});
         return nullptr;
@@ -1156,7 +1156,7 @@ void Ride::update()
     RideBreakdownUpdate(*this);
 
     // Various things include news messages
-    if (lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_DUE_INSPECTION))
+    if (lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection))
     {
         // Breakdown updates originally were performed when (id == (gCurrentTicks / 2) & 0xFF)
         // with the increased MAX_RIDES the update is tied to the first byte of the id this allows
@@ -1169,7 +1169,7 @@ void Ride::update()
     RideInspectionUpdate(*this);
 
     // If ride is simulating but crashed, reset the vehicles
-    if (status == RideStatus::simulating && (lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+    if (status == RideStatus::simulating && lifecycleFlags.has(RideFlag::crashed))
     {
         // We require this to execute right away during the simulation, always ignore network and queue.
         auto gameAction = GameActions::RideSetStatusAction(id, RideStatus::simulating);
@@ -1183,9 +1183,9 @@ void Ride::update()
  */
 void updateChairlift(Ride& ride)
 {
-    if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+    if (!ride.lifecycleFlags.has(RideFlag::onTrack))
         return;
-    if ((ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed)
         && ride.breakdownReasonPending == 0)
         return;
 
@@ -1346,7 +1346,7 @@ static void RideInspectionUpdate(Ride& ride)
     // An inspection interval of 0 minutes means the ride is set to never be inspected.
     if (inspectionIntervalMinutes == 0)
     {
-        ride.lifecycleFlags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+        ride.lifecycleFlags.unset(RideFlag::dueInspection);
         return;
     }
 
@@ -1356,13 +1356,12 @@ static void RideInspectionUpdate(Ride& ride)
     if (inspectionIntervalMinutes > ride.lastInspection)
         return;
 
-    if (ride.lifecycleFlags
-        & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_DUE_INSPECTION
-           | RIDE_LIFECYCLE_CRASHED))
+    if (ride.lifecycleFlags.hasAny(
+            RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection, RideFlag::crashed))
         return;
 
     // Inspect the first station that has an exit
-    ride.lifecycleFlags |= RIDE_LIFECYCLE_DUE_INSPECTION;
+    ride.lifecycleFlags.set(RideFlag::dueInspection);
     ride.mechanicStatus = MechanicStatus::calling;
 
     auto stationIndex = RideGetFirstValidStationExit(ride);
@@ -1406,7 +1405,7 @@ static void RideBreakdownUpdate(Ride& ride)
     if (gLegacyScene == LegacyScene::trackDesigner)
         return;
 
-    if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+    if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
         ride.downtimeHistory[0]++;
 
     if (!(currentTicks & 8191))
@@ -1429,7 +1428,7 @@ static void RideBreakdownUpdate(Ride& ride)
         ride.windowInvalidateFlags.set(RideInvalidateFlag::maintenance);
     }
 
-    if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
         return;
     if (ride.status == RideStatus::closed || ride.status == RideStatus::simulating)
         return;
@@ -1557,10 +1556,10 @@ void RidePrepareBreakdown(Ride& ride, int32_t breakdownReason)
     StationIndex i;
     Vehicle* vehicle;
 
-    if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::crashed))
         return;
 
-    ride.lifecycleFlags |= RIDE_LIFECYCLE_BREAKDOWN_PENDING;
+    ride.lifecycleFlags.set(RideFlag::breakdownPending);
 
     ride.breakdownReasonPending = breakdownReason;
     ride.breakdownSoundModifier = 0;
@@ -1646,7 +1645,7 @@ void RideBreakdownAddNewsItem(const Ride& ride)
 static void RideBreakdownStatusUpdate(Ride& ride)
 {
     // Warn player if ride hasn't been fixed for ages
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (ride.lifecycleFlags.has(RideFlag::brokenDown))
     {
         ride.notFixedTimeout++;
         // When there has been a full 255 timeout ticks this
@@ -1679,13 +1678,13 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
     // Turn a pending breakdown into a breakdown.
     if ((mechanicStatus == MechanicStatus::undefined || mechanicStatus == MechanicStatus::calling
          || mechanicStatus == MechanicStatus::heading)
-        && (ride.lifecycleFlags & RIDE_LIFECYCLE_BREAKDOWN_PENDING) && !(ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+        && ride.lifecycleFlags.has(RideFlag::breakdownPending) && !ride.lifecycleFlags.has(RideFlag::brokenDown))
     {
         auto breakdownReason = ride.breakdownReasonPending;
         if (breakdownReason == BREAKDOWN_SAFETY_CUT_OUT || breakdownReason == BREAKDOWN_BRAKES_FAILURE
             || breakdownReason == BREAKDOWN_CONTROL_FAILURE)
         {
-            ride.lifecycleFlags |= RIDE_LIFECYCLE_BROKEN_DOWN;
+            ride.lifecycleFlags.set(RideFlag::brokenDown);
             ride.windowInvalidateFlags.set(RideInvalidateFlag::maintenance, RideInvalidateFlag::list, RideInvalidateFlag::main);
             ride.breakdownReason = breakdownReason;
             RideBreakdownAddNewsItem(ride);
@@ -1694,7 +1693,7 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
     switch (mechanicStatus)
     {
         case MechanicStatus::undefined:
-            if (ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+            if (ride.lifecycleFlags.has(RideFlag::brokenDown))
             {
                 ride.mechanicStatus = MechanicStatus::calling;
             }
@@ -1702,8 +1701,7 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
         case MechanicStatus::calling:
             if (ride.getRideTypeDescriptor().AvailableBreakdowns == 0)
             {
-                ride.lifecycleFlags &= ~(
-                    RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_DUE_INSPECTION);
+                ride.lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection);
                 break;
             }
 
@@ -1712,7 +1710,7 @@ static void RideMechanicStatusUpdate(Ride& ride, MechanicStatus mechanicStatus)
         case MechanicStatus::heading:
         {
             auto mechanic = RideGetMechanic(ride);
-            bool rideNeedsRepair = (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN));
+            bool rideNeedsRepair = ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown);
             if (mechanic == nullptr
                 || (mechanic->State != PeepState::headingToInspection && mechanic->State != PeepState::answering)
                 || mechanic->CurrentRide != ride.id)
@@ -1769,7 +1767,7 @@ static void RideCallMechanic(Ride& ride, Peep* mechanic, int32_t forInspection)
  */
 static void RideCallClosestMechanic(Ride& ride)
 {
-    auto forInspection = (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)) == 0;
+    auto forInspection = !ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown);
     auto mechanic = RideFindClosestMechanic(ride, forInspection);
     if (mechanic != nullptr)
         RideCallMechanic(ride, mechanic, forInspection);
@@ -1865,7 +1863,7 @@ Staff* RideGetMechanic(const Ride& ride)
 
 Staff* RideGetAssignedMechanic(const Ride& ride)
 {
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (ride.lifecycleFlags.has(RideFlag::brokenDown))
     {
         if (ride.mechanicStatus == MechanicStatus::heading || ride.mechanicStatus == MechanicStatus::fixing
             || ride.mechanicStatus == MechanicStatus::hasFixedStationBrakes)
@@ -1890,7 +1888,7 @@ static int32_t RideMusicSampleRate(const Ride& ride)
     int32_t sampleRate = 22050;
 
     // Alter sample rate for a power cut effect
-    if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
     {
         sampleRate = ride.breakdownSoundModifier * 70;
         if (ride.breakdownReasonPending != BREAKDOWN_CONTROL_FAILURE)
@@ -1908,7 +1906,7 @@ static int32_t RideMusicSampleRate(const Ride& ride)
 static bool RideMusicBreakdownEffect(Ride& ride)
 {
     // Oscillate parameters for a power cut effect when breaking down
-    if (ride.lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (ride.lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
     {
         if (ride.breakdownReasonPending == BREAKDOWN_CONTROL_FAILURE)
         {
@@ -1918,7 +1916,7 @@ static bool RideMusicBreakdownEffect(Ride& ride)
         }
         else
         {
-            if ((ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN) || ride.breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
+            if (ride.lifecycleFlags.has(RideFlag::brokenDown) || ride.breakdownReasonPending == BREAKDOWN_BRAKES_FAILURE
                 || ride.breakdownReasonPending == BREAKDOWN_CONTROL_FAILURE)
             {
                 if (ride.breakdownSoundModifier != 255)
@@ -1967,7 +1965,7 @@ void CircusMusicUpdate(Ride& ride)
  */
 void DefaultMusicUpdate(Ride& ride)
 {
-    if (ride.status != RideStatus::open || !(ride.lifecycleFlags & RIDE_LIFECYCLE_MUSIC))
+    if (ride.status != RideStatus::open || !ride.lifecycleFlags.has(RideFlag::music))
     {
         ride.musicTuneId = kTuneIDNull;
         return;
@@ -2106,7 +2104,7 @@ void RideMeasurementsUpdate()
     for (auto& ride : RideManager(gameState))
     {
         auto measurement = ride.measurement.get();
-        if (measurement != nullptr && (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK) && ride.status != RideStatus::simulating)
+        if (measurement != nullptr && ride.lifecycleFlags.has(RideFlag::onTrack) && ride.status != RideStatus::simulating)
         {
             if (measurement->flags.has(RideMeasurementFlag::running))
             {
@@ -3207,7 +3205,7 @@ static void RideSetStartFinishPoints(RideId rideIndex, const CoordsXYE& startEle
     else if (rtd.specialType == RtdSpecialType::boatHire)
         RideSetBoatHireReturnPoint(*ride, startElement);
 
-    if (ride->isBlockSectioned() && !(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+    if (ride->isBlockSectioned() && !ride->lifecycleFlags.has(RideFlag::onTrack))
     {
         RideOpenBlockBrakes(startElement);
     }
@@ -3441,7 +3439,7 @@ static Vehicle* VehicleCreateCar(
         }
         vehicle->SetState(Vehicle::Status::movingToEndOfStation);
 
-        if (ride.hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS))
+        if (ride.lifecycleFlags.has(RideFlag::reversedTrains))
         {
             vehicle->SubType = carIndex == (ride.numCarsPerTrain - 1) ? Vehicle::Type::head : Vehicle::Type::tail;
             vehicle->flags.set(VehicleFlag::carIsReversed);
@@ -3463,7 +3461,7 @@ static TrainReference VehicleCreateTrain(
     Ride& ride, const CoordsXYZ& trainPos, int32_t vehicleIndex, int32_t* remainingDistance, TrackElement* trackElement)
 {
     TrainReference train = { nullptr, nullptr };
-    bool isReversed = ride.hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS);
+    bool isReversed = ride.lifecycleFlags.has(RideFlag::reversedTrains);
 
     for (int32_t carIndex = 0; carIndex < ride.numCarsPerTrain; carIndex++)
     {
@@ -3660,7 +3658,7 @@ ResultWithMessage Ride::createVehicles(const CoordsXYE& element, bool isApplying
     if (!VehicleCreateTrains(*this, vehiclePos, trackElement, numberOfTrains))
     {
         // This flag is needed for Ride::removeVehicles()
-        lifecycleFlags |= RIDE_LIFECYCLE_ON_TRACK;
+        lifecycleFlags.set(RideFlag::onTrack);
         removeVehicles();
         return { false, STR_UNABLE_TO_CREATE_ENOUGH_VEHICLES };
     }
@@ -3668,7 +3666,7 @@ ResultWithMessage Ride::createVehicles(const CoordsXYE& element, bool isApplying
 
     // Initialise station departs
     // 006DDDD0:
-    lifecycleFlags |= RIDE_LIFECYCLE_ON_TRACK;
+    lifecycleFlags.set(RideFlag::onTrack);
     for (int32_t i = 0; i < Limits::kMaxStationsPerRide; i++)
     {
         stations[i].Depart = (stations[i].Depart & kStationDepartFlag) | 1;
@@ -3720,7 +3718,7 @@ void Ride::moveTrainsToBlockBrakes(const CoordsXYZ& firstBlockPosition, TrackEle
     // If the ride has a cable lift, we don't want to fetch the cable lift element and the block preceding it
     TrackElement* cableLiftTileElement = nullptr;
     TrackElement* cableLiftPreviousBlock = nullptr;
-    if (lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED)
+    if (lifecycleFlags.has(RideFlag::cableLiftHillComponentUsed))
     {
         cableLiftTileElement = MapGetTrackElementAt(cableLiftLoc);
         if (cableLiftTileElement != nullptr)
@@ -3959,7 +3957,7 @@ static ResultWithMessage RideCreateCableLift(RideId rideIndex, bool isApplying)
     head->prev_vehicle_on_ride = tail->Id;
     tail->next_vehicle_on_ride = head->Id;
 
-    ride->lifecycleFlags |= RIDE_LIFECYCLE_CABLE_LIFT;
+    ride->lifecycleFlags.set(RideFlag::cableLift);
     head->CableLiftUpdateTrackMotion();
     return { true };
 }
@@ -4179,7 +4177,7 @@ ResultWithMessage Ride::open(bool isApplying)
     if (isApplying)
     {
         chainQueues();
-        lifecycleFlags |= RIDE_LIFECYCLE_EVER_BEEN_OPENED;
+        lifecycleFlags.set(RideFlag::everBeenOpened);
     }
 
     CoordsXYE trackElement = {};
@@ -4683,9 +4681,8 @@ void InvalidateTestResults(Ride& ride)
 {
     ride.measurement = {};
     ride.ratings.setNull();
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_TESTED;
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    ride.lifecycleFlags.unset(RideFlag::tested, RideFlag::testInProgress);
+    if (ride.lifecycleFlags.has(RideFlag::onTrack))
     {
         for (int32_t i = 0; i < ride.numTrains; i++)
         {
@@ -4710,12 +4707,10 @@ void InvalidateTestResults(Ride& ride)
  */
 void RideFixBreakdown(Ride& ride, int32_t reliabilityIncreaseFactor)
 {
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_BREAKDOWN_PENDING;
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_BROKEN_DOWN;
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_DUE_INSPECTION;
+    ride.lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown, RideFlag::dueInspection);
     ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list, RideInvalidateFlag::maintenance);
 
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (ride.lifecycleFlags.has(RideFlag::onTrack))
     {
         for (int32_t i = 0; i < ride.numTrains; i++)
         {
@@ -5849,19 +5844,6 @@ void Ride::updateRideTypeForAllPieces()
     }
 }
 
-bool Ride::hasLifecycleFlag(uint32_t flag) const
-{
-    return (lifecycleFlags & flag) != 0;
-}
-
-void Ride::setLifecycleFlag(uint32_t flag, bool on)
-{
-    if (on)
-        lifecycleFlags |= flag;
-    else
-        lifecycleFlags &= ~flag;
-}
-
 bool Ride::hasRecolourableShopItems() const
 {
     const auto rideEntry = getRideEntry();
@@ -6034,7 +6016,7 @@ ResultWithMessage Ride::changeStatusCreateVehicles(bool isApplying, const Coords
         RideSetStartFinishPoints(id, trackElement);
 
     const auto& rtd = getRideTypeDescriptor();
-    if (!rtd.flags.has(RtdFlag::noVehicles) && !(lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+    if (!rtd.flags.has(RtdFlag::noVehicles) && !lifecycleFlags.has(RideFlag::onTrack))
     {
         const auto createVehicleResult = createVehicles(trackElement, isApplying, isSimulating);
         if (!createVehicleResult.Successful)
@@ -6043,8 +6025,8 @@ ResultWithMessage Ride::changeStatusCreateVehicles(bool isApplying, const Coords
         }
     }
 
-    if (rtd.flags.has(RtdFlag::allowCableLiftHill) && (lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED)
-        && !(lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT))
+    if (rtd.flags.has(RtdFlag::allowCableLiftHill) && lifecycleFlags.has(RideFlag::cableLiftHillComponentUsed)
+        && !lifecycleFlags.has(RideFlag::cableLift))
     {
         const auto createCableLiftResult = RideCreateCableLift(id, isApplying);
         if (!createCableLiftResult.Successful)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -105,6 +105,34 @@ enum class RideTestingFlag : uint8_t
 };
 using RideTestingFlags = FlagHolder<uint32_t, RideTestingFlag>;
 
+enum class RideFlag : uint8_t
+{
+    onTrack,
+    tested,
+    testInProgress,
+    noRawStats,
+    passStationNoStopping,
+    onRidePhoto,
+    breakdownPending,
+    brokenDown,
+    dueInspection,
+    queueFull,
+    crashed,
+    hasStalledVehicle,
+    everBeenOpened,
+    music,
+    indestructible,
+    indestructibleTrack,
+    cableLiftHillComponentUsed,
+    cableLift,
+    notCustomDesign,    // Used for the Award for Best Custom-designed Rides
+    sixFlagsDeprecated, // Not used anymore
+    fixedRatings,       // When set, the ratings will not be updated (useful for hacked rides).
+    randomShopColours,
+    reversedTrains,
+};
+using RideFlags = FlagHolder<uint32_t, RideFlag>;
+
 struct RideStation
 {
     static constexpr uint8_t kNoTrain = std::numeric_limits<uint8_t>::max();
@@ -332,7 +360,7 @@ struct Ride
     uint8_t numBlockBrakes{};
     uint8_t liftHillSpeed{};
     uint32_t guestsFavourite{};
-    uint32_t lifecycleFlags{};
+    RideFlags lifecycleFlags{};
     uint16_t totalAirTime{};
     StationIndex currentTestStation{ StationIndex::GetNull() };
     uint8_t numCircuits{};
@@ -468,9 +496,6 @@ public:
     const OpenRCT2::StationObject* getStationObject() const;
     const OpenRCT2::MusicObject* getMusicObject() const;
 
-    bool hasLifecycleFlag(uint32_t flag) const;
-    void setLifecycleFlag(uint32_t flag, bool on);
-
     bool hasRecolourableShopItems() const;
     bool hasStation() const;
 
@@ -502,34 +527,6 @@ static_assert(sizeof(TrackBeginEnd) == 36);
 #endif
 
 #pragma pack(pop)
-
-// Constants used by the lifecycleFlags property at 0x1D0
-enum
-{
-    RIDE_LIFECYCLE_ON_TRACK = 1 << 0,
-    RIDE_LIFECYCLE_TESTED = 1 << 1,
-    RIDE_LIFECYCLE_TEST_IN_PROGRESS = 1 << 2,
-    RIDE_LIFECYCLE_NO_RAW_STATS = 1 << 3,
-    RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING = 1 << 4,
-    RIDE_LIFECYCLE_ON_RIDE_PHOTO = 1 << 5,
-    RIDE_LIFECYCLE_BREAKDOWN_PENDING = 1 << 6,
-    RIDE_LIFECYCLE_BROKEN_DOWN = 1 << 7,
-    RIDE_LIFECYCLE_DUE_INSPECTION = 1 << 8,
-    RIDE_LIFECYCLE_QUEUE_FULL = 1 << 9,
-    RIDE_LIFECYCLE_CRASHED = 1 << 10,
-    RIDE_LIFECYCLE_HAS_STALLED_VEHICLE = 1 << 11,
-    RIDE_LIFECYCLE_EVER_BEEN_OPENED = 1 << 12,
-    RIDE_LIFECYCLE_MUSIC = 1 << 13,
-    RIDE_LIFECYCLE_INDESTRUCTIBLE = 1 << 14,
-    RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK = 1 << 15,
-    RIDE_LIFECYCLE_CABLE_LIFT_HILL_COMPONENT_USED = 1 << 16,
-    RIDE_LIFECYCLE_CABLE_LIFT = 1 << 17,
-    RIDE_LIFECYCLE_NOT_CUSTOM_DESIGN = 1 << 18,    // Used for the Award for Best Custom-designed Rides
-    RIDE_LIFECYCLE_SIX_FLAGS_DEPRECATED = 1 << 19, // Not used anymore
-    RIDE_LIFECYCLE_FIXED_RATINGS = 1 << 20,        // When set, the ratings will not be updated (useful for hacked rides).
-    RIDE_LIFECYCLE_RANDOM_SHOP_COLOURS = 1 << 21,
-    RIDE_LIFECYCLE_REVERSED_TRAINS = 1 << 22,
-};
 
 enum
 {

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -360,7 +360,7 @@ struct Ride
     uint8_t numBlockBrakes{};
     uint8_t liftHillSpeed{};
     uint32_t guestsFavourite{};
-    RideFlags lifecycleFlags{};
+    RideFlags flags{};
     uint16_t totalAirTime{};
     StationIndex currentTestStation{ StationIndex::GetNull() };
     uint8_t numCircuits{};

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -101,7 +101,7 @@ static int32_t ride_check_if_construction_allowed(Ride& ride)
         ContextShowError(STR_INVALID_RIDE_TYPE, STR_CANT_EDIT_INVALID_RIDE_TYPE, ft);
         return 0;
     }
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (ride.lifecycleFlags.has(RideFlag::brokenDown))
     {
         ride.formatNameTo(ft);
         ContextShowError(STR_CANT_START_CONSTRUCTION_ON, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING, ft);
@@ -154,9 +154,9 @@ void RideConstructionStart(Ride& ride)
  */
 static void ride_remove_cable_lift(Ride& ride)
 {
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT)
+    if (ride.lifecycleFlags.has(RideFlag::cableLift))
     {
-        ride.lifecycleFlags &= ~RIDE_LIFECYCLE_CABLE_LIFT;
+        ride.lifecycleFlags.unset(RideFlag::cableLift);
         auto spriteIndex = ride.cableLift;
         do
         {
@@ -178,10 +178,9 @@ static void ride_remove_cable_lift(Ride& ride)
  */
 void Ride::removeVehicles()
 {
-    if (lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK)
+    if (lifecycleFlags.has(RideFlag::onTrack))
     {
-        lifecycleFlags &= ~RIDE_LIFECYCLE_ON_TRACK;
-        lifecycleFlags &= ~(RIDE_LIFECYCLE_TEST_IN_PROGRESS | RIDE_LIFECYCLE_HAS_STALLED_VEHICLE);
+        lifecycleFlags.unset(RideFlag::onTrack, RideFlag::testInProgress, RideFlag::hasStalledVehicle);
 
         for (size_t i = 0; i <= Limits::kMaxTrainsPerRide; i++)
         {
@@ -224,7 +223,7 @@ void RideClearForConstruction(Ride& ride)
 {
     ride.measurement = {};
 
-    ride.lifecycleFlags &= ~(RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN);
+    ride.lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown);
     ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
 
     // Open circuit rides will go directly into building mode (creating ghosts) where it would normally clear the stats,
@@ -973,7 +972,7 @@ bool RideModify(const CoordsXYE& input)
     if (rideEntry == nullptr || !ride_check_if_construction_allowed(*ride))
         return false;
 
-    if (ride->lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE && !getGameState().cheats.makeAllDestructible)
+    if (ride->lifecycleFlags.has(RideFlag::indestructible) && !getGameState().cheats.makeAllDestructible)
     {
         Formatter ft;
         ride->formatNameTo(ft);

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -101,7 +101,7 @@ static int32_t ride_check_if_construction_allowed(Ride& ride)
         ContextShowError(STR_INVALID_RIDE_TYPE, STR_CANT_EDIT_INVALID_RIDE_TYPE, ft);
         return 0;
     }
-    if (ride.lifecycleFlags.has(RideFlag::brokenDown))
+    if (ride.flags.has(RideFlag::brokenDown))
     {
         ride.formatNameTo(ft);
         ContextShowError(STR_CANT_START_CONSTRUCTION_ON, STR_HAS_BROKEN_DOWN_AND_REQUIRES_FIXING, ft);
@@ -154,9 +154,9 @@ void RideConstructionStart(Ride& ride)
  */
 static void ride_remove_cable_lift(Ride& ride)
 {
-    if (ride.lifecycleFlags.has(RideFlag::cableLift))
+    if (ride.flags.has(RideFlag::cableLift))
     {
-        ride.lifecycleFlags.unset(RideFlag::cableLift);
+        ride.flags.unset(RideFlag::cableLift);
         auto spriteIndex = ride.cableLift;
         do
         {
@@ -178,9 +178,9 @@ static void ride_remove_cable_lift(Ride& ride)
  */
 void Ride::removeVehicles()
 {
-    if (lifecycleFlags.has(RideFlag::onTrack))
+    if (flags.has(RideFlag::onTrack))
     {
-        lifecycleFlags.unset(RideFlag::onTrack, RideFlag::testInProgress, RideFlag::hasStalledVehicle);
+        flags.unset(RideFlag::onTrack, RideFlag::testInProgress, RideFlag::hasStalledVehicle);
 
         for (size_t i = 0; i <= Limits::kMaxTrainsPerRide; i++)
         {
@@ -223,7 +223,7 @@ void RideClearForConstruction(Ride& ride)
 {
     ride.measurement = {};
 
-    ride.lifecycleFlags.unset(RideFlag::breakdownPending, RideFlag::brokenDown);
+    ride.flags.unset(RideFlag::breakdownPending, RideFlag::brokenDown);
     ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
 
     // Open circuit rides will go directly into building mode (creating ghosts) where it would normally clear the stats,
@@ -972,7 +972,7 @@ bool RideModify(const CoordsXYE& input)
     if (rideEntry == nullptr || !ride_check_if_construction_allowed(*ride))
         return false;
 
-    if (ride->lifecycleFlags.has(RideFlag::indestructible) && !getGameState().cheats.makeAllDestructible)
+    if (ride->flags.has(RideFlag::indestructible) && !getGameState().cheats.makeAllDestructible)
     {
         Formatter ft;
         ride->formatNameTo(ft);

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -263,7 +263,7 @@ static bool ShouldSkipRatingCalculation(const Ride& ride)
     }
 
     // Skip rides that have a fixed rating.
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_FIXED_RATINGS)
+    if (ride.lifecycleFlags.has(RideFlag::fixedRatings))
     {
         return true;
     }
@@ -880,12 +880,11 @@ static void RideRatingsCalculate(RideRating::UpdateState& state, Ride& ride)
     switch (rrd.Type)
     {
         case RatingsCalculationType::Normal:
-            if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+            if (!ride.lifecycleFlags.has(RideFlag::tested))
                 return;
             break;
         case RatingsCalculationType::FlatRide:
-            ride.lifecycleFlags |= RIDE_LIFECYCLE_TESTED;
-            ride.lifecycleFlags |= RIDE_LIFECYCLE_NO_RAW_STATS;
+            ride.lifecycleFlags.set(RideFlag::tested, RideFlag::noRawStats);
             break;
         case RatingsCalculationType::Stall:
             ride.upkeepCost = RideComputeUpkeep(state, ride);
@@ -1071,7 +1070,7 @@ static void RideRatingsCalculate(RideRating::UpdateState& state, Ride& ride)
 
 #ifdef ENABLE_SCRIPTING
     // Only call the 'ride.ratings.calculate' API hook if testing of the ride is complete
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_TESTED)
+    if (ride.lifecycleFlags.has(RideFlag::tested))
     {
         auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
         if (hookEngine.HasSubscriptions(HookType::rideRatingsCalculate))
@@ -1194,7 +1193,7 @@ static money64 RideComputeUpkeep(RideRating::UpdateState& state, const Ride& rid
     totalLength *= ride.getRideTypeDescriptor().UpkeepCosts.TrackLengthMultiplier;
     upkeep += static_cast<uint16_t>(totalLength >> 10);
 
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO)
+    if (ride.lifecycleFlags.has(RideFlag::onRidePhoto))
     {
         // The original code read from a table starting at 0x0097E3AE and
         // incrementing by 0x12 bytes between values. However, all of these
@@ -1908,7 +1907,7 @@ static void RideRatingsApplyBonusOperationOption(RideRating::Tuple& ratings, con
 
 static void RideRatingsApplyBonusReversedTrains(RideRating::Tuple& ratings, const Ride& ride, RatingsModifier modifier)
 {
-    if (ride.hasLifecycleFlag(RIDE_LIFECYCLE_REVERSED_TRAINS))
+    if (ride.lifecycleFlags.has(RideFlag::reversedTrains))
     {
         RideRatingsAdd(
             ratings, ((ratings.excitement * modifier.excitement) >> 7), (ratings.intensity * modifier.intensity) >> 7,
@@ -1950,7 +1949,7 @@ static void RideRatingsApplyBonusMazeSize(RideRating::Tuple& ratings, const Ride
 static void RideRatingsApplyBonusBoatHireNoCircuit(RideRating::Tuple& ratings, const Ride& ride, RatingsModifier modifier)
 {
     // Most likely checking if the ride has does not have a circuit
-    if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+    if (!ride.lifecycleFlags.has(RideFlag::tested))
     {
         RideRatingsAdd(ratings, modifier.excitement, modifier.intensity, modifier.nausea);
     }

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -263,7 +263,7 @@ static bool ShouldSkipRatingCalculation(const Ride& ride)
     }
 
     // Skip rides that have a fixed rating.
-    if (ride.lifecycleFlags.has(RideFlag::fixedRatings))
+    if (ride.flags.has(RideFlag::fixedRatings))
     {
         return true;
     }
@@ -880,11 +880,11 @@ static void RideRatingsCalculate(RideRating::UpdateState& state, Ride& ride)
     switch (rrd.Type)
     {
         case RatingsCalculationType::Normal:
-            if (!ride.lifecycleFlags.has(RideFlag::tested))
+            if (!ride.flags.has(RideFlag::tested))
                 return;
             break;
         case RatingsCalculationType::FlatRide:
-            ride.lifecycleFlags.set(RideFlag::tested, RideFlag::noRawStats);
+            ride.flags.set(RideFlag::tested, RideFlag::noRawStats);
             break;
         case RatingsCalculationType::Stall:
             ride.upkeepCost = RideComputeUpkeep(state, ride);
@@ -1070,7 +1070,7 @@ static void RideRatingsCalculate(RideRating::UpdateState& state, Ride& ride)
 
 #ifdef ENABLE_SCRIPTING
     // Only call the 'ride.ratings.calculate' API hook if testing of the ride is complete
-    if (ride.lifecycleFlags.has(RideFlag::tested))
+    if (ride.flags.has(RideFlag::tested))
     {
         auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
         if (hookEngine.HasSubscriptions(HookType::rideRatingsCalculate))
@@ -1193,7 +1193,7 @@ static money64 RideComputeUpkeep(RideRating::UpdateState& state, const Ride& rid
     totalLength *= ride.getRideTypeDescriptor().UpkeepCosts.TrackLengthMultiplier;
     upkeep += static_cast<uint16_t>(totalLength >> 10);
 
-    if (ride.lifecycleFlags.has(RideFlag::onRidePhoto))
+    if (ride.flags.has(RideFlag::onRidePhoto))
     {
         // The original code read from a table starting at 0x0097E3AE and
         // incrementing by 0x12 bytes between values. However, all of these
@@ -1907,7 +1907,7 @@ static void RideRatingsApplyBonusOperationOption(RideRating::Tuple& ratings, con
 
 static void RideRatingsApplyBonusReversedTrains(RideRating::Tuple& ratings, const Ride& ride, RatingsModifier modifier)
 {
-    if (ride.lifecycleFlags.has(RideFlag::reversedTrains))
+    if (ride.flags.has(RideFlag::reversedTrains))
     {
         RideRatingsAdd(
             ratings, ((ratings.excitement * modifier.excitement) >> 7), (ratings.intensity * modifier.intensity) >> 7,
@@ -1949,7 +1949,7 @@ static void RideRatingsApplyBonusMazeSize(RideRating::Tuple& ratings, const Ride
 static void RideRatingsApplyBonusBoatHireNoCircuit(RideRating::Tuple& ratings, const Ride& ride, RatingsModifier modifier)
 {
     // Most likely checking if the ride has does not have a circuit
-    if (!ride.lifecycleFlags.has(RideFlag::tested))
+    if (!ride.flags.has(RideFlag::tested))
     {
         RideRatingsAdd(ratings, modifier.excitement, modifier.intensity, modifier.nausea);
     }

--- a/src/openrct2/ride/ShopItem.cpp
+++ b/src/openrct2/ride/ShopItem.cpp
@@ -136,7 +136,7 @@ money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem)
             {
                 return ride.price[1];
             }
-            if (GetShopItemDescriptor(shopItem).IsPhoto() && ride.lifecycleFlags.has(RideFlag::onRidePhoto))
+            if (GetShopItemDescriptor(shopItem).IsPhoto() && ride.flags.has(RideFlag::onRidePhoto))
             {
                 return ride.price[1];
             }

--- a/src/openrct2/ride/ShopItem.cpp
+++ b/src/openrct2/ride/ShopItem.cpp
@@ -136,7 +136,7 @@ money64 ShopItemGetCommonPrice(Ride* forRide, const ShopItem shopItem)
             {
                 return ride.price[1];
             }
-            if (GetShopItemDescriptor(shopItem).IsPhoto() && (ride.lifecycleFlags & RIDE_LIFECYCLE_ON_RIDE_PHOTO))
+            if (GetShopItemDescriptor(shopItem).IsPhoto() && ride.lifecycleFlags.has(RideFlag::onRidePhoto))
             {
                 return ride.price[1];
             }

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -98,13 +98,13 @@ static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex)
 
     // Change of station depart flag should really call invalidate_station_start
     // but since dodgems do not have station lights there is no point.
-    if (ride.status == RideStatus::closed || ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+    if (ride.status == RideStatus::closed || ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
     {
         station.Depart &= ~kStationDepartFlag;
         return;
     }
 
-    if (ride.lifecycleFlags.has(RideFlag::passStationNoStopping))
+    if (ride.flags.has(RideFlag::passStationNoStopping))
     {
         int32_t dx = ride.timeLimit * 32;
         int32_t dh = (dx >> 8) & 0xFF;
@@ -118,7 +118,7 @@ static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex)
                 continue;
 
             // End match
-            ride.lifecycleFlags.unset(RideFlag::passStationNoStopping);
+            ride.flags.unset(RideFlag::passStationNoStopping);
             station.Depart &= ~kStationDepartFlag;
             return;
         }
@@ -143,7 +143,7 @@ static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex)
         }
 
         // Begin the match
-        ride.lifecycleFlags.set(RideFlag::passStationNoStopping);
+        ride.flags.set(RideFlag::passStationNoStopping);
         station.Depart |= kStationDepartFlag;
         ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
     }
@@ -158,7 +158,7 @@ static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
     auto& station = ride.getStation(stationIndex);
     int32_t time = station.Depart & kStationDepartMask;
     const auto currentTicks = getGameState().currentTicks;
-    if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed)
+    if (ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed)
         || (ride.status == RideStatus::closed && ride.numRiders == 0))
     {
         if (time != 0 && time != 127 && !(currentTicks & 7))
@@ -192,7 +192,7 @@ static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
 static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
 {
     auto& station = ride.getStation(stationIndex);
-    if (ride.status == RideStatus::closed || ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+    if (ride.status == RideStatus::closed || ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
     {
         if (station.Depart & kStationDepartFlag)
         {
@@ -202,7 +202,7 @@ static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
         return;
     }
 
-    if (ride.lifecycleFlags.has(RideFlag::passStationNoStopping))
+    if (ride.flags.has(RideFlag::passStationNoStopping))
     {
         int32_t numLaps = ride.numLaps;
 
@@ -226,7 +226,7 @@ static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
                 }
 
                 // Race is over
-                ride.lifecycleFlags.unset(RideFlag::passStationNoStopping);
+                ride.flags.unset(RideFlag::passStationNoStopping);
                 if (station.Depart & kStationDepartFlag)
                 {
                     station.Depart &= ~kStationDepartFlag;
@@ -261,7 +261,7 @@ static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
 
         // Begin the race
         RideRaceInitVehicleSpeeds(ride);
-        ride.lifecycleFlags.set(RideFlag::passStationNoStopping);
+        ride.flags.set(RideFlag::passStationNoStopping);
         if (!(station.Depart & kStationDepartFlag))
         {
             station.Depart |= kStationDepartFlag;

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -98,13 +98,13 @@ static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex)
 
     // Change of station depart flag should really call invalidate_station_start
     // but since dodgems do not have station lights there is no point.
-    if (ride.status == RideStatus::closed || (ride.lifecycleFlags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED)))
+    if (ride.status == RideStatus::closed || ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
     {
         station.Depart &= ~kStationDepartFlag;
         return;
     }
 
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+    if (ride.lifecycleFlags.has(RideFlag::passStationNoStopping))
     {
         int32_t dx = ride.timeLimit * 32;
         int32_t dh = (dx >> 8) & 0xFF;
@@ -118,7 +118,7 @@ static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex)
                 continue;
 
             // End match
-            ride.lifecycleFlags &= ~RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING;
+            ride.lifecycleFlags.unset(RideFlag::passStationNoStopping);
             station.Depart &= ~kStationDepartFlag;
             return;
         }
@@ -143,7 +143,7 @@ static void RideUpdateStationDodgems(Ride& ride, StationIndex stationIndex)
         }
 
         // Begin the match
-        ride.lifecycleFlags |= RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING;
+        ride.lifecycleFlags.set(RideFlag::passStationNoStopping);
         station.Depart |= kStationDepartFlag;
         ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
     }
@@ -158,7 +158,7 @@ static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
     auto& station = ride.getStation(stationIndex);
     int32_t time = station.Depart & kStationDepartMask;
     const auto currentTicks = getGameState().currentTicks;
-    if ((ride.lifecycleFlags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+    if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed)
         || (ride.status == RideStatus::closed && ride.numRiders == 0))
     {
         if (time != 0 && time != 127 && !(currentTicks & 7))
@@ -192,7 +192,7 @@ static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
 static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
 {
     auto& station = ride.getStation(stationIndex);
-    if (ride.status == RideStatus::closed || (ride.lifecycleFlags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED)))
+    if (ride.status == RideStatus::closed || ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
     {
         if (station.Depart & kStationDepartFlag)
         {
@@ -202,7 +202,7 @@ static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
         return;
     }
 
-    if (ride.lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+    if (ride.lifecycleFlags.has(RideFlag::passStationNoStopping))
     {
         int32_t numLaps = ride.numLaps;
 
@@ -226,7 +226,7 @@ static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
                 }
 
                 // Race is over
-                ride.lifecycleFlags &= ~RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING;
+                ride.lifecycleFlags.unset(RideFlag::passStationNoStopping);
                 if (station.Depart & kStationDepartFlag)
                 {
                     station.Depart &= ~kStationDepartFlag;
@@ -261,7 +261,7 @@ static void RideUpdateStationRace(Ride& ride, StationIndex stationIndex)
 
         // Begin the race
         RideRaceInitVehicleSpeeds(ride);
-        ride.lifecycleFlags |= RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING;
+        ride.lifecycleFlags.set(RideFlag::passStationNoStopping);
         if (!(station.Depart & kStationDepartFlag))
         {
             station.Depart |= kStationDepartFlag;

--- a/src/openrct2/ride/Vehicle.Crash.cpp
+++ b/src/openrct2/ride/Vehicle.Crash.cpp
@@ -65,7 +65,7 @@ void Vehicle::SimulateCrash() const
     auto curRide = GetRide();
     if (curRide != nullptr)
     {
-        curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+        curRide->lifecycleFlags.set(RideFlag::crashed);
     }
 }
 
@@ -89,7 +89,7 @@ void Vehicle::UpdateCollisionSetup()
 
     SetState(Status::crashed, sub_state);
 
-    if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+    if (!curRide->lifecycleFlags.has(RideFlag::crashed))
     {
         auto frontVehicle = GetHead();
         auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
@@ -108,7 +108,7 @@ void Vehicle::UpdateCollisionSetup()
         }
     }
 
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+    curRide->lifecycleFlags.set(RideFlag::crashed);
     curRide->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
     KillAllPassengersInTrain();
 
@@ -373,7 +373,7 @@ void Vehicle::CrashOnLand()
     InvokeVehicleCrashHook(Id, "land");
 #endif
 
-    if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+    if (!curRide->lifecycleFlags.has(RideFlag::crashed))
     {
         auto frontVehicle = GetHead();
         auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
@@ -391,7 +391,7 @@ void Vehicle::CrashOnLand()
             GameActions::ExecuteNested(&gameAction, getGameState());
         }
     }
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+    curRide->lifecycleFlags.set(RideFlag::crashed);
     curRide->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
 
     if (IsHead())
@@ -441,7 +441,7 @@ void Vehicle::CrashOnWater()
     InvokeVehicleCrashHook(Id, "water");
 #endif
 
-    if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
+    if (!curRide->lifecycleFlags.has(RideFlag::crashed))
     {
         auto frontVehicle = GetHead();
         auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
@@ -459,7 +459,7 @@ void Vehicle::CrashOnWater()
             GameActions::ExecuteNested(&gameAction, getGameState());
         }
     }
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+    curRide->lifecycleFlags.set(RideFlag::crashed);
     curRide->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
 
     if (IsHead())

--- a/src/openrct2/ride/Vehicle.Crash.cpp
+++ b/src/openrct2/ride/Vehicle.Crash.cpp
@@ -65,7 +65,7 @@ void Vehicle::SimulateCrash() const
     auto curRide = GetRide();
     if (curRide != nullptr)
     {
-        curRide->lifecycleFlags.set(RideFlag::crashed);
+        curRide->flags.set(RideFlag::crashed);
     }
 }
 
@@ -89,7 +89,7 @@ void Vehicle::UpdateCollisionSetup()
 
     SetState(Status::crashed, sub_state);
 
-    if (!curRide->lifecycleFlags.has(RideFlag::crashed))
+    if (!curRide->flags.has(RideFlag::crashed))
     {
         auto frontVehicle = GetHead();
         auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
@@ -108,7 +108,7 @@ void Vehicle::UpdateCollisionSetup()
         }
     }
 
-    curRide->lifecycleFlags.set(RideFlag::crashed);
+    curRide->flags.set(RideFlag::crashed);
     curRide->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
     KillAllPassengersInTrain();
 
@@ -373,7 +373,7 @@ void Vehicle::CrashOnLand()
     InvokeVehicleCrashHook(Id, "land");
 #endif
 
-    if (!curRide->lifecycleFlags.has(RideFlag::crashed))
+    if (!curRide->flags.has(RideFlag::crashed))
     {
         auto frontVehicle = GetHead();
         auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
@@ -391,7 +391,7 @@ void Vehicle::CrashOnLand()
             GameActions::ExecuteNested(&gameAction, getGameState());
         }
     }
-    curRide->lifecycleFlags.set(RideFlag::crashed);
+    curRide->flags.set(RideFlag::crashed);
     curRide->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
 
     if (IsHead())
@@ -441,7 +441,7 @@ void Vehicle::CrashOnWater()
     InvokeVehicleCrashHook(Id, "water");
 #endif
 
-    if (!curRide->lifecycleFlags.has(RideFlag::crashed))
+    if (!curRide->flags.has(RideFlag::crashed))
     {
         auto frontVehicle = GetHead();
         auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
@@ -459,7 +459,7 @@ void Vehicle::CrashOnWater()
             GameActions::ExecuteNested(&gameAction, getGameState());
         }
     }
-    curRide->lifecycleFlags.set(RideFlag::crashed);
+    curRide->flags.set(RideFlag::crashed);
     curRide->windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
 
     if (IsHead())

--- a/src/openrct2/ride/Vehicle.Dodgems.cpp
+++ b/src/openrct2/ride/Vehicle.Dodgems.cpp
@@ -74,7 +74,7 @@ void Vehicle::UpdateDodgemsMode()
         TimeActive++;
     }
 
-    if (curRide->lifecycleFlags.has(RideFlag::passStationNoStopping))
+    if (curRide->flags.has(RideFlag::passStationNoStopping))
         return;
 
     // Mark the dodgem as not in use.
@@ -98,7 +98,7 @@ int32_t Vehicle::UpdateMotionDodgems()
         return _vehicleMotionTrackFlags;
 
     int32_t nextVelocity = velocity + acceleration;
-    if (curRide->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
+    if (curRide->flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
         && curRide->breakdownReasonPending == BREAKDOWN_SAFETY_CUT_OUT)
     {
         nextVelocity = 0;
@@ -110,7 +110,7 @@ int32_t Vehicle::UpdateMotionDodgems()
     _vehicleUnkF64E10 = 1;
 
     acceleration = 0;
-    if (!curRide->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
+    if (!curRide->flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
         || curRide->breakdownReasonPending != BREAKDOWN_SAFETY_CUT_OUT)
     {
         if ((getGameState().currentTicks & 1) && var_34 != 0)

--- a/src/openrct2/ride/Vehicle.Dodgems.cpp
+++ b/src/openrct2/ride/Vehicle.Dodgems.cpp
@@ -74,7 +74,7 @@ void Vehicle::UpdateDodgemsMode()
         TimeActive++;
     }
 
-    if (curRide->lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+    if (curRide->lifecycleFlags.has(RideFlag::passStationNoStopping))
         return;
 
     // Mark the dodgem as not in use.
@@ -98,7 +98,7 @@ int32_t Vehicle::UpdateMotionDodgems()
         return _vehicleMotionTrackFlags;
 
     int32_t nextVelocity = velocity + acceleration;
-    if (curRide->lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (curRide->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
         && curRide->breakdownReasonPending == BREAKDOWN_SAFETY_CUT_OUT)
     {
         nextVelocity = 0;
@@ -110,7 +110,7 @@ int32_t Vehicle::UpdateMotionDodgems()
     _vehicleUnkF64E10 = 1;
 
     acceleration = 0;
-    if (!(curRide->lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (!curRide->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown)
         || curRide->breakdownReasonPending != BREAKDOWN_SAFETY_CUT_OUT)
     {
         if ((getGameState().currentTicks & 1) && var_34 != 0)

--- a/src/openrct2/ride/Vehicle.Station.cpp
+++ b/src/openrct2/ride/Vehicle.Station.cpp
@@ -86,7 +86,7 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
     /* Ride vehicles are not on the track (e.g. ride is/was under
      * construction), so just return; vehicle_id for this station
      * is SPRITE_INDEX_NULL. */
-    if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_ON_TRACK))
+    if (!ride->lifecycleFlags.has(RideFlag::onTrack))
     {
         return true;
     }
@@ -210,7 +210,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
     {
         Ride* sv_ride = GetRide(sv->ride_id);
 
-        if (!(sv_ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+        if (!sv_ride->lifecycleFlags.has(RideFlag::brokenDown))
         {
             if (sv_ride->status != RideStatus::closed)
             {
@@ -463,13 +463,13 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
     if (curRide == nullptr)
         return;
 
-    if (curRide->status == RideStatus::open && !(curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (curRide->status == RideStatus::open && !curRide->lifecycleFlags.has(RideFlag::brokenDown)
         && !flags.has(VehicleFlag::readyToDepart))
     {
         return;
     }
 
-    if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (!curRide->lifecycleFlags.has(RideFlag::brokenDown))
     {
         const auto& rtd = curRide->getRideTypeDescriptor();
         // Original code did not check if the ride was a boat hire, causing empty boats to leave the platform when closing a
@@ -689,7 +689,7 @@ void Vehicle::UpdateWaitingToDepart()
     const auto& currentStation = curRide->getStation(current_station);
 
     bool shouldBreak = false;
-    if (curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+    if (curRide->lifecycleFlags.has(RideFlag::brokenDown))
     {
         switch (curRide->breakdownReasonPending)
         {
@@ -766,7 +766,7 @@ void Vehicle::UpdateWaitingToDepart()
 
     SetState(Status::departing);
 
-    if (curRide->lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT)
+    if (curRide->lifecycleFlags.has(RideFlag::cableLift))
     {
         CoordsXYE track;
         int32_t zUnused;
@@ -954,7 +954,7 @@ void Vehicle::UpdateUnloadingPassengers()
             if (sub_state != 1)
                 return;
 
-            if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TESTED) && flags.has(VehicleFlag::testing)
+            if (!curRide->lifecycleFlags.has(RideFlag::tested) && flags.has(VehicleFlag::testing)
                 && curRide->currentTestSegment + 1 >= curRide->numStations)
             {
                 UpdateTestFinish();
@@ -995,7 +995,7 @@ void Vehicle::UpdateUnloadingPassengers()
             return;
     }
 
-    if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TESTED) && flags.has(VehicleFlag::testing)
+    if (!curRide->lifecycleFlags.has(RideFlag::tested) && flags.has(VehicleFlag::testing)
         && curRide->currentTestSegment + 1 >= curRide->numStations)
     {
         UpdateTestFinish();
@@ -1021,10 +1021,10 @@ void Vehicle::UpdateDeparting()
     {
         if (flags.has(VehicleFlag::trainIsBroken))
         {
-            if (curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+            if (curRide->lifecycleFlags.has(RideFlag::brokenDown))
                 return;
 
-            curRide->lifecycleFlags |= RIDE_LIFECYCLE_BROKEN_DOWN;
+            curRide->lifecycleFlags.set(RideFlag::brokenDown);
             RideBreakdownAddNewsItem(*curRide);
 
             curRide->windowInvalidateFlags.set(
@@ -1050,7 +1050,7 @@ void Vehicle::UpdateDeparting()
             Play3D(SoundId::rideLaunch2, GetLocation());
         }
 
-        if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+        if (!curRide->lifecycleFlags.has(RideFlag::tested))
         {
             if (flags.has(VehicleFlag::testing))
             {
@@ -1064,7 +1064,7 @@ void Vehicle::UpdateDeparting()
                     UpdateTestFinish();
                 }
             }
-            else if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TEST_IN_PROGRESS) && !IsGhost())
+            else if (!curRide->lifecycleFlags.has(RideFlag::testInProgress) && !IsGhost())
             {
                 TestReset();
             }
@@ -1293,7 +1293,7 @@ void Vehicle::CheckIfMissing()
     if (curRide == nullptr)
         return;
 
-    if (curRide->lifecycleFlags & (RIDE_LIFECYCLE_BROKEN_DOWN | RIDE_LIFECYCLE_CRASHED))
+    if (curRide->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
         return;
 
     if (curRide->isBlockSectioned())
@@ -1303,7 +1303,7 @@ void Vehicle::CheckIfMissing()
         return;
 
     lost_time_out++;
-    if (curRide->lifecycleFlags & RIDE_LIFECYCLE_HAS_STALLED_VEHICLE)
+    if (curRide->lifecycleFlags.has(RideFlag::hasStalledVehicle))
         return;
 
     uint16_t limit = curRide->type == RIDE_TYPE_BOAT_HIRE ? 15360 : 9600;
@@ -1311,7 +1311,7 @@ void Vehicle::CheckIfMissing()
     if (lost_time_out <= limit)
         return;
 
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_HAS_STALLED_VEHICLE;
+    curRide->lifecycleFlags.set(RideFlag::hasStalledVehicle);
 
     if (Config::Get().notifications.rideStalledVehicles)
     {
@@ -1514,7 +1514,7 @@ void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEnt
 {
     if (sub_state == 0)
     {
-        if (curRide.mode == RideMode::race && curRide.lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+        if (curRide.mode == RideMode::race && curRide.lifecycleFlags.has(RideFlag::passStationNoStopping))
         {
             return;
         }
@@ -1711,7 +1711,7 @@ void Vehicle::UpdateArriving()
         return;
     }
 
-    if (curRide->mode == RideMode::race && curRide->lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
+    if (curRide->mode == RideMode::race && curRide->lifecycleFlags.has(RideFlag::passStationNoStopping))
     {
         SetState(Status::departing, 1);
         return;

--- a/src/openrct2/ride/Vehicle.Station.cpp
+++ b/src/openrct2/ride/Vehicle.Station.cpp
@@ -86,7 +86,7 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
     /* Ride vehicles are not on the track (e.g. ride is/was under
      * construction), so just return; vehicle_id for this station
      * is SPRITE_INDEX_NULL. */
-    if (!ride->lifecycleFlags.has(RideFlag::onTrack))
+    if (!ride->flags.has(RideFlag::onTrack))
     {
         return true;
     }
@@ -210,7 +210,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
     {
         Ride* sv_ride = GetRide(sv->ride_id);
 
-        if (!sv_ride->lifecycleFlags.has(RideFlag::brokenDown))
+        if (!sv_ride->flags.has(RideFlag::brokenDown))
         {
             if (sv_ride->status != RideStatus::closed)
             {
@@ -463,13 +463,13 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
     if (curRide == nullptr)
         return;
 
-    if (curRide->status == RideStatus::open && !curRide->lifecycleFlags.has(RideFlag::brokenDown)
+    if (curRide->status == RideStatus::open && !curRide->flags.has(RideFlag::brokenDown)
         && !flags.has(VehicleFlag::readyToDepart))
     {
         return;
     }
 
-    if (!curRide->lifecycleFlags.has(RideFlag::brokenDown))
+    if (!curRide->flags.has(RideFlag::brokenDown))
     {
         const auto& rtd = curRide->getRideTypeDescriptor();
         // Original code did not check if the ride was a boat hire, causing empty boats to leave the platform when closing a
@@ -689,7 +689,7 @@ void Vehicle::UpdateWaitingToDepart()
     const auto& currentStation = curRide->getStation(current_station);
 
     bool shouldBreak = false;
-    if (curRide->lifecycleFlags.has(RideFlag::brokenDown))
+    if (curRide->flags.has(RideFlag::brokenDown))
     {
         switch (curRide->breakdownReasonPending)
         {
@@ -766,7 +766,7 @@ void Vehicle::UpdateWaitingToDepart()
 
     SetState(Status::departing);
 
-    if (curRide->lifecycleFlags.has(RideFlag::cableLift))
+    if (curRide->flags.has(RideFlag::cableLift))
     {
         CoordsXYE track;
         int32_t zUnused;
@@ -954,7 +954,7 @@ void Vehicle::UpdateUnloadingPassengers()
             if (sub_state != 1)
                 return;
 
-            if (!curRide->lifecycleFlags.has(RideFlag::tested) && flags.has(VehicleFlag::testing)
+            if (!curRide->flags.has(RideFlag::tested) && flags.has(VehicleFlag::testing)
                 && curRide->currentTestSegment + 1 >= curRide->numStations)
             {
                 UpdateTestFinish();
@@ -995,7 +995,7 @@ void Vehicle::UpdateUnloadingPassengers()
             return;
     }
 
-    if (!curRide->lifecycleFlags.has(RideFlag::tested) && flags.has(VehicleFlag::testing)
+    if (!curRide->flags.has(RideFlag::tested) && flags.has(VehicleFlag::testing)
         && curRide->currentTestSegment + 1 >= curRide->numStations)
     {
         UpdateTestFinish();
@@ -1021,10 +1021,10 @@ void Vehicle::UpdateDeparting()
     {
         if (flags.has(VehicleFlag::trainIsBroken))
         {
-            if (curRide->lifecycleFlags.has(RideFlag::brokenDown))
+            if (curRide->flags.has(RideFlag::brokenDown))
                 return;
 
-            curRide->lifecycleFlags.set(RideFlag::brokenDown);
+            curRide->flags.set(RideFlag::brokenDown);
             RideBreakdownAddNewsItem(*curRide);
 
             curRide->windowInvalidateFlags.set(
@@ -1050,7 +1050,7 @@ void Vehicle::UpdateDeparting()
             Play3D(SoundId::rideLaunch2, GetLocation());
         }
 
-        if (!curRide->lifecycleFlags.has(RideFlag::tested))
+        if (!curRide->flags.has(RideFlag::tested))
         {
             if (flags.has(VehicleFlag::testing))
             {
@@ -1064,7 +1064,7 @@ void Vehicle::UpdateDeparting()
                     UpdateTestFinish();
                 }
             }
-            else if (!curRide->lifecycleFlags.has(RideFlag::testInProgress) && !IsGhost())
+            else if (!curRide->flags.has(RideFlag::testInProgress) && !IsGhost())
             {
                 TestReset();
             }
@@ -1293,7 +1293,7 @@ void Vehicle::CheckIfMissing()
     if (curRide == nullptr)
         return;
 
-    if (curRide->lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+    if (curRide->flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
         return;
 
     if (curRide->isBlockSectioned())
@@ -1303,7 +1303,7 @@ void Vehicle::CheckIfMissing()
         return;
 
     lost_time_out++;
-    if (curRide->lifecycleFlags.has(RideFlag::hasStalledVehicle))
+    if (curRide->flags.has(RideFlag::hasStalledVehicle))
         return;
 
     uint16_t limit = curRide->type == RIDE_TYPE_BOAT_HIRE ? 15360 : 9600;
@@ -1311,7 +1311,7 @@ void Vehicle::CheckIfMissing()
     if (lost_time_out <= limit)
         return;
 
-    curRide->lifecycleFlags.set(RideFlag::hasStalledVehicle);
+    curRide->flags.set(RideFlag::hasStalledVehicle);
 
     if (Config::Get().notifications.rideStalledVehicles)
     {
@@ -1514,7 +1514,7 @@ void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEnt
 {
     if (sub_state == 0)
     {
-        if (curRide.mode == RideMode::race && curRide.lifecycleFlags.has(RideFlag::passStationNoStopping))
+        if (curRide.mode == RideMode::race && curRide.flags.has(RideFlag::passStationNoStopping))
         {
             return;
         }
@@ -1711,7 +1711,7 @@ void Vehicle::UpdateArriving()
         return;
     }
 
-    if (curRide->mode == RideMode::race && curRide->lifecycleFlags.has(RideFlag::passStationNoStopping))
+    if (curRide->mode == RideMode::race && curRide->flags.has(RideFlag::passStationNoStopping))
     {
         SetState(Status::departing, 1);
         return;

--- a/src/openrct2/ride/Vehicle.TrackMotion.cpp
+++ b/src/openrct2/ride/Vehicle.TrackMotion.cpp
@@ -229,7 +229,7 @@ void Vehicle::CheckAndApplyBlockSectionStopSite()
     {
         case TrackElemType::blockBrakes:
             // Check if this brake is the start of a cable lift
-            if (curRide->lifecycleFlags.has(RideFlag::cableLift))
+            if (curRide->flags.has(RideFlag::cableLift))
             {
                 CoordsXYE track;
                 int32_t zUnused;
@@ -710,7 +710,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
             || trackType == TrackElemType::rightEighthToDiag || trackType == TrackElemType::leftEighthToOrthogonal
             || trackType == TrackElemType::rightEighthToOrthogonal || trackType == TrackElemType::diagFlat
             || trackType == TrackElemType::sBendLeft || trackType == TrackElemType::sBendRight
-            || (curRide.lifecycleFlags.has(RideFlag::passStationNoStopping) && tileElement->AsTrack()->IsStation()))
+            || (curRide.flags.has(RideFlag::passStationNoStopping) && tileElement->AsTrack()->IsStation()))
         {
             UpdateGoKartAttemptSwitchLanes();
         }

--- a/src/openrct2/ride/Vehicle.TrackMotion.cpp
+++ b/src/openrct2/ride/Vehicle.TrackMotion.cpp
@@ -229,7 +229,7 @@ void Vehicle::CheckAndApplyBlockSectionStopSite()
     {
         case TrackElemType::blockBrakes:
             // Check if this brake is the start of a cable lift
-            if (curRide->lifecycleFlags & RIDE_LIFECYCLE_CABLE_LIFT)
+            if (curRide->lifecycleFlags.has(RideFlag::cableLift))
             {
                 CoordsXYE track;
                 int32_t zUnused;
@@ -710,7 +710,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(
             || trackType == TrackElemType::rightEighthToDiag || trackType == TrackElemType::leftEighthToOrthogonal
             || trackType == TrackElemType::rightEighthToOrthogonal || trackType == TrackElemType::diagFlat
             || trackType == TrackElemType::sBendLeft || trackType == TrackElemType::sBendRight
-            || ((curRide.lifecycleFlags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING) && tileElement->AsTrack()->IsStation()))
+            || (curRide.lifecycleFlags.has(RideFlag::passStationNoStopping) && tileElement->AsTrack()->IsStation()))
         {
             UpdateGoKartAttemptSwitchLanes();
         }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -253,9 +253,9 @@ bool Vehicle::CloseRestraints()
             && (curRide->breakdownReasonPending == BREAKDOWN_RESTRAINTS_STUCK_OPEN
                 || curRide->breakdownReasonPending == BREAKDOWN_DOORS_STUCK_OPEN))
         {
-            if (!curRide->lifecycleFlags.has(RideFlag::brokenDown))
+            if (!curRide->flags.has(RideFlag::brokenDown))
             {
-                curRide->lifecycleFlags.set(RideFlag::brokenDown);
+                curRide->flags.set(RideFlag::brokenDown);
 
                 RideBreakdownAddNewsItem(*curRide);
 
@@ -369,9 +369,9 @@ bool Vehicle::OpenRestraints()
             && (curRide->breakdownReasonPending == BREAKDOWN_RESTRAINTS_STUCK_CLOSED
                 || curRide->breakdownReasonPending == BREAKDOWN_DOORS_STUCK_CLOSED))
         {
-            if (!curRide->lifecycleFlags.has(RideFlag::brokenDown))
+            if (!curRide->flags.has(RideFlag::brokenDown))
             {
-                curRide->lifecycleFlags.set(RideFlag::brokenDown);
+                curRide->flags.set(RideFlag::brokenDown);
 
                 RideBreakdownAddNewsItem(*curRide);
 
@@ -434,8 +434,8 @@ void Vehicle::UpdateMeasurements()
 
     if (status == Status::travellingBoat)
     {
-        curRide->lifecycleFlags.set(RideFlag::tested, RideFlag::noRawStats);
-        curRide->lifecycleFlags.unset(RideFlag::testInProgress);
+        curRide->flags.set(RideFlag::tested, RideFlag::noRawStats);
+        curRide->flags.unset(RideFlag::testInProgress);
         flags.unset(VehicleFlag::testing);
 
         auto* windowMgr = Ui::GetWindowManager();
@@ -766,7 +766,7 @@ void Vehicle::Update()
         UpdateMeasurements();
 
     _vehicleBreakdown = 255;
-    if (curRide->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
+    if (curRide->flags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
     {
         _vehicleBreakdown = curRide->breakdownReasonPending;
         auto carEntry = &rideEntry->Cars[vehicle_type];
@@ -902,8 +902,8 @@ void Vehicle::PeepEasterEggHereWeAre() const
  */
 static void test_finish(Ride& ride)
 {
-    ride.lifecycleFlags.unset(RideFlag::testInProgress);
-    ride.lifecycleFlags.set(RideFlag::tested);
+    ride.flags.unset(RideFlag::testInProgress);
+    ride.flags.set(RideFlag::tested);
     ride.windowInvalidateFlags.set(RideInvalidateFlag::ratings);
 
     auto rideStations = ride.getStations();
@@ -949,8 +949,8 @@ void Vehicle::UpdateTestFinish()
  */
 static void test_reset(Ride& ride, StationIndex curStation)
 {
-    ride.lifecycleFlags.set(RideFlag::testInProgress);
-    ride.lifecycleFlags.unset(RideFlag::noRawStats);
+    ride.flags.set(RideFlag::testInProgress);
+    ride.flags.unset(RideFlag::noRawStats);
     ride.maxSpeed = 0;
     ride.averageSpeed = 0;
     ride.currentTestSegment = 0;
@@ -1063,10 +1063,10 @@ void Vehicle::UpdateTravellingCableLift()
     {
         if (flags.has(VehicleFlag::trainIsBroken))
         {
-            if (curRide->lifecycleFlags.has(RideFlag::brokenDown))
+            if (curRide->flags.has(RideFlag::brokenDown))
                 return;
 
-            curRide->lifecycleFlags.set(RideFlag::brokenDown);
+            curRide->flags.set(RideFlag::brokenDown);
             RideBreakdownAddNewsItem(*curRide);
             curRide->windowInvalidateFlags.set(
                 RideInvalidateFlag::main, RideInvalidateFlag::list, RideInvalidateFlag::maintenance);
@@ -1080,7 +1080,7 @@ void Vehicle::UpdateTravellingCableLift()
 
         sub_state = 1;
         PeepEasterEggHereWeAre();
-        if (!curRide->lifecycleFlags.has(RideFlag::tested))
+        if (!curRide->flags.has(RideFlag::tested))
         {
             if (flags.has(VehicleFlag::testing))
             {
@@ -1094,7 +1094,7 @@ void Vehicle::UpdateTravellingCableLift()
                     UpdateTestFinish();
                 }
             }
-            else if (!curRide->lifecycleFlags.has(RideFlag::testInProgress) && !IsGhost())
+            else if (!curRide->flags.has(RideFlag::testInProgress) && !IsGhost())
             {
                 TestReset();
             }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -253,9 +253,9 @@ bool Vehicle::CloseRestraints()
             && (curRide->breakdownReasonPending == BREAKDOWN_RESTRAINTS_STUCK_OPEN
                 || curRide->breakdownReasonPending == BREAKDOWN_DOORS_STUCK_OPEN))
         {
-            if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+            if (!curRide->lifecycleFlags.has(RideFlag::brokenDown))
             {
-                curRide->lifecycleFlags |= RIDE_LIFECYCLE_BROKEN_DOWN;
+                curRide->lifecycleFlags.set(RideFlag::brokenDown);
 
                 RideBreakdownAddNewsItem(*curRide);
 
@@ -369,9 +369,9 @@ bool Vehicle::OpenRestraints()
             && (curRide->breakdownReasonPending == BREAKDOWN_RESTRAINTS_STUCK_CLOSED
                 || curRide->breakdownReasonPending == BREAKDOWN_DOORS_STUCK_CLOSED))
         {
-            if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+            if (!curRide->lifecycleFlags.has(RideFlag::brokenDown))
             {
-                curRide->lifecycleFlags |= RIDE_LIFECYCLE_BROKEN_DOWN;
+                curRide->lifecycleFlags.set(RideFlag::brokenDown);
 
                 RideBreakdownAddNewsItem(*curRide);
 
@@ -434,9 +434,8 @@ void Vehicle::UpdateMeasurements()
 
     if (status == Status::travellingBoat)
     {
-        curRide->lifecycleFlags |= RIDE_LIFECYCLE_TESTED;
-        curRide->lifecycleFlags |= RIDE_LIFECYCLE_NO_RAW_STATS;
-        curRide->lifecycleFlags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
+        curRide->lifecycleFlags.set(RideFlag::tested, RideFlag::noRawStats);
+        curRide->lifecycleFlags.unset(RideFlag::testInProgress);
         flags.unset(VehicleFlag::testing);
 
         auto* windowMgr = Ui::GetWindowManager();
@@ -767,7 +766,7 @@ void Vehicle::Update()
         UpdateMeasurements();
 
     _vehicleBreakdown = 255;
-    if (curRide->lifecycleFlags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
+    if (curRide->lifecycleFlags.hasAny(RideFlag::breakdownPending, RideFlag::brokenDown))
     {
         _vehicleBreakdown = curRide->breakdownReasonPending;
         auto carEntry = &rideEntry->Cars[vehicle_type];
@@ -903,8 +902,8 @@ void Vehicle::PeepEasterEggHereWeAre() const
  */
 static void test_finish(Ride& ride)
 {
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
-    ride.lifecycleFlags |= RIDE_LIFECYCLE_TESTED;
+    ride.lifecycleFlags.unset(RideFlag::testInProgress);
+    ride.lifecycleFlags.set(RideFlag::tested);
     ride.windowInvalidateFlags.set(RideInvalidateFlag::ratings);
 
     auto rideStations = ride.getStations();
@@ -950,8 +949,8 @@ void Vehicle::UpdateTestFinish()
  */
 static void test_reset(Ride& ride, StationIndex curStation)
 {
-    ride.lifecycleFlags |= RIDE_LIFECYCLE_TEST_IN_PROGRESS;
-    ride.lifecycleFlags &= ~RIDE_LIFECYCLE_NO_RAW_STATS;
+    ride.lifecycleFlags.set(RideFlag::testInProgress);
+    ride.lifecycleFlags.unset(RideFlag::noRawStats);
     ride.maxSpeed = 0;
     ride.averageSpeed = 0;
     ride.currentTestSegment = 0;
@@ -1064,10 +1063,10 @@ void Vehicle::UpdateTravellingCableLift()
     {
         if (flags.has(VehicleFlag::trainIsBroken))
         {
-            if (curRide->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
+            if (curRide->lifecycleFlags.has(RideFlag::brokenDown))
                 return;
 
-            curRide->lifecycleFlags |= RIDE_LIFECYCLE_BROKEN_DOWN;
+            curRide->lifecycleFlags.set(RideFlag::brokenDown);
             RideBreakdownAddNewsItem(*curRide);
             curRide->windowInvalidateFlags.set(
                 RideInvalidateFlag::main, RideInvalidateFlag::list, RideInvalidateFlag::maintenance);
@@ -1081,7 +1080,7 @@ void Vehicle::UpdateTravellingCableLift()
 
         sub_state = 1;
         PeepEasterEggHereWeAre();
-        if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+        if (!curRide->lifecycleFlags.has(RideFlag::tested))
         {
             if (flags.has(VehicleFlag::testing))
             {
@@ -1095,7 +1094,7 @@ void Vehicle::UpdateTravellingCableLift()
                     UpdateTestFinish();
                 }
             }
-            else if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_TEST_IN_PROGRESS) && !IsGhost())
+            else if (!curRide->lifecycleFlags.has(RideFlag::testInProgress) && !IsGhost())
             {
                 TestReset();
             }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -539,12 +539,12 @@ static ResultWithMessage ScenarioPrepareRidesForSave(GameState_t& gameState)
             // If there are more than 5 roller coasters, only mark the first five.
             if (isFiveCoasterObjective && (RideEntryHasCategory(*rideEntry, RideCategory::rollerCoaster) && rcs < 5))
             {
-                ride.lifecycleFlags.set(RideFlag::indestructibleTrack);
+                ride.flags.set(RideFlag::indestructibleTrack);
                 rcs++;
             }
             else
             {
-                ride.lifecycleFlags.unset(RideFlag::indestructibleTrack);
+                ride.flags.unset(RideFlag::indestructibleTrack);
             }
         }
     }
@@ -568,7 +568,7 @@ static ResultWithMessage ScenarioPrepareRidesForSave(GameState_t& gameState)
                 auto ride = GetRide(it.element->AsTrack()->GetRideIndex());
 
                 // In the previous step, this flag was set on the first five roller coasters.
-                if (ride != nullptr && ride->lifecycleFlags.has(RideFlag::indestructibleTrack))
+                if (ride != nullptr && ride->flags.has(RideFlag::indestructibleTrack))
                 {
                     markTrackAsIndestructible = true;
                 }

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -539,12 +539,12 @@ static ResultWithMessage ScenarioPrepareRidesForSave(GameState_t& gameState)
             // If there are more than 5 roller coasters, only mark the first five.
             if (isFiveCoasterObjective && (RideEntryHasCategory(*rideEntry, RideCategory::rollerCoaster) && rcs < 5))
             {
-                ride.lifecycleFlags |= RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK;
+                ride.lifecycleFlags.set(RideFlag::indestructibleTrack);
                 rcs++;
             }
             else
             {
-                ride.lifecycleFlags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK;
+                ride.lifecycleFlags.unset(RideFlag::indestructibleTrack);
             }
         }
     }
@@ -568,7 +568,7 @@ static ResultWithMessage ScenarioPrepareRidesForSave(GameState_t& gameState)
                 auto ride = GetRide(it.element->AsTrack()->GetRideIndex());
 
                 // In the previous step, this flag was set on the first five roller coasters.
-                if (ride != nullptr && ride->lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+                if (ride != nullptr && ride->lifecycleFlags.has(RideFlag::indestructibleTrack))
                 {
                     markTrackAsIndestructible = true;
                 }

--- a/src/openrct2/scenario/ScenarioObjective.cpp
+++ b/src/openrct2/scenario/ScenarioObjective.cpp
@@ -212,7 +212,7 @@ namespace OpenRCT2::Scenario
                 auto rideEntry = ride.getRideEntry();
                 if (rideEntry != nullptr)
                 {
-                    if ((ride.lifecycleFlags & RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+                    if (ride.lifecycleFlags.has(RideFlag::indestructibleTrack)
                         && RideEntryHasCategory(*rideEntry, RideCategory::rollerCoaster))
                     {
                         rcs++;

--- a/src/openrct2/scenario/ScenarioObjective.cpp
+++ b/src/openrct2/scenario/ScenarioObjective.cpp
@@ -212,7 +212,7 @@ namespace OpenRCT2::Scenario
                 auto rideEntry = ride.getRideEntry();
                 if (rideEntry != nullptr)
                 {
-                    if (ride.lifecycleFlags.has(RideFlag::indestructibleTrack)
+                    if (ride.flags.has(RideFlag::indestructibleTrack)
                         && RideEntryHasCategory(*rideEntry, RideCategory::rollerCoaster))
                     {
                         rcs++;

--- a/src/openrct2/scripting/bindings/ride/ScRide.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.cpp
@@ -119,7 +119,7 @@ namespace OpenRCT2::Scripting
     uint32_t ScRide::lifecycleFlags_get() const
     {
         auto ride = GetRide();
-        return ride != nullptr ? ride->lifecycleFlags : 0;
+        return ride != nullptr ? ride->lifecycleFlags.holder : 0;
     }
 
     void ScRide::lifecycleFlags_set(uint32_t value)
@@ -128,7 +128,7 @@ namespace OpenRCT2::Scripting
         auto ride = GetRide();
         if (ride != nullptr)
         {
-            ride->lifecycleFlags = value;
+            ride->lifecycleFlags.holder = value;
         }
     }
 
@@ -530,7 +530,7 @@ namespace OpenRCT2::Scripting
 
         if (ride != nullptr)
         {
-            if (!(ride->lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN))
+            if (!ride->lifecycleFlags.has(RideFlag::brokenDown))
             {
                 return "none";
             }

--- a/src/openrct2/scripting/bindings/ride/ScRide.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.cpp
@@ -116,19 +116,19 @@ namespace OpenRCT2::Scripting
         return "";
     }
 
-    uint32_t ScRide::lifecycleFlags_get() const
+    uint32_t ScRide::flags_get() const
     {
         auto ride = GetRide();
-        return ride != nullptr ? ride->lifecycleFlags.holder : 0;
+        return ride != nullptr ? ride->flags.holder : 0;
     }
 
-    void ScRide::lifecycleFlags_set(uint32_t value)
+    void ScRide::flags_set(uint32_t value)
     {
         ThrowIfGameStateNotMutable();
         auto ride = GetRide();
         if (ride != nullptr)
         {
-            ride->lifecycleFlags.holder = value;
+            ride->flags.holder = value;
         }
     }
 
@@ -530,7 +530,7 @@ namespace OpenRCT2::Scripting
 
         if (ride != nullptr)
         {
-            if (!ride->lifecycleFlags.has(RideFlag::brokenDown))
+            if (!ride->flags.has(RideFlag::brokenDown))
             {
                 return "none";
             }
@@ -656,7 +656,8 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScRide::classification_get, nullptr, "classification");
         dukglue_register_property(ctx, &ScRide::name_get, &ScRide::name_set, "name");
         dukglue_register_property(ctx, &ScRide::status_get, nullptr, "status");
-        dukglue_register_property(ctx, &ScRide::lifecycleFlags_get, &ScRide::lifecycleFlags_set, "lifecycleFlags");
+        dukglue_register_property(ctx, &ScRide::flags_get, &ScRide::flags_set, "lifecycleFlags");
+        dukglue_register_property(ctx, &ScRide::flags_get, &ScRide::flags_set, "flags");
         dukglue_register_property(ctx, &ScRide::mode_get, &ScRide::mode_set, "mode");
         dukglue_register_property(ctx, &ScRide::departFlags_get, &ScRide::departFlags_set, "departFlags");
         dukglue_register_property(ctx, &ScRide::minimumWaitingTime_get, &ScRide::minimumWaitingTime_set, "minimumWaitingTime");

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -84,9 +84,9 @@ namespace OpenRCT2::Scripting
 
         std::string status_get() const;
 
-        uint32_t lifecycleFlags_get() const;
+        uint32_t flags_get() const;
 
-        void lifecycleFlags_set(uint32_t value);
+        void flags_set(uint32_t value);
 
         uint8_t mode_get() const;
 

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -86,9 +86,7 @@ namespace OpenRCT2::Park
         {
             if (ride.status != RideStatus::open)
                 continue;
-            if (ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
-                continue;
-            if (ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED)
+            if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                 continue;
 
             // Add ride value
@@ -117,9 +115,7 @@ namespace OpenRCT2::Park
         {
             if (ride.status != RideStatus::open)
                 continue;
-            if (ride.lifecycleFlags & RIDE_LIFECYCLE_BROKEN_DOWN)
-                continue;
-            if (ride.lifecycleFlags & RIDE_LIFECYCLE_CRASHED)
+            if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                 continue;
 
             // Add guest score for ride type
@@ -128,7 +124,7 @@ namespace OpenRCT2::Park
             // If difficult guest generation, extra guests are available for good rides
             if (park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
             {
-                if (!(ride.lifecycleFlags & RIDE_LIFECYCLE_TESTED))
+                if (!ride.lifecycleFlags.has(RideFlag::tested))
                     continue;
                 if (!ride.getRideTypeDescriptor().flags.has(RtdFlag::hasTrack))
                     continue;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -86,7 +86,7 @@ namespace OpenRCT2::Park
         {
             if (ride.status != RideStatus::open)
                 continue;
-            if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+            if (ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                 continue;
 
             // Add ride value
@@ -115,7 +115,7 @@ namespace OpenRCT2::Park
         {
             if (ride.status != RideStatus::open)
                 continue;
-            if (ride.lifecycleFlags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
+            if (ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
                 continue;
 
             // Add guest score for ride type
@@ -124,7 +124,7 @@ namespace OpenRCT2::Park
             // If difficult guest generation, extra guests are available for good rides
             if (park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
             {
-                if (!ride.lifecycleFlags.has(RideFlag::tested))
+                if (!ride.flags.has(RideFlag::tested))
                     continue;
                 if (!ride.getRideTypeDescriptor().flags.has(RtdFlag::hasTrack))
                     continue;


### PR DESCRIPTION
Self-explanatory.

I think it’s also a good idea to rename the underlying variable to just `flags` since the "lifecycle" part seems to be meaningless. If whoever reviews this agrees, I’ll push a commit for that.