### PR TITLE
Fix #26140: TimeInQueue overflows back to 0 after 65535 (about a year)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#26111] Vehicle colours tab can go out of bounds in certain edge cases.
 - Fix: [#26118] Windows installers for releases are not signed properly.
 - Fix: [#26128] The loan spinner widget does not appear on the same baseline as the text around it.
+- Fix: [#26140] The time a guest has spent in a queue overflows back to 0 after it reaches 65535 (about a year).
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7525,7 +7525,7 @@ int32_t GetPeepFaceSpriteLarge(Guest* peep)
  */
 bool Guest::UpdateQueuePosition(PeepActionType previous_action)
 {
-    TimeInQueue = std::min<uint32_t>(TimeInQueue + 1, 65535);
+    TimeInQueue = AddClamp<uint16_t>(TimeInQueue, 1);
 
     auto* guestNext = getGameState().entities.GetEntity<Guest>(GuestNextInQueue);
     if (guestNext == nullptr)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7525,7 +7525,8 @@ int32_t GetPeepFaceSpriteLarge(Guest* peep)
  */
 bool Guest::UpdateQueuePosition(PeepActionType previous_action)
 {
-    TimeInQueue++;
+    TimeInQueue = std::min<uint32_t>(TimeInQueue + 1, 65535);
+    std::cout << "Queue time: " << TimeInQueue + 0 << "\n";
 
     auto* guestNext = getGameState().entities.GetEntity<Guest>(GuestNextInQueue);
     if (guestNext == nullptr)

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7526,7 +7526,6 @@ int32_t GetPeepFaceSpriteLarge(Guest* peep)
 bool Guest::UpdateQueuePosition(PeepActionType previous_action)
 {
     TimeInQueue = std::min<uint32_t>(TimeInQueue + 1, 65535);
-    std::cout << "Queue time: " << TimeInQueue + 0 << "\n";
 
     auto* guestNext = getGameState().entities.GetEntity<Guest>(GuestNextInQueue);
     if (guestNext == nullptr)

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -48,7 +48,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 1;
+constexpr uint8_t kStreamVersion = 2;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Fixes #26140