### PR TITLE
Properly scope namespace of RCTObjectEntry

### DIFF
--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -23,7 +23,10 @@
 enum class TileInspectorPage : int16_t;
 
 struct ResearchItem;
-struct RCTObjectEntry;
+namespace OpenRCT2
+{
+    struct RCTObjectEntry;
+}
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
     #pragma GCC diagnostic push

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -16,7 +16,10 @@
 
 #include <memory>
 
-struct RCTObjectEntry;
+namespace OpenRCT2
+{
+    struct RCTObjectEntry;
+}
 
 namespace OpenRCT2::Scenario
 {


### PR DESCRIPTION
Unify namespace of `RCTObjectEntry` forward declarations