### PR TITLE
Minor refactor about constants related to ticks per month

### DIFF
--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -73,14 +73,14 @@ int32_t Date::GetYear() const
 
 bool Date::IsDayStart() const
 {
-    if (monthTicks < 4)
+    if (monthTicks < kMonthTicksIncrement)
     {
         return false;
     }
-    int32_t prevMonthTick = monthTicks - 4;
+    int32_t prevMonthTick = monthTicks - kMonthTicksIncrement;
     int32_t currentMonth = GetMonth();
     int32_t currentDaysInMonth = GetDaysInMonth(currentMonth);
-    return ((currentDaysInMonth * monthTicks) >> 16 != (currentDaysInMonth * prevMonthTick) >> 16);
+    return ((currentDaysInMonth * monthTicks) / kMonthTicksPerMonth != (currentDaysInMonth * prevMonthTick) / kMonthTicksPerMonth);
 }
 
 bool Date::IsWeekStart() const

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -18,7 +18,6 @@ using namespace OpenRCT2;
 constexpr int32_t kMonthTicksIncrement = 4;
 constexpr int32_t kMaskWeekTicks = 0x3FFF;
 constexpr int32_t kMaskFortnightTicks = 0x7FFF;
-constexpr int32_t kMaskMonthTicks = 0xFFFF;
 
 // rct2: 0x00993988
 static const int16_t days_in_month[MONTH_COUNT] = {
@@ -109,7 +108,7 @@ int32_t Date::GetDaysInMonth(int32_t month)
 void OpenRCT2::DateUpdate(GameState_t& gameState)
 {
     int32_t monthTicks = gameState.date.monthTicks + kMonthTicksIncrement;
-    if (monthTicks > kMaskMonthTicks)
+    if (monthTicks >= kMonthTicksPerMonth)
     {
         gameState.date.monthTicks = 0;
         gameState.date.monthsElapsed++;

--- a/src/openrct2/Date.h
+++ b/src/openrct2/Date.h
@@ -12,7 +12,7 @@
 #include <cstdint>
 
 constexpr int32_t kMaxYear = 8192;
-constexpr int32_t kTicksPerMonth = 0x10000;
+constexpr int32_t kMonthTicksPerMonth = 0x10000;
 
 enum
 {

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -355,7 +355,7 @@ static void ScenarioUpdateDayNightCycle()
 
     if (gLegacyScene == LegacyScene::playing && Config::Get().general.dayNightCycle)
     {
-        float monthFraction = GetDate().GetMonthTicks() / static_cast<float>(kTicksPerMonth);
+        float monthFraction = GetDate().GetMonthTicks() / static_cast<float>(kMonthTicksPerMonth);
         if (monthFraction < (1 / 8.0f))
         {
             gDayNightCycle = 0.0f;


### PR DESCRIPTION
Very minor refactor.

* `kTicksPerMonth` was named incorrectly: it is not the number of ticks per month, it is 4 times larger!
* `kMaskMonthTicks` is not needed: it defined effectively the same thing, but a little more obtusely.
* `IsDayStart()` used magic numbers for values that already have konstants.

**Additional thoughts**
I considered attempting to change things so that monthTicks counts ticks elapsed this month instead of 4 times that, but I felt I should start smaller as that would be a bigger change than I first anticipated.
