### PR TITLE
Fix mapgen window size in enlarged UI mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Fix: [#26118] Windows installers for releases are not signed properly.
 - Fix: [#26128] The loan spinner widget does not appear on the same baseline as the text around it.
 - Fix: [#26140] The time a guest has spent in a queue overflows back to 0 after it reaches 65535 (about a year).
+- Fix: [#26159] The map generator window is not resized correctly in Enlarged UI mode.
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -292,6 +292,7 @@ namespace OpenRCT2::Ui::Windows
 
             initScrollWidgets();
             invalidate();
+            onResize();
         }
 
         void SetPressedTab()


### PR DESCRIPTION
The mapgen window was not getting the right window size in enlarged UI mode. This PR addresses this issue.