### PR TITLE
Resolve function declaration and definition parameter name mismatch

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -117,7 +117,7 @@ public:
 
     void Clear(RenderTarget& rt, PaletteIndex paletteIndex) override;
     void FillRect(
-        RenderTarget& rt, PaletteIndex paletteIndex, int32_t x, int32_t y, int32_t w, int32_t h,
+        RenderTarget& rt, PaletteIndex paletteIndex, int32_t left, int32_t top, int32_t right, int32_t bottom,
         bool crossHatch = false) override;
     void FilterRect(
         RenderTarget& rt, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -62,7 +62,7 @@ namespace OpenRCT2::Ui
         void Close() override;
         void Hide() override;
         void Toggle();
-        void WriteLine(const std::string& s, FormatToken colourFormat) override;
+        void WriteLine(const std::string& input, FormatToken colourFormat) override;
 
         void Input(ConsoleInput input);
         void RefreshCaret(size_t position = 0);

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -77,7 +77,7 @@ namespace OpenRCT2::Ui::Windows
     void WindowInitScrollWidgets(WindowBase& w);
     void WindowUpdateScrollWidgets(WindowBase& w);
 
-    void WindowMovePosition(WindowBase& w, const ScreenCoordsXY& screenCoords);
+    void WindowMovePosition(WindowBase& w, const ScreenCoordsXY& deltaCoords);
     void WindowSetPosition(WindowBase& w, const ScreenCoordsXY& screenCoords);
     void WindowMoveAndSnap(WindowBase& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
     void WindowRelocateWindows(int32_t width, int32_t height);

--- a/src/openrct2-ui/scripting/CustomWindow.h
+++ b/src/openrct2-ui/scripting/CustomWindow.h
@@ -24,7 +24,7 @@ namespace OpenRCT2::Ui::Windows
     std::string GetWindowTitle(WindowBase* w);
     void UpdateWindowTitle(WindowBase* w, std::string_view value);
     void UpdateWindowTab(WindowBase* w, int32_t tabIndex);
-    void UpdateWidgetText(WindowBase* w, WidgetIndex widget, std::string_view string_view);
+    void UpdateWidgetText(WindowBase* w, WidgetIndex widget, std::string_view value);
     void UpdateWidgetItems(WindowBase* w, WidgetIndex widgetIndex, const std::vector<std::string>& items);
     void UpdateWidgetColour(WindowBase* w, WidgetIndex widgetIndex, Drawing::Colour colour);
     void UpdateWidgetSelectedIndex(WindowBase* w, WidgetIndex widgetIndex, int32_t selectedIndex);

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -49,7 +49,7 @@ void FinishObjectSelection();
 ResultWithMessage WindowEditorObjectSelectionSelectObject(
     uint8_t isMasterObject, EditorInputFlags flags, const OpenRCT2::ObjectRepositoryItem* item);
 ResultWithMessage WindowEditorObjectSelectionSelectObject(
-    uint8_t isMasterObject, EditorInputFlags flags, const OpenRCT2::ObjectEntryDescriptor& entry);
+    uint8_t isMasterObject, EditorInputFlags flags, const OpenRCT2::ObjectEntryDescriptor& descriptor);
 
 /**
  * Removes all unused objects from the object selection.

--- a/src/openrct2/world/tile_element/TrackElement.h
+++ b/src/openrct2/world/tile_element/TrackElement.h
@@ -83,7 +83,7 @@ namespace OpenRCT2
 
     public:
         TrackElemType GetTrackType() const;
-        void SetTrackType(TrackElemType newEntryIndex);
+        void SetTrackType(TrackElemType newType);
 
         ride_type_t GetRideType() const;
         void SetRideType(ride_type_t rideType);


### PR DESCRIPTION
This is a first pass, was being flagged by [readability-inconsistent-declaration-parameter-name](https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html), why this matters: in some IDEs like JetBrains' the tooltips for hovering over functions get the signature from the declaration