### PR TITLE
Cleanup TrackPaintUtilLeftQuarterTurn{1,3}TileTunnel declaration

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Tunnel.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Tunnel.cpp
@@ -18,9 +18,6 @@ static std::array<TunnelGroupMap, kTunnelGroupCount> tunnelMap = {
                     TunnelType::InvertedFlatTo25Deg, TunnelType::InvertedFlat },
 };
 
-void TrackPaintUtilRightQuarterTurn3TilesTunnel(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, TunnelType tunnelType);
-
 void PaintUtilPushTunnelLeft(PaintSession& session, uint16_t height, TunnelType type)
 {
     if (!session.LeftTunnels.full())

--- a/src/openrct2/paint/tile_element/Paint.Tunnel.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Tunnel.cpp
@@ -18,9 +18,6 @@ static std::array<TunnelGroupMap, kTunnelGroupCount> tunnelMap = {
                     TunnelType::InvertedFlatTo25Deg, TunnelType::InvertedFlat },
 };
 
-void TrackPaintUtilLeftQuarterTurn1TileTunnel(
-    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, TunnelType startTunnel,
-    int8_t endOffset, TunnelType endTunnel);
 void TrackPaintUtilRightQuarterTurn3TilesTunnel(
     PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, TunnelType tunnelType);
 

--- a/src/openrct2/paint/tile_element/Paint.Tunnel.h
+++ b/src/openrct2/paint/tile_element/Paint.Tunnel.h
@@ -123,6 +123,9 @@ void TrackPaintUtilRightQuarterTurn3TilesTunnel(
     uint8_t trackSequence);
 
 void TrackPaintUtilLeftQuarterTurn1TileTunnel(
+    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, TunnelType startTunnel,
+    int8_t endOffset, TunnelType endTunnel);
+void TrackPaintUtilLeftQuarterTurn1TileTunnel(
     PaintSession& session, TunnelGroup group, Direction direction, uint16_t baseHeight, int8_t startOffset,
     TunnelSubType startTunnel, int8_t endOffset, TunnelSubType endTunnel);
 void TrackPaintUtilRightQuarterTurn1TileTunnel(

--- a/src/openrct2/paint/tile_element/Paint.Tunnel.h
+++ b/src/openrct2/paint/tile_element/Paint.Tunnel.h
@@ -118,6 +118,9 @@ void TrackPaintUtilRightQuarterTurn3Tiles25DegDownTunnel(
 void TrackPaintUtilLeftQuarterTurn3TilesTunnel(
     PaintSession& session, TunnelGroup group, TunnelSubType tunnelType, int16_t height, Direction direction,
     uint8_t trackSequence);
+
+void TrackPaintUtilRightQuarterTurn3TilesTunnel(
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, TunnelType tunnelType);
 void TrackPaintUtilRightQuarterTurn3TilesTunnel(
     PaintSession& session, TunnelGroup group, TunnelSubType tunnelType, int16_t height, Direction direction,
     uint8_t trackSequence);

--- a/src/openrct2/paint/track/gentle/GhostTrain.cpp
+++ b/src/openrct2/paint/track/gentle/GhostTrain.cpp
@@ -22,9 +22,6 @@ using namespace OpenRCT2;
 
 static constexpr TunnelGroup kTunnelGroupIncline = TunnelGroup::Standard;
 
-void TrackPaintUtilRightQuarterTurn3TilesTunnel(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, TunnelType tunnelType);
-
 enum
 {
     SprGhostTrainTrackFlatSwNe = 28821,

--- a/src/openrct2/paint/track/gentle/GhostTrain.cpp
+++ b/src/openrct2/paint/track/gentle/GhostTrain.cpp
@@ -13,6 +13,7 @@
 #include "../../Paint.h"
 #include "../../support/MetalSupports.h"
 #include "../../support/WoodenSupports.h"
+#include "../../tile_element/Paint.Tunnel.h"
 #include "../../tile_element/Segment.h"
 #include "../../track/Segment.h"
 #include "../../track/Support.h"
@@ -21,9 +22,6 @@ using namespace OpenRCT2;
 
 static constexpr TunnelGroup kTunnelGroupIncline = TunnelGroup::Standard;
 
-void TrackPaintUtilLeftQuarterTurn1TileTunnel(
-    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, TunnelType startTunnel,
-    int8_t endOffset, TunnelType endTunnel);
 void TrackPaintUtilRightQuarterTurn3TilesTunnel(
     PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, TunnelType tunnelType);
 


### PR DESCRIPTION
There's something wrong with the ghost train tunnel.

@mixiate @Gymnasiast can you please take a look?

```
/home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/GhostTrain.cpp:492:55: error: cannot convert ‘uint8_t’ {aka ‘unsigned char’} to ‘TunnelGroup’
  492 |     TrackPaintUtilLeftQuarterTurn1TileTunnel(session, direction, height, 0, tunnelStartImage, 0, tunnelEndImage);
      |                                                       ^~~~~~~~~
      |                                                       |
      |                                                       uint8_t {aka unsigned char}
In file included from /home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/../../../ride/../paint/Paint.h:20,
                 from /home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/../../../ride/TrackPaint.h:12,
                 from /home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/../../../ride/TrackStyle.h:12,
                 from /home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/../../../ride/RideData.h:36,
                 from /home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/GhostTrain.cpp:10:
/home/janisozaur/workspace/openrct2/src/openrct2/paint/track/gentle/../../../ride/../paint/tile_element/Paint.Tunnel.h:126:40: note: initializing argument 2 of ‘void TrackPaintUtilLeftQuarterTurn1TileTunnel(PaintSession&, TunnelGroup, Direction, uint16_t, int8_t, TunnelSubType, int8_t, TunnelSubType)’
  126 |     PaintSession& session, TunnelGroup group, Direction direction, uint16_t baseHeight, int8_t startOffset,
      |                            ~~~~~~~~~~~~^~~~~
```