### PR TITLE
Use -> syntactic sugar where appropriate

### DIFF
--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -244,8 +244,8 @@ namespace OpenRCT2::Ui
 
             for (auto it = outFiltersStorage.begin(); it != outFiltersStorage.end();)
             {
-                const wchar_t* Name = (*it++).c_str();
-                const wchar_t* Pattern = (*it++).c_str();
+                const wchar_t* Name = (it++)->c_str();
+                const wchar_t* Pattern = (it++)->c_str();
                 result.push_back({ Name, Pattern });
             }
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -124,7 +124,7 @@ BasicTextureInfo TextureCache::GetOrLoadGlyphTexture(const ImageId imageId, cons
     auto cacheInfo = LoadGlyphTexture(imageId, paletteMap);
     auto it = _glyphTextureMap.insert(std::make_pair(glyphId, cacheInfo));
 
-    return (it.first)->second;
+    return it.first->second;
 }
 
 BasicTextureInfo TextureCache::GetOrLoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height)

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -124,7 +124,7 @@ BasicTextureInfo TextureCache::GetOrLoadGlyphTexture(const ImageId imageId, cons
     auto cacheInfo = LoadGlyphTexture(imageId, paletteMap);
     auto it = _glyphTextureMap.insert(std::make_pair(glyphId, cacheInfo));
 
-    return (*it.first).second;
+    return (it.first)->second;
 }
 
 BasicTextureInfo TextureCache::GetOrLoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height)

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1212,7 +1212,7 @@ void Staff::UpdateSweeping()
     }
     if (auto loc = UpdateAction(); loc.has_value())
     {
-        int16_t actionZ = GetZOnSlope((*loc).x, (*loc).y);
+        int16_t actionZ = GetZOnSlope(loc->x, loc->y);
         MoveTo({ loc.value(), actionZ });
         return;
     }

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -376,7 +376,7 @@ static constexpr float kWindowScrollLocations[][2] = {
                     if ((*it)->flags.has(WindowFlag::dead))
                         continue;
 
-                    auto w2 = (*it).get();
+                    auto w2 = it->get();
                     auto x1 = w2->windowPos.x - 10;
                     auto y1 = w2->windowPos.y - 10;
                     if (x2 >= x1 && x2 <= w2->width + x1 + 20)
@@ -560,7 +560,7 @@ static constexpr float kWindowScrollLocations[][2] = {
         // Draw the window and any other overlapping transparent windows
         for (auto it = WindowGetIterator(&w); it != gWindowList.end(); it++)
         {
-            auto* v = (*it).get();
+            auto* v = it->get();
             if (v->flags.has(WindowFlag::dead))
                 continue;
             if ((&w == v || v->flags.has(WindowFlag::transparent)) && v->isVisible)

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -306,7 +306,7 @@ namespace OpenRCT2::Network
                             auto entry = ServerListEntry::FromJson(jinfo);
                             if (entry.has_value())
                             {
-                                (*entry).Local = true;
+                                entry->Local = true;
                                 entries.push_back(std::move(*entry));
                             }
                         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3064,7 +3064,7 @@ static void RideSetMazeEntranceExitPoints(Ride& ride)
     position->SetNull();
 
     // Enumerate entrance and exit positions
-    for (position = positions; !(position->IsNull()); position++)
+    for (position = positions; !position->IsNull(); position++)
     {
         auto entranceExitMapPos = position->ToCoordsXYZ();
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3061,10 +3061,10 @@ static void RideSetMazeEntranceExitPoints(Ride& ride)
             *position++ = station.Exit;
         }
     }
-    (*position++).SetNull();
+    position->SetNull();
 
     // Enumerate entrance and exit positions
-    for (position = positions; !(*position).IsNull(); position++)
+    for (position = positions; !(position->IsNull()); position++)
     {
         auto entranceExitMapPos = position->ToCoordsXYZ();
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -203,7 +203,7 @@ void Vehicle::UpdateTrackChange()
         return;
 
     _vehicleCurPosition = TrackLocation
-        + CoordsXYZ{ moveInfo->x, moveInfo->y, moveInfo->z + GetRideTypeDescriptor((*curRide).type).Heights.VehicleZOffset };
+        + CoordsXYZ{ moveInfo->x, moveInfo->y, moveInfo->z + GetRideTypeDescriptor(curRide->type).Heights.VehicleZOffset };
     Orientation = moveInfo->yaw;
     roll = moveInfo->roll;
     pitch = moveInfo->pitch;


### PR DESCRIPTION
This makes use of the `->` notation in some places where the more explicit `*` dereference notation was being used