### PR TITLE
Disambiguate OpenRCT2::ObjectManager

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -451,7 +451,7 @@ namespace OpenRCT2::Ui
                 auto banner = tileElement->AsBanner()->GetBanner();
                 if (banner != nullptr)
                 {
-                    auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+                    auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
 
                     auto ft = Formatter();
                     ft.Add<StringId>(STR_MAP_TOOLTIP_BANNER_STRINGID_STRINGID);

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -291,7 +291,7 @@ namespace OpenRCT2::Ui::Windows
             Widget& colourBtn = widgets[WIDX_MAIN_COLOUR];
             colourBtn.type = WidgetType::empty;
 
-            auto* bannerEntry = OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+            auto* bannerEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
             if (bannerEntry != nullptr && (bannerEntry->flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR))
             {
                 colourBtn.type = WidgetType::colourBtn;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -207,7 +207,7 @@ namespace OpenRCT2::Ui::Windows
 
             const SceneryGroupEntry* GetSceneryGroupEntry() const
             {
-                return ObjectManager::GetObjectEntry<SceneryGroupEntry>(SceneryGroupIndex);
+                return ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(SceneryGroupIndex);
             }
         };
 
@@ -593,7 +593,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_LARGE)
                     {
-                        const auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(
+                        const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(
                             tabSelectedScenery.EntryIndex);
                         if (sceneryEntry != nullptr)
                         {
@@ -602,7 +602,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_WALL)
                     {
-                        const auto* sceneryEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(
+                        const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(
                             tabSelectedScenery.EntryIndex);
                         if (sceneryEntry != nullptr)
                         {
@@ -611,7 +611,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_PATH_ITEM)
                     {
-                        const auto* sceneryEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(
+                        const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(
                             tabSelectedScenery.EntryIndex);
                         if (sceneryEntry != nullptr)
                         {
@@ -620,7 +620,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_SMALL)
                     {
-                        const auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(
+                        const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(
                             tabSelectedScenery.EntryIndex);
                         if (sceneryEntry != nullptr)
                         {
@@ -730,7 +730,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = WidgetType::flatBtn;
 
-                    auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(tabSelectedScenery.EntryIndex);
+                    auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (sceneryEntry != nullptr && sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_ROTATABLE))
                     {
                         widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WidgetType::flatBtn;
@@ -769,7 +769,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (tabSelectedScenery.SceneryType == SCENERY_TYPE_BANNER)
                 {
-                    auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(tabSelectedScenery.EntryIndex);
+                    auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (bannerEntry != nullptr && bannerEntry->flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR)
                     {
                         widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
@@ -777,7 +777,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_LARGE)
                 {
-                    auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(tabSelectedScenery.EntryIndex);
+                    auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (sceneryEntry != nullptr)
                     {
                         if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR
@@ -792,7 +792,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_WALL)
                 {
-                    auto* wallEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(tabSelectedScenery.EntryIndex);
+                    auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (wallEntry != nullptr && wallEntry->flags & (WALL_SCENERY_HAS_PRIMARY_COLOUR | WALL_SCENERY_HAS_GLASS))
                     {
                         widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
@@ -810,7 +810,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_SMALL)
                 {
-                    auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(tabSelectedScenery.EntryIndex);
+                    auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(tabSelectedScenery.EntryIndex);
 
                     if (sceneryEntry != nullptr
                         && sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR | SMALL_SCENERY_FLAG_HAS_GLASS))
@@ -996,7 +996,7 @@ namespace OpenRCT2::Ui::Windows
 
             for (ObjectEntryIndex scenerySetIndex = 0; scenerySetIndex < kMaxTabs - kReservedTabCount; scenerySetIndex++)
             {
-                const auto* sceneryGroupEntry = ObjectManager::GetObjectEntry<SceneryGroupEntry>(scenerySetIndex);
+                const auto* sceneryGroupEntry = ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(scenerySetIndex);
                 if (sceneryGroupEntry != nullptr && SceneryGroupIsInvented(scenerySetIndex))
                 {
                     SceneryTabInfo tabInfo;
@@ -1025,7 +1025,7 @@ namespace OpenRCT2::Ui::Windows
             // small scenery
             for (ObjectEntryIndex sceneryId = 0; sceneryId < kMaxSmallSceneryObjects; sceneryId++)
             {
-                const auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(sceneryId);
+                const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(sceneryId);
                 if (sceneryEntry != nullptr)
                 {
                     initSceneryEntry({ SCENERY_TYPE_SMALL, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1035,7 +1035,7 @@ namespace OpenRCT2::Ui::Windows
             // large scenery
             for (ObjectEntryIndex sceneryId = 0; sceneryId < kMaxLargeSceneryObjects; sceneryId++)
             {
-                const auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(sceneryId);
+                const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(sceneryId);
                 if (sceneryEntry != nullptr)
                 {
                     initSceneryEntry({ SCENERY_TYPE_LARGE, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1045,7 +1045,7 @@ namespace OpenRCT2::Ui::Windows
             // walls
             for (ObjectEntryIndex sceneryId = 0; sceneryId < kMaxWallSceneryObjects; sceneryId++)
             {
-                const auto* sceneryEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(sceneryId);
+                const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(sceneryId);
                 if (sceneryEntry != nullptr)
                 {
                     initSceneryEntry({ SCENERY_TYPE_WALL, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1055,7 +1055,7 @@ namespace OpenRCT2::Ui::Windows
             // banners
             for (ObjectEntryIndex sceneryId = 0; sceneryId < kMaxBannerObjects; sceneryId++)
             {
-                const auto* sceneryEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(sceneryId);
+                const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(sceneryId);
                 if (sceneryEntry != nullptr)
                 {
                     initSceneryEntry({ SCENERY_TYPE_BANNER, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1064,7 +1064,7 @@ namespace OpenRCT2::Ui::Windows
 
             for (ObjectEntryIndex sceneryId = 0; sceneryId < kMaxPathAdditionObjects; sceneryId++)
             {
-                const auto* sceneryEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(sceneryId);
+                const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(sceneryId);
                 if (sceneryEntry != nullptr)
                 {
                     initSceneryEntry({ SCENERY_TYPE_PATH_ITEM, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1530,7 +1530,7 @@ namespace OpenRCT2::Ui::Windows
         template<typename TObjectType>
         std::pair<StringId, money64> GetNameAndPriceByType(const ScenerySelection& selectedScenery)
         {
-            auto* sceneryEntry = ObjectManager::GetObjectEntry<TObjectType>(selectedScenery.EntryIndex);
+            auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<TObjectType>(selectedScenery.EntryIndex);
             if (sceneryEntry != nullptr)
             {
                 return { sceneryEntry->name, sceneryEntry->price };
@@ -1594,7 +1594,7 @@ namespace OpenRCT2::Ui::Windows
         {
             if (scenerySelection.SceneryType == SCENERY_TYPE_BANNER)
             {
-                auto bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(scenerySelection.EntryIndex);
+                auto bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(scenerySelection.EntryIndex);
                 if (bannerEntry == nullptr)
                     return;
 
@@ -1604,7 +1604,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else if (scenerySelection.SceneryType == SCENERY_TYPE_LARGE)
             {
-                auto sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(scenerySelection.EntryIndex);
+                auto sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(scenerySelection.EntryIndex);
                 if (sceneryEntry == nullptr)
                     return;
 
@@ -1619,7 +1619,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else if (scenerySelection.SceneryType == SCENERY_TYPE_WALL)
             {
-                auto wallEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(scenerySelection.EntryIndex);
+                auto wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(scenerySelection.EntryIndex);
                 if (wallEntry == nullptr)
                     return;
 
@@ -1658,7 +1658,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else if (scenerySelection.SceneryType == SCENERY_TYPE_PATH_ITEM)
             {
-                auto* pathAdditionEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(scenerySelection.EntryIndex);
+                auto* pathAdditionEntry = ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(scenerySelection.EntryIndex);
                 if (pathAdditionEntry == nullptr)
                     return;
 
@@ -1667,7 +1667,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                auto sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(scenerySelection.EntryIndex);
+                auto sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(scenerySelection.EntryIndex);
                 if (sceneryEntry == nullptr)
                     return;
 
@@ -1803,7 +1803,7 @@ namespace OpenRCT2::Ui::Windows
                 gMapSelectPositionB.y = mapTile.y;
             }
 
-            auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(selection.EntryIndex);
+            auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(selection.EntryIndex);
 
             gMapSelectType = MapSelectType::full;
             if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_FULL_TILE) && !gWindowSceneryScatterEnabled)
@@ -1948,7 +1948,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(selection.EntryIndex);
+            auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(selection.EntryIndex);
 
             gMapSelectFlags.set(MapSelectFlag::enableConstruct);
 
@@ -2284,7 +2284,7 @@ namespace OpenRCT2::Ui::Windows
                     auto banner = info.Element->AsBanner()->GetBanner();
                     if (banner != nullptr)
                     {
-                        auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+                        auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
                         if (bannerEntry->flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR)
                         {
                             auto repaintScenery = GameActions::BannerSetColourAction(
@@ -2313,7 +2313,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     SmallSceneryElement* sceneryElement = info.Element->AsSmallScenery();
                     auto entryIndex = sceneryElement->GetEntryIndex();
-                    auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(entryIndex);
+                    auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(entryIndex);
                     if (sceneryEntry != nullptr)
                     {
                         WindowScenerySetSelectedItem(
@@ -2326,7 +2326,7 @@ namespace OpenRCT2::Ui::Windows
                 case ViewportInteractionItem::wall:
                 {
                     auto entryIndex = info.Element->AsWall()->GetEntryIndex();
-                    auto* sceneryEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(entryIndex);
+                    auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(entryIndex);
                     if (sceneryEntry != nullptr)
                     {
                         WindowScenerySetSelectedItem(
@@ -2339,7 +2339,7 @@ namespace OpenRCT2::Ui::Windows
                 case ViewportInteractionItem::largeScenery:
                 {
                     auto entryIndex = info.Element->AsLargeScenery()->GetEntryIndex();
-                    auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(entryIndex);
+                    auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(entryIndex);
                     if (sceneryEntry != nullptr)
                     {
                         WindowScenerySetSelectedItem(
@@ -2355,7 +2355,7 @@ namespace OpenRCT2::Ui::Windows
                     auto banner = info.Element->AsBanner()->GetBanner();
                     if (banner != nullptr)
                     {
-                        auto sceneryEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+                        auto sceneryEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
                         if (sceneryEntry != nullptr)
                         {
                             WindowScenerySetSelectedItem(
@@ -2367,7 +2367,7 @@ namespace OpenRCT2::Ui::Windows
                 case ViewportInteractionItem::pathAddition:
                 {
                     auto entryIndex = info.Element->AsPath()->GetAdditionEntryIndex();
-                    auto* pathAdditionEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(entryIndex);
+                    auto* pathAdditionEntry = ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(entryIndex);
                     if (pathAdditionEntry != nullptr)
                     {
                         WindowScenerySetSelectedItem(
@@ -2463,7 +2463,7 @@ namespace OpenRCT2::Ui::Windows
                 std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);
             bool can_raise_item = false;
 
-            const auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(sceneryIndex);
+            const auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(sceneryIndex);
             if (sceneryEntry == nullptr)
             {
                 gridPos.SetNull();
@@ -2676,7 +2676,7 @@ namespace OpenRCT2::Ui::Windows
             uint16_t maxPossibleHeight = ZoomLevel::max().ApplyTo(
                 std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);
 
-            auto* wallEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(sceneryIndex);
+            auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(sceneryIndex);
             if (wallEntry != nullptr)
             {
                 maxPossibleHeight -= wallEntry->height;
@@ -2760,7 +2760,7 @@ namespace OpenRCT2::Ui::Windows
             uint16_t maxPossibleHeight = ZoomLevel::max().ApplyTo(
                 std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);
 
-            auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(sceneryIndex);
+            auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(sceneryIndex);
             if (sceneryEntry)
             {
                 int16_t maxClearZ = 0;
@@ -2923,7 +2923,7 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t q = 0; q < quantity; q++)
             {
                 int32_t zCoordinate = gSceneryPlaceZ;
-                auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(selectedScenery);
+                auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(selectedScenery);
 
                 int16_t cur_grid_x = gridPos.x;
                 int16_t cur_grid_y = gridPos.y;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -252,7 +252,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (_isSmall)
             {
-                auto* wallEntry = OpenRCT2::ObjectManager::GetObjectEntry<WallSceneryEntry>(_sceneryEntry);
+                auto* wallEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(_sceneryEntry);
 
                 main_colour_btn->type = WidgetType::empty;
                 text_colour_btn->type = WidgetType::empty;
@@ -271,7 +271,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryEntry);
+                auto* sceneryEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(_sceneryEntry);
 
                 main_colour_btn->type = WidgetType::empty;
                 text_colour_btn->type = WidgetType::empty;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1517,7 +1517,8 @@ static uint64_t PageDisabledWidgets[] = {
                             { colours[1] });
 
                         // Banner info
-                        auto* largeSceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(largeSceneryType);
+                        auto* largeSceneryEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(
+                            largeSceneryType);
                         if (largeSceneryEntry != nullptr && largeSceneryEntry->scrolling_mode != kScrollingModeNone)
                         {
                             auto banner = sceneryElement->GetBanner();

--- a/src/openrct2/actions/footpath/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathAdditionPlaceAction.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::GameActions
             return res;
         }
 
-        auto* pathAdditionEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(_entryIndex);
+        auto* pathAdditionEntry = ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(_entryIndex);
         if (pathAdditionEntry == nullptr)
         {
             LOG_ERROR("Unknown footpath addition entry for entryIndex %d", _entryIndex);
@@ -162,7 +162,7 @@ namespace OpenRCT2::GameActions
             return res;
         }
 
-        auto* pathAdditionEntry = ObjectManager::GetObjectEntry<PathAdditionEntry>(_entryIndex);
+        auto* pathAdditionEntry = ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(_entryIndex);
         if (pathAdditionEntry == nullptr)
         {
             LOG_ERROR("Unknown footpath addition entry for entryIndex %d", _entryIndex);

--- a/src/openrct2/actions/scenery/BannerPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/BannerPlaceAction.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_POSITION_THIS_HERE, STR_TOO_MANY_BANNERS_IN_GAME);
         }
 
-        auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(_bannerType);
+        auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(_bannerType);
         if (bannerEntry == nullptr)
         {
             LOG_ERROR("Banner entry not found for bannerType %u", _bannerType);
@@ -124,7 +124,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::noFreeElements, STR_CANT_POSITION_THIS_HERE, STR_TILE_ELEMENT_LIMIT_REACHED);
         }
 
-        auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(_bannerType);
+        auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(_bannerType);
         if (bannerEntry == nullptr)
         {
             LOG_ERROR("Banner entry not found for bannerType %u", _bannerType);

--- a/src/openrct2/actions/scenery/BannerRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/BannerRemoveAction.cpp
@@ -84,7 +84,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
 
-        auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+        auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
         if (bannerEntry != nullptr)
         {
             res.cost = -((bannerEntry->price * 3) / 4);
@@ -124,7 +124,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_REMOVE_THIS, kStringIdNone);
         }
 
-        auto* bannerEntry = ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+        auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
         if (bannerEntry != nullptr)
         {
             res.cost = -((bannerEntry->price * 3) / 4);

--- a/src/openrct2/actions/scenery/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/LargeSceneryPlaceAction.cpp
@@ -100,7 +100,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
-        auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
+        auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
         if (sceneryEntry == nullptr)
         {
             LOG_ERROR("Large scenery entry not found for sceneryType %u", _sceneryType);
@@ -208,7 +208,7 @@ namespace OpenRCT2::GameActions
 
         money64 supportsCost = 0;
 
-        auto* sceneryEntry = ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
+        auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
         if (sceneryEntry == nullptr)
         {
             LOG_ERROR("Large scenery entry not found for sceneryType = %u", _sceneryType);

--- a/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
@@ -122,7 +122,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_POSITION_THIS_HERE, STR_ERR_VALUE_OUT_OF_RANGE);
         }
 
-        auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
+        auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
         if (sceneryEntry == nullptr)
         {
             LOG_ERROR("Small scenery object entry not found for sceneryType %u", _sceneryType);
@@ -313,7 +313,7 @@ namespace OpenRCT2::GameActions
             res.position.z = surfaceHeight;
         }
 
-        auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
+        auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
         if (sceneryEntry == nullptr)
         {
             LOG_ERROR("Small scenery object entry not found for sceneryType %u", _sceneryType);

--- a/src/openrct2/actions/scenery/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryRemoveAction.cpp
@@ -63,7 +63,7 @@ namespace OpenRCT2::GameActions
             return Result(Status::invalidParameters, STR_CANT_REMOVE_THIS, STR_OFF_EDGE_OF_MAP);
         }
 
-        auto* entry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
+        auto* entry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
         if (entry == nullptr)
         {
             return Result(Status::invalidParameters, STR_CANT_REMOVE_THIS, STR_INVALID_SELECTION_OF_OBJECTS);
@@ -110,7 +110,7 @@ namespace OpenRCT2::GameActions
     {
         Result res = Result();
 
-        auto* entry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
+        auto* entry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
         if (entry == nullptr)
         {
             LOG_ERROR("Invalid small scenery type %u", _sceneryType);

--- a/src/openrct2/actions/scenery/WallPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/WallPlaceAction.cpp
@@ -227,7 +227,7 @@ namespace OpenRCT2::GameActions
             }
         }
 
-        auto* wallEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(_wallType);
+        auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(_wallType);
 
         if (wallEntry == nullptr)
         {
@@ -314,7 +314,7 @@ namespace OpenRCT2::GameActions
         }
         auto targetLoc = CoordsXYZ(_loc, targetHeight);
 
-        auto* wallEntry = ObjectManager::GetObjectEntry<WallSceneryEntry>(_wallType);
+        auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(_wallType);
 
         if (wallEntry == nullptr)
         {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -553,7 +553,7 @@ void LoadPalette()
 
     uint32_t palette = SPR_GAME_DEFAULT_PALETTE;
 
-    auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
+    auto water_type = OpenRCT2::ObjectEntryManager::GetObjectEntry<WaterObjectEntry>(0);
     if (water_type != nullptr)
     {
         Guard::Assert(water_type->mainPalette != kImageIndexUndefined, "Failed to load water palette");
@@ -748,7 +748,7 @@ void UpdatePalette(std::span<const BGRAColour> palette, PaletteIndex startIndex,
  */
 void UpdatePaletteEffects()
 {
-    auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
+    auto water_type = OpenRCT2::ObjectEntryManager::GetObjectEntry<WaterObjectEntry>(0);
 
     if (gClimateLightningFlash == 1)
     {

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -283,7 +283,8 @@ void ResearchFinishItem(const ResearchItem& researchItem)
     else
     {
         // Scenery
-        const auto* sceneryGroupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(researchItem.entryIndex);
+        const auto* sceneryGroupEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(
+            researchItem.entryIndex);
         if (sceneryGroupEntry != nullptr)
         {
             SceneryGroupSetInvented(researchItem.entryIndex);
@@ -489,7 +490,7 @@ void ResearchPopulateListRandom()
     // Scenery
     for (uint32_t i = 0; i < kMaxSceneryGroupObjects; i++)
     {
-        const auto* sceneryGroupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
+        const auto* sceneryGroupEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (sceneryGroupEntry == nullptr)
         {
             continue;
@@ -629,7 +630,7 @@ void ScenerySetNotInvented(const ScenerySelection& sceneryItem)
 bool SceneryGroupIsInvented(int32_t sgIndex)
 {
     auto& gameState = getGameState();
-    const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(sgIndex);
+    const auto sgEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(sgIndex);
     if (sgEntry == nullptr || sgEntry->SceneryEntries.empty())
     {
         return false;
@@ -655,7 +656,7 @@ bool SceneryGroupIsInvented(int32_t sgIndex)
 
 void SceneryGroupSetInvented(int32_t sgIndex)
 {
-    const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(sgIndex);
+    const auto sgEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(sgIndex);
     if (sgEntry != nullptr)
     {
         for (const auto& entry : sgEntry->SceneryEntries)
@@ -669,7 +670,7 @@ void SetAllSceneryGroupsNotInvented()
 {
     for (int32_t i = 0; i < kMaxSceneryGroupObjects; ++i)
     {
-        const auto* scenery_set = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
+        const auto* scenery_set = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (scenery_set == nullptr)
         {
             continue;
@@ -735,7 +736,7 @@ StringId ResearchItem::GetName() const
         return rideEntry->naming.Name;
     }
 
-    const auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(entryIndex);
+    const auto* sceneryEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(entryIndex);
     if (sceneryEntry == nullptr)
     {
         return kStringIdEmpty;
@@ -772,7 +773,7 @@ static void ResearchRemoveNullItems(std::vector<ResearchItem>& items)
         }
         else
         {
-            return OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(researchItem.entryIndex) == nullptr;
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(researchItem.entryIndex) == nullptr;
         }
     });
     items.erase(it, std::end(items));
@@ -797,7 +798,7 @@ static void ResearchMarkItemAsResearched(const ResearchItem& item)
     }
     else if (item.type == Research::EntryType::scenery)
     {
-        const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(item.entryIndex);
+        const auto sgEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(item.entryIndex);
         if (sgEntry != nullptr)
         {
             for (const auto& sceneryEntry : sgEntry->SceneryEntries)
@@ -893,7 +894,7 @@ static void ResearchAddAllMissingItems(bool isResearched)
 
     for (ObjectEntryIndex i = 0; i < kMaxSceneryGroupObjects; i++)
     {
-        const auto* groupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
+        const auto* groupEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (groupEntry != nullptr)
         {
             ResearchInsertSceneryGroupEntry(i, isResearched);

--- a/src/openrct2/object/ObjectEntryManager.cpp
+++ b/src/openrct2/object/ObjectEntryManager.cpp
@@ -13,7 +13,7 @@
 #include "Object.h"
 #include "ObjectManager.h"
 
-namespace OpenRCT2::ObjectManager
+namespace OpenRCT2::ObjectEntryManager
 {
     const void* GetObjectEntry(ObjectType type, ObjectEntryIndex idx)
     {
@@ -24,4 +24,4 @@ namespace OpenRCT2::ObjectManager
         }
         return object->GetLegacyData();
     }
-} // namespace OpenRCT2::ObjectManager
+} // namespace OpenRCT2::ObjectEntryManager

--- a/src/openrct2/object/ObjectEntryManager.h
+++ b/src/openrct2/object/ObjectEntryManager.h
@@ -11,7 +11,7 @@
 
 #include "ObjectTypes.h"
 
-namespace OpenRCT2::ObjectManager
+namespace OpenRCT2::ObjectEntryManager
 {
     const void* GetObjectEntry(ObjectType type, ObjectEntryIndex idx);
 
@@ -20,4 +20,4 @@ namespace OpenRCT2::ObjectManager
     {
         return reinterpret_cast<const T*>(GetObjectEntry(T::kObjectType, idx));
     }
-} // namespace OpenRCT2::ObjectManager
+} // namespace OpenRCT2::ObjectEntryManager

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -76,7 +76,7 @@ void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const
         return;
     }
 
-    auto* bannerEntry = OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+    auto* bannerEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
     if (bannerEntry == nullptr)
     {
         return;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -971,7 +971,7 @@ static GameActions::Result TrackDesignPlaceSceneryElementRemoveGhost(
             uint8_t quadrant = scenery.getQuadrant() + _currentTrackPieceDirection;
             quadrant &= 3;
 
-            auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(entryInfo->Index);
+            auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(entryInfo->Index);
             if (!(!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_FULL_TILE) && sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_DIAGONAL))
                 && sceneryEntry->HasFlag(
                     SMALL_SCENERY_FLAG_DIAGONAL | SMALL_SCENERY_FLAG_HALF_SPACE | SMALL_SCENERY_FLAG_THREE_QUARTERS))

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -322,7 +322,7 @@ static void ScenarioWeekUpdate()
     RideCheckAllReachable();
     RideUpdateFavouritedStat();
 
-    auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
+    auto water_type = OpenRCT2::ObjectEntryManager::GetObjectEntry<WaterObjectEntry>(0);
 
     if (month <= MONTH_APRIL && water_type != nullptr && water_type->flags & WATER_FLAGS_ALLOW_DUCKS)
     {

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -350,15 +350,15 @@ static bool IsSceneryEntryValid(const ScenerySelection& item)
     switch (item.SceneryType)
     {
         case SCENERY_TYPE_SMALL:
-            return OpenRCT2::ObjectManager::GetObjectEntry<SmallSceneryEntry>(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_PATH_ITEM:
-            return OpenRCT2::ObjectManager::GetObjectEntry<PathAdditionEntry>(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_WALL:
-            return OpenRCT2::ObjectManager::GetObjectEntry<WallSceneryEntry>(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_LARGE:
-            return OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_BANNER:
-            return OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(item.EntryIndex) != nullptr;
         default:
             return false;
     }
@@ -432,7 +432,7 @@ static MiscScenery GetAllMiscScenery()
     std::vector<ObjectEntryIndex> sceneryGroupIds;
     for (ObjectEntryIndex i = 0; i < kMaxSceneryGroupObjects; i++)
     {
-        const auto* sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
+        const auto* sgEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (sgEntry != nullptr)
         {
             referencedBySceneryGroups.insert(
@@ -451,35 +451,35 @@ static MiscScenery GetAllMiscScenery()
             {
                 case ObjectType::smallScenery:
                 {
-                    const auto* objectEntry = OpenRCT2::ObjectManager::GetObjectEntry<SmallSceneryEntry>(i);
+                    const auto* objectEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(i);
                     if (objectEntry != nullptr)
                         linkedSceneryGroup = objectEntry->scenery_tab_id;
                     break;
                 }
                 case ObjectType::largeScenery:
                 {
-                    const auto* objectEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(i);
+                    const auto* objectEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(i);
                     if (objectEntry != nullptr)
                         linkedSceneryGroup = objectEntry->scenery_tab_id;
                     break;
                 }
                 case ObjectType::walls:
                 {
-                    const auto* objectEntry = OpenRCT2::ObjectManager::GetObjectEntry<WallSceneryEntry>(i);
+                    const auto* objectEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(i);
                     if (objectEntry != nullptr)
                         linkedSceneryGroup = objectEntry->scenery_tab_id;
                     break;
                 }
                 case ObjectType::banners:
                 {
-                    const auto* objectEntry = OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(i);
+                    const auto* objectEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(i);
                     if (objectEntry != nullptr)
                         linkedSceneryGroup = objectEntry->scenery_tab_id;
                     break;
                 }
                 case ObjectType::pathAdditions:
                 {
-                    const auto* objectEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathAdditionEntry>(i);
+                    const auto* objectEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(i);
                     if (objectEntry != nullptr)
                         linkedSceneryGroup = objectEntry->scenery_tab_id;
                     break;

--- a/src/openrct2/world/map_generator/TreePlacement.cpp
+++ b/src/openrct2/world/map_generator/TreePlacement.cpp
@@ -64,7 +64,7 @@ namespace OpenRCT2::World::MapGenerator
 
     static void placeTree(ObjectEntryIndex type, const CoordsXY& loc)
     {
-        auto* sceneryEntry = ObjectManager::GetObjectEntry<SmallSceneryEntry>(type);
+        auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(type);
         if (sceneryEntry == nullptr)
         {
             return;
@@ -124,7 +124,7 @@ namespace OpenRCT2::World::MapGenerator
 
         for (auto i = 0u; i < getObjectEntryGroupCount(ObjectType::smallScenery); i++)
         {
-            auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<SmallSceneryEntry>(i);
+            auto* sceneryEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(i);
             auto entry = ObjectEntryGetObject(ObjectType::smallScenery, i);
 
             if (sceneryEntry == nullptr)

--- a/src/openrct2/world/tile_element/BannerElement.cpp
+++ b/src/openrct2/world/tile_element/BannerElement.cpp
@@ -17,7 +17,7 @@ namespace OpenRCT2
         auto banner = GetBanner();
         if (banner != nullptr)
         {
-            return OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
+            return OpenRCT2::ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
         }
         return nullptr;
     }

--- a/src/openrct2/world/tile_element/LargeSceneryElement.cpp
+++ b/src/openrct2/world/tile_element/LargeSceneryElement.cpp
@@ -91,7 +91,7 @@ namespace OpenRCT2
 
     const LargeSceneryEntry* LargeSceneryElement::GetEntry() const
     {
-        return OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(GetEntryIndex());
+        return OpenRCT2::ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(GetEntryIndex());
     }
 
     uint8_t LargeSceneryElement::GetSequenceIndex() const

--- a/src/openrct2/world/tile_element/PathElement.cpp
+++ b/src/openrct2/world/tile_element/PathElement.cpp
@@ -155,7 +155,7 @@ namespace OpenRCT2
     {
         if (!HasAddition())
             return nullptr;
-        return ObjectManager::GetObjectEntry<PathAdditionEntry>(GetAdditionEntryIndex());
+        return ObjectEntryManager::GetObjectEntry<PathAdditionEntry>(GetAdditionEntryIndex());
     }
 
     void PathElement::SetAddition(uint8_t newAddition)

--- a/src/openrct2/world/tile_element/SmallSceneryElement.cpp
+++ b/src/openrct2/world/tile_element/SmallSceneryElement.cpp
@@ -127,6 +127,6 @@ namespace OpenRCT2
 
     const SmallSceneryEntry* SmallSceneryElement::GetEntry() const
     {
-        return ObjectManager::GetObjectEntry<SmallSceneryEntry>(entryIndex);
+        return ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(entryIndex);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/world/tile_element/WallElement.cpp
+++ b/src/openrct2/world/tile_element/WallElement.cpp
@@ -87,7 +87,7 @@ namespace OpenRCT2
 
     const WallSceneryEntry* WallElement::GetEntry() const
     {
-        return ObjectManager::GetObjectEntry<WallSceneryEntry>(entryIndex);
+        return ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(entryIndex);
     }
 
     void WallElement::SetEntryIndex(uint16_t newIndex)


### PR DESCRIPTION
Part of work for unity builds, see https://github.com/OpenRCT2/OpenRCT2/pull/26144

I've decided to submit this as a separate PR to make it easier to review, I do expect some critique here.

`OpenRCT2::ObjectManager` is both a class:
https://github.com/OpenRCT2/OpenRCT2/blob/e219349c97f91746230cc84d372b7ce1ea4e3d0a/src/openrct2/object/ObjectManager.cpp#L44-L58

and a namespace:

https://github.com/OpenRCT2/OpenRCT2/blob/e219349c97f91746230cc84d372b7ce1ea4e3d0a/src/openrct2/object/ObjectEntryManager.h#L14

I've decided to rename the latter.