### PR TITLE
Add more context to IStream exceptions

### DIFF
--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -13,6 +13,7 @@
 #include "Path.hpp"
 #include "String.hpp"
 
+#include <cinttypes>
 #include <string_view>
 
 #ifndef _WIN32
@@ -214,7 +215,8 @@ namespace OpenRCT2
         }
         char msg[256];
         std::snprintf(
-            msg, sizeof(msg), "Unable to read %lu bytes from file. Position: %lu, FileSize: %lu, feof = %d, ferror = %d",
+            msg, sizeof(msg),
+            "Unable to read %" PRIu64 " bytes from file. Position: %" PRIu64 ", FileSize: %" PRIu64 ", feof = %d, ferror = %d",
             length, position, _fileSize, feof(_file), ferror(_file));
         throw IOException(msg);
     }
@@ -235,7 +237,8 @@ namespace OpenRCT2
             char msg[256];
             std::snprintf(
                 msg, sizeof(msg),
-                "Unable to write %lu bytes to file. Count = %ld, Position = %lu, FileSize = %lu, feof = %d, ferror = %d",
+                "Unable to write %" PRIu64 " bytes to file. Count = %zu, Position = %" PRIu64 ", FileSize = %" PRIu64
+                ", feof = %d, ferror = %d",
                 length, count, position, _fileSize, feof(_file), ferror(_file));
             throw IOException(msg);
         }

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -207,11 +207,16 @@ namespace OpenRCT2
             }
             throw IOException("Attempted to read past end of file.");
         }
+        uint64_t position = GetPosition();
         if (fread(buffer, 1, static_cast<size_t>(length), _file) == length)
         {
             return;
         }
-        throw IOException("Attempted to read past end of file.");
+        char msg[256];
+        std::snprintf(
+            msg, sizeof(msg), "Unable to read %lu bytes from file. Position: %lu, FileSize: %lu, feof = %d, ferror = %d",
+            length, position, _fileSize, feof(_file), ferror(_file));
+        throw IOException(msg);
     }
 
     void FileStream::Write(const void* buffer, uint64_t length)
@@ -224,15 +229,18 @@ namespace OpenRCT2
         {
             return;
         }
+        uint64_t position = GetPosition();
         if (auto count = fwrite(buffer, static_cast<size_t>(length), 1, _file); count != 1)
         {
-            std::string error = "Unable to write " + std::to_string(length) + " bytes to file. Count = " + std::to_string(count)
-                + ", errno = " + std::to_string(errno);
-            throw IOException(error);
+            char msg[256];
+            std::snprintf(
+                msg, sizeof(msg),
+                "Unable to write %lu bytes to file. Count = %ld, Position = %lu, FileSize = %lu, feof = %d, ferror = %d",
+                length, count, position, _fileSize, feof(_file), ferror(_file));
+            throw IOException(msg);
         }
 
-        uint64_t position = GetPosition();
-        _fileSize = std::max(_fileSize, position);
+        _fileSize = std::max(_fileSize, position + length);
     }
 
     uint64_t FileStream::TryRead(void* buffer, uint64_t length)

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -100,7 +100,11 @@ namespace OpenRCT2
     void MemoryStream::SetPosition(uint64_t position)
     {
         if (position > _dataSize)
-            throw IOException("New position out of bounds.");
+        {
+            char msg[256];
+            std::snprintf(msg, sizeof(msg), "Attempted to set position to %lu, stream length %lu.", position, _dataSize);
+            throw IOException(msg);
+        }
         _position = static_cast<size_t>(position);
     }
 
@@ -124,7 +128,13 @@ namespace OpenRCT2
     void MemoryStream::Read(void* buffer, uint64_t length)
     {
         if (_position + length > _dataSize)
-            throw IOException("Attempted to read past end of stream.");
+        {
+            char msg[256];
+            std::snprintf(
+                msg, sizeof(msg), "Attempted to read past end of stream. Position: %lu, Length: %lu, DataSize: %lu", _position,
+                length, _dataSize);
+            throw IOException(msg);
+        }
 
         std::memcpy(buffer, _data + _position, length);
         _position += static_cast<size_t>(length);
@@ -155,7 +165,13 @@ namespace OpenRCT2
     const void* MemoryStream::ReadDirect(size_t length)
     {
         if (_position + length > _dataSize)
-            throw IOException("Attempted to read past end of stream.");
+        {
+            char msg[256];
+            std::snprintf(
+                msg, sizeof(msg), "Attempted to read past end of stream. Position: %lu, Length: %lu, DataSize: %lu", _position,
+                length, _dataSize);
+            throw IOException(msg);
+        }
 
         const void* readPosition = _data + _position;
         _position += length;

--- a/src/openrct2/core/MemoryStream.cpp
+++ b/src/openrct2/core/MemoryStream.cpp
@@ -12,6 +12,7 @@
 #include "Guard.hpp"
 #include "Memory.hpp"
 
+#include <cinttypes>
 #include <cstring>
 
 namespace OpenRCT2
@@ -102,7 +103,8 @@ namespace OpenRCT2
         if (position > _dataSize)
         {
             char msg[256];
-            std::snprintf(msg, sizeof(msg), "Attempted to set position to %lu, stream length %lu.", position, _dataSize);
+            std::snprintf(
+                msg, sizeof(msg), "Attempted to set position to %" PRIu64 ", stream length %zu.", position, _dataSize);
             throw IOException(msg);
         }
         _position = static_cast<size_t>(position);
@@ -131,8 +133,8 @@ namespace OpenRCT2
         {
             char msg[256];
             std::snprintf(
-                msg, sizeof(msg), "Attempted to read past end of stream. Position: %lu, Length: %lu, DataSize: %lu", _position,
-                length, _dataSize);
+                msg, sizeof(msg), "Attempted to read past end of stream. Position: %zu, Length: %" PRIu64 ", DataSize: %zu.",
+                _position, length, _dataSize);
             throw IOException(msg);
         }
 
@@ -168,7 +170,7 @@ namespace OpenRCT2
         {
             char msg[256];
             std::snprintf(
-                msg, sizeof(msg), "Attempted to read past end of stream. Position: %lu, Length: %lu, DataSize: %lu", _position,
+                msg, sizeof(msg), "Attempted to read past end of stream. Position: %zu, Length: %zu, DataSize: %zu.", _position,
                 length, _dataSize);
             throw IOException(msg);
         }

--- a/src/openrct2/core/MemoryStream.h
+++ b/src/openrct2/core/MemoryStream.h
@@ -13,6 +13,7 @@
 #include "IStream.hpp"
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
 #include <vector>
 
@@ -90,7 +91,13 @@ namespace OpenRCT2
         void Read(void* buffer)
         {
             if (_position + N > _dataSize)
-                throw IOException("Attempted to read past end of stream.");
+            {
+                char message[256];
+                std::snprintf(
+                    message, sizeof(message), "Attempted to read past end of stream. Position: %zu, Length: %zu, DataSize: %zu",
+                    _position, N, _dataSize);
+                throw IOException(message);
+            }
 
             std::memcpy(buffer, _data + _position, N);
             _position += static_cast<size_t>(N);


### PR DESCRIPTION
This adds a bit more context to `IStream` exceptions. Some methods already supply that information, but most don't. This unifies approach we have.