### PR TITLE
Refactor: Rename internal track design window methods to camelCase

### DIFF
--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -126,7 +126,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onClose() override
         {
-            ClearProvisional();
+            clearProvisional();
             ViewportSetVisibility(ViewportVisibility::standard);
             gMapSelectFlags.unset(MapSelectFlag::enableConstruct);
             gMapSelectFlags.unset(MapSelectFlag::enableArrow);
@@ -144,7 +144,7 @@ namespace OpenRCT2::Ui::Windows
                     close();
                     break;
                 case WIDX_ROTATE:
-                    ClearProvisional();
+                    clearProvisional();
                     _currentTrackPieceDirection = (_currentTrackPieceDirection + 1) & 3;
                     invalidate();
                     _placementLoc.SetNull();
@@ -196,16 +196,16 @@ namespace OpenRCT2::Ui::Windows
             CoordsXY mapCoords = ViewportInteractionGetTileStartAtCursor(targetScreenCoords);
             if (mapCoords.IsNull())
             {
-                ClearProvisional();
+                clearProvisional();
                 return;
             }
 
             // Get base Z position
             // NB: always use the actual screenCoords here, not the shifted ones
-            auto maybeMapZ = GetBaseZ(mapCoords, screenCoords);
+            auto maybeMapZ = getBaseZ(mapCoords, screenCoords);
             if (!maybeMapZ.has_value())
             {
-                ClearProvisional();
+                clearProvisional();
                 return;
             }
 
@@ -223,9 +223,9 @@ namespace OpenRCT2::Ui::Windows
             money64 cost = kMoney64Undefined;
             if (GameIsNotPaused() || getGameState().cheats.buildInPauseMode)
             {
-                ClearProvisional();
+                clearProvisional();
                 CoordsXYZD ghostTrackLoc = trackLoc;
-                auto res = FindValidTrackDesignPlaceHeight(ghostTrackLoc, { CommandFlag::noSpend, CommandFlag::ghost });
+                auto res = findValidTrackDesignPlaceHeight(ghostTrackLoc, { CommandFlag::noSpend, CommandFlag::ghost });
 
                 if (res.error == GameActions::Status::ok)
                 {
@@ -262,7 +262,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            ClearProvisional();
+            clearProvisional();
             gMapSelectFlags.unset(MapSelectFlag::enable);
             gMapSelectFlags.unset(MapSelectFlag::enableConstruct);
             gMapSelectFlags.unset(MapSelectFlag::enableArrow);
@@ -276,21 +276,21 @@ namespace OpenRCT2::Ui::Windows
             CoordsXY mapCoords = ViewportInteractionGetTileStartAtCursor(targetScreenCoords);
             if (mapCoords.IsNull())
             {
-                ClearProvisional();
+                clearProvisional();
                 return;
             }
 
             // NB: always use the actual screenCoords here, not the shifted ones
-            auto maybeMapZ = GetBaseZ(mapCoords, screenCoords);
+            auto maybeMapZ = getBaseZ(mapCoords, screenCoords);
             if (!maybeMapZ.has_value())
             {
-                ClearProvisional();
+                clearProvisional();
                 return;
             }
 
             // Try increasing Z until a feasible placement is found
             CoordsXYZ trackLoc = { mapCoords, maybeMapZ.value() };
-            auto res = FindValidTrackDesignPlaceHeight(trackLoc, {});
+            auto res = findValidTrackDesignPlaceHeight(trackLoc, {});
             if (res.error != GameActions::Status::ok)
             {
                 // Unable to build track
@@ -346,7 +346,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolAbort(WidgetIndex widgetIndex) override
         {
-            ClearProvisional();
+            clearProvisional();
         }
 
         void onViewportRotate() override
@@ -446,11 +446,11 @@ namespace OpenRCT2::Ui::Windows
                 const auto& rtd = GetRideTypeDescriptor(td.trackAndVehicle.rtdIndex);
                 if (rtd.specialType == RtdSpecialType::maze)
                 {
-                    DrawMiniPreviewMaze(td, pass, origin, min, max);
+                    drawMiniPreviewMaze(td, pass, origin, min, max);
                 }
                 else
                 {
-                    DrawMiniPreviewTrack(td, pass, origin, min, max);
+                    drawMiniPreviewTrack(td, pass, origin, min, max);
                 }
             }
         }
@@ -462,7 +462,7 @@ namespace OpenRCT2::Ui::Windows
         }
 
     private:
-        void ClearProvisional()
+        void clearProvisional()
         {
             if (_hasPlacementGhost)
             {
@@ -477,7 +477,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        std::optional<int32_t> GetBaseZ([[maybe_unused]] const CoordsXY& loc, const ScreenCoordsXY& screenCoords)
+        std::optional<int32_t> getBaseZ([[maybe_unused]] const CoordsXY& loc, const ScreenCoordsXY& screenCoords)
         {
             CoordsXY mapCoords = ViewportInteractionGetTileStartAtCursor(screenCoords);
             auto surfaceElement = MapGetSurfaceElementAt(mapCoords);
@@ -596,7 +596,7 @@ namespace OpenRCT2::Ui::Windows
                        *_trackDesign, RideGetTemporaryForPreview(), { mapCoords, _trackPlaceZ, _currentTrackPieceDirection });
         }
 
-        void DrawMiniPreviewEntrances(
+        void drawMiniPreviewEntrances(
             const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max, Direction rotation)
         {
             for (const auto& entrance : td.entranceElements)
@@ -612,10 +612,10 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    auto pixelPosition = DrawMiniPreviewGetPixelPosition(rotatedAndOffsetEntrance);
-                    if (DrawMiniPreviewIsPixelInBounds(pixelPosition))
+                    auto pixelPosition = drawMiniPreviewGetPixelPosition(rotatedAndOffsetEntrance);
+                    if (drawMiniPreviewIsPixelInBounds(pixelPosition))
                     {
-                        PaletteIndex* pixel = DrawMiniPreviewGetPixelPtr(pixelPosition);
+                        PaletteIndex* pixel = drawMiniPreviewGetPixelPtr(pixelPosition);
                         auto colour = entrance.isExit ? kPaletteIndexColourExit : kPaletteIndexColourEntrance;
                         for (int32_t i = 0; i < 4; i++)
                         {
@@ -629,7 +629,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawMiniPreviewTrack(const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
+        void drawMiniPreviewTrack(const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
         {
             const uint8_t rotation = (_currentTrackPieceDirection + GetCurrentRotation()) & 3;
 
@@ -654,10 +654,10 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        auto pixelPosition = DrawMiniPreviewGetPixelPosition(rotatedAndOffsetTrackBlock);
-                        if (DrawMiniPreviewIsPixelInBounds(pixelPosition))
+                        auto pixelPosition = drawMiniPreviewGetPixelPosition(rotatedAndOffsetTrackBlock);
+                        if (drawMiniPreviewIsPixelInBounds(pixelPosition))
                         {
-                            PaletteIndex* pixel = DrawMiniPreviewGetPixelPtr(pixelPosition);
+                            PaletteIndex* pixel = drawMiniPreviewGetPixelPtr(pixelPosition);
 
                             auto bits = trackBlock.quarterTile.Rotate(curTrackRotation & 3).GetBaseQuarterOccupied();
 
@@ -698,10 +698,10 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            DrawMiniPreviewEntrances(td, pass, origin, min, max, rotation);
+            drawMiniPreviewEntrances(td, pass, origin, min, max, rotation);
         }
 
-        void DrawMiniPreviewMaze(const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
+        void drawMiniPreviewMaze(const TrackDesign& td, int32_t pass, const CoordsXY& origin, CoordsXY& min, CoordsXY& max)
         {
             uint8_t rotation = (_currentTrackPieceDirection + GetCurrentRotation()) & 3;
             for (const auto& mazeElement : td.mazeElements)
@@ -717,10 +717,10 @@ namespace OpenRCT2::Ui::Windows
                 }
                 else
                 {
-                    auto pixelPosition = DrawMiniPreviewGetPixelPosition(rotatedMazeCoords);
-                    if (DrawMiniPreviewIsPixelInBounds(pixelPosition))
+                    auto pixelPosition = drawMiniPreviewGetPixelPosition(rotatedMazeCoords);
+                    if (drawMiniPreviewIsPixelInBounds(pixelPosition))
                     {
-                        auto* pixel = DrawMiniPreviewGetPixelPtr(pixelPosition);
+                        auto* pixel = drawMiniPreviewGetPixelPtr(pixelPosition);
 
                         auto colour = kPaletteIndexColourTrack;
                         for (int32_t i = 0; i < 4; i++)
@@ -734,26 +734,26 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            DrawMiniPreviewEntrances(td, pass, origin, min, max, rotation);
+            drawMiniPreviewEntrances(td, pass, origin, min, max, rotation);
         }
 
-        ScreenCoordsXY DrawMiniPreviewGetPixelPosition(const CoordsXY& location)
+        ScreenCoordsXY drawMiniPreviewGetPixelPosition(const CoordsXY& location)
         {
             auto tilePos = TileCoordsXY(location);
             return { (80 + (tilePos.y - tilePos.x) * 4), (38 + (tilePos.y + tilePos.x) * 2) };
         }
 
-        bool DrawMiniPreviewIsPixelInBounds(const ScreenCoordsXY& pixel)
+        bool drawMiniPreviewIsPixelInBounds(const ScreenCoordsXY& pixel)
         {
             return pixel.x >= 0 && pixel.y >= 0 && pixel.x <= 160 && pixel.y <= 75;
         }
 
-        PaletteIndex* DrawMiniPreviewGetPixelPtr(const ScreenCoordsXY& pixel)
+        PaletteIndex* drawMiniPreviewGetPixelPtr(const ScreenCoordsXY& pixel)
         {
             return &_miniPreview[pixel.y * kTrackMiniPreviewSize.width + pixel.x];
         }
 
-        GameActions::Result FindValidTrackDesignPlaceHeight(CoordsXYZ& loc, CommandFlags newFlags)
+        GameActions::Result findValidTrackDesignPlaceHeight(CoordsXYZ& loc, CommandFlags newFlags)
         {
             GameActions::Result res;
             for (int32_t i = 0; i < 7; i++, loc.z += kCoordsZStep)

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -87,7 +87,7 @@ namespace OpenRCT2::Ui::Windows
         bool _selectedItemIsBeingUpdated;
         bool _reloadTrackDesigns;
 
-        void FilterList()
+        void filterList()
         {
             _filteredTrackIds.clear();
 
@@ -120,7 +120,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void SelectFromList(int32_t listIndex)
+        void selectFromList(int32_t listIndex)
         {
             Audio::Play(Audio::SoundId::click1, 0, this->windowPos.x + (this->width / 2));
             if (gLegacyScene != LegacyScene::trackDesignsManager)
@@ -168,7 +168,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        int32_t GetListItemFromPosition(const ScreenCoordsXY& screenCoords)
+        int32_t getListItemFromPosition(const ScreenCoordsXY& screenCoords)
         {
             size_t maxItems = _filteredTrackIds.size();
             if (gLegacyScene != LegacyScene::trackDesignsManager)
@@ -185,7 +185,7 @@ namespace OpenRCT2::Ui::Windows
             return index;
         }
 
-        void LoadDesignsList(RideSelection item)
+        void loadDesignsList(RideSelection item)
         {
             auto repo = GetContext()->GetTrackDesignRepository();
             std::string entryName;
@@ -198,10 +198,10 @@ namespace OpenRCT2::Ui::Windows
             }
             _trackDesigns = repo->GetItemsForObjectEntry(item.Type, entryName);
 
-            FilterList();
+            filterList();
         }
 
-        bool LoadDesignPreview(const u8string& path)
+        bool loadDesignPreview(const u8string& path)
         {
             _loadedTrackDesign = TrackDesignImport(path.c_str());
             if (_loadedTrackDesign != nullptr)
@@ -224,7 +224,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgets(_trackListWidgets);
             widgets[WIDX_FILTER_STRING].string = _filterString;
 
-            LoadDesignsList(_window_track_list_item);
+            loadDesignsList(_window_track_list_item);
 
             WindowInitScrollWidgets(*this);
             _selectedItemIsBeingUpdated = false;
@@ -244,7 +244,7 @@ namespace OpenRCT2::Ui::Windows
             _loadedTrackDesignIndex = kTrackDesignIndexUnloaded;
         }
 
-        void ReopenTrackManager()
+        void reopenTrackManager()
         {
             auto* windowMgr = GetWindowManager();
             windowMgr->CloseByNumber(WindowClass::manageTrackDesign, number);
@@ -267,7 +267,7 @@ namespace OpenRCT2::Ui::Windows
             // try to load the track manager again, and an infinite loop will result.
             if ((gLegacyScene == LegacyScene::trackDesignsManager) && gScreenAge != 0)
             {
-                ReopenTrackManager();
+                reopenTrackManager();
             }
         }
 
@@ -296,7 +296,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     else
                     {
-                        ReopenTrackManager();
+                        reopenTrackManager();
                     }
                     break;
                 case WIDX_FILTER_STRING:
@@ -318,7 +318,7 @@ namespace OpenRCT2::Ui::Windows
                     }
 
                     String::set(_filterString, sizeof(_filterString), "");
-                    FilterList();
+                    filterList();
                     invalidate();
                     break;
             }
@@ -341,10 +341,10 @@ namespace OpenRCT2::Ui::Windows
         {
             if (!_selectedItemIsBeingUpdated)
             {
-                int32_t i = GetListItemFromPosition(screenCoords);
+                int32_t i = getListItemFromPosition(screenCoords);
                 if (i != -1)
                 {
-                    SelectFromList(i);
+                    selectFromList(i);
                 }
             }
         }
@@ -353,7 +353,7 @@ namespace OpenRCT2::Ui::Windows
         {
             if (!_selectedItemIsBeingUpdated)
             {
-                int32_t i = GetListItemFromPosition(screenCoords);
+                int32_t i = getListItemFromPosition(screenCoords);
                 if (i != -1 && selectedListItem != i)
                 {
                     selectedListItem = i;
@@ -372,7 +372,7 @@ namespace OpenRCT2::Ui::Windows
 
             String::set(_filterString, sizeof(_filterString), std::string(text).c_str());
 
-            FilterList();
+            filterList();
 
             scrolls->contentOffsetY = 0;
 
@@ -445,7 +445,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (_reloadTrackDesigns)
             {
-                LoadDesignsList(_window_track_list_item);
+                loadDesignsList(_window_track_list_item);
                 selectedListItem = 0;
                 invalidate();
                 _reloadTrackDesigns = false;
@@ -489,7 +489,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (_loadedTrackDesignIndex != trackIndex)
             {
-                if (LoadDesignPreview(path))
+                if (loadDesignPreview(path))
                 {
                     _loadedTrackDesignIndex = trackIndex;
                 }
@@ -744,12 +744,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void SetIsBeingUpdated(const bool beingUpdated)
+        void setIsBeingUpdated(const bool beingUpdated)
         {
             _selectedItemIsBeingUpdated = beingUpdated;
         }
 
-        void ReloadTrackDesigns()
+        void reloadTrackDesigns()
         {
             _reloadTrackDesigns = true;
         }
@@ -780,7 +780,7 @@ namespace OpenRCT2::Ui::Windows
         auto* trackListWindow = static_cast<TrackListWindow*>(windowMgr->FindByClass(WindowClass::trackDesignList));
         if (trackListWindow != nullptr)
         {
-            trackListWindow->ReloadTrackDesigns();
+            trackListWindow->reloadTrackDesigns();
         }
     }
 
@@ -790,7 +790,7 @@ namespace OpenRCT2::Ui::Windows
         auto* trackListWindow = static_cast<TrackListWindow*>(windowMgr->FindByClass(WindowClass::trackDesignList));
         if (trackListWindow != nullptr)
         {
-            trackListWindow->SetIsBeingUpdated(beingUpdated);
+            trackListWindow->setIsBeingUpdated(beingUpdated);
         }
     }
 } // namespace OpenRCT2::Ui::Windows


### PR DESCRIPTION
Renames private/internal class methods in TrackListWindow and TrackDesignPlaceWindow to follow camelCase naming 