### PR TITLE
Fix #25763: Crash when opening the Footpath window in Multiplayer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#23519] Title sequence cannot open .sea scenarios from RCTC.
 - Fix: [#25237] Wrong colours on the Knight costume (original bug).
 - Fix: [#25712, #25727] Crash during startup from window list race condition.
+- Fix: [#25763] Crash when opening the Footpath window in Multiplayer.
 - Fix: [#25910] Folders starting with numbers are sorted incorrectly (e.g. 1, 10, 2 instead of 1, 2, 10).
 - Fix: [#25954] Guests display hats, balloons, and umbrellas while puking.
 - Fix: [#25961] Fix crash when rendering malformed vehicles in the ride window.

--- a/src/openrct2/network/Network.h
+++ b/src/openrct2/network/Network.h
@@ -94,8 +94,8 @@ namespace OpenRCT2::Network
     [[nodiscard]] uint8_t GetDefaultGroup();
     [[nodiscard]] int32_t GetNumActions();
     [[nodiscard]] StringId GetActionNameStringID(uint32_t index);
-    [[nodiscard]] int32_t CanPerformAction(uint32_t groupindex, Permission index);
-    [[nodiscard]] int32_t CanPerformCommand(uint32_t groupindex, int32_t index);
+    [[nodiscard]] bool CanPerformAction(uint32_t groupindex, Permission index);
+    [[nodiscard]] bool CanPerformCommand(uint32_t groupindex, int32_t index);
     void SetPickupPeep(uint8_t playerid, Peep* peep);
     [[nodiscard]] Peep* GetPickupPeep(uint8_t playerid);
     void SetPickupPeepOldX(uint8_t playerid, int32_t x);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -3827,18 +3827,20 @@ namespace OpenRCT2::Network
         return kStringIdNone;
     }
 
-    int32_t CanPerformAction(uint32_t groupindex, Permission index)
+    bool CanPerformAction(uint32_t groupindex, Permission index)
     {
         auto& network = GetContext()->GetNetwork();
-        Guard::IndexInRange(groupindex, network.group_list);
+        if (groupindex >= network.group_list.size())
+            return false;
 
         return network.group_list[groupindex]->CanPerformAction(index);
     }
 
-    int32_t CanPerformCommand(uint32_t groupindex, int32_t index)
+    bool CanPerformCommand(uint32_t groupindex, int32_t index)
     {
         auto& network = GetContext()->GetNetwork();
-        Guard::IndexInRange(groupindex, network.group_list);
+        if (groupindex >= network.group_list.size())
+            return false;
 
         return network.group_list[groupindex]->CanPerformCommand(static_cast<GameCommand>(index)); // TODO
     }
@@ -4269,13 +4271,13 @@ namespace OpenRCT2::Network
     {
         return -1;
     }
-    int32_t CanPerformAction(uint32_t groupindex, Permission index)
+    bool CanPerformAction(uint32_t groupindex, Permission index)
     {
-        return 0;
+        return false;
     }
-    int32_t CanPerformCommand(uint32_t groupindex, int32_t index)
+    bool CanPerformCommand(uint32_t groupindex, int32_t index)
     {
-        return 0;
+        return false;
     }
     void SetPickupPeep(uint8_t playerid, Peep* peep)
     {


### PR DESCRIPTION
As of 28 February 2026, there are 14(!) crash reports open for this. As a player doesn’t have to be part of a group, the group index may be out of bounds. In this case, they are a spectator and can’t perform any action. Make `CanPerformAction()` and `CanPerformCommand()` simply return false in these cases.