### PR TITLE
Simplify check for dry weather

### DIFF
--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -183,8 +183,7 @@ void SmallSceneryElement::UpdateAge(const CoordsXY& sceneryPos)
         return;
     }
 
-    if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_CAN_BE_WATERED) || Weather::isDry(gameState.weatherCurrent.weatherType)
-        || GetAge() < 5)
+    if (!sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_CAN_BE_WATERED) || Weather::isDry() || GetAge() < 5)
     {
         IncreaseAge(sceneryPos);
         return;

--- a/src/openrct2/world/Weather.cpp
+++ b/src/openrct2/world/Weather.cpp
@@ -267,6 +267,12 @@ namespace OpenRCT2::Weather
         updateThunderSound();
     }
 
+    bool isDry()
+    {
+        auto& weather = getGameState().weatherCurrent.weatherType;
+        return weather == Type::Sunny || weather == Type::PartiallyCloudy || weather == Type::Cloudy;
+    }
+
     bool isRaining()
     {
         auto& weather = getGameState().weatherCurrent.weatherType;
@@ -294,11 +300,6 @@ namespace OpenRCT2::Weather
     bool isPrecipitating()
     {
         return isRaining() || isSnowingHeavily();
-    }
-
-    bool isDry(Type weather)
-    {
-        return weather == Type::Sunny || weather == Type::PartiallyCloudy || weather == Type::Cloudy;
     }
 
     bool hasWeatherEffect()

--- a/src/openrct2/world/Weather.h
+++ b/src/openrct2/world/Weather.h
@@ -92,12 +92,12 @@ namespace OpenRCT2::Weather
     void stopWeatherSound();
     void forceWeather(Type weather);
 
+    bool isDry();
     bool isRaining();
     bool isTransitioningToSnow();
     bool isSnowing();
     bool isSnowingHeavily();
     bool isPrecipitating();
-    bool isDry(Type);
     bool hasWeatherEffect();
     Drawing::FilterPaletteID getWeatherGloomPaletteId(const State& state);
     uint32_t getWeatherSpriteId(Type weatherType);


### PR DESCRIPTION
I saw this while I was working on something. Hopefully in the future a `OpenRCT2::Climate` namespace gets added to the Climate header so we can get rid of the `Climate` prefix for the function names