### PR TITLE
Fix #25993: Toggling 'allow arbitrary ride type changes' does not resize open ride windows

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.33 (in development)
 ------------------------------------------------------------------------
 - Fix: [#10616] Quarter-tile trees cannot be placed on dry portions of half-water tiles.
+- Fix: [#25993] Toggling “allow arbitrary ride type changes” does not resize open ride windows.
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.
 
 0.4.32 (2026-03-01)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -671,6 +671,7 @@ namespace OpenRCT2::Ui::Windows
         uint16_t _rideColour = 0;
         std::vector<EntranceTypeLabel> _entranceDropdownData;
         bool _autoScrollGraph = true;
+        bool _lastAllowArbitraryRideTypeChanges = false;
 
         uint8_t getNumVisibleCars()
         {
@@ -782,6 +783,7 @@ namespace OpenRCT2::Ui::Windows
             UpdateOverallView(*ride);
 
             PopulateVehicleTypeDropdown(*ride, true);
+            _lastAllowArbitraryRideTypeChanges = getGameState().cheats.allowArbitraryRideTypeChanges;
         }
 
         void onClose() override
@@ -2280,6 +2282,17 @@ namespace OpenRCT2::Ui::Windows
             onPrepareDraw();
             invalidateWidget(WIDX_TAB_1);
 
+            // Resize window if cheat state changed
+            auto& gameState = getGameState();
+            if (_lastAllowArbitraryRideTypeChanges != gameState.cheats.allowArbitraryRideTypeChanges)
+            {
+                _lastAllowArbitraryRideTypeChanges = gameState.cheats.allowArbitraryRideTypeChanges;
+                invalidate();
+                onResize();
+                onPrepareDraw();
+                invalidate();
+            }
+
             // Update status
             auto ride = GetRide(rideId);
             if (ride != nullptr)
@@ -2291,7 +2304,7 @@ namespace OpenRCT2::Ui::Windows
 
                     if (_viewIndex <= ride->numTrains)
                     {
-                        Vehicle* vehicle = getGameState().entities.GetEntity<Vehicle>(ride->vehicles[_viewIndex - 1]);
+                        Vehicle* vehicle = gameState.entities.GetEntity<Vehicle>(ride->vehicles[_viewIndex - 1]);
                         if (vehicle == nullptr
                             || (vehicle->status != Vehicle::Status::travelling
                                 && vehicle->status != Vehicle::Status::travellingCableLift


### PR DESCRIPTION
Fixes #25993

1. Track the cheat state in `_lastAllowArbitraryRideTypeChanges` member variable
2. Check for cheat state changes in `onUpdate()` and trigger a full window resize when detected


![openrct2_IGrRLhUwbV](https://github.com/user-attachments/assets/a1654471-beca-4206-8d30-23b98e9c1a2f)
