### PR TITLE
Clean up some comments

### DIFF
--- a/src/openrct2/Diagnostic.h
+++ b/src/openrct2/Diagnostic.h
@@ -38,9 +38,8 @@ enum class DiagnosticLevel
  *    #endif // DEBUG_LEVEL_2
  * #endif // DEBUG_LEVEL_1
  *
- * The defines will be either 0 or 1 so compiler will complain about undefined
- * macro if you forget to include the file, which would not happen if we were
- * only checking whether the define is present or not.
+ * The defines will be either 0 or 1 so compiler will complain about undefined macro if you forget to include the file,
+ * which would not happen if we were only checking whether the define is present.
  */
 
 #if defined(DEBUG)

--- a/src/openrct2/actions/ride/RideCreateAction.cpp
+++ b/src/openrct2/actions/ride/RideCreateAction.cpp
@@ -261,7 +261,7 @@ namespace OpenRCT2::GameActions
                 }
             }
 
-            // Set the on-ride photo price, whether the ride has one or not (except shops).
+            // Set the on-ride photo price, regardless of the ride having them (except shops).
             if (!rtd.flags.has(RtdFlag::isShopOrFacility) && ShopItemHasCommonPrice(ShopItem::photo))
             {
                 auto price = ShopItemGetCommonPrice(ride, ShopItem::photo);

--- a/src/openrct2/core/FileScanner.h
+++ b/src/openrct2/core/FileScanner.h
@@ -51,7 +51,7 @@ namespace OpenRCT2::Path
      * Scans a directory and optionally sub directories for files that matches the
      * given pattern and returns an enumerator.
      * @param pattern The path followed by a semi-colon delimited list of wildcard patterns.
-     * @param recurse Whether to scan sub directories or not.
+     * @param recurse Whether to scan sub directories.
      * @returns A new FileScanner, this must be deleted when no longer needed.
      */
     [[nodiscard]] std::unique_ptr<IFileScanner> ScanDirectory(const std::string& pattern, bool recurse);

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -27,7 +27,7 @@ enum class DrawingEngine : int32_t
 enum DrawingEngineFlag
 {
     /**
-     * Whether or not the engine will only draw changed blocks of the screen each frame.
+     * Whether the engine will only draw changed blocks of the screen each frame.
      */
     dirtyOptimisations,
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1970,9 +1970,8 @@ static Ride* GuestFindBestRideToGoOn(Guest& guest)
 }
 
 /**
- * This function is called whenever a peep is deciding whether or not they want
- * to go on a ride or visit a shop. They may be physically present at the
- * ride/shop, or they may just be thinking about it.
+ * This function is called whenever a peep is deciding whether they want to go on a ride or visit a shop.
+ * They may be physically present at the ride/shop, or they may just be thinking about it.
  *  rct2: 0x006960AB
  */
 bool Guest::ShouldGoOnRide(Ride& ride, StationIndex entranceNum, bool atQueue, bool thinking)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2709,8 +2709,7 @@ void Ride::chainQueues() const
 
         auto mapLocation = station.Entrance.ToCoordsXYZ();
 
-        // This will fire for every entrance on this x, y and z, regardless whether that actually belongs to
-        // the ride or not.
+        // This will fire for every entrance on this x, y and z, regardless whether that actually belongs to the ride.
         TileElement* tileElement = MapGetFirstElementAt(station.Entrance);
         if (tileElement != nullptr)
         {

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -8,8 +8,7 @@
  *****************************************************************************/
 
 /**
- * Whether a particular ride has a running track or not. Will probably end up
- * being used in various places in the game.
+ * Whether a particular ride has a running track. Will probably end up being used in various places in the game.
  *
  * Data source is 0x0097E3AC
  *

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -380,8 +380,7 @@ enum class RtdFlag : uint8_t
 
     isFlatRide,
 
-    // Whether or not guests will go on the ride again if they liked it
-    // (this is usually applied to everything apart from transport rides).
+    // Whether guests will go on the ride again if they liked it (usually applied to everything apart from transport rides).
     guestsWillRideAgain,
 
     // Used by Toilets and First Aid to mark that guest should go
@@ -394,7 +393,7 @@ enum class RtdFlag : uint8_t
     sellsFood,
     sellsDrinks,
 
-    // Whether or not vehicle colours can be set
+    // Whether vehicle colours can be set
     hasVehicleColours,
 
     checkForStalling,

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -998,7 +998,7 @@ void Vehicle::TestReset()
     test_reset(*curRide, current_station);
 }
 
-// The result of this function is used to decide whether a vehicle on a tower ride should go further up or not.
+// The result of this function is used to decide whether a vehicle on a tower ride should go further up.
 // Therefore, it will return true if anything is amiss.
 bool Vehicle::CurrentTowerElementIsTop()
 {


### PR DESCRIPTION
This simply removes the redundant "or not" from phrases that use whether in comments. In some cases this allows the comments to fit better in less lines taking into account the 128 characters column limit.