### PR TITLE
Fix loan spinner widget to adhere to baseline

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,9 +3,11 @@
 - Change: [#25962] The station style dropdown now shows entrance icons next to the labels for easier selection.
 - Fix: [#10616] Quarter-tile trees cannot be placed on dry portions of half-water tiles.
 - Fix: [#25735] Ride synchronisation z-check works incorrectly.
+- Fix: [#25962] Dropdown triangle glyphs are not optically centred.
 - Fix: [#25993] Toggling “allow arbitrary ride type changes” does not resize open ride windows.
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.
 - Fix: [#26118] Windows installers for releases are not signed properly.
+- Fix: [#26128] The loan spinner widget does not appear on the same baseline as the text around it.
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -118,7 +118,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto _windowFinancesSummaryWidgets = makeWidgets(
         makeFinancesWidgets(STR_FINANCIAL_SUMMARY, kTabContentSizeSummary, kWindowSizeSummary),
         makeWidget        ({130,  50}, {391, 211}, WidgetType::scroll,  WindowColour::secondary, SCROLL_HORIZONTAL              ),
-        makeSpinnerWidgets({ 64, 279}, { 97,  14}, WidgetType::spinner, WindowColour::secondary, STR_FINANCES_SUMMARY_LOAN_VALUE) // NB: 3 widgets
+        makeSpinnerWidgets({ 64, 277}, { 97,  14}, WidgetType::spinner, WindowColour::secondary, STR_FINANCES_SUMMARY_LOAN_VALUE) // NB: 3 widgets
     );
 
     static constexpr auto _windowFinancesCashWidgets = makeWidgets(


### PR DESCRIPTION
This is probably a case of "when you see it...", but it was bothering me :smile:

Before:
<img width="1253" height="128" alt="Screenshot 2026-03-02 at 19 51 56" src="https://github.com/user-attachments/assets/1e435289-402b-4d44-baad-2d510f3b2b72" />

After:
<img width="1253" height="131" alt="Screenshot 2026-03-02 at 19 52 16" src="https://github.com/user-attachments/assets/b97e4925-07af-4c1b-820e-ccf4a4817a82" />
