### PR TITLE
Fix #10616: Quarter tile trees cannot be placed on dry portions of half water tiles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.33 (in development)
 ------------------------------------------------------------------------
+- Fix: [#10616] Quarter-tile trees cannot be placed on dry portions of half-water tiles.
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.
 
 0.4.32 (2026-03-01)

--- a/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
@@ -154,10 +154,10 @@ namespace OpenRCT2::GameActions
         waterHeight = TileElementWaterHeight(loc2);
 
         surfaceHeight = landHeight;
-        // If on water
-        if (waterHeight > 0)
+        // If on water (land at this quadrant is below water level)
+        if (waterHeight > 0 && landHeight < waterHeight)
         {
-            // BaseHeight2 is now the water height
+            // surfaceHeight is now the water height
             surfaceHeight = waterHeight;
             if (_loc.z == 0)
             {
@@ -204,7 +204,8 @@ namespace OpenRCT2::GameActions
         }
 
         if (!gameState.cheats.disableClearanceChecks && (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_REQUIRE_FLAT_SURFACE))
-            && !supportsRequired && !isOnWater && surfaceElement != nullptr && (surfaceElement->GetSlope() != kTileSlopeFlat))
+            && !supportsRequired && surfaceElement != nullptr && surfaceElement->GetWaterHeight() == 0
+            && (surfaceElement->GetSlope() != kTileSlopeFlat))
         {
             return Result(Status::disallowed, STR_CANT_POSITION_THIS_HERE, STR_LEVEL_LAND_REQUIRED);
         }
@@ -346,10 +347,10 @@ namespace OpenRCT2::GameActions
         waterHeight = TileElementWaterHeight({ x2, y2 });
 
         surfaceHeight = landHeight;
-        // If on water
-        if (waterHeight > 0)
+        // If on water (land at this quadrant is below water level)
+        if (waterHeight > 0 && landHeight < waterHeight)
         {
-            // BaseHeight2 is now the water height
+            // surfaceHeight is now the water height
             surfaceHeight = waterHeight;
         }
         auto targetHeight = _loc.z;


### PR DESCRIPTION
Fixes #10616 

The water placement check now only treats a quadrant as "on water" when the land at that specific quadrant is actually below water level, rather than checking the entire tile. This also adjusts the flat surface requirement check to use the tiles water height to keep the original behavior where scenery requiring flat surfaces can still be placed on sloped tiles that have water

![openrct2_QmgLx81BdP](https://github.com/user-attachments/assets/6c855cc5-c442-40ee-b6a9-5b8b31503961)
