### PR TITLE
Disable LTO on resolute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
             distro: Ubuntu
             release: resolute
             image: ghcr.io/openrct2/openrct2-build:26-resolute
-            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz"
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz" -DDISABLE_IPO=on
           - platform: x86_64
             distro: Debian
             release: bookworm


### PR DESCRIPTION
Apparently LTO with GCC makes it miss some warnings

See https://github.com/OpenRCT2/OpenRCT2/issues/26117