### PR TITLE
Move Map and Footpath units into OpenRCT2 namespace

### DIFF
--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -1002,23 +1002,23 @@ struct DataSerializerTraitsT<Banner>
 };
 
 template<>
-struct DataSerializerTraitsT<FootpathSlope>
+struct DataSerializerTraitsT<OpenRCT2::FootpathSlope>
 {
-    static void encode(OpenRCT2::IStream* stream, const FootpathSlope& slope)
+    static void encode(OpenRCT2::IStream* stream, const OpenRCT2::FootpathSlope& slope)
     {
         uint8_t combined = (EnumValue(slope.type) << 2) | (slope.direction % kNumOrthogonalDirections);
         stream->WriteValue(combined);
     }
 
-    static void decode(OpenRCT2::IStream* stream, FootpathSlope& slope)
+    static void decode(OpenRCT2::IStream* stream, OpenRCT2::FootpathSlope& slope)
     {
         auto combined = stream->ReadValue<uint8_t>();
-        auto type = static_cast<FootpathSlopeType>(combined >> 2);
+        auto type = static_cast<OpenRCT2::FootpathSlopeType>(combined >> 2);
         Direction direction = combined & 0b00000011;
-        slope = FootpathSlope{ type, direction };
+        slope = OpenRCT2::FootpathSlope{ type, direction };
     }
 
-    static void log(OpenRCT2::IStream* stream, const FootpathSlope& slope)
+    static void log(OpenRCT2::IStream* stream, const OpenRCT2::FootpathSlope& slope)
     {
         char msg[128] = {};
         snprintf(msg, sizeof(msg), "FootpathSlope(type = %d, direction = %d)", EnumValue(slope.type), slope.direction);

--- a/src/openrct2/object/FootpathEntry.h
+++ b/src/openrct2/object/FootpathEntry.h
@@ -12,8 +12,6 @@
 #include "../localisation/StringIdType.h"
 #include "ObjectTypes.h"
 
-enum class RailingEntrySupportType : uint8_t;
-
 namespace OpenRCT2
 {
     enum
@@ -22,6 +20,8 @@ namespace OpenRCT2
         FOOTPATH_ENTRY_FLAG_IS_QUEUE = (1 << 3),
         FOOTPATH_ENTRY_FLAG_NO_SLOPE_RAILINGS = (1 << 4),
     };
+
+    enum class RailingEntrySupportType : uint8_t;
 
     struct FootpathEntry
     {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -26,13 +26,15 @@
 #include <thread>
 
 struct EntityBase;
-enum class RailingEntrySupportType : uint8_t;
+
 enum class ViewportInteractionItem : uint8_t;
 
 namespace OpenRCT2
 {
     struct TileElement;
     struct SurfaceElement;
+
+    enum class RailingEntrySupportType : uint8_t;
 } // namespace OpenRCT2
 
 struct AttachedPaintStruct

--- a/src/openrct2/paint/support/MetalSupports.h
+++ b/src/openrct2/paint/support/MetalSupports.h
@@ -86,8 +86,12 @@ enum class MetalSupportPlace : uint8_t
     none = 255,
 };
 
+namespace OpenRCT2
+{
+    struct PathRailingsDescriptor;
+}
+
 struct PaintSession;
-struct PathRailingsDescriptor;
 
 /** @deprecated */
 bool MetalASupportsPaintSetup(
@@ -108,4 +112,4 @@ void DrawSupportsSideBySide(
     int32_t heightExtra = 0);
 bool PathPoleSupportsPaintSetup(
     PaintSession& session, MetalSupportPlace supportPlace, bool isSloped, int32_t height, ImageId imageTemplate,
-    const PathRailingsDescriptor& railings);
+    const OpenRCT2::PathRailingsDescriptor& railings);

--- a/src/openrct2/paint/support/WoodenSupports.h
+++ b/src/openrct2/paint/support/WoodenSupports.h
@@ -65,7 +65,11 @@ enum class WoodenSupportTransitionType : uint8_t
 constexpr int32_t kWoodenSupportTransitionTypeCount = 21;
 
 struct PaintSession;
-struct PathRailingsDescriptor;
+
+namespace OpenRCT2
+{
+    struct PathRailingsDescriptor;
+}
 
 bool WoodenASupportsPaintSetup(
     PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
@@ -81,7 +85,7 @@ bool WoodenBSupportsPaintSetupRotated(
     ImageId imageTemplate, WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::none);
 bool PathBoxSupportsPaintSetup(
     PaintSession& session, WoodenSupportSubType supportType, bool isSloped, Direction slopeRotation, int32_t height,
-    ImageId imageTemplate, const PathRailingsDescriptor& pathPaintInfo);
+    ImageId imageTemplate, const OpenRCT2::PathRailingsDescriptor& pathPaintInfo);
 bool DrawSupportForSequenceA(
     PaintSession& session, WoodenSupportType supportType, OpenRCT2::TrackElemType trackType, uint8_t sequence,
     Direction direction, int32_t height, ImageId imageTemplate);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -48,1871 +48,1894 @@
 #include <bit>
 #include <iterator>
 
-using namespace OpenRCT2;
-using namespace OpenRCT2::TrackMetadata;
-using OpenRCT2::GameActions::CommandFlag;
-using OpenRCT2::GameActions::CommandFlags;
-
-void FootpathUpdateQueueEntranceBanner(const CoordsXY& footpathPos, TileElement* tileElement);
-
-FootpathSelection gFootpathSelection;
-uint8_t gFootpathGroundFlags;
-
-static RideId* _footpathQueueChainNext;
-static RideId _footpathQueueChain[64];
-
-// This is the coordinates that a user of the bin should move to
-// rct2: 0x00992A4C
-const std::array<CoordsXY, kNumOrthogonalDirections> BinUseOffsets = {
-    CoordsXY{ 11, 16 },
-    { 16, 21 },
-    { 21, 16 },
-    { 16, 11 },
-};
-
-// These are the offsets for bench positions on footpaths, 2 for each edge
-// rct2: 0x00981F2C, 0x00981F2E
-const std::array<CoordsXY, 2 * kNumOrthogonalDirections> BenchUseOffsets = {
-    CoordsXY{ 7, 12 }, { 12, 25 }, { 25, 20 }, { 20, 7 }, { 7, 20 }, { 20, 25 }, { 25, 12 }, { 12, 7 },
-};
-
-/** rct2: 0x00981D6C, 0x00981D6E */
-const std::array<CoordsXY, kNumOrthogonalDirections> DirectionOffsets = {
-    CoordsXY{ -1, 0 },
-    { 0, 1 },
-    { 1, 0 },
-    { 0, -1 },
-};
-
-/** rct2: 0x0098D7F0 */
-static constexpr uint8_t connected_path_count[] = {
-    0, // 0b0000
-    1, // 0b0001
-    1, // 0b0010
-    2, // 0b0011
-    1, // 0b0100
-    2, // 0b0101
-    2, // 0b0110
-    3, // 0b0111
-    1, // 0b1000
-    2, // 0b1001
-    2, // 0b1010
-    3, // 0b1011
-    2, // 0b1100
-    3, // 0b1101
-    3, // 0b1110
-    4, // 0b1111
-};
-
-/** rct2: 0x0098D8B4 */
-static constexpr FootpathSlope kDefaultPathSlope[] = {
-    { FootpathSlopeType::flat },      { FootpathSlopeType::irregular }, { FootpathSlopeType::irregular },
-    { FootpathSlopeType::sloped, 2 }, { FootpathSlopeType::irregular }, { FootpathSlopeType::irregular },
-    { FootpathSlopeType::sloped, 3 }, { FootpathSlopeType::raise },     { FootpathSlopeType::irregular },
-    { FootpathSlopeType::sloped, 1 }, { FootpathSlopeType::irregular }, { FootpathSlopeType::raise },
-    { FootpathSlopeType::sloped, 0 }, { FootpathSlopeType::raise },     { FootpathSlopeType::raise },
-    { FootpathSlopeType::irregular },
-};
-
-static bool entrance_has_direction(const EntranceElement& entranceElement, int32_t direction)
+namespace OpenRCT2
 {
-    return entranceElement.GetDirections() & (1 << (direction & 3));
-}
+    using namespace OpenRCT2::TrackMetadata;
+    using OpenRCT2::GameActions::CommandFlag;
+    using OpenRCT2::GameActions::CommandFlags;
 
-PathElement* MapGetFootpathElement(const CoordsXYZ& coords)
-{
-    TileElement* tileElement = MapGetFirstElementAt(coords);
-    do
+    void FootpathUpdateQueueEntranceBanner(const CoordsXY& footpathPos, TileElement* tileElement);
+
+    FootpathSelection gFootpathSelection;
+    uint8_t gFootpathGroundFlags;
+
+    static RideId* _footpathQueueChainNext;
+    static RideId _footpathQueueChain[64];
+
+    // This is the coordinates that a user of the bin should move to
+    // rct2: 0x00992A4C
+    const std::array<CoordsXY, kNumOrthogonalDirections> BinUseOffsets = {
+        CoordsXY{ 11, 16 },
+        { 16, 21 },
+        { 21, 16 },
+        { 16, 11 },
+    };
+
+    // These are the offsets for bench positions on footpaths, 2 for each edge
+    // rct2: 0x00981F2C, 0x00981F2E
+    const std::array<CoordsXY, 2 * kNumOrthogonalDirections> BenchUseOffsets = {
+        CoordsXY{ 7, 12 }, { 12, 25 }, { 25, 20 }, { 20, 7 }, { 7, 20 }, { 20, 25 }, { 25, 12 }, { 12, 7 },
+    };
+
+    /** rct2: 0x00981D6C, 0x00981D6E */
+    const std::array<CoordsXY, kNumOrthogonalDirections> DirectionOffsets = {
+        CoordsXY{ -1, 0 },
+        { 0, 1 },
+        { 1, 0 },
+        { 0, -1 },
+    };
+
+    /** rct2: 0x0098D7F0 */
+    static constexpr uint8_t connected_path_count[] = {
+        0, // 0b0000
+        1, // 0b0001
+        1, // 0b0010
+        2, // 0b0011
+        1, // 0b0100
+        2, // 0b0101
+        2, // 0b0110
+        3, // 0b0111
+        1, // 0b1000
+        2, // 0b1001
+        2, // 0b1010
+        3, // 0b1011
+        2, // 0b1100
+        3, // 0b1101
+        3, // 0b1110
+        4, // 0b1111
+    };
+
+    /** rct2: 0x0098D8B4 */
+    static constexpr FootpathSlope kDefaultPathSlope[] = {
+        { FootpathSlopeType::flat },      { FootpathSlopeType::irregular }, { FootpathSlopeType::irregular },
+        { FootpathSlopeType::sloped, 2 }, { FootpathSlopeType::irregular }, { FootpathSlopeType::irregular },
+        { FootpathSlopeType::sloped, 3 }, { FootpathSlopeType::raise },     { FootpathSlopeType::irregular },
+        { FootpathSlopeType::sloped, 1 }, { FootpathSlopeType::irregular }, { FootpathSlopeType::raise },
+        { FootpathSlopeType::sloped, 0 }, { FootpathSlopeType::raise },     { FootpathSlopeType::raise },
+        { FootpathSlopeType::irregular },
+    };
+
+    static bool entrance_has_direction(const EntranceElement& entranceElement, int32_t direction)
     {
+        return entranceElement.GetDirections() & (1 << (direction & 3));
+    }
+
+    PathElement* MapGetFootpathElement(const CoordsXYZ& coords)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(coords);
+        do
+        {
+            if (tileElement == nullptr)
+                break;
+            auto* pathElement = tileElement->AsPath();
+            if (pathElement != nullptr && pathElement->GetBaseZ() == coords.z)
+                return pathElement;
+        } while (!(tileElement++)->IsLastForTile());
+
+        return nullptr;
+    }
+
+    /**
+     *
+     *  rct2: 0x00673883
+     */
+    void FootpathRemoveLitter(const CoordsXYZ& footpathPos)
+    {
+        std::vector<Litter*> removals;
+        for (auto litter : EntityTileList<Litter>(footpathPos))
+        {
+            int32_t distanceZ = abs(litter->z - footpathPos.z);
+            if (distanceZ <= 32)
+            {
+                removals.push_back(litter);
+            }
+        }
+        for (auto* litter : removals)
+        {
+            litter->Invalidate();
+            getGameState().entities.EntityRemove(litter);
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x0069A48B
+     */
+    void FootpathInterruptPeeps(const CoordsXYZ& footpathPos)
+    {
+        auto quad = EntityTileList<Peep>(footpathPos);
+        for (auto peep : quad)
+        {
+            if (peep->State == PeepState::sitting || peep->State == PeepState::watching)
+            {
+                auto location = peep->GetLocation();
+                if (location.z == footpathPos.z)
+                {
+                    auto destination = location.ToTileCentre();
+                    peep->SetState(PeepState::walking);
+                    peep->SetDestination(destination, 5);
+                    peep->UpdateCurrentAnimationType();
+                }
+            }
+        }
+    }
+
+    static PathElement* FootpathConnectCornersGetNeighbour(const CoordsXYZ& footpathPos, int32_t requireEdges)
+    {
+        if (!MapIsLocationValid(footpathPos))
+        {
+            return nullptr;
+        }
+
+        TileElement* tileElement = MapGetFirstElementAt(footpathPos);
         if (tileElement == nullptr)
-            break;
-        auto* pathElement = tileElement->AsPath();
-        if (pathElement != nullptr && pathElement->GetBaseZ() == coords.z)
+            return nullptr;
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+            auto pathElement = tileElement->AsPath();
+            if (pathElement->IsQueue())
+                continue;
+            if (tileElement->GetBaseZ() != footpathPos.z)
+                continue;
+            if (!(pathElement->GetEdgesAndCorners() & requireEdges))
+                continue;
+
             return pathElement;
-    } while (!(tileElement++)->IsLastForTile());
+        } while (!(tileElement++)->IsLastForTile());
 
-    return nullptr;
-}
-
-/**
- *
- *  rct2: 0x00673883
- */
-void FootpathRemoveLitter(const CoordsXYZ& footpathPos)
-{
-    std::vector<Litter*> removals;
-    for (auto litter : EntityTileList<Litter>(footpathPos))
-    {
-        int32_t distanceZ = abs(litter->z - footpathPos.z);
-        if (distanceZ <= 32)
-        {
-            removals.push_back(litter);
-        }
-    }
-    for (auto* litter : removals)
-    {
-        litter->Invalidate();
-        getGameState().entities.EntityRemove(litter);
-    }
-}
-
-/**
- *
- *  rct2: 0x0069A48B
- */
-void FootpathInterruptPeeps(const CoordsXYZ& footpathPos)
-{
-    auto quad = EntityTileList<Peep>(footpathPos);
-    for (auto peep : quad)
-    {
-        if (peep->State == PeepState::sitting || peep->State == PeepState::watching)
-        {
-            auto location = peep->GetLocation();
-            if (location.z == footpathPos.z)
-            {
-                auto destination = location.ToTileCentre();
-                peep->SetState(PeepState::walking);
-                peep->SetDestination(destination, 5);
-                peep->UpdateCurrentAnimationType();
-            }
-        }
-    }
-}
-
-static PathElement* FootpathConnectCornersGetNeighbour(const CoordsXYZ& footpathPos, int32_t requireEdges)
-{
-    if (!MapIsLocationValid(footpathPos))
-    {
         return nullptr;
     }
 
-    TileElement* tileElement = MapGetFirstElementAt(footpathPos);
-    if (tileElement == nullptr)
-        return nullptr;
-    do
+    /**
+     * Sets the corner edges of four path tiles.
+     * The function will search for a path in the direction given, then check clockwise to see if it there is a path and again
+     * until it reaches the initial path. In other words, checks if there are four paths together so that it can set the inner
+     * corners of each one.
+     *
+     *  rct2: 0x006A70EB
+     */
+    static void FootpathConnectCorners(const CoordsXY& footpathPos, PathElement* initialTileElement)
     {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-        auto pathElement = tileElement->AsPath();
-        if (pathElement->IsQueue())
-            continue;
-        if (tileElement->GetBaseZ() != footpathPos.z)
-            continue;
-        if (!(pathElement->GetEdgesAndCorners() & requireEdges))
-            continue;
+        using PathElementCoordsPair = std::pair<PathElement*, CoordsXY>;
+        std::array<PathElementCoordsPair, 4> tileElements;
 
-        return pathElement;
-    } while (!(tileElement++)->IsLastForTile());
+        if (initialTileElement->IsQueue())
+            return;
+        if (initialTileElement->IsSloped())
+            return;
 
-    return nullptr;
-}
-
-/**
- * Sets the corner edges of four path tiles.
- * The function will search for a path in the direction given, then check clockwise to see if it there is a path and again until
- * it reaches the initial path. In other words, checks if there are four paths together so that it can set the inner corners of
- * each one.
- *
- *  rct2: 0x006A70EB
- */
-static void FootpathConnectCorners(const CoordsXY& footpathPos, PathElement* initialTileElement)
-{
-    using PathElementCoordsPair = std::pair<PathElement*, CoordsXY>;
-    std::array<PathElementCoordsPair, 4> tileElements;
-
-    if (initialTileElement->IsQueue())
-        return;
-    if (initialTileElement->IsSloped())
-        return;
-
-    std::get<0>(tileElements) = { initialTileElement, footpathPos };
-    int32_t z = initialTileElement->GetBaseZ();
-    for (int32_t initialDirection = 0; initialDirection < kNumOrthogonalDirections; initialDirection++)
-    {
-        int32_t direction = initialDirection;
-        auto currentPos = footpathPos + CoordsDirectionDelta[direction];
-
-        std::get<1>(tileElements) = { FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << DirectionReverse(direction))),
-                                      currentPos };
-        if (std::get<1>(tileElements).first == nullptr)
-            continue;
-
-        direction = DirectionNext(direction);
-        currentPos += CoordsDirectionDelta[direction];
-        std::get<2>(tileElements) = { FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << DirectionReverse(direction))),
-                                      currentPos };
-        if (std::get<2>(tileElements).first == nullptr)
-            continue;
-
-        direction = DirectionNext(direction);
-        currentPos += CoordsDirectionDelta[direction];
-        // First check link to previous tile
-        std::get<3>(tileElements) = { FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << DirectionReverse(direction))),
-                                      currentPos };
-        if (std::get<3>(tileElements).first == nullptr)
-            continue;
-        // Second check link to initial tile
-        std::get<3>(tileElements) = { FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << ((direction + 1) & 3))),
-                                      currentPos };
-        if (std::get<3>(tileElements).first == nullptr)
-            continue;
-
-        direction = DirectionNext(direction);
-        std::get<3>(tileElements).first->SetCorners(std::get<3>(tileElements).first->GetCorners() | (1 << (direction)));
-        MapInvalidateElement(std::get<3>(tileElements).second, reinterpret_cast<TileElement*>(std::get<3>(tileElements).first));
-
-        direction = DirectionPrev(direction);
-        std::get<2>(tileElements).first->SetCorners(std::get<2>(tileElements).first->GetCorners() | (1 << (direction)));
-
-        MapInvalidateElement(std::get<2>(tileElements).second, reinterpret_cast<TileElement*>(std::get<2>(tileElements).first));
-
-        direction = DirectionPrev(direction);
-        std::get<1>(tileElements).first->SetCorners(std::get<1>(tileElements).first->GetCorners() | (1 << (direction)));
-
-        MapInvalidateElement(std::get<1>(tileElements).second, reinterpret_cast<TileElement*>(std::get<1>(tileElements).first));
-
-        direction = initialDirection;
-        std::get<0>(tileElements).first->SetCorners(std::get<0>(tileElements).first->GetCorners() | (1 << (direction)));
-        MapInvalidateElement(std::get<0>(tileElements).second, reinterpret_cast<TileElement*>(std::get<0>(tileElements).first));
-    }
-}
-
-struct FootpathNeighbour
-{
-    uint8_t order;
-    uint8_t direction;
-    RideId ride_index;
-    StationIndex entrance_index;
-};
-
-struct FootpathNeighbourList
-{
-    FootpathNeighbour items[8];
-    size_t count;
-};
-
-static int32_t FootpathNeighbourCompare(const void* a, const void* b)
-{
-    uint8_t va = (static_cast<const FootpathNeighbour*>(a))->order;
-    uint8_t vb = (static_cast<const FootpathNeighbour*>(b))->order;
-    if (va < vb)
-        return 1;
-    if (va > vb)
-        return -1;
-
-    uint8_t da = (static_cast<const FootpathNeighbour*>(a))->direction;
-    uint8_t db = (static_cast<const FootpathNeighbour*>(b))->direction;
-    if (da < db)
-        return -1;
-    if (da > db)
-        return 1;
-    return 0;
-}
-
-static void FootpathNeighbourListInit(FootpathNeighbourList* neighbourList)
-{
-    neighbourList->count = 0;
-}
-
-static void FootpathNeighbourListPush(
-    FootpathNeighbourList* neighbourList, int32_t order, int32_t direction, RideId rideIndex, ::StationIndex entrance_index)
-{
-    Guard::Assert(neighbourList->count < std::size(neighbourList->items));
-    neighbourList->items[neighbourList->count].order = order;
-    neighbourList->items[neighbourList->count].direction = direction;
-    neighbourList->items[neighbourList->count].ride_index = rideIndex;
-    neighbourList->items[neighbourList->count].entrance_index = entrance_index;
-    neighbourList->count++;
-}
-
-static bool FootpathNeighbourListPop(FootpathNeighbourList* neighbourList, FootpathNeighbour* outNeighbour)
-{
-    if (neighbourList->count == 0)
-        return false;
-
-    *outNeighbour = neighbourList->items[0];
-    const size_t bytesToMove = (neighbourList->count - 1) * sizeof(neighbourList->items[0]);
-    memmove(&neighbourList->items[0], &neighbourList->items[1], bytesToMove);
-    neighbourList->count--;
-    return true;
-}
-
-static void FootpathNeighbourListRemove(FootpathNeighbourList* neighbourList, size_t index)
-{
-    Guard::ArgumentInRange<size_t>(index, 0, neighbourList->count - 1);
-    int32_t itemsRemaining = static_cast<int32_t>(neighbourList->count - index) - 1;
-    if (itemsRemaining > 0)
-    {
-        memmove(&neighbourList->items[index], &neighbourList->items[index + 1], sizeof(FootpathNeighbour) * itemsRemaining);
-    }
-    neighbourList->count--;
-}
-
-static void FoopathNeighbourListSort(FootpathNeighbourList* neighbourList)
-{
-    qsort(neighbourList->items, neighbourList->count, sizeof(FootpathNeighbour), FootpathNeighbourCompare);
-}
-
-static TileElement* FootpathGetElement(const CoordsXYRangedZ& footpathPos, int32_t direction)
-{
-    TileElement* tileElement = MapGetFirstElementAt(footpathPos);
-    if (tileElement == nullptr)
-        return nullptr;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-
-        if (footpathPos.clearanceZ == tileElement->GetBaseZ())
+        std::get<0>(tileElements) = { initialTileElement, footpathPos };
+        int32_t z = initialTileElement->GetBaseZ();
+        for (int32_t initialDirection = 0; initialDirection < kNumOrthogonalDirections; initialDirection++)
         {
-            if (tileElement->AsPath()->IsSloped())
-            {
-                auto slope = tileElement->AsPath()->GetSlopeDirection();
-                if (slope != direction)
-                    break;
-            }
-            return tileElement;
+            int32_t direction = initialDirection;
+            auto currentPos = footpathPos + CoordsDirectionDelta[direction];
+
+            std::get<1>(tileElements) = {
+                FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << DirectionReverse(direction))), currentPos
+            };
+            if (std::get<1>(tileElements).first == nullptr)
+                continue;
+
+            direction = DirectionNext(direction);
+            currentPos += CoordsDirectionDelta[direction];
+            std::get<2>(tileElements) = {
+                FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << DirectionReverse(direction))), currentPos
+            };
+            if (std::get<2>(tileElements).first == nullptr)
+                continue;
+
+            direction = DirectionNext(direction);
+            currentPos += CoordsDirectionDelta[direction];
+            // First check link to previous tile
+            std::get<3>(tileElements) = {
+                FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << DirectionReverse(direction))), currentPos
+            };
+            if (std::get<3>(tileElements).first == nullptr)
+                continue;
+            // Second check link to initial tile
+            std::get<3>(tileElements) = { FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << ((direction + 1) & 3))),
+                                          currentPos };
+            if (std::get<3>(tileElements).first == nullptr)
+                continue;
+
+            direction = DirectionNext(direction);
+            std::get<3>(tileElements).first->SetCorners(std::get<3>(tileElements).first->GetCorners() | (1 << (direction)));
+            MapInvalidateElement(
+                std::get<3>(tileElements).second, reinterpret_cast<TileElement*>(std::get<3>(tileElements).first));
+
+            direction = DirectionPrev(direction);
+            std::get<2>(tileElements).first->SetCorners(std::get<2>(tileElements).first->GetCorners() | (1 << (direction)));
+
+            MapInvalidateElement(
+                std::get<2>(tileElements).second, reinterpret_cast<TileElement*>(std::get<2>(tileElements).first));
+
+            direction = DirectionPrev(direction);
+            std::get<1>(tileElements).first->SetCorners(std::get<1>(tileElements).first->GetCorners() | (1 << (direction)));
+
+            MapInvalidateElement(
+                std::get<1>(tileElements).second, reinterpret_cast<TileElement*>(std::get<1>(tileElements).first));
+
+            direction = initialDirection;
+            std::get<0>(tileElements).first->SetCorners(std::get<0>(tileElements).first->GetCorners() | (1 << (direction)));
+            MapInvalidateElement(
+                std::get<0>(tileElements).second, reinterpret_cast<TileElement*>(std::get<0>(tileElements).first));
         }
-        if (footpathPos.baseZ == tileElement->GetBaseZ())
-        {
-            if (!tileElement->AsPath()->IsSloped())
-                break;
+    }
 
-            auto slope = DirectionReverse(tileElement->AsPath()->GetSlopeDirection());
-            if (slope != direction)
-                break;
-
-            return tileElement;
-        }
-    } while (!(tileElement++)->IsLastForTile());
-    return nullptr;
-}
-
-/**
- * Attempt to connect a newly disconnected queue tile to the specified path tile
- */
-static bool FootpathReconnectQueueToPath(
-    const CoordsXY& footpathPos, TileElement* tileElement, int32_t action, int32_t direction)
-{
-    if (((tileElement->AsPath()->GetEdges() & (1 << direction)) == 0) ^ (action < 0))
-        return false;
-
-    auto targetQueuePos = footpathPos + CoordsDirectionDelta[direction];
-
-    if (action < 0)
+    struct FootpathNeighbour
     {
-        if (WallInTheWay({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction))
+        uint8_t order;
+        uint8_t direction;
+        RideId ride_index;
+        StationIndex entrance_index;
+    };
+
+    struct FootpathNeighbourList
+    {
+        FootpathNeighbour items[8];
+        size_t count;
+    };
+
+    static int32_t FootpathNeighbourCompare(const void* a, const void* b)
+    {
+        uint8_t va = (static_cast<const FootpathNeighbour*>(a))->order;
+        uint8_t vb = (static_cast<const FootpathNeighbour*>(b))->order;
+        if (va < vb)
+            return 1;
+        if (va > vb)
+            return -1;
+
+        uint8_t da = (static_cast<const FootpathNeighbour*>(a))->direction;
+        uint8_t db = (static_cast<const FootpathNeighbour*>(b))->direction;
+        if (da < db)
+            return -1;
+        if (da > db)
+            return 1;
+        return 0;
+    }
+
+    static void FootpathNeighbourListInit(FootpathNeighbourList* neighbourList)
+    {
+        neighbourList->count = 0;
+    }
+
+    static void FootpathNeighbourListPush(
+        FootpathNeighbourList* neighbourList, int32_t order, int32_t direction, RideId rideIndex, ::StationIndex entrance_index)
+    {
+        Guard::Assert(neighbourList->count < std::size(neighbourList->items));
+        neighbourList->items[neighbourList->count].order = order;
+        neighbourList->items[neighbourList->count].direction = direction;
+        neighbourList->items[neighbourList->count].ride_index = rideIndex;
+        neighbourList->items[neighbourList->count].entrance_index = entrance_index;
+        neighbourList->count++;
+    }
+
+    static bool FootpathNeighbourListPop(FootpathNeighbourList* neighbourList, FootpathNeighbour* outNeighbour)
+    {
+        if (neighbourList->count == 0)
             return false;
 
-        if (WallInTheWay(
-                { targetQueuePos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, DirectionReverse(direction)))
-            return false;
-    }
-
-    int32_t z = tileElement->GetBaseZ();
-    TileElement* targetFootpathElement = FootpathGetElement({ targetQueuePos, z - kLandHeightStep, z }, direction);
-    if (targetFootpathElement != nullptr && !targetFootpathElement->AsPath()->IsQueue())
-    {
-        auto targetQueueElement = targetFootpathElement->AsPath();
-        tileElement->AsPath()->SetSlopeDirection(0);
-        if (action > 0)
-        {
-            tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() & ~(1 << direction));
-            targetQueueElement->SetEdges(targetQueueElement->GetEdges() & ~(1 << (DirectionReverse(direction) & 3)));
-            if (action >= 2)
-                tileElement->AsPath()->SetSlopeDirection(direction);
-        }
-        else if (action < 0)
-        {
-            tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << direction));
-            targetQueueElement->SetEdges(targetQueueElement->GetEdges() | (1 << (DirectionReverse(direction) & 3)));
-        }
-        if (action != 0)
-            MapInvalidateTileFull(targetQueuePos);
+        *outNeighbour = neighbourList->items[0];
+        const size_t bytesToMove = (neighbourList->count - 1) * sizeof(neighbourList->items[0]);
+        memmove(&neighbourList->items[0], &neighbourList->items[1], bytesToMove);
+        neighbourList->count--;
         return true;
     }
-    return false;
-}
 
-static bool FootpathDisconnectQueueFromPath(const CoordsXY& footpathPos, TileElement* tileElement, int32_t action)
-{
-    if (!tileElement->AsPath()->IsQueue())
-        return false;
-
-    if (tileElement->AsPath()->IsSloped())
-        return false;
-
-    uint8_t c = connected_path_count[tileElement->AsPath()->GetEdges()];
-    if ((action < 0) ? (c >= 2) : (c < 2))
-        return false;
-
-    if (action < 0)
+    static void FootpathNeighbourListRemove(FootpathNeighbourList* neighbourList, size_t index)
     {
-        uint8_t direction = tileElement->AsPath()->GetSlopeDirection();
-        if (FootpathReconnectQueueToPath(footpathPos, tileElement, action, direction))
-            return true;
-    }
-
-    for (Direction direction : kAllDirections)
-    {
-        if ((action < 0) && (direction == tileElement->AsPath()->GetSlopeDirection()))
-            continue;
-        if (FootpathReconnectQueueToPath(footpathPos, tileElement, action, direction))
-            return true;
-    }
-
-    return false;
-}
-
-/**
- *
- *  rct2: 0x006A6D7E
- */
-
-static void Loc6A6FD2(const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* initialTileElement, bool query)
-{
-    if ((initialTileElement)->GetType() == TileElementType::Path)
-    {
-        if (!query)
+        Guard::ArgumentInRange<size_t>(index, 0, neighbourList->count - 1);
+        int32_t itemsRemaining = static_cast<int32_t>(neighbourList->count - index) - 1;
+        if (itemsRemaining > 0)
         {
-            initialTileElement->AsPath()->SetEdges(initialTileElement->AsPath()->GetEdges() | (1 << direction));
-            MapInvalidateElement(initialTileElementPos, initialTileElement);
+            memmove(&neighbourList->items[index], &neighbourList->items[index + 1], sizeof(FootpathNeighbour) * itemsRemaining);
         }
+        neighbourList->count--;
     }
-}
 
-static void Loc6A6F1F(
-    const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* tileElement, TileElement* initialTileElement,
-    const CoordsXY& targetPos, CommandFlags flags, bool query, FootpathNeighbourList* neighbourList)
-{
-    if (query)
+    static void FoopathNeighbourListSort(FootpathNeighbourList* neighbourList)
     {
-        if (WallInTheWay({ targetPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, DirectionReverse(direction)))
+        qsort(neighbourList->items, neighbourList->count, sizeof(FootpathNeighbour), FootpathNeighbourCompare);
+    }
+
+    static TileElement* FootpathGetElement(const CoordsXYRangedZ& footpathPos, int32_t direction)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(footpathPos);
+        if (tileElement == nullptr)
+            return nullptr;
+        do
         {
-            return;
-        }
-        if (tileElement->AsPath()->IsQueue())
-        {
-            if (connected_path_count[tileElement->AsPath()->GetEdges()] < 2)
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+
+            if (footpathPos.clearanceZ == tileElement->GetBaseZ())
             {
-                FootpathNeighbourListPush(
-                    neighbourList, 4, direction, tileElement->AsPath()->GetRideIndex(),
-                    tileElement->AsPath()->GetStationIndex());
+                if (tileElement->AsPath()->IsSloped())
+                {
+                    auto slope = tileElement->AsPath()->GetSlopeDirection();
+                    if (slope != direction)
+                        break;
+                }
+                return tileElement;
+            }
+            if (footpathPos.baseZ == tileElement->GetBaseZ())
+            {
+                if (!tileElement->AsPath()->IsSloped())
+                    break;
+
+                auto slope = DirectionReverse(tileElement->AsPath()->GetSlopeDirection());
+                if (slope != direction)
+                    break;
+
+                return tileElement;
+            }
+        } while (!(tileElement++)->IsLastForTile());
+        return nullptr;
+    }
+
+    /**
+     * Attempt to connect a newly disconnected queue tile to the specified path tile
+     */
+    static bool FootpathReconnectQueueToPath(
+        const CoordsXY& footpathPos, TileElement* tileElement, int32_t action, int32_t direction)
+    {
+        if (((tileElement->AsPath()->GetEdges() & (1 << direction)) == 0) ^ (action < 0))
+            return false;
+
+        auto targetQueuePos = footpathPos + CoordsDirectionDelta[direction];
+
+        if (action < 0)
+        {
+            if (WallInTheWay({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction))
+                return false;
+
+            if (WallInTheWay(
+                    { targetQueuePos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, DirectionReverse(direction)))
+                return false;
+        }
+
+        int32_t z = tileElement->GetBaseZ();
+        TileElement* targetFootpathElement = FootpathGetElement({ targetQueuePos, z - kLandHeightStep, z }, direction);
+        if (targetFootpathElement != nullptr && !targetFootpathElement->AsPath()->IsQueue())
+        {
+            auto targetQueueElement = targetFootpathElement->AsPath();
+            tileElement->AsPath()->SetSlopeDirection(0);
+            if (action > 0)
+            {
+                tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() & ~(1 << direction));
+                targetQueueElement->SetEdges(targetQueueElement->GetEdges() & ~(1 << (DirectionReverse(direction) & 3)));
+                if (action >= 2)
+                    tileElement->AsPath()->SetSlopeDirection(direction);
+            }
+            else if (action < 0)
+            {
+                tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << direction));
+                targetQueueElement->SetEdges(targetQueueElement->GetEdges() | (1 << (DirectionReverse(direction) & 3)));
+            }
+            if (action != 0)
+                MapInvalidateTileFull(targetQueuePos);
+            return true;
+        }
+        return false;
+    }
+
+    static bool FootpathDisconnectQueueFromPath(const CoordsXY& footpathPos, TileElement* tileElement, int32_t action)
+    {
+        if (!tileElement->AsPath()->IsQueue())
+            return false;
+
+        if (tileElement->AsPath()->IsSloped())
+            return false;
+
+        uint8_t c = connected_path_count[tileElement->AsPath()->GetEdges()];
+        if ((action < 0) ? (c >= 2) : (c < 2))
+            return false;
+
+        if (action < 0)
+        {
+            uint8_t direction = tileElement->AsPath()->GetSlopeDirection();
+            if (FootpathReconnectQueueToPath(footpathPos, tileElement, action, direction))
+                return true;
+        }
+
+        for (Direction direction : kAllDirections)
+        {
+            if ((action < 0) && (direction == tileElement->AsPath()->GetSlopeDirection()))
+                continue;
+            if (FootpathReconnectQueueToPath(footpathPos, tileElement, action, direction))
+                return true;
+        }
+
+        return false;
+    }
+
+    /**
+     *
+     *  rct2: 0x006A6D7E
+     */
+
+    static void Loc6A6FD2(
+        const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* initialTileElement, bool query)
+    {
+        if ((initialTileElement)->GetType() == TileElementType::Path)
+        {
+            if (!query)
+            {
+                initialTileElement->AsPath()->SetEdges(initialTileElement->AsPath()->GetEdges() | (1 << direction));
+                MapInvalidateElement(initialTileElementPos, initialTileElement);
+            }
+        }
+    }
+
+    static void Loc6A6F1F(
+        const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* tileElement, TileElement* initialTileElement,
+        const CoordsXY& targetPos, CommandFlags flags, bool query, FootpathNeighbourList* neighbourList)
+    {
+        if (query)
+        {
+            if (WallInTheWay({ targetPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, DirectionReverse(direction)))
+            {
+                return;
+            }
+            if (tileElement->AsPath()->IsQueue())
+            {
+                if (connected_path_count[tileElement->AsPath()->GetEdges()] < 2)
+                {
+                    FootpathNeighbourListPush(
+                        neighbourList, 4, direction, tileElement->AsPath()->GetRideIndex(),
+                        tileElement->AsPath()->GetStationIndex());
+                }
+                else
+                {
+                    if ((initialTileElement)->GetType() == TileElementType::Path && initialTileElement->AsPath()->IsQueue())
+                    {
+                        if (FootpathDisconnectQueueFromPath(targetPos, tileElement, 0))
+                        {
+                            FootpathNeighbourListPush(
+                                neighbourList, 3, direction, tileElement->AsPath()->GetRideIndex(),
+                                tileElement->AsPath()->GetStationIndex());
+                        }
+                    }
+                }
             }
             else
             {
-                if ((initialTileElement)->GetType() == TileElementType::Path && initialTileElement->AsPath()->IsQueue())
+                FootpathNeighbourListPush(neighbourList, 2, direction, RideId::GetNull(), StationIndex::GetNull());
+            }
+        }
+        else
+        {
+            const bool isGhost = flags.has(CommandFlag::ghost);
+            FootpathDisconnectQueueFromPath(targetPos, tileElement, isGhost ? 2 : 1);
+            tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << DirectionReverse(direction)));
+            if (tileElement->AsPath()->IsQueue())
+            {
+                FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
+            }
+        }
+        if (!flags.hasAny(CommandFlag::ghost, CommandFlag::allowDuringPaused))
+        {
+            FootpathInterruptPeeps({ targetPos, tileElement->GetBaseZ() });
+        }
+        MapInvalidateElement(targetPos, tileElement);
+        Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
+    }
+
+    static void Loc6A6D7E(
+        const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* initialTileElement, CommandFlags flags,
+        bool query, FootpathNeighbourList* neighbourList)
+    {
+        auto targetPos = CoordsXY{ initialTileElementPos } + CoordsDirectionDelta[direction];
+        if ((gLegacyScene == LegacyScene::scenarioEditor || getGameState().cheats.sandboxMode) && MapIsEdge(targetPos))
+        {
+            if (query)
+            {
+                FootpathNeighbourListPush(neighbourList, 7, direction, RideId::GetNull(), StationIndex::GetNull());
+            }
+            Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
+        }
+        else
+        {
+            TileElement* tileElement = MapGetFirstElementAt(targetPos);
+            if (tileElement == nullptr)
+                return;
+            do
+            {
+                switch (tileElement->GetType())
                 {
-                    if (FootpathDisconnectQueueFromPath(targetPos, tileElement, 0))
+                    case TileElementType::Path:
+                        if (tileElement->GetBaseZ() == initialTileElementPos.z)
+                        {
+                            if (!tileElement->AsPath()->IsSloped() || tileElement->AsPath()->GetSlopeDirection() == direction)
+                            {
+                                Loc6A6F1F(
+                                    initialTileElementPos, direction, tileElement, initialTileElement, targetPos, flags, query,
+                                    neighbourList);
+                            }
+                            return;
+                        }
+                        if (tileElement->GetBaseZ() == initialTileElementPos.z - kLandHeightStep)
+                        {
+                            if (tileElement->AsPath()->IsSloped()
+                                && tileElement->AsPath()->GetSlopeDirection() == DirectionReverse(direction))
+                            {
+                                Loc6A6F1F(
+                                    initialTileElementPos, direction, tileElement, initialTileElement, targetPos, flags, query,
+                                    neighbourList);
+                            }
+                            return;
+                        }
+                        break;
+                    case TileElementType::Track:
+                        if (initialTileElementPos.z == tileElement->GetBaseZ())
+                        {
+                            auto ride = GetRide(tileElement->AsTrack()->GetRideIndex());
+                            if (ride == nullptr)
+                            {
+                                continue;
+                            }
+
+                            if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
+                            {
+                                continue;
+                            }
+
+                            const auto trackType = tileElement->AsTrack()->GetTrackType();
+                            const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
+                            const auto& ted = GetTrackElementDescriptor(trackType);
+                            if (!ted.sequenceData.sequences[trackSequence].flags.has(SequenceFlag::connectsToPath))
+                            {
+                                return;
+                            }
+                            uint16_t dx = DirectionReverse(
+                                (direction - tileElement->GetDirection()) & kTileElementDirectionMask);
+                            auto connectionSides = ted.sequenceData.sequences[trackSequence].getEntranceConnectionSides();
+                            if (!(connectionSides & (1 << dx)))
+                            {
+                                return;
+                            }
+                            if (query)
+                            {
+                                FootpathNeighbourListPush(
+                                    neighbourList, 1, direction, tileElement->AsTrack()->GetRideIndex(),
+                                    StationIndex::GetNull());
+                            }
+                            Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
+                            return;
+                        }
+                        break;
+                    case TileElementType::Entrance:
+                        if (initialTileElementPos.z == tileElement->GetBaseZ())
+                        {
+                            if (entrance_has_direction(
+                                    *(tileElement->AsEntrance()), DirectionReverse(direction - tileElement->GetDirection())))
+                            {
+                                if (query)
+                                {
+                                    FootpathNeighbourListPush(
+                                        neighbourList, 8, direction, tileElement->AsEntrance()->GetRideIndex(),
+                                        tileElement->AsEntrance()->GetStationIndex());
+                                }
+                                else
+                                {
+                                    if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
+                                    {
+                                        FootpathQueueChainPush(tileElement->AsEntrance()->GetRideIndex());
+                                    }
+                                }
+                                Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
+                                return;
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                }
+
+            } while (!(tileElement++)->IsLastForTile());
+        }
+    }
+
+    // TODO: Change this into a simple check that validates if the direction should be fully checked with Loc6A6D7E and move the
+    // calling of Loc6A6D7E into the parent function.
+    static void Loc6A6C85(
+        const CoordsXYE& tileElementPos, int32_t direction, CommandFlags flags, bool query,
+        FootpathNeighbourList* neighbourList)
+    {
+        if (query
+            && WallInTheWay(
+                { tileElementPos, tileElementPos.element->GetBaseZ(), tileElementPos.element->GetClearanceZ() }, direction))
+            return;
+
+        if (tileElementPos.element->GetType() == TileElementType::Entrance)
+        {
+            if (!entrance_has_direction(
+                    *(tileElementPos.element->AsEntrance()), direction - tileElementPos.element->GetDirection()))
+            {
+                return;
+            }
+        }
+
+        if (tileElementPos.element->GetType() == TileElementType::Track)
+        {
+            auto ride = GetRide(tileElementPos.element->AsTrack()->GetRideIndex());
+            if (ride == nullptr)
+            {
+                return;
+            }
+
+            if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
+            {
+                return;
+            }
+
+            const auto trackType = tileElementPos.element->AsTrack()->GetTrackType();
+            const uint8_t trackSequence = tileElementPos.element->AsTrack()->GetSequenceIndex();
+            const auto& ted = GetTrackElementDescriptor(trackType);
+            if (!ted.sequenceData.sequences[trackSequence].flags.has(SequenceFlag::connectsToPath))
+            {
+                return;
+            }
+            uint16_t dx = (direction - tileElementPos.element->GetDirection()) & kTileElementDirectionMask;
+            auto connectionSides = ted.sequenceData.sequences[trackSequence].getEntranceConnectionSides();
+            if (!(connectionSides & (1 << dx)))
+            {
+                return;
+            }
+        }
+
+        auto pos = CoordsXYZ{ tileElementPos, tileElementPos.element->GetBaseZ() };
+        if (tileElementPos.element->GetType() == TileElementType::Path)
+        {
+            if (tileElementPos.element->AsPath()->IsSloped())
+            {
+                if ((tileElementPos.element->AsPath()->GetSlopeDirection() - direction) & 1)
+                {
+                    return;
+                }
+                if (tileElementPos.element->AsPath()->GetSlopeDirection() == direction)
+                {
+                    pos.z += kLandHeightStep;
+                }
+            }
+        }
+
+        Loc6A6D7E(pos, direction, tileElementPos.element, flags, query, neighbourList);
+    }
+
+    /**
+     *
+     *  rct2: 0x006A6C66
+     */
+    void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, CommandFlags flags)
+    {
+        FootpathNeighbourList neighbourList;
+        FootpathNeighbour neighbour;
+
+        FootpathUpdateQueueChains();
+
+        FootpathNeighbourListInit(&neighbourList);
+
+        FootpathUpdateQueueEntranceBanner(footpathPos, tileElement);
+        for (Direction direction : kAllDirections)
+        {
+            Loc6A6C85({ footpathPos, tileElement }, direction, flags, true, &neighbourList);
+        }
+
+        FoopathNeighbourListSort(&neighbourList);
+
+        if (tileElement->GetType() == TileElementType::Path && tileElement->AsPath()->IsQueue())
+        {
+            RideId rideIndex = RideId::GetNull();
+            StationIndex entranceIndex = StationIndex::GetNull();
+            for (size_t i = 0; i < neighbourList.count; i++)
+            {
+                if (!neighbourList.items[i].ride_index.IsNull())
+                {
+                    if (rideIndex.IsNull())
                     {
-                        FootpathNeighbourListPush(
-                            neighbourList, 3, direction, tileElement->AsPath()->GetRideIndex(),
-                            tileElement->AsPath()->GetStationIndex());
+                        rideIndex = neighbourList.items[i].ride_index;
+                        entranceIndex = neighbourList.items[i].entrance_index;
                     }
+                    else if (rideIndex != neighbourList.items[i].ride_index)
+                    {
+                        FootpathNeighbourListRemove(&neighbourList, i);
+                    }
+                    else if (
+                        rideIndex == neighbourList.items[i].ride_index && entranceIndex != neighbourList.items[i].entrance_index
+                        && !neighbourList.items[i].entrance_index.IsNull())
+                    {
+                        FootpathNeighbourListRemove(&neighbourList, i);
+                    }
+                }
+            }
+
+            neighbourList.count = std::min<size_t>(neighbourList.count, 2);
+        }
+
+        while (FootpathNeighbourListPop(&neighbourList, &neighbour))
+        {
+            Loc6A6C85({ footpathPos, tileElement }, neighbour.direction, flags, false, nullptr);
+        }
+
+        if (tileElement->GetType() == TileElementType::Path)
+        {
+            FootpathConnectCorners(footpathPos, tileElement->AsPath());
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006A742F
+     */
+    void FootpathChainRideQueue(
+        RideId rideIndex, StationIndex entranceIndex, const CoordsXY& initialFootpathPos, TileElement* const initialTileElement,
+        int32_t direction)
+    {
+        TileElement* lastPathElement = nullptr;
+        TileElement* lastQueuePathElement = nullptr;
+        auto tileElement = initialTileElement;
+        auto curQueuePos = initialFootpathPos;
+        auto lastPath = curQueuePos;
+        int32_t baseZ = tileElement->GetBaseZ();
+        int32_t lastPathDirection = direction;
+
+        for (;;)
+        {
+            if (tileElement->GetType() == TileElementType::Path)
+            {
+                lastPathElement = tileElement;
+                lastPath = curQueuePos;
+                lastPathDirection = direction;
+                if (tileElement->AsPath()->IsSloped())
+                {
+                    if (tileElement->AsPath()->GetSlopeDirection() == direction)
+                    {
+                        baseZ += kLandHeightStep;
+                    }
+                }
+            }
+
+            auto targetQueuePos = curQueuePos + CoordsDirectionDelta[direction];
+            tileElement = MapGetFirstElementAt(targetQueuePos);
+            bool foundQueue = false;
+            if (tileElement != nullptr)
+            {
+                do
+                {
+                    if (lastQueuePathElement == tileElement)
+                        continue;
+                    if (tileElement->GetType() != TileElementType::Path)
+                        continue;
+                    if (tileElement->GetBaseZ() == baseZ)
+                    {
+                        if (tileElement->AsPath()->IsSloped())
+                        {
+                            if (tileElement->AsPath()->GetSlopeDirection() != direction)
+                                break;
+                        }
+                        foundQueue = true;
+                        break;
+                    }
+                    if (tileElement->GetBaseZ() == baseZ - kLandHeightStep)
+                    {
+                        if (!tileElement->AsPath()->IsSloped())
+                            break;
+
+                        if (DirectionReverse(tileElement->AsPath()->GetSlopeDirection()) != direction)
+                            break;
+
+                        baseZ -= kLandHeightStep;
+                        foundQueue = true;
+                        break;
+                    }
+                } while (!(tileElement++)->IsLastForTile());
+            }
+            if (!foundQueue)
+                break;
+
+            if (tileElement->AsPath()->IsQueue())
+            {
+                // Fix #2051: Stop queue paths that are already connected to two other tiles
+                //            from connecting to the tile we are coming from.
+                uint32_t edges = tileElement->AsPath()->GetEdges();
+                uint32_t numEdges = std::popcount(edges);
+                if (numEdges >= 2)
+                {
+                    int32_t requiredEdgeMask = 1 << DirectionReverse(direction);
+                    if (!(edges & requiredEdgeMask))
+                    {
+                        break;
+                    }
+                }
+
+                tileElement->AsPath()->SetHasQueueBanner(false);
+                tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << DirectionReverse(direction)));
+                tileElement->AsPath()->SetRideIndex(rideIndex);
+                tileElement->AsPath()->SetStationIndex(entranceIndex);
+
+                curQueuePos = targetQueuePos;
+                MapInvalidateElement(targetQueuePos, tileElement);
+
+                if (lastQueuePathElement == nullptr)
+                {
+                    lastQueuePathElement = tileElement;
+                }
+
+                if (tileElement->AsPath()->GetEdges() & (1 << direction))
+                    continue;
+
+                direction = (direction + 1) & 3;
+                if (tileElement->AsPath()->GetEdges() & (1 << direction))
+                    continue;
+
+                direction = DirectionReverse(direction);
+                if (tileElement->AsPath()->GetEdges() & (1 << direction))
+                    continue;
+            }
+            break;
+        }
+
+        if (!rideIndex.IsNull() && lastPathElement != nullptr)
+        {
+            if (lastPathElement->AsPath()->IsQueue())
+            {
+                lastPathElement->AsPath()->SetHasQueueBanner(true);
+                lastPathElement->AsPath()->SetQueueBannerDirection(lastPathDirection); // set the ride sign direction
+
+                MapAnimations::MarkTileForInvalidation(TileCoordsXY(lastPath));
+            }
+        }
+    }
+
+    void FootpathQueueChainReset()
+    {
+        _footpathQueueChainNext = _footpathQueueChain;
+    }
+
+    /**
+     *
+     *  rct2: 0x006A76E9
+     */
+    void FootpathQueueChainPush(RideId rideIndex)
+    {
+        if (!rideIndex.IsNull())
+        {
+            auto* lastSlot = _footpathQueueChain + std::size(_footpathQueueChain) - 1;
+            if (_footpathQueueChainNext <= lastSlot)
+            {
+                *_footpathQueueChainNext++ = rideIndex;
+            }
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006A759F
+     */
+    void FootpathUpdateQueueChains()
+    {
+        for (auto* queueChainPtr = _footpathQueueChain; queueChainPtr < _footpathQueueChainNext; queueChainPtr++)
+        {
+            RideId rideIndex = *queueChainPtr;
+            auto ride = GetRide(rideIndex);
+            if (ride == nullptr)
+                continue;
+
+            for (const auto& station : ride->getStations())
+            {
+                if (station.Entrance.IsNull())
+                    continue;
+
+                TileElement* tileElement = MapGetFirstElementAt(station.Entrance);
+                if (tileElement != nullptr)
+                {
+                    do
+                    {
+                        if (tileElement->GetType() != TileElementType::Entrance)
+                            continue;
+                        if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
+                            continue;
+                        if (tileElement->AsEntrance()->GetRideIndex() != rideIndex)
+                            continue;
+
+                        Direction direction = DirectionReverse(tileElement->GetDirection());
+                        FootpathChainRideQueue(
+                            rideIndex, ride->getStationIndex(&station), station.Entrance.ToCoordsXY(), tileElement, direction);
+                    } while (!(tileElement++)->IsLastForTile());
+                }
+            }
+        }
+    }
+
+    int32_t FootpathQueueCountConnections(const CoordsXY& position, const PathElement& pathElement)
+    {
+        int32_t connectionCount = 0;
+        for (const Direction direction : kAllDirections)
+        {
+            const uint8_t edge = 1 << direction;
+            if (pathElement.GetEdges() & edge)
+            {
+                const CoordsXY adjacentPathPosition = position + CoordsDirectionDelta[direction];
+                const int32_t z = pathElement.GetBaseZ();
+                const TileElement* tileElement = FootpathGetElement(
+                    { adjacentPathPosition, z, z + kLandHeightStep }, direction);
+
+                if (tileElement == nullptr)
+                {
+                    tileElement = FootpathGetElement({ adjacentPathPosition, z - kLandHeightStep, z }, direction);
+
+                    if (tileElement == nullptr)
+                    {
+                        const EntranceElement* entrance = MapGetRideEntranceElementAt(
+                            CoordsXYZ{ adjacentPathPosition, z }, true);
+                        if (entrance == nullptr)
+                        {
+                            entrance = MapGetRideEntranceElementAt(
+                                CoordsXYZ{ adjacentPathPosition, z + kLandHeightStep }, true);
+                            if (entrance == nullptr)
+                                continue;
+                        }
+
+                        if (entrance_has_direction(*entrance, direction + entrance->GetDirection()))
+                        {
+                            connectionCount++;
+                        }
+                        continue;
+                    }
+                }
+
+                const PathElement& adjacentPath = *tileElement->AsPath();
+
+                if (adjacentPath.GetEdges() & Numerics::rol4(edge, 2))
+                {
+                    connectionCount++;
+                }
+            }
+        }
+        return connectionCount;
+    }
+
+    /**
+     *
+     *  rct2: 0x0069ADBD
+     */
+    static void FootpathFixOwnership(const CoordsXY& mapPos)
+    {
+        const auto* surfaceElement = MapGetSurfaceElementAt(mapPos);
+        uint16_t ownership;
+
+        // Unlikely to be NULL unless deliberate.
+        if (surfaceElement != nullptr)
+        {
+            // If the tile is not safe to own construction rights of, erase them.
+            if (CheckMaxAllowableLandRightsForTile({ mapPos, surfaceElement->BaseHeight << 3 }) == OWNERSHIP_UNOWNED)
+            {
+                ownership = OWNERSHIP_UNOWNED;
+            }
+            // If the tile is safe to own construction rights of, do not erase construction rights.
+            else
+            {
+                ownership = surfaceElement->GetOwnership();
+                // You can't own the entrance path.
+                if (ownership == OWNERSHIP_OWNED || ownership == OWNERSHIP_AVAILABLE)
+                {
+                    ownership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;
                 }
             }
         }
         else
         {
-            FootpathNeighbourListPush(neighbourList, 2, direction, RideId::GetNull(), StationIndex::GetNull());
+            ownership = OWNERSHIP_UNOWNED;
         }
-    }
-    else
-    {
-        const bool isGhost = flags.has(CommandFlag::ghost);
-        FootpathDisconnectQueueFromPath(targetPos, tileElement, isGhost ? 2 : 1);
-        tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << DirectionReverse(direction)));
-        if (tileElement->AsPath()->IsQueue())
-        {
-            FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
-        }
-    }
-    if (!flags.hasAny(CommandFlag::ghost, CommandFlag::allowDuringPaused))
-    {
-        FootpathInterruptPeeps({ targetPos, tileElement->GetBaseZ() });
-    }
-    MapInvalidateElement(targetPos, tileElement);
-    Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
-}
 
-static void Loc6A6D7E(
-    const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* initialTileElement, CommandFlags flags, bool query,
-    FootpathNeighbourList* neighbourList)
-{
-    auto targetPos = CoordsXY{ initialTileElementPos } + CoordsDirectionDelta[direction];
-    if ((gLegacyScene == LegacyScene::scenarioEditor || getGameState().cheats.sandboxMode) && MapIsEdge(targetPos))
-    {
-        if (query)
-        {
-            FootpathNeighbourListPush(neighbourList, 7, direction, RideId::GetNull(), StationIndex::GetNull());
-        }
-        Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
+        auto landSetRightsAction = GameActions::LandSetRightsAction(
+            mapPos, GameActions::LandSetRightSetting::SetOwnershipWithChecks, ownership);
+        landSetRightsAction.SetFlags({ CommandFlag::noSpend });
+        GameActions::Execute(&landSetRightsAction, getGameState());
     }
-    else
+
+    static bool GetNextDirection(uint32_t edges, int32_t* direction)
     {
-        TileElement* tileElement = MapGetFirstElementAt(targetPos);
+        int32_t index = Numerics::bitScanForward(edges);
+        if (index == -1)
+            return false;
+
+        *direction = index;
+        return true;
+    }
+
+    /**
+     *
+     *  rct2: 0x0069AC1A
+     * @param flags (1 << 0): Ignore queues
+     *              (1 << 5): Unown
+     *              (1 << 7): Ignore no entry signs
+     */
+    static int32_t FootpathIsConnectedToMapEdgeHelper(CoordsXYZ footpathPos, int32_t direction, int32_t flags)
+    {
+        int32_t returnVal = FOOTPATH_SEARCH_INCOMPLETE;
+
+        struct TileState
+        {
+            bool processed = false;
+            CoordsXYZ footpathPos;
+            int32_t direction;
+            int32_t level;
+            int32_t distanceFromJunction;
+            int32_t junctionTolerance;
+        };
+
+        // Vector of all of the child tile elements for us to explore
+        std::vector<TileState> tiles;
+        TileElement* tileElement = nullptr;
+        int numPendingTiles = 0;
+
+        TileState currentTile = { false, footpathPos, direction, 0, 0, 16 };
+
+        // Captures the current state of the variables and stores them in tiles vector for iteration later
+        auto CaptureCurrentTileState = [&tiles, &numPendingTiles](TileState t_currentTile) -> void {
+            // Search for an entry of this tile in our list already
+            for (const TileState& tile : tiles)
+            {
+                if (tile.footpathPos == t_currentTile.footpathPos && tile.direction == t_currentTile.direction)
+                    return;
+            }
+
+            // If we get here we did not find it, so insert the tile into our list
+            tiles.push_back(t_currentTile);
+            ++numPendingTiles;
+        };
+
+        // Loads the next tile to visit into our variables
+        auto LoadNextTileElement = [&tiles, &numPendingTiles](TileState& t_currentTile) -> void {
+            // Do not continue if there are no tiles in the list
+            if (tiles.empty())
+                return;
+
+            // Find the next unprocessed tile
+            for (size_t tileIndex = tiles.size() - 1; tileIndex > 0; --tileIndex)
+            {
+                if (tiles[tileIndex].processed)
+                    continue;
+                --numPendingTiles;
+                t_currentTile = tiles[tileIndex];
+                tiles[tileIndex].processed = true;
+                return;
+            }
+            // Default to tile 0
+            --numPendingTiles;
+            t_currentTile = tiles[0];
+            tiles[0].processed = true;
+        };
+
+        // Encapsulate the tile skipping logic to make do-while more readable
+        auto SkipTileElement = [](int32_t ste_flags, TileElement* ste_tileElement, int32_t& ste_slopeDirection,
+                                  int32_t ste_direction, const CoordsXYZ& ste_targetPos) {
+            if (ste_tileElement->GetType() != TileElementType::Path)
+                return true;
+
+            if (ste_tileElement->AsPath()->IsSloped()
+                && (ste_slopeDirection = ste_tileElement->AsPath()->GetSlopeDirection()) != ste_direction)
+            {
+                if (DirectionReverse(ste_slopeDirection) != ste_direction)
+                    return true;
+                if (ste_tileElement->GetBaseZ() + kPathHeightStep != ste_targetPos.z)
+                    return true;
+            }
+            else if (ste_tileElement->GetBaseZ() != ste_targetPos.z)
+                return true;
+
+            if (!(ste_flags & FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES))
+                if (ste_tileElement->AsPath()->IsQueue())
+                    return true;
+            return false;
+        };
+
+        int32_t edges, slopeDirection;
+
+        // Capture the current tile state to begin the loop
+        CaptureCurrentTileState(currentTile);
+
+        // Loop on this until all tiles are processed or we return
+        while (numPendingTiles > 0)
+        {
+            LoadNextTileElement(currentTile);
+
+            CoordsXYZ targetPos = CoordsXYZ{ CoordsXY{ currentTile.footpathPos } + CoordsDirectionDelta[currentTile.direction],
+                                             currentTile.footpathPos.z };
+
+            if (++currentTile.level > 250)
+                return FOOTPATH_SEARCH_TOO_COMPLEX;
+
+            // Return immediately if we are at the edge of the map and not unowning
+            // Or if we are unowning and have no tiles left
+            if ((MapIsEdge(targetPos) && !(flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN)))
+            {
+                return FOOTPATH_SEARCH_SUCCESS;
+            }
+
+            tileElement = MapGetFirstElementAt(targetPos);
+            if (tileElement == nullptr)
+                return currentTile.level == 1 ? FOOTPATH_SEARCH_NOT_FOUND : FOOTPATH_SEARCH_INCOMPLETE;
+
+            // Loop while there are unvisited TileElements at targetPos
+            do
+            {
+                if (SkipTileElement(flags, tileElement, slopeDirection, currentTile.direction, targetPos))
+                    continue;
+
+                // Unown the footpath if needed
+                if (flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN)
+                    FootpathFixOwnership(targetPos);
+
+                edges = tileElement->AsPath()->GetEdges();
+                currentTile.direction = DirectionReverse(currentTile.direction);
+                if (!tileElement->IsLastForTile() && !(flags & FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_NO_ENTRY))
+                {
+                    int elementIndex = 1;
+                    // Loop over all elements and cull appropriate edges
+                    do
+                    {
+                        if (tileElement[elementIndex].GetType() == TileElementType::Path)
+                            break;
+                        if (tileElement[elementIndex].GetType() != TileElementType::Banner)
+                        {
+                            continue;
+                        }
+                        edges &= tileElement[elementIndex].AsBanner()->GetAllowedEdges();
+                    } while (!tileElement[elementIndex++].IsLastForTile());
+                }
+
+                // Exclude the direction we came from
+                targetPos.z = tileElement->GetBaseZ();
+                edges &= ~(1 << currentTile.direction);
+
+                if (!GetNextDirection(edges, &currentTile.direction))
+                    break;
+
+                edges &= ~(1 << currentTile.direction);
+                if (edges == 0)
+                {
+                    // Only possible direction to go
+                    if (tileElement->AsPath()->IsSloped()
+                        && tileElement->AsPath()->GetSlopeDirection() == currentTile.direction)
+                        targetPos.z += kPathHeightStep;
+
+                    // Prepare the next iteration
+                    currentTile.footpathPos = targetPos;
+                    ++currentTile.distanceFromJunction;
+                    CaptureCurrentTileState(currentTile);
+                }
+                else
+                {
+                    // We have reached a junction
+                    --currentTile.junctionTolerance;
+                    if (currentTile.distanceFromJunction != 0)
+                    {
+                        --currentTile.junctionTolerance;
+                    }
+
+                    if (currentTile.junctionTolerance < 0 && !(flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN))
+                    {
+                        returnVal = FOOTPATH_SEARCH_TOO_COMPLEX;
+                        break;
+                    }
+
+                    // Loop until there are no more directions we can go
+                    do
+                    {
+                        edges &= ~(1 << currentTile.direction);
+                        if (tileElement->AsPath()->IsSloped()
+                            && tileElement->AsPath()->GetSlopeDirection() == currentTile.direction)
+                        {
+                            targetPos.z += kPathHeightStep;
+                        }
+
+                        // Add each possible path to the list of pending tiles
+                        currentTile.footpathPos = targetPos;
+                        currentTile.distanceFromJunction = 0;
+                        CaptureCurrentTileState(currentTile);
+                    } while (GetNextDirection(edges, &currentTile.direction));
+                }
+                break;
+            } while (!(tileElement++)->IsLastForTile());
+
+            // Return success if we have unowned all tiles in our pending list
+            if ((flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN) && numPendingTiles <= 0)
+            {
+                return FOOTPATH_SEARCH_SUCCESS;
+            }
+        }
+        return currentTile.level == 1 ? FOOTPATH_SEARCH_NOT_FOUND : returnVal;
+    }
+
+    // TODO: Use GAME_COMMAND_FLAGS
+    int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags)
+    {
+        flags |= FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES;
+        return FootpathIsConnectedToMapEdgeHelper(footpathPos, direction, flags);
+    }
+
+    /**
+     *
+     *  rct2: 0x006A8B12
+     *  clears the wide footpath flag for all footpaths
+     *  at location
+     */
+    static void FootpathClearWide(const CoordsXY& footpathPos)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(footpathPos);
         if (tileElement == nullptr)
             return;
         do
         {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+            tileElement->AsPath()->SetWide(false);
+        } while (!(tileElement++)->IsLastForTile());
+    }
+
+    /**
+     *
+     *  rct2: 0x006A8ACF
+     *  returns footpath element if it can be made wide
+     *  returns NULL if it can not be made wide
+     */
+    static TileElement* FootpathCanBeWide(const CoordsXYZ& footpathPos)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(footpathPos);
+        if (tileElement == nullptr)
+            return nullptr;
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+            if (footpathPos.z != tileElement->GetBaseZ())
+                continue;
+            if (tileElement->AsPath()->IsQueue())
+                continue;
+            if (tileElement->AsPath()->IsSloped())
+                continue;
+            return tileElement;
+        } while (!(tileElement++)->IsLastForTile());
+
+        return nullptr;
+    }
+
+    /**
+     *
+     *  rct2: 0x006A87BB
+     */
+    void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos)
+    {
+        if (MapIsEdge(footpathPos))
+            return;
+
+        FootpathClearWide(footpathPos);
+        /* Rather than clearing the wide flag of the following tiles and
+         * checking the state of them later, leave them intact and assume
+         * they were cleared. Consequently only the wide flag for this single
+         * tile is modified by this update.
+         * This is important for avoiding glitches in pathfinding that occurs
+         * between the batches of updates to the path wide flags.
+         * Corresponding pathList[] indexes for the following tiles
+         * are: 2, 3, 4, 5.
+         * Note: indexes 3, 4, 5 are reset in the current call;
+         *       index 2 is reset in the previous call. */
+        // x += 0x20;
+        // FootpathClearWide(x, y);
+        // y += 0x20;
+        // FootpathClearWide(x, y);
+        // x -= 0x20;
+        // FootpathClearWide(x, y);
+        // y -= 0x20;
+
+        // Only consider approx. 1/8 of tiles for wide path status
+        // (NB: the other 7/8 do get cleared above!)
+        if (!(footpathPos.x & 0xE0) || (!(footpathPos.y & 0xE0)))
+            return;
+
+        TileElement* tileElement = MapGetFirstElementAt(footpathPos);
+        if (tileElement == nullptr)
+            return;
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+
+            if (tileElement->AsPath()->IsQueue())
+                continue;
+
+            if (tileElement->AsPath()->IsSloped())
+                continue;
+
+            if (tileElement->AsPath()->GetEdges() == 0)
+                continue;
+
+            auto height = tileElement->GetBaseZ();
+
+            // pathList is a list of elements, set by Sub6A8ACF adjacent to x,y
+            // Spanned from 0x00F3EFA8 to 0x00F3EFC7 (8 elements) in the original
+            std::array<TileElement*, 8> pathList;
+            for (std::size_t direction = 0; direction < pathList.size(); ++direction)
+            {
+                auto footpathLoc = CoordsXYZ(footpathPos + CoordsDirectionDelta[direction], height);
+                pathList[direction] = FootpathCanBeWide(footpathLoc);
+            }
+
+            uint8_t pathConnections = 0;
+            if (tileElement->AsPath()->GetEdges() & EDGE_NW)
+            {
+                pathConnections |= FOOTPATH_CONNECTION_NW;
+                const auto* pathElement = std::get<3>(pathList);
+                if (pathElement != nullptr && pathElement->AsPath()->IsWide())
+                {
+                    pathConnections &= ~FOOTPATH_CONNECTION_NW;
+                }
+            }
+
+            if (tileElement->AsPath()->GetEdges() & EDGE_NE)
+            {
+                pathConnections |= FOOTPATH_CONNECTION_NE;
+                const auto* pathElement = std::get<0>(pathList);
+                if (pathElement != nullptr && pathElement->AsPath()->IsWide())
+                {
+                    pathConnections &= ~FOOTPATH_CONNECTION_NE;
+                }
+            }
+
+            if (tileElement->AsPath()->GetEdges() & EDGE_SE)
+            {
+                pathConnections |= FOOTPATH_CONNECTION_SE;
+                /* In the following:
+                 * footpath_element_is_wide(pathList[1])
+                 * is always false due to the tile update order
+                 * in combination with reset tiles.
+                 * Commented out since it will never occur. */
+                // if (pathList[1] != nullptr) {
+                //  if (footpath_element_is_wide(pathList[1])) {
+                //      pathConnections &= ~FOOTPATH_CONNECTION_SE;
+                //  }
+                //}
+            }
+
+            if (tileElement->AsPath()->GetEdges() & EDGE_SW)
+            {
+                pathConnections |= FOOTPATH_CONNECTION_SW;
+                /* In the following:
+                 * footpath_element_is_wide(pathList[2])
+                 * is always false due to the tile update order
+                 * in combination with reset tiles.
+                 * Commented out since it will never occur. */
+                // if (pathList[2] != nullptr) {
+                //  if (footpath_element_is_wide(pathList[2])) {
+                //      pathConnections &= ~FOOTPATH_CONNECTION_SW;
+                //  }
+                //}
+            }
+
+            if ((pathConnections & FOOTPATH_CONNECTION_NW) && std::get<3>(pathList) != nullptr
+                && !std::get<3>(pathList)->AsPath()->IsWide())
+            {
+                constexpr uint8_t edgeMask1 = EDGE_SE | EDGE_SW;
+                const auto* pathElement0 = std::get<0>(pathList);
+                const auto* pathElement7 = std::get<7>(pathList);
+                if ((pathConnections & FOOTPATH_CONNECTION_NE) && pathElement7 != nullptr && !pathElement7->AsPath()->IsWide()
+                    && (pathElement7->AsPath()->GetEdges() & edgeMask1) == edgeMask1 && pathElement0 != nullptr
+                    && !pathElement0->AsPath()->IsWide())
+                {
+                    pathConnections |= FOOTPATH_CONNECTION_S;
+                }
+
+                /* In the following:
+                 * footpath_element_is_wide(pathList[2])
+                 * is always false due to the tile update order
+                 * in combination with reset tiles.
+                 * Short circuit the logic appropriately. */
+                constexpr uint8_t edgeMask2 = EDGE_NE | EDGE_SE;
+                const auto* pathElement2 = std::get<2>(pathList);
+                const auto* pathElement6 = std::get<6>(pathList);
+                if ((pathConnections & FOOTPATH_CONNECTION_SW) && pathElement6 != nullptr && !(pathElement6)->AsPath()->IsWide()
+                    && (pathElement6->AsPath()->GetEdges() & edgeMask2) == edgeMask2 && pathElement2 != nullptr)
+                {
+                    pathConnections |= FOOTPATH_CONNECTION_E;
+                }
+            }
+
+            /* In the following:
+             * footpath_element_is_wide(pathList[4])
+             * footpath_element_is_wide(pathList[1])
+             * are always false due to the tile update order
+             * in combination with reset tiles.
+             * Short circuit the logic appropriately. */
+            if ((pathConnections & FOOTPATH_CONNECTION_SE) && std::get<1>(pathList) != nullptr)
+            {
+                constexpr uint8_t edgeMask1 = EDGE_SW | EDGE_NW;
+                const auto* pathElement0 = std::get<0>(pathList);
+                const auto* pathElement4 = std::get<4>(pathList);
+                if ((pathConnections & FOOTPATH_CONNECTION_NE) && (pathElement4 != nullptr)
+                    && (pathElement4->AsPath()->GetEdges() & edgeMask1) == edgeMask1 && pathElement0 != nullptr
+                    && !pathElement0->AsPath()->IsWide())
+                {
+                    pathConnections |= FOOTPATH_CONNECTION_W;
+                }
+
+                /* In the following:
+                 * footpath_element_is_wide(pathList[5])
+                 * footpath_element_is_wide(pathList[2])
+                 * are always false due to the tile update order
+                 * in combination with reset tiles.
+                 * Short circuit the logic appropriately. */
+                constexpr uint8_t edgeMask2 = EDGE_NE | EDGE_NW;
+                const auto* pathElement2 = std::get<2>(pathList);
+                const auto* pathElement5 = std::get<5>(pathList);
+                if ((pathConnections & FOOTPATH_CONNECTION_SW) && pathElement5 != nullptr
+                    && (pathElement5->AsPath()->GetEdges() & edgeMask2) == edgeMask2 && pathElement2 != nullptr)
+                {
+                    pathConnections |= FOOTPATH_CONNECTION_N;
+                }
+            }
+
+            if ((pathConnections & FOOTPATH_CONNECTION_NW)
+                && (pathConnections & (FOOTPATH_CONNECTION_E | FOOTPATH_CONNECTION_S)))
+            {
+                pathConnections &= ~FOOTPATH_CONNECTION_NW;
+            }
+
+            if ((pathConnections & FOOTPATH_CONNECTION_NE)
+                && (pathConnections & (FOOTPATH_CONNECTION_W | FOOTPATH_CONNECTION_S)))
+            {
+                pathConnections &= ~FOOTPATH_CONNECTION_NE;
+            }
+
+            if ((pathConnections & FOOTPATH_CONNECTION_SE)
+                && (pathConnections & (FOOTPATH_CONNECTION_N | FOOTPATH_CONNECTION_W)))
+            {
+                pathConnections &= ~FOOTPATH_CONNECTION_SE;
+            }
+
+            if ((pathConnections & FOOTPATH_CONNECTION_SW)
+                && (pathConnections & (FOOTPATH_CONNECTION_E | FOOTPATH_CONNECTION_N)))
+            {
+                pathConnections &= ~FOOTPATH_CONNECTION_SW;
+            }
+
+            if (!(pathConnections
+                  & (FOOTPATH_CONNECTION_NE | FOOTPATH_CONNECTION_SE | FOOTPATH_CONNECTION_SW | FOOTPATH_CONNECTION_NW)))
+            {
+                uint8_t e = tileElement->AsPath()->GetEdgesAndCorners();
+                if ((e != 0b10101111) && (e != 0b01011111) && (e != 0b11101111))
+                    tileElement->AsPath()->SetWide(true);
+            }
+        } while (!(tileElement++)->IsLastForTile());
+    }
+
+    bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position)
+    {
+        auto pathElement = MapGetFirstTileElementWithBaseHeightBetween<PathElement>({ position, position.z + kPathHeightStep });
+        return pathElement != nullptr && pathElement->IsBlockedByVehicle();
+    }
+
+    /**
+     *
+     *  rct2: 0x006A7642
+     */
+    void FootpathUpdateQueueEntranceBanner(const CoordsXY& footpathPos, TileElement* tileElement)
+    {
+        const auto elementType = tileElement->GetType();
+        if (elementType == TileElementType::Path)
+        {
+            if (tileElement->AsPath()->IsQueue())
+            {
+                FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
+                for (int32_t direction = 0; direction < kNumOrthogonalDirections; direction++)
+                {
+                    if (tileElement->AsPath()->GetEdges() & (1 << direction))
+                    {
+                        FootpathChainRideQueue(
+                            RideId::GetNull(), StationIndex::FromUnderlying(0), footpathPos, tileElement, direction);
+                    }
+                }
+                tileElement->AsPath()->SetRideIndex(RideId::GetNull());
+            }
+        }
+        else if (elementType == TileElementType::Entrance)
+        {
+            if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
+            {
+                FootpathQueueChainPush(tileElement->AsEntrance()->GetRideIndex());
+                FootpathChainRideQueue(
+                    RideId::GetNull(), StationIndex::FromUnderlying(0), footpathPos, tileElement,
+                    DirectionReverse(tileElement->GetDirection()));
+            }
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006A6B7F
+     */
+    static void FootpathRemoveEdgesTowardsHere(
+        const CoordsXYZ& footpathPos, int32_t direction, TileElement* tileElement, bool isQueue)
+    {
+        if (tileElement->AsPath()->IsQueue())
+        {
+            FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
+        }
+
+        auto d = DirectionReverse(direction);
+        tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() & ~(1 << d));
+        int32_t cd = ((d - 1) & 3);
+        tileElement->AsPath()->SetCorners(tileElement->AsPath()->GetCorners() & ~(1 << cd));
+        cd = ((cd + 1) & 3);
+        tileElement->AsPath()->SetCorners(tileElement->AsPath()->GetCorners() & ~(1 << cd));
+        MapInvalidateTile({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+
+        if (isQueue)
+            FootpathDisconnectQueueFromPath(footpathPos, tileElement, -1);
+
+        Direction shiftedDirection = (direction + 1) & 3;
+        auto targetFootPathPos = CoordsXYZ{ CoordsXY{ footpathPos } + CoordsDirectionDelta[shiftedDirection], footpathPos.z };
+
+        tileElement = MapGetFirstElementAt(targetFootPathPos);
+        if (tileElement == nullptr)
+            return;
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+            if (tileElement->GetBaseZ() != targetFootPathPos.z)
+                continue;
+
+            if (tileElement->AsPath()->IsSloped())
+                break;
+
+            cd = ((shiftedDirection + 1) & 3);
+            tileElement->AsPath()->SetCorners(tileElement->AsPath()->GetCorners() & ~(1 << cd));
+            MapInvalidateTile({ targetFootPathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+            break;
+        } while (!(tileElement++)->IsLastForTile());
+    }
+
+    /**
+     *
+     *  rct2: 0x006A6B14
+     */
+    static void FootpathRemoveEdgesTowards(const CoordsXYRangedZ& footPathPos, int32_t direction, bool isQueue)
+    {
+        if (!MapIsLocationValid(footPathPos))
+        {
+            return;
+        }
+
+        TileElement* tileElement = MapGetFirstElementAt(footPathPos);
+        if (tileElement == nullptr)
+            return;
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+
+            if (footPathPos.clearanceZ == tileElement->GetBaseZ())
+            {
+                if (tileElement->AsPath()->IsSloped())
+                {
+                    uint8_t slope = tileElement->AsPath()->GetSlopeDirection();
+                    if (slope != direction)
+                        break;
+                }
+                FootpathRemoveEdgesTowardsHere({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
+                break;
+            }
+
+            if (footPathPos.baseZ == tileElement->GetBaseZ())
+            {
+                if (!tileElement->AsPath()->IsSloped())
+                    break;
+
+                uint8_t slope = DirectionReverse(tileElement->AsPath()->GetSlopeDirection());
+                if (slope != direction)
+                    break;
+
+                FootpathRemoveEdgesTowardsHere({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
+                break;
+            }
+        } while (!(tileElement++)->IsLastForTile());
+    }
+
+    // Returns true when there is an element at the given coordinates that want to connect to a path with the given direction
+    // (ride entrances and exits, shops, paths).
+    bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(coords);
+        if (tileElement == nullptr)
+            return false;
+        do
+        {
+            // Don't check the element that gets removed
+            if (tileElement == elementToBeRemoved)
+                continue;
+
             switch (tileElement->GetType())
             {
                 case TileElementType::Path:
-                    if (tileElement->GetBaseZ() == initialTileElementPos.z)
+                    if (tileElement->BaseHeight == coords.z)
                     {
-                        if (!tileElement->AsPath()->IsSloped() || tileElement->AsPath()->GetSlopeDirection() == direction)
-                        {
-                            Loc6A6F1F(
-                                initialTileElementPos, direction, tileElement, initialTileElement, targetPos, flags, query,
-                                neighbourList);
-                        }
-                        return;
+                        if (!tileElement->AsPath()->IsSloped())
+                            // The footpath is flat, it can be connected to from any direction
+                            return true;
+                        if (tileElement->AsPath()->GetSlopeDirection() == DirectionReverse(coords.direction))
+                            // The footpath is sloped and its lowest point matches the edge connection
+                            return true;
                     }
-                    if (tileElement->GetBaseZ() == initialTileElementPos.z - kLandHeightStep)
+                    else if (tileElement->BaseHeight + 2 == coords.z)
                     {
-                        if (tileElement->AsPath()->IsSloped()
-                            && tileElement->AsPath()->GetSlopeDirection() == DirectionReverse(direction))
-                        {
-                            Loc6A6F1F(
-                                initialTileElementPos, direction, tileElement, initialTileElement, targetPos, flags, query,
-                                neighbourList);
-                        }
-                        return;
+                        if (tileElement->AsPath()->IsSloped() && tileElement->AsPath()->GetSlopeDirection() == coords.direction)
+                            // The footpath is sloped and its higher point matches the edge connection
+                            return true;
                     }
                     break;
                 case TileElementType::Track:
-                    if (initialTileElementPos.z == tileElement->GetBaseZ())
+                    if (tileElement->BaseHeight == coords.z)
                     {
                         auto ride = GetRide(tileElement->AsTrack()->GetRideIndex());
                         if (ride == nullptr)
-                        {
                             continue;
-                        }
 
                         if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
-                        {
-                            continue;
-                        }
+                            break;
 
                         const auto trackType = tileElement->AsTrack()->GetTrackType();
                         const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
                         const auto& ted = GetTrackElementDescriptor(trackType);
-                        if (!ted.sequenceData.sequences[trackSequence].flags.has(SequenceFlag::connectsToPath))
+                        if (ted.sequenceData.sequences[trackSequence].flags.has(SequenceFlag::connectsToPath))
                         {
-                            return;
+                            uint16_t dx = ((coords.direction - tileElement->GetDirection()) & kTileElementDirectionMask);
+                            auto connectionSides = ted.sequenceData.sequences[trackSequence].getEntranceConnectionSides();
+                            if (connectionSides & (1 << dx))
+                            {
+                                // Track element has the flags required for the given direction
+                                return true;
+                            }
                         }
-                        uint16_t dx = DirectionReverse((direction - tileElement->GetDirection()) & kTileElementDirectionMask);
-                        auto connectionSides = ted.sequenceData.sequences[trackSequence].getEntranceConnectionSides();
-                        if (!(connectionSides & (1 << dx)))
-                        {
-                            return;
-                        }
-                        if (query)
-                        {
-                            FootpathNeighbourListPush(
-                                neighbourList, 1, direction, tileElement->AsTrack()->GetRideIndex(), StationIndex::GetNull());
-                        }
-                        Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
-                        return;
                     }
                     break;
                 case TileElementType::Entrance:
-                    if (initialTileElementPos.z == tileElement->GetBaseZ())
+                    if (tileElement->BaseHeight == coords.z)
                     {
                         if (entrance_has_direction(
-                                *(tileElement->AsEntrance()), DirectionReverse(direction - tileElement->GetDirection())))
+                                *(tileElement->AsEntrance()), coords.direction - tileElement->GetDirection()))
                         {
-                            if (query)
-                            {
-                                FootpathNeighbourListPush(
-                                    neighbourList, 8, direction, tileElement->AsEntrance()->GetRideIndex(),
-                                    tileElement->AsEntrance()->GetStationIndex());
-                            }
-                            else
-                            {
-                                if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
-                                {
-                                    FootpathQueueChainPush(tileElement->AsEntrance()->GetRideIndex());
-                                }
-                            }
-                            Loc6A6FD2(initialTileElementPos, direction, initialTileElement, query);
-                            return;
+                            // Entrance wants to be connected towards the given direction
+                            return true;
                         }
                     }
                     break;
                 default:
                     break;
             }
-
         } while (!(tileElement++)->IsLastForTile());
-    }
-}
 
-// TODO: Change this into a simple check that validates if the direction should be fully checked with Loc6A6D7E and move the
-// calling of Loc6A6D7E into the parent function.
-static void Loc6A6C85(
-    const CoordsXYE& tileElementPos, int32_t direction, CommandFlags flags, bool query, FootpathNeighbourList* neighbourList)
-{
-    if (query
-        && WallInTheWay(
-            { tileElementPos, tileElementPos.element->GetBaseZ(), tileElementPos.element->GetClearanceZ() }, direction))
-        return;
-
-    if (tileElementPos.element->GetType() == TileElementType::Entrance)
-    {
-        if (!entrance_has_direction(
-                *(tileElementPos.element->AsEntrance()), direction - tileElementPos.element->GetDirection()))
-        {
-            return;
-        }
+        return false;
     }
 
-    if (tileElementPos.element->GetType() == TileElementType::Track)
+    /**
+     *
+     *  rct2: 0x006A6AA7
+     * @param x x-coordinate in units (not tiles)
+     * @param y y-coordinate in units (not tiles)
+     */
+    void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, TileElement* tileElement)
     {
-        auto ride = GetRide(tileElementPos.element->AsTrack()->GetRideIndex());
-        if (ride == nullptr)
+        if (tileElement->GetType() == TileElementType::Track)
         {
-            return;
-        }
-
-        if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
-        {
-            return;
-        }
-
-        const auto trackType = tileElementPos.element->AsTrack()->GetTrackType();
-        const uint8_t trackSequence = tileElementPos.element->AsTrack()->GetSequenceIndex();
-        const auto& ted = GetTrackElementDescriptor(trackType);
-        if (!ted.sequenceData.sequences[trackSequence].flags.has(SequenceFlag::connectsToPath))
-        {
-            return;
-        }
-        uint16_t dx = (direction - tileElementPos.element->GetDirection()) & kTileElementDirectionMask;
-        auto connectionSides = ted.sequenceData.sequences[trackSequence].getEntranceConnectionSides();
-        if (!(connectionSides & (1 << dx)))
-        {
-            return;
-        }
-    }
-
-    auto pos = CoordsXYZ{ tileElementPos, tileElementPos.element->GetBaseZ() };
-    if (tileElementPos.element->GetType() == TileElementType::Path)
-    {
-        if (tileElementPos.element->AsPath()->IsSloped())
-        {
-            if ((tileElementPos.element->AsPath()->GetSlopeDirection() - direction) & 1)
-            {
+            auto rideIndex = tileElement->AsTrack()->GetRideIndex();
+            auto ride = GetRide(rideIndex);
+            if (ride == nullptr)
                 return;
-            }
-            if (tileElementPos.element->AsPath()->GetSlopeDirection() == direction)
-            {
-                pos.z += kLandHeightStep;
-            }
+
+            if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
+                return;
         }
-    }
 
-    Loc6A6D7E(pos, direction, tileElementPos.element, flags, query, neighbourList);
-}
+        FootpathUpdateQueueEntranceBanner(footpathPos, tileElement);
 
-/**
- *
- *  rct2: 0x006A6C66
- */
-void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, CommandFlags flags)
-{
-    FootpathNeighbourList neighbourList;
-    FootpathNeighbour neighbour;
-
-    FootpathUpdateQueueChains();
-
-    FootpathNeighbourListInit(&neighbourList);
-
-    FootpathUpdateQueueEntranceBanner(footpathPos, tileElement);
-    for (Direction direction : kAllDirections)
-    {
-        Loc6A6C85({ footpathPos, tileElement }, direction, flags, true, &neighbourList);
-    }
-
-    FoopathNeighbourListSort(&neighbourList);
-
-    if (tileElement->GetType() == TileElementType::Path && tileElement->AsPath()->IsQueue())
-    {
-        RideId rideIndex = RideId::GetNull();
-        StationIndex entranceIndex = StationIndex::GetNull();
-        for (size_t i = 0; i < neighbourList.count; i++)
+        for (uint8_t direction = 0; direction < kNumOrthogonalDirections; direction++)
         {
-            if (!neighbourList.items[i].ride_index.IsNull())
+            int32_t z1 = tileElement->BaseHeight;
+            if (tileElement->GetType() == TileElementType::Path)
             {
-                if (rideIndex.IsNull())
+                if (tileElement->AsPath()->IsSloped())
                 {
-                    rideIndex = neighbourList.items[i].ride_index;
-                    entranceIndex = neighbourList.items[i].entrance_index;
+                    int32_t slope = tileElement->AsPath()->GetSlopeDirection();
+                    // Sloped footpaths don't connect sideways
+                    if ((slope - direction) & 1)
+                        continue;
+
+                    // When a path is sloped, the higher point of the path is 2 units higher
+                    z1 += (slope == direction) ? 2 : 0;
                 }
-                else if (rideIndex != neighbourList.items[i].ride_index)
-                {
-                    FootpathNeighbourListRemove(&neighbourList, i);
-                }
-                else if (
-                    rideIndex == neighbourList.items[i].ride_index && entranceIndex != neighbourList.items[i].entrance_index
-                    && !neighbourList.items[i].entrance_index.IsNull())
-                {
-                    FootpathNeighbourListRemove(&neighbourList, i);
-                }
+            }
+
+            // When clearance checks were disabled a neighbouring path can be connected to both the path-ghost and to something
+            // else, so before removing edges from neighbouring paths we have to make sure there is nothing else they are
+            // connected to.
+            if (!TileElementWantsPathConnectionTowards({ TileCoordsXY{ footpathPos }, z1, direction }, tileElement))
+            {
+                bool isQueue = tileElement->GetType() == TileElementType::Path ? tileElement->AsPath()->IsQueue() : false;
+                int32_t z0 = z1 - 2;
+                FootpathRemoveEdgesTowards(
+                    { footpathPos + CoordsDirectionDelta[direction], z0 * kCoordsZStep, z1 * kCoordsZStep }, direction,
+                    isQueue);
             }
         }
 
-        neighbourList.count = std::min<size_t>(neighbourList.count, 2);
-    }
-
-    while (FootpathNeighbourListPop(&neighbourList, &neighbour))
-    {
-        Loc6A6C85({ footpathPos, tileElement }, neighbour.direction, flags, false, nullptr);
-    }
-
-    if (tileElement->GetType() == TileElementType::Path)
-    {
-        FootpathConnectCorners(footpathPos, tileElement->AsPath());
-    }
-}
-
-/**
- *
- *  rct2: 0x006A742F
- */
-void FootpathChainRideQueue(
-    RideId rideIndex, StationIndex entranceIndex, const CoordsXY& initialFootpathPos, TileElement* const initialTileElement,
-    int32_t direction)
-{
-    TileElement* lastPathElement = nullptr;
-    TileElement* lastQueuePathElement = nullptr;
-    auto tileElement = initialTileElement;
-    auto curQueuePos = initialFootpathPos;
-    auto lastPath = curQueuePos;
-    int32_t baseZ = tileElement->GetBaseZ();
-    int32_t lastPathDirection = direction;
-
-    for (;;)
-    {
         if (tileElement->GetType() == TileElementType::Path)
-        {
-            lastPathElement = tileElement;
-            lastPath = curQueuePos;
-            lastPathDirection = direction;
-            if (tileElement->AsPath()->IsSloped())
-            {
-                if (tileElement->AsPath()->GetSlopeDirection() == direction)
-                {
-                    baseZ += kLandHeightStep;
-                }
-            }
-        }
-
-        auto targetQueuePos = curQueuePos + CoordsDirectionDelta[direction];
-        tileElement = MapGetFirstElementAt(targetQueuePos);
-        bool foundQueue = false;
-        if (tileElement != nullptr)
-        {
-            do
-            {
-                if (lastQueuePathElement == tileElement)
-                    continue;
-                if (tileElement->GetType() != TileElementType::Path)
-                    continue;
-                if (tileElement->GetBaseZ() == baseZ)
-                {
-                    if (tileElement->AsPath()->IsSloped())
-                    {
-                        if (tileElement->AsPath()->GetSlopeDirection() != direction)
-                            break;
-                    }
-                    foundQueue = true;
-                    break;
-                }
-                if (tileElement->GetBaseZ() == baseZ - kLandHeightStep)
-                {
-                    if (!tileElement->AsPath()->IsSloped())
-                        break;
-
-                    if (DirectionReverse(tileElement->AsPath()->GetSlopeDirection()) != direction)
-                        break;
-
-                    baseZ -= kLandHeightStep;
-                    foundQueue = true;
-                    break;
-                }
-            } while (!(tileElement++)->IsLastForTile());
-        }
-        if (!foundQueue)
-            break;
-
-        if (tileElement->AsPath()->IsQueue())
-        {
-            // Fix #2051: Stop queue paths that are already connected to two other tiles
-            //            from connecting to the tile we are coming from.
-            uint32_t edges = tileElement->AsPath()->GetEdges();
-            uint32_t numEdges = std::popcount(edges);
-            if (numEdges >= 2)
-            {
-                int32_t requiredEdgeMask = 1 << DirectionReverse(direction);
-                if (!(edges & requiredEdgeMask))
-                {
-                    break;
-                }
-            }
-
-            tileElement->AsPath()->SetHasQueueBanner(false);
-            tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << DirectionReverse(direction)));
-            tileElement->AsPath()->SetRideIndex(rideIndex);
-            tileElement->AsPath()->SetStationIndex(entranceIndex);
-
-            curQueuePos = targetQueuePos;
-            MapInvalidateElement(targetQueuePos, tileElement);
-
-            if (lastQueuePathElement == nullptr)
-            {
-                lastQueuePathElement = tileElement;
-            }
-
-            if (tileElement->AsPath()->GetEdges() & (1 << direction))
-                continue;
-
-            direction = (direction + 1) & 3;
-            if (tileElement->AsPath()->GetEdges() & (1 << direction))
-                continue;
-
-            direction = DirectionReverse(direction);
-            if (tileElement->AsPath()->GetEdges() & (1 << direction))
-                continue;
-        }
-        break;
+            tileElement->AsPath()->SetEdgesAndCorners(0);
     }
 
-    if (!rideIndex.IsNull() && lastPathElement != nullptr)
+    const FootpathObject* GetLegacyFootpathEntry(ObjectEntryIndex entryIndex)
     {
-        if (lastPathElement->AsPath()->IsQueue())
-        {
-            lastPathElement->AsPath()->SetHasQueueBanner(true);
-            lastPathElement->AsPath()->SetQueueBannerDirection(lastPathDirection); // set the ride sign direction
-
-            MapAnimations::MarkTileForInvalidation(TileCoordsXY(lastPath));
-        }
+        auto& objMgr = GetContext()->GetObjectManager();
+        return objMgr.GetLoadedObject<FootpathObject>(entryIndex);
     }
-}
 
-void FootpathQueueChainReset()
-{
-    _footpathQueueChainNext = _footpathQueueChain;
-}
-
-/**
- *
- *  rct2: 0x006A76E9
- */
-void FootpathQueueChainPush(RideId rideIndex)
-{
-    if (!rideIndex.IsNull())
+    const FootpathSurfaceObject* GetPathSurfaceEntry(ObjectEntryIndex entryIndex)
     {
-        auto* lastSlot = _footpathQueueChain + std::size(_footpathQueueChain) - 1;
-        if (_footpathQueueChainNext <= lastSlot)
-        {
-            *_footpathQueueChainNext++ = rideIndex;
-        }
+        auto& objMgr = GetContext()->GetObjectManager();
+        return objMgr.GetLoadedObject<FootpathSurfaceObject>(entryIndex);
     }
-}
 
-/**
- *
- *  rct2: 0x006A759F
- */
-void FootpathUpdateQueueChains()
-{
-    for (auto* queueChainPtr = _footpathQueueChain; queueChainPtr < _footpathQueueChainNext; queueChainPtr++)
+    const FootpathRailingsObject* GetPathRailingsEntry(ObjectEntryIndex entryIndex)
     {
-        RideId rideIndex = *queueChainPtr;
-        auto ride = GetRide(rideIndex);
+        auto& objMgr = GetContext()->GetObjectManager();
+        return objMgr.GetLoadedObject<FootpathRailingsObject>(entryIndex);
+    }
+
+    RideId PathElement::GetRideIndex() const
+    {
+        return rideIndex;
+    }
+
+    void PathElement::SetRideIndex(RideId newRideIndex)
+    {
+        rideIndex = newRideIndex;
+    }
+
+    uint8_t PathElement::GetAdditionStatus() const
+    {
+        return AdditionStatus;
+    }
+
+    void PathElement::SetAdditionStatus(uint8_t newStatus)
+    {
+        AdditionStatus = newStatus;
+    }
+
+    uint8_t PathElement::GetEdges() const
+    {
+        return EdgesAndCorners & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
+    }
+
+    void PathElement::SetEdges(uint8_t newEdges)
+    {
+        EdgesAndCorners &= ~FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
+        EdgesAndCorners |= (newEdges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK);
+    }
+
+    uint8_t PathElement::GetCorners() const
+    {
+        return EdgesAndCorners >> 4;
+    }
+
+    void PathElement::SetCorners(uint8_t newCorners)
+    {
+        EdgesAndCorners &= ~FOOTPATH_PROPERTIES_EDGES_CORNERS_MASK;
+        EdgesAndCorners |= (newCorners << 4);
+    }
+
+    uint8_t PathElement::GetEdgesAndCorners() const
+    {
+        return EdgesAndCorners;
+    }
+
+    void PathElement::SetEdgesAndCorners(uint8_t newEdgesAndCorners)
+    {
+        EdgesAndCorners = newEdgesAndCorners;
+    }
+
+    bool PathElement::IsLevelCrossing(const CoordsXY& coords) const
+    {
+        auto trackElement = MapGetTrackElementAt({ coords, GetBaseZ() });
+        if (trackElement == nullptr)
+        {
+            return false;
+        }
+
+        if (trackElement->GetTrackType() != TrackElemType::flat)
+        {
+            return false;
+        }
+
+        auto ride = GetRide(trackElement->GetRideIndex());
         if (ride == nullptr)
-            continue;
-
-        for (const auto& station : ride->getStations())
         {
-            if (station.Entrance.IsNull())
-                continue;
-
-            TileElement* tileElement = MapGetFirstElementAt(station.Entrance);
-            if (tileElement != nullptr)
-            {
-                do
-                {
-                    if (tileElement->GetType() != TileElementType::Entrance)
-                        continue;
-                    if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
-                        continue;
-                    if (tileElement->AsEntrance()->GetRideIndex() != rideIndex)
-                        continue;
-
-                    Direction direction = DirectionReverse(tileElement->GetDirection());
-                    FootpathChainRideQueue(
-                        rideIndex, ride->getStationIndex(&station), station.Entrance.ToCoordsXY(), tileElement, direction);
-                } while (!(tileElement++)->IsLastForTile());
-            }
+            return false;
         }
-    }
-}
 
-int32_t FootpathQueueCountConnections(const CoordsXY& position, const PathElement& pathElement)
-{
-    int32_t connectionCount = 0;
-    for (const Direction direction : kAllDirections)
-    {
-        const uint8_t edge = 1 << direction;
-        if (pathElement.GetEdges() & edge)
-        {
-            const CoordsXY adjacentPathPosition = position + CoordsDirectionDelta[direction];
-            const int32_t z = pathElement.GetBaseZ();
-            const TileElement* tileElement = FootpathGetElement({ adjacentPathPosition, z, z + kLandHeightStep }, direction);
-
-            if (tileElement == nullptr)
-            {
-                tileElement = FootpathGetElement({ adjacentPathPosition, z - kLandHeightStep, z }, direction);
-
-                if (tileElement == nullptr)
-                {
-                    const EntranceElement* entrance = MapGetRideEntranceElementAt(CoordsXYZ{ adjacentPathPosition, z }, true);
-                    if (entrance == nullptr)
-                    {
-                        entrance = MapGetRideEntranceElementAt(CoordsXYZ{ adjacentPathPosition, z + kLandHeightStep }, true);
-                        if (entrance == nullptr)
-                            continue;
-                    }
-
-                    if (entrance_has_direction(*entrance, direction + entrance->GetDirection()))
-                    {
-                        connectionCount++;
-                    }
-                    continue;
-                }
-            }
-
-            const PathElement& adjacentPath = *tileElement->AsPath();
-
-            if (adjacentPath.GetEdges() & Numerics::rol4(edge, 2))
-            {
-                connectionCount++;
-            }
-        }
-    }
-    return connectionCount;
-}
-
-/**
- *
- *  rct2: 0x0069ADBD
- */
-static void FootpathFixOwnership(const CoordsXY& mapPos)
-{
-    const auto* surfaceElement = MapGetSurfaceElementAt(mapPos);
-    uint16_t ownership;
-
-    // Unlikely to be NULL unless deliberate.
-    if (surfaceElement != nullptr)
-    {
-        // If the tile is not safe to own construction rights of, erase them.
-        if (CheckMaxAllowableLandRightsForTile({ mapPos, surfaceElement->BaseHeight << 3 }) == OWNERSHIP_UNOWNED)
-        {
-            ownership = OWNERSHIP_UNOWNED;
-        }
-        // If the tile is safe to own construction rights of, do not erase construction rights.
-        else
-        {
-            ownership = surfaceElement->GetOwnership();
-            // You can't own the entrance path.
-            if (ownership == OWNERSHIP_OWNED || ownership == OWNERSHIP_AVAILABLE)
-            {
-                ownership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;
-            }
-        }
-    }
-    else
-    {
-        ownership = OWNERSHIP_UNOWNED;
+        return ride->getRideTypeDescriptor().flags.has(RtdFlag::supportsLevelCrossings);
     }
 
-    auto landSetRightsAction = GameActions::LandSetRightsAction(
-        mapPos, GameActions::LandSetRightSetting::SetOwnershipWithChecks, ownership);
-    landSetRightsAction.SetFlags({ CommandFlag::noSpend });
-    GameActions::Execute(&landSetRightsAction, getGameState());
-}
-
-static bool GetNextDirection(uint32_t edges, int32_t* direction)
-{
-    int32_t index = Numerics::bitScanForward(edges);
-    if (index == -1)
-        return false;
-
-    *direction = index;
-    return true;
-}
-
-/**
- *
- *  rct2: 0x0069AC1A
- * @param flags (1 << 0): Ignore queues
- *              (1 << 5): Unown
- *              (1 << 7): Ignore no entry signs
- */
-static int32_t FootpathIsConnectedToMapEdgeHelper(CoordsXYZ footpathPos, int32_t direction, int32_t flags)
-{
-    int32_t returnVal = FOOTPATH_SEARCH_INCOMPLETE;
-
-    struct TileState
+    bool FootpathIsZAndDirectionValid(const PathElement& pathElement, int32_t currentZ, int32_t currentDirection)
     {
-        bool processed = false;
-        CoordsXYZ footpathPos;
-        int32_t direction;
-        int32_t level;
-        int32_t distanceFromJunction;
-        int32_t junctionTolerance;
-    };
-
-    // Vector of all of the child tile elements for us to explore
-    std::vector<TileState> tiles;
-    TileElement* tileElement = nullptr;
-    int numPendingTiles = 0;
-
-    TileState currentTile = { false, footpathPos, direction, 0, 0, 16 };
-
-    // Captures the current state of the variables and stores them in tiles vector for iteration later
-    auto CaptureCurrentTileState = [&tiles, &numPendingTiles](TileState t_currentTile) -> void {
-        // Search for an entry of this tile in our list already
-        for (const TileState& tile : tiles)
+        if (pathElement.IsSloped())
         {
-            if (tile.footpathPos == t_currentTile.footpathPos && tile.direction == t_currentTile.direction)
-                return;
-        }
-
-        // If we get here we did not find it, so insert the tile into our list
-        tiles.push_back(t_currentTile);
-        ++numPendingTiles;
-    };
-
-    // Loads the next tile to visit into our variables
-    auto LoadNextTileElement = [&tiles, &numPendingTiles](TileState& t_currentTile) -> void {
-        // Do not continue if there are no tiles in the list
-        if (tiles.empty())
-            return;
-
-        // Find the next unprocessed tile
-        for (size_t tileIndex = tiles.size() - 1; tileIndex > 0; --tileIndex)
-        {
-            if (tiles[tileIndex].processed)
-                continue;
-            --numPendingTiles;
-            t_currentTile = tiles[tileIndex];
-            tiles[tileIndex].processed = true;
-            return;
-        }
-        // Default to tile 0
-        --numPendingTiles;
-        t_currentTile = tiles[0];
-        tiles[0].processed = true;
-    };
-
-    // Encapsulate the tile skipping logic to make do-while more readable
-    auto SkipTileElement = [](int32_t ste_flags, TileElement* ste_tileElement, int32_t& ste_slopeDirection,
-                              int32_t ste_direction, const CoordsXYZ& ste_targetPos) {
-        if (ste_tileElement->GetType() != TileElementType::Path)
-            return true;
-
-        if (ste_tileElement->AsPath()->IsSloped()
-            && (ste_slopeDirection = ste_tileElement->AsPath()->GetSlopeDirection()) != ste_direction)
-        {
-            if (DirectionReverse(ste_slopeDirection) != ste_direction)
-                return true;
-            if (ste_tileElement->GetBaseZ() + kPathHeightStep != ste_targetPos.z)
-                return true;
-        }
-        else if (ste_tileElement->GetBaseZ() != ste_targetPos.z)
-            return true;
-
-        if (!(ste_flags & FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES))
-            if (ste_tileElement->AsPath()->IsQueue())
-                return true;
-        return false;
-    };
-
-    int32_t edges, slopeDirection;
-
-    // Capture the current tile state to begin the loop
-    CaptureCurrentTileState(currentTile);
-
-    // Loop on this until all tiles are processed or we return
-    while (numPendingTiles > 0)
-    {
-        LoadNextTileElement(currentTile);
-
-        CoordsXYZ targetPos = CoordsXYZ{ CoordsXY{ currentTile.footpathPos } + CoordsDirectionDelta[currentTile.direction],
-                                         currentTile.footpathPos.z };
-
-        if (++currentTile.level > 250)
-            return FOOTPATH_SEARCH_TOO_COMPLEX;
-
-        // Return immediately if we are at the edge of the map and not unowning
-        // Or if we are unowning and have no tiles left
-        if ((MapIsEdge(targetPos) && !(flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN)))
-        {
-            return FOOTPATH_SEARCH_SUCCESS;
-        }
-
-        tileElement = MapGetFirstElementAt(targetPos);
-        if (tileElement == nullptr)
-            return currentTile.level == 1 ? FOOTPATH_SEARCH_NOT_FOUND : FOOTPATH_SEARCH_INCOMPLETE;
-
-        // Loop while there are unvisited TileElements at targetPos
-        do
-        {
-            if (SkipTileElement(flags, tileElement, slopeDirection, currentTile.direction, targetPos))
-                continue;
-
-            // Unown the footpath if needed
-            if (flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN)
-                FootpathFixOwnership(targetPos);
-
-            edges = tileElement->AsPath()->GetEdges();
-            currentTile.direction = DirectionReverse(currentTile.direction);
-            if (!tileElement->IsLastForTile() && !(flags & FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_NO_ENTRY))
+            int32_t slopeDirection = pathElement.GetSlopeDirection();
+            if (slopeDirection == currentDirection)
             {
-                int elementIndex = 1;
-                // Loop over all elements and cull appropriate edges
-                do
-                {
-                    if (tileElement[elementIndex].GetType() == TileElementType::Path)
-                        break;
-                    if (tileElement[elementIndex].GetType() != TileElementType::Banner)
-                    {
-                        continue;
-                    }
-                    edges &= tileElement[elementIndex].AsBanner()->GetAllowedEdges();
-                } while (!tileElement[elementIndex++].IsLastForTile());
-            }
-
-            // Exclude the direction we came from
-            targetPos.z = tileElement->GetBaseZ();
-            edges &= ~(1 << currentTile.direction);
-
-            if (!GetNextDirection(edges, &currentTile.direction))
-                break;
-
-            edges &= ~(1 << currentTile.direction);
-            if (edges == 0)
-            {
-                // Only possible direction to go
-                if (tileElement->AsPath()->IsSloped() && tileElement->AsPath()->GetSlopeDirection() == currentTile.direction)
-                    targetPos.z += kPathHeightStep;
-
-                // Prepare the next iteration
-                currentTile.footpathPos = targetPos;
-                ++currentTile.distanceFromJunction;
-                CaptureCurrentTileState(currentTile);
+                if (currentZ != pathElement.BaseHeight)
+                    return false;
             }
             else
             {
-                // We have reached a junction
-                --currentTile.junctionTolerance;
-                if (currentTile.distanceFromJunction != 0)
-                {
-                    --currentTile.junctionTolerance;
-                }
-
-                if (currentTile.junctionTolerance < 0 && !(flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN))
-                {
-                    returnVal = FOOTPATH_SEARCH_TOO_COMPLEX;
-                    break;
-                }
-
-                // Loop until there are no more directions we can go
-                do
-                {
-                    edges &= ~(1 << currentTile.direction);
-                    if (tileElement->AsPath()->IsSloped()
-                        && tileElement->AsPath()->GetSlopeDirection() == currentTile.direction)
-                    {
-                        targetPos.z += kPathHeightStep;
-                    }
-
-                    // Add each possible path to the list of pending tiles
-                    currentTile.footpathPos = targetPos;
-                    currentTile.distanceFromJunction = 0;
-                    CaptureCurrentTileState(currentTile);
-                } while (GetNextDirection(edges, &currentTile.direction));
-            }
-            break;
-        } while (!(tileElement++)->IsLastForTile());
-
-        // Return success if we have unowned all tiles in our pending list
-        if ((flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN) && numPendingTiles <= 0)
-        {
-            return FOOTPATH_SEARCH_SUCCESS;
-        }
-    }
-    return currentTile.level == 1 ? FOOTPATH_SEARCH_NOT_FOUND : returnVal;
-}
-
-// TODO: Use GAME_COMMAND_FLAGS
-int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags)
-{
-    flags |= FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES;
-    return FootpathIsConnectedToMapEdgeHelper(footpathPos, direction, flags);
-}
-
-/**
- *
- *  rct2: 0x006A8B12
- *  clears the wide footpath flag for all footpaths
- *  at location
- */
-static void FootpathClearWide(const CoordsXY& footpathPos)
-{
-    TileElement* tileElement = MapGetFirstElementAt(footpathPos);
-    if (tileElement == nullptr)
-        return;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-        tileElement->AsPath()->SetWide(false);
-    } while (!(tileElement++)->IsLastForTile());
-}
-
-/**
- *
- *  rct2: 0x006A8ACF
- *  returns footpath element if it can be made wide
- *  returns NULL if it can not be made wide
- */
-static TileElement* FootpathCanBeWide(const CoordsXYZ& footpathPos)
-{
-    TileElement* tileElement = MapGetFirstElementAt(footpathPos);
-    if (tileElement == nullptr)
-        return nullptr;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-        if (footpathPos.z != tileElement->GetBaseZ())
-            continue;
-        if (tileElement->AsPath()->IsQueue())
-            continue;
-        if (tileElement->AsPath()->IsSloped())
-            continue;
-        return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-/**
- *
- *  rct2: 0x006A87BB
- */
-void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos)
-{
-    if (MapIsEdge(footpathPos))
-        return;
-
-    FootpathClearWide(footpathPos);
-    /* Rather than clearing the wide flag of the following tiles and
-     * checking the state of them later, leave them intact and assume
-     * they were cleared. Consequently only the wide flag for this single
-     * tile is modified by this update.
-     * This is important for avoiding glitches in pathfinding that occurs
-     * between the batches of updates to the path wide flags.
-     * Corresponding pathList[] indexes for the following tiles
-     * are: 2, 3, 4, 5.
-     * Note: indexes 3, 4, 5 are reset in the current call;
-     *       index 2 is reset in the previous call. */
-    // x += 0x20;
-    // FootpathClearWide(x, y);
-    // y += 0x20;
-    // FootpathClearWide(x, y);
-    // x -= 0x20;
-    // FootpathClearWide(x, y);
-    // y -= 0x20;
-
-    // Only consider approx. 1/8 of tiles for wide path status
-    // (NB: the other 7/8 do get cleared above!)
-    if (!(footpathPos.x & 0xE0) || (!(footpathPos.y & 0xE0)))
-        return;
-
-    TileElement* tileElement = MapGetFirstElementAt(footpathPos);
-    if (tileElement == nullptr)
-        return;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-
-        if (tileElement->AsPath()->IsQueue())
-            continue;
-
-        if (tileElement->AsPath()->IsSloped())
-            continue;
-
-        if (tileElement->AsPath()->GetEdges() == 0)
-            continue;
-
-        auto height = tileElement->GetBaseZ();
-
-        // pathList is a list of elements, set by Sub6A8ACF adjacent to x,y
-        // Spanned from 0x00F3EFA8 to 0x00F3EFC7 (8 elements) in the original
-        std::array<TileElement*, 8> pathList;
-        for (std::size_t direction = 0; direction < pathList.size(); ++direction)
-        {
-            auto footpathLoc = CoordsXYZ(footpathPos + CoordsDirectionDelta[direction], height);
-            pathList[direction] = FootpathCanBeWide(footpathLoc);
-        }
-
-        uint8_t pathConnections = 0;
-        if (tileElement->AsPath()->GetEdges() & EDGE_NW)
-        {
-            pathConnections |= FOOTPATH_CONNECTION_NW;
-            const auto* pathElement = std::get<3>(pathList);
-            if (pathElement != nullptr && pathElement->AsPath()->IsWide())
-            {
-                pathConnections &= ~FOOTPATH_CONNECTION_NW;
+                slopeDirection = DirectionReverse(slopeDirection);
+                if (slopeDirection != currentDirection)
+                    return false;
+                if (currentZ != pathElement.BaseHeight + 2)
+                    return false;
             }
         }
-
-        if (tileElement->AsPath()->GetEdges() & EDGE_NE)
-        {
-            pathConnections |= FOOTPATH_CONNECTION_NE;
-            const auto* pathElement = std::get<0>(pathList);
-            if (pathElement != nullptr && pathElement->AsPath()->IsWide())
-            {
-                pathConnections &= ~FOOTPATH_CONNECTION_NE;
-            }
-        }
-
-        if (tileElement->AsPath()->GetEdges() & EDGE_SE)
-        {
-            pathConnections |= FOOTPATH_CONNECTION_SE;
-            /* In the following:
-             * footpath_element_is_wide(pathList[1])
-             * is always false due to the tile update order
-             * in combination with reset tiles.
-             * Commented out since it will never occur. */
-            // if (pathList[1] != nullptr) {
-            //  if (footpath_element_is_wide(pathList[1])) {
-            //      pathConnections &= ~FOOTPATH_CONNECTION_SE;
-            //  }
-            //}
-        }
-
-        if (tileElement->AsPath()->GetEdges() & EDGE_SW)
-        {
-            pathConnections |= FOOTPATH_CONNECTION_SW;
-            /* In the following:
-             * footpath_element_is_wide(pathList[2])
-             * is always false due to the tile update order
-             * in combination with reset tiles.
-             * Commented out since it will never occur. */
-            // if (pathList[2] != nullptr) {
-            //  if (footpath_element_is_wide(pathList[2])) {
-            //      pathConnections &= ~FOOTPATH_CONNECTION_SW;
-            //  }
-            //}
-        }
-
-        if ((pathConnections & FOOTPATH_CONNECTION_NW) && std::get<3>(pathList) != nullptr
-            && !std::get<3>(pathList)->AsPath()->IsWide())
-        {
-            constexpr uint8_t edgeMask1 = EDGE_SE | EDGE_SW;
-            const auto* pathElement0 = std::get<0>(pathList);
-            const auto* pathElement7 = std::get<7>(pathList);
-            if ((pathConnections & FOOTPATH_CONNECTION_NE) && pathElement7 != nullptr && !pathElement7->AsPath()->IsWide()
-                && (pathElement7->AsPath()->GetEdges() & edgeMask1) == edgeMask1 && pathElement0 != nullptr
-                && !pathElement0->AsPath()->IsWide())
-            {
-                pathConnections |= FOOTPATH_CONNECTION_S;
-            }
-
-            /* In the following:
-             * footpath_element_is_wide(pathList[2])
-             * is always false due to the tile update order
-             * in combination with reset tiles.
-             * Short circuit the logic appropriately. */
-            constexpr uint8_t edgeMask2 = EDGE_NE | EDGE_SE;
-            const auto* pathElement2 = std::get<2>(pathList);
-            const auto* pathElement6 = std::get<6>(pathList);
-            if ((pathConnections & FOOTPATH_CONNECTION_SW) && pathElement6 != nullptr && !(pathElement6)->AsPath()->IsWide()
-                && (pathElement6->AsPath()->GetEdges() & edgeMask2) == edgeMask2 && pathElement2 != nullptr)
-            {
-                pathConnections |= FOOTPATH_CONNECTION_E;
-            }
-        }
-
-        /* In the following:
-         * footpath_element_is_wide(pathList[4])
-         * footpath_element_is_wide(pathList[1])
-         * are always false due to the tile update order
-         * in combination with reset tiles.
-         * Short circuit the logic appropriately. */
-        if ((pathConnections & FOOTPATH_CONNECTION_SE) && std::get<1>(pathList) != nullptr)
-        {
-            constexpr uint8_t edgeMask1 = EDGE_SW | EDGE_NW;
-            const auto* pathElement0 = std::get<0>(pathList);
-            const auto* pathElement4 = std::get<4>(pathList);
-            if ((pathConnections & FOOTPATH_CONNECTION_NE) && (pathElement4 != nullptr)
-                && (pathElement4->AsPath()->GetEdges() & edgeMask1) == edgeMask1 && pathElement0 != nullptr
-                && !pathElement0->AsPath()->IsWide())
-            {
-                pathConnections |= FOOTPATH_CONNECTION_W;
-            }
-
-            /* In the following:
-             * footpath_element_is_wide(pathList[5])
-             * footpath_element_is_wide(pathList[2])
-             * are always false due to the tile update order
-             * in combination with reset tiles.
-             * Short circuit the logic appropriately. */
-            constexpr uint8_t edgeMask2 = EDGE_NE | EDGE_NW;
-            const auto* pathElement2 = std::get<2>(pathList);
-            const auto* pathElement5 = std::get<5>(pathList);
-            if ((pathConnections & FOOTPATH_CONNECTION_SW) && pathElement5 != nullptr
-                && (pathElement5->AsPath()->GetEdges() & edgeMask2) == edgeMask2 && pathElement2 != nullptr)
-            {
-                pathConnections |= FOOTPATH_CONNECTION_N;
-            }
-        }
-
-        if ((pathConnections & FOOTPATH_CONNECTION_NW) && (pathConnections & (FOOTPATH_CONNECTION_E | FOOTPATH_CONNECTION_S)))
-        {
-            pathConnections &= ~FOOTPATH_CONNECTION_NW;
-        }
-
-        if ((pathConnections & FOOTPATH_CONNECTION_NE) && (pathConnections & (FOOTPATH_CONNECTION_W | FOOTPATH_CONNECTION_S)))
-        {
-            pathConnections &= ~FOOTPATH_CONNECTION_NE;
-        }
-
-        if ((pathConnections & FOOTPATH_CONNECTION_SE) && (pathConnections & (FOOTPATH_CONNECTION_N | FOOTPATH_CONNECTION_W)))
-        {
-            pathConnections &= ~FOOTPATH_CONNECTION_SE;
-        }
-
-        if ((pathConnections & FOOTPATH_CONNECTION_SW) && (pathConnections & (FOOTPATH_CONNECTION_E | FOOTPATH_CONNECTION_N)))
-        {
-            pathConnections &= ~FOOTPATH_CONNECTION_SW;
-        }
-
-        if (!(pathConnections
-              & (FOOTPATH_CONNECTION_NE | FOOTPATH_CONNECTION_SE | FOOTPATH_CONNECTION_SW | FOOTPATH_CONNECTION_NW)))
-        {
-            uint8_t e = tileElement->AsPath()->GetEdgesAndCorners();
-            if ((e != 0b10101111) && (e != 0b01011111) && (e != 0b11101111))
-                tileElement->AsPath()->SetWide(true);
-        }
-    } while (!(tileElement++)->IsLastForTile());
-}
-
-bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position)
-{
-    auto pathElement = MapGetFirstTileElementWithBaseHeightBetween<PathElement>({ position, position.z + kPathHeightStep });
-    return pathElement != nullptr && pathElement->IsBlockedByVehicle();
-}
-
-/**
- *
- *  rct2: 0x006A7642
- */
-void FootpathUpdateQueueEntranceBanner(const CoordsXY& footpathPos, TileElement* tileElement)
-{
-    const auto elementType = tileElement->GetType();
-    if (elementType == TileElementType::Path)
-    {
-        if (tileElement->AsPath()->IsQueue())
-        {
-            FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
-            for (int32_t direction = 0; direction < kNumOrthogonalDirections; direction++)
-            {
-                if (tileElement->AsPath()->GetEdges() & (1 << direction))
-                {
-                    FootpathChainRideQueue(
-                        RideId::GetNull(), StationIndex::FromUnderlying(0), footpathPos, tileElement, direction);
-                }
-            }
-            tileElement->AsPath()->SetRideIndex(RideId::GetNull());
-        }
-    }
-    else if (elementType == TileElementType::Entrance)
-    {
-        if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
-        {
-            FootpathQueueChainPush(tileElement->AsEntrance()->GetRideIndex());
-            FootpathChainRideQueue(
-                RideId::GetNull(), StationIndex::FromUnderlying(0), footpathPos, tileElement,
-                DirectionReverse(tileElement->GetDirection()));
-        }
-    }
-}
-
-/**
- *
- *  rct2: 0x006A6B7F
- */
-static void FootpathRemoveEdgesTowardsHere(
-    const CoordsXYZ& footpathPos, int32_t direction, TileElement* tileElement, bool isQueue)
-{
-    if (tileElement->AsPath()->IsQueue())
-    {
-        FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
-    }
-
-    auto d = DirectionReverse(direction);
-    tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() & ~(1 << d));
-    int32_t cd = ((d - 1) & 3);
-    tileElement->AsPath()->SetCorners(tileElement->AsPath()->GetCorners() & ~(1 << cd));
-    cd = ((cd + 1) & 3);
-    tileElement->AsPath()->SetCorners(tileElement->AsPath()->GetCorners() & ~(1 << cd));
-    MapInvalidateTile({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
-
-    if (isQueue)
-        FootpathDisconnectQueueFromPath(footpathPos, tileElement, -1);
-
-    Direction shiftedDirection = (direction + 1) & 3;
-    auto targetFootPathPos = CoordsXYZ{ CoordsXY{ footpathPos } + CoordsDirectionDelta[shiftedDirection], footpathPos.z };
-
-    tileElement = MapGetFirstElementAt(targetFootPathPos);
-    if (tileElement == nullptr)
-        return;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-        if (tileElement->GetBaseZ() != targetFootPathPos.z)
-            continue;
-
-        if (tileElement->AsPath()->IsSloped())
-            break;
-
-        cd = ((shiftedDirection + 1) & 3);
-        tileElement->AsPath()->SetCorners(tileElement->AsPath()->GetCorners() & ~(1 << cd));
-        MapInvalidateTile({ targetFootPathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
-        break;
-    } while (!(tileElement++)->IsLastForTile());
-}
-
-/**
- *
- *  rct2: 0x006A6B14
- */
-static void FootpathRemoveEdgesTowards(const CoordsXYRangedZ& footPathPos, int32_t direction, bool isQueue)
-{
-    if (!MapIsLocationValid(footPathPos))
-    {
-        return;
-    }
-
-    TileElement* tileElement = MapGetFirstElementAt(footPathPos);
-    if (tileElement == nullptr)
-        return;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-
-        if (footPathPos.clearanceZ == tileElement->GetBaseZ())
-        {
-            if (tileElement->AsPath()->IsSloped())
-            {
-                uint8_t slope = tileElement->AsPath()->GetSlopeDirection();
-                if (slope != direction)
-                    break;
-            }
-            FootpathRemoveEdgesTowardsHere({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
-            break;
-        }
-
-        if (footPathPos.baseZ == tileElement->GetBaseZ())
-        {
-            if (!tileElement->AsPath()->IsSloped())
-                break;
-
-            uint8_t slope = DirectionReverse(tileElement->AsPath()->GetSlopeDirection());
-            if (slope != direction)
-                break;
-
-            FootpathRemoveEdgesTowardsHere({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
-            break;
-        }
-    } while (!(tileElement++)->IsLastForTile());
-}
-
-// Returns true when there is an element at the given coordinates that want to connect to a path with the given direction (ride
-// entrances and exits, shops, paths).
-bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved)
-{
-    TileElement* tileElement = MapGetFirstElementAt(coords);
-    if (tileElement == nullptr)
-        return false;
-    do
-    {
-        // Don't check the element that gets removed
-        if (tileElement == elementToBeRemoved)
-            continue;
-
-        switch (tileElement->GetType())
-        {
-            case TileElementType::Path:
-                if (tileElement->BaseHeight == coords.z)
-                {
-                    if (!tileElement->AsPath()->IsSloped())
-                        // The footpath is flat, it can be connected to from any direction
-                        return true;
-                    if (tileElement->AsPath()->GetSlopeDirection() == DirectionReverse(coords.direction))
-                        // The footpath is sloped and its lowest point matches the edge connection
-                        return true;
-                }
-                else if (tileElement->BaseHeight + 2 == coords.z)
-                {
-                    if (tileElement->AsPath()->IsSloped() && tileElement->AsPath()->GetSlopeDirection() == coords.direction)
-                        // The footpath is sloped and its higher point matches the edge connection
-                        return true;
-                }
-                break;
-            case TileElementType::Track:
-                if (tileElement->BaseHeight == coords.z)
-                {
-                    auto ride = GetRide(tileElement->AsTrack()->GetRideIndex());
-                    if (ride == nullptr)
-                        continue;
-
-                    if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
-                        break;
-
-                    const auto trackType = tileElement->AsTrack()->GetTrackType();
-                    const uint8_t trackSequence = tileElement->AsTrack()->GetSequenceIndex();
-                    const auto& ted = GetTrackElementDescriptor(trackType);
-                    if (ted.sequenceData.sequences[trackSequence].flags.has(SequenceFlag::connectsToPath))
-                    {
-                        uint16_t dx = ((coords.direction - tileElement->GetDirection()) & kTileElementDirectionMask);
-                        auto connectionSides = ted.sequenceData.sequences[trackSequence].getEntranceConnectionSides();
-                        if (connectionSides & (1 << dx))
-                        {
-                            // Track element has the flags required for the given direction
-                            return true;
-                        }
-                    }
-                }
-                break;
-            case TileElementType::Entrance:
-                if (tileElement->BaseHeight == coords.z)
-                {
-                    if (entrance_has_direction(*(tileElement->AsEntrance()), coords.direction - tileElement->GetDirection()))
-                    {
-                        // Entrance wants to be connected towards the given direction
-                        return true;
-                    }
-                }
-                break;
-            default:
-                break;
-        }
-    } while (!(tileElement++)->IsLastForTile());
-
-    return false;
-}
-
-/**
- *
- *  rct2: 0x006A6AA7
- * @param x x-coordinate in units (not tiles)
- * @param y y-coordinate in units (not tiles)
- */
-void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, TileElement* tileElement)
-{
-    if (tileElement->GetType() == TileElementType::Track)
-    {
-        auto rideIndex = tileElement->AsTrack()->GetRideIndex();
-        auto ride = GetRide(rideIndex);
-        if (ride == nullptr)
-            return;
-
-        if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide))
-            return;
-    }
-
-    FootpathUpdateQueueEntranceBanner(footpathPos, tileElement);
-
-    for (uint8_t direction = 0; direction < kNumOrthogonalDirections; direction++)
-    {
-        int32_t z1 = tileElement->BaseHeight;
-        if (tileElement->GetType() == TileElementType::Path)
-        {
-            if (tileElement->AsPath()->IsSloped())
-            {
-                int32_t slope = tileElement->AsPath()->GetSlopeDirection();
-                // Sloped footpaths don't connect sideways
-                if ((slope - direction) & 1)
-                    continue;
-
-                // When a path is sloped, the higher point of the path is 2 units higher
-                z1 += (slope == direction) ? 2 : 0;
-            }
-        }
-
-        // When clearance checks were disabled a neighbouring path can be connected to both the path-ghost and to something
-        // else, so before removing edges from neighbouring paths we have to make sure there is nothing else they are connected
-        // to.
-        if (!TileElementWantsPathConnectionTowards({ TileCoordsXY{ footpathPos }, z1, direction }, tileElement))
-        {
-            bool isQueue = tileElement->GetType() == TileElementType::Path ? tileElement->AsPath()->IsQueue() : false;
-            int32_t z0 = z1 - 2;
-            FootpathRemoveEdgesTowards(
-                { footpathPos + CoordsDirectionDelta[direction], z0 * kCoordsZStep, z1 * kCoordsZStep }, direction, isQueue);
-        }
-    }
-
-    if (tileElement->GetType() == TileElementType::Path)
-        tileElement->AsPath()->SetEdgesAndCorners(0);
-}
-
-const FootpathObject* GetLegacyFootpathEntry(ObjectEntryIndex entryIndex)
-{
-    auto& objMgr = GetContext()->GetObjectManager();
-    return objMgr.GetLoadedObject<FootpathObject>(entryIndex);
-}
-
-const FootpathSurfaceObject* GetPathSurfaceEntry(ObjectEntryIndex entryIndex)
-{
-    auto& objMgr = GetContext()->GetObjectManager();
-    return objMgr.GetLoadedObject<FootpathSurfaceObject>(entryIndex);
-}
-
-const FootpathRailingsObject* GetPathRailingsEntry(ObjectEntryIndex entryIndex)
-{
-    auto& objMgr = GetContext()->GetObjectManager();
-    return objMgr.GetLoadedObject<FootpathRailingsObject>(entryIndex);
-}
-
-RideId PathElement::GetRideIndex() const
-{
-    return rideIndex;
-}
-
-void PathElement::SetRideIndex(RideId newRideIndex)
-{
-    rideIndex = newRideIndex;
-}
-
-uint8_t PathElement::GetAdditionStatus() const
-{
-    return AdditionStatus;
-}
-
-void PathElement::SetAdditionStatus(uint8_t newStatus)
-{
-    AdditionStatus = newStatus;
-}
-
-uint8_t PathElement::GetEdges() const
-{
-    return EdgesAndCorners & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
-}
-
-void PathElement::SetEdges(uint8_t newEdges)
-{
-    EdgesAndCorners &= ~FOOTPATH_PROPERTIES_EDGES_EDGES_MASK;
-    EdgesAndCorners |= (newEdges & FOOTPATH_PROPERTIES_EDGES_EDGES_MASK);
-}
-
-uint8_t PathElement::GetCorners() const
-{
-    return EdgesAndCorners >> 4;
-}
-
-void PathElement::SetCorners(uint8_t newCorners)
-{
-    EdgesAndCorners &= ~FOOTPATH_PROPERTIES_EDGES_CORNERS_MASK;
-    EdgesAndCorners |= (newCorners << 4);
-}
-
-uint8_t PathElement::GetEdgesAndCorners() const
-{
-    return EdgesAndCorners;
-}
-
-void PathElement::SetEdgesAndCorners(uint8_t newEdgesAndCorners)
-{
-    EdgesAndCorners = newEdgesAndCorners;
-}
-
-bool PathElement::IsLevelCrossing(const CoordsXY& coords) const
-{
-    auto trackElement = MapGetTrackElementAt({ coords, GetBaseZ() });
-    if (trackElement == nullptr)
-    {
-        return false;
-    }
-
-    if (trackElement->GetTrackType() != TrackElemType::flat)
-    {
-        return false;
-    }
-
-    auto ride = GetRide(trackElement->GetRideIndex());
-    if (ride == nullptr)
-    {
-        return false;
-    }
-
-    return ride->getRideTypeDescriptor().flags.has(RtdFlag::supportsLevelCrossings);
-}
-
-bool FootpathIsZAndDirectionValid(const PathElement& pathElement, int32_t currentZ, int32_t currentDirection)
-{
-    if (pathElement.IsSloped())
-    {
-        int32_t slopeDirection = pathElement.GetSlopeDirection();
-        if (slopeDirection == currentDirection)
+        else
         {
             if (currentZ != pathElement.BaseHeight)
                 return false;
         }
-        else
+        return true;
+    }
+
+    FootpathPlacementResult FootpathGetOnTerrainPlacement(const TileCoordsXY& location)
+    {
+        auto* surfaceElement = MapGetSurfaceElementAt(location);
+        if (surfaceElement == nullptr)
+            return {};
+
+        return FootpathGetOnTerrainPlacement(*surfaceElement);
+    }
+
+    FootpathPlacementResult FootpathGetOnTerrainPlacement(const SurfaceElement& surfaceElement)
+    {
+        int32_t baseZ = surfaceElement.GetBaseZ();
+        auto slope = kDefaultPathSlope[surfaceElement.GetSlope() & kTileSlopeRaisedCornersMask];
+        if (slope.type == FootpathSlopeType::raise)
         {
-            slopeDirection = DirectionReverse(slopeDirection);
-            if (slopeDirection != currentDirection)
-                return false;
-            if (currentZ != pathElement.BaseHeight + 2)
-                return false;
+            slope.type = FootpathSlopeType::flat;
+            baseZ += kPathHeightStep;
         }
+
+        return { baseZ, slope };
     }
-    else
-    {
-        if (currentZ != pathElement.BaseHeight)
-            return false;
-    }
-    return true;
-}
-
-FootpathPlacementResult FootpathGetOnTerrainPlacement(const TileCoordsXY& location)
-{
-    auto* surfaceElement = MapGetSurfaceElementAt(location);
-    if (surfaceElement == nullptr)
-        return {};
-
-    return FootpathGetOnTerrainPlacement(*surfaceElement);
-}
-
-FootpathPlacementResult FootpathGetOnTerrainPlacement(const SurfaceElement& surfaceElement)
-{
-    int32_t baseZ = surfaceElement.GetBaseZ();
-    auto slope = kDefaultPathSlope[surfaceElement.GetSlope() & kTileSlopeRaisedCornersMask];
-    if (slope.type == FootpathSlopeType::raise)
-    {
-        slope.type = FootpathSlopeType::flat;
-        baseZ += kPathHeightStep;
-    }
-
-    return { baseZ, slope };
-}
+} // namespace OpenRCT2

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -191,6 +191,8 @@ void FootpathChainRideQueue(
 void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos);
 bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position);
 
+bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const OpenRCT2::TileElement* elementToBeRemoved);
+
 int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
 void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, OpenRCT2::TileElement* tileElement);
 

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -29,181 +29,179 @@ namespace OpenRCT2
     struct PathElement;
     struct SurfaceElement;
     struct TileElement;
+
+    constexpr auto kFootpathMaxHeight = 248 * kCoordsZStep;
+    constexpr auto kFootpathMinHeight = 2 * kCoordsZStep;
+    constexpr auto kPathHeightStep = 2 * kCoordsZStep;
+    constexpr auto kPathClearance = 4 * kCoordsZStep;
+
+    enum class RailingEntrySupportType : uint8_t
+    {
+        box = 0,
+        pole = 1,
+        count
+    };
+
+    struct PathSurfaceDescriptor
+    {
+        StringId name = kStringIdNone;
+        ImageIndex image{};
+        ImageIndex previewImage{};
+        uint8_t flags{};
+    };
+    constexpr PathSurfaceDescriptor kPathSurfaceDescriptorDummy{};
+
+    struct PathRailingsDescriptor
+    {
+        StringId name = kStringIdNone;
+        ImageIndex previewImage{};
+        ImageIndex bridgeImage{};
+        ImageIndex railingsImage{};
+        RailingEntrySupportType supportType{};
+        Drawing::Colour supportColour = Drawing::kColourNull;
+        uint8_t flags{};
+        uint8_t scrollingMode = kScrollingModeNone;
+    };
+    constexpr PathRailingsDescriptor kPathRailingsDescriptorDummy{};
+
+    using PathConstructFlags = uint8_t;
+    namespace PathConstructFlag
+    {
+        constexpr PathConstructFlags IsQueue = 1 << 0;
+        constexpr PathConstructFlags IsLegacyPathObject = 1 << 1;
+    } // namespace PathConstructFlag
+
+    struct FootpathSelection
+    {
+        ObjectEntryIndex legacyPath = kObjectEntryIndexNull;
+        ObjectEntryIndex normalSurface = kObjectEntryIndexNull;
+        ObjectEntryIndex queueSurface = kObjectEntryIndexNull;
+        ObjectEntryIndex railings = kObjectEntryIndexNull;
+        bool isQueueSelected{};
+
+        ObjectEntryIndex getSelectedSurface() const
+        {
+            return isQueueSelected ? queueSurface : normalSurface;
+        }
+    };
+
+    enum class FootpathSlopeType : uint8_t
+    {
+        flat,
+        sloped,
+        /**
+         * Land has one corner down, raise the Z coordinate and place a flat piece.
+         */
+        raise,
+        /**
+         * Terrain has a shape that allows for two different path slopes, and as such it cannot autoplace a piece
+         * without further context of the surrounding paths.
+         */
+        irregular,
+    };
+
+    struct FootpathSlope
+    {
+        FootpathSlopeType type{};
+        Direction direction{};
+
+        constexpr bool operator==(const FootpathSlope& rhs) const
+        {
+            return type == rhs.type && direction == rhs.direction;
+        }
+    };
+
+    struct FootpathPlacementResult
+    {
+        int32_t baseZ{};
+        FootpathSlope slope{};
+
+        bool isValid()
+        {
+            return baseZ > 0;
+        }
+    };
+
+    enum
+    {
+        RAILING_ENTRY_FLAG_HAS_SUPPORT_BASE_SPRITE = (1 << 0),
+        RAILING_ENTRY_FLAG_DRAW_PATH_OVER_SUPPORTS = (1 << 1), // When elevated
+        RAILING_ENTRY_FLAG_NO_QUEUE_BANNER = (1 << 2),
+    };
+
+    enum
+    {
+        FOOTPATH_SEARCH_SUCCESS,
+        FOOTPATH_SEARCH_NOT_FOUND,
+        FOOTPATH_SEARCH_INCOMPLETE,
+        FOOTPATH_SEARCH_TOO_COMPLEX
+    };
+
+    enum
+    {
+        SLOPE_IS_IRREGULAR_FLAG = (1 << 3), // Flag set in `DefaultPathSlope[]` and checked in `footpath_place_real`
+        RAISE_FOOTPATH_FLAG = (1 << 4)
+    };
+
+    enum
+    {
+        FOOTPATH_CORNER_0 = (1 << 0),
+        FOOTPATH_CORNER_1 = (1 << 1),
+        FOOTPATH_CORNER_2 = (1 << 2),
+        FOOTPATH_CORNER_3 = (1 << 3),
+    };
+
+    enum
+    {
+        FOOTPATH_CONNECTION_S = (1 << 0),
+        FOOTPATH_CONNECTION_NE = (1 << 1),
+        FOOTPATH_CONNECTION_W = (1 << 2),
+        FOOTPATH_CONNECTION_SE = (1 << 3),
+        FOOTPATH_CONNECTION_N = (1 << 4),
+        FOOTPATH_CONNECTION_SW = (1 << 5),
+        FOOTPATH_CONNECTION_E = (1 << 6),
+        FOOTPATH_CONNECTION_NW = (1 << 7),
+    };
+
+    enum
+    {
+        FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES = (1 << 0),
+        FOOTPATH_CONNECTED_MAP_EDGE_UNOWN = (1 << 5),
+        FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_NO_ENTRY = (1 << 7)
+    };
+
+    extern FootpathSelection gFootpathSelection;
+    extern uint8_t gFootpathGroundFlags;
+
+    // Given a direction, this will return how to increase/decrease the x and y coordinates.
+    extern const std::array<CoordsXY, kNumOrthogonalDirections> DirectionOffsets;
+    extern const std::array<CoordsXY, kNumOrthogonalDirections> BinUseOffsets;
+    extern const std::array<CoordsXY, kNumOrthogonalDirections * 2> BenchUseOffsets;
+
+    PathElement* MapGetFootpathElement(const CoordsXYZ& coords);
+    void FootpathInterruptPeeps(const CoordsXYZ& footpathPos);
+    void FootpathRemoveLitter(const CoordsXYZ& footpathPos);
+    void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, GameActions::CommandFlags flags);
+    void FootpathUpdateQueueChains();
+    void FootpathChainRideQueue(
+        RideId rideIndex, StationIndex entranceIndex, const CoordsXY& footpathPos, TileElement* tileElement, int32_t direction);
+    void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos);
+    bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position);
+
+    bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const TileElement* elementToBeRemoved);
+
+    int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
+    void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, TileElement* tileElement);
+
+    const FootpathObject* GetLegacyFootpathEntry(ObjectEntryIndex entryIndex);
+    const FootpathSurfaceObject* GetPathSurfaceEntry(ObjectEntryIndex entryIndex);
+    const FootpathRailingsObject* GetPathRailingsEntry(ObjectEntryIndex entryIndex);
+
+    void FootpathQueueChainReset();
+    void FootpathQueueChainPush(RideId rideIndex);
+    int32_t FootpathQueueCountConnections(const CoordsXY& position, const PathElement& pathElement);
+    bool FootpathIsZAndDirectionValid(const PathElement& tileElement, int32_t currentZ, int32_t currentDirection);
+
+    FootpathPlacementResult FootpathGetOnTerrainPlacement(const TileCoordsXY& location);
+    FootpathPlacementResult FootpathGetOnTerrainPlacement(const SurfaceElement& surfaceElement);
 } // namespace OpenRCT2
-
-constexpr auto kFootpathMaxHeight = 248 * kCoordsZStep;
-constexpr auto kFootpathMinHeight = 2 * kCoordsZStep;
-constexpr auto kPathHeightStep = 2 * kCoordsZStep;
-constexpr auto kPathClearance = 4 * kCoordsZStep;
-
-enum class RailingEntrySupportType : uint8_t
-{
-    box = 0,
-    pole = 1,
-    count
-};
-
-struct PathSurfaceDescriptor
-{
-    StringId name = kStringIdNone;
-    ImageIndex image{};
-    ImageIndex previewImage{};
-    uint8_t flags{};
-};
-constexpr PathSurfaceDescriptor kPathSurfaceDescriptorDummy{};
-
-struct PathRailingsDescriptor
-{
-    StringId name = kStringIdNone;
-    ImageIndex previewImage{};
-    ImageIndex bridgeImage{};
-    ImageIndex railingsImage{};
-    RailingEntrySupportType supportType{};
-    OpenRCT2::Drawing::Colour supportColour = OpenRCT2::Drawing::kColourNull;
-    uint8_t flags{};
-    uint8_t scrollingMode = kScrollingModeNone;
-};
-constexpr PathRailingsDescriptor kPathRailingsDescriptorDummy{};
-
-using PathConstructFlags = uint8_t;
-namespace OpenRCT2::PathConstructFlag
-{
-    constexpr PathConstructFlags IsQueue = 1 << 0;
-    constexpr PathConstructFlags IsLegacyPathObject = 1 << 1;
-} // namespace OpenRCT2::PathConstructFlag
-
-struct FootpathSelection
-{
-    OpenRCT2::ObjectEntryIndex legacyPath = OpenRCT2::kObjectEntryIndexNull;
-    OpenRCT2::ObjectEntryIndex normalSurface = OpenRCT2::kObjectEntryIndexNull;
-    OpenRCT2::ObjectEntryIndex queueSurface = OpenRCT2::kObjectEntryIndexNull;
-    OpenRCT2::ObjectEntryIndex railings = OpenRCT2::kObjectEntryIndexNull;
-    bool isQueueSelected{};
-
-    OpenRCT2::ObjectEntryIndex getSelectedSurface() const
-    {
-        return isQueueSelected ? queueSurface : normalSurface;
-    }
-};
-
-enum class FootpathSlopeType : uint8_t
-{
-    flat,
-    sloped,
-    /**
-     * Land has one corner down, raise the Z coordinate and place a flat piece.
-     */
-    raise,
-    /**
-     * Terrain has a shape that allows for two different path slopes, and as such it cannot autoplace a piece
-     * without further context of the surrounding paths.
-     */
-    irregular,
-};
-
-struct FootpathSlope
-{
-    FootpathSlopeType type{};
-    Direction direction{};
-
-    constexpr bool operator==(const FootpathSlope& rhs) const
-    {
-        return type == rhs.type && direction == rhs.direction;
-    }
-};
-
-struct FootpathPlacementResult
-{
-    int32_t baseZ{};
-    FootpathSlope slope{};
-
-    bool isValid()
-    {
-        return baseZ > 0;
-    }
-};
-
-enum
-{
-    RAILING_ENTRY_FLAG_HAS_SUPPORT_BASE_SPRITE = (1 << 0),
-    RAILING_ENTRY_FLAG_DRAW_PATH_OVER_SUPPORTS = (1 << 1), // When elevated
-    RAILING_ENTRY_FLAG_NO_QUEUE_BANNER = (1 << 2),
-};
-
-enum
-{
-    FOOTPATH_SEARCH_SUCCESS,
-    FOOTPATH_SEARCH_NOT_FOUND,
-    FOOTPATH_SEARCH_INCOMPLETE,
-    FOOTPATH_SEARCH_TOO_COMPLEX
-};
-
-enum
-{
-    SLOPE_IS_IRREGULAR_FLAG = (1 << 3), // Flag set in `DefaultPathSlope[]` and checked in `footpath_place_real`
-    RAISE_FOOTPATH_FLAG = (1 << 4)
-};
-
-enum
-{
-    FOOTPATH_CORNER_0 = (1 << 0),
-    FOOTPATH_CORNER_1 = (1 << 1),
-    FOOTPATH_CORNER_2 = (1 << 2),
-    FOOTPATH_CORNER_3 = (1 << 3),
-};
-
-enum
-{
-    FOOTPATH_CONNECTION_S = (1 << 0),
-    FOOTPATH_CONNECTION_NE = (1 << 1),
-    FOOTPATH_CONNECTION_W = (1 << 2),
-    FOOTPATH_CONNECTION_SE = (1 << 3),
-    FOOTPATH_CONNECTION_N = (1 << 4),
-    FOOTPATH_CONNECTION_SW = (1 << 5),
-    FOOTPATH_CONNECTION_E = (1 << 6),
-    FOOTPATH_CONNECTION_NW = (1 << 7),
-};
-
-enum
-{
-    FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES = (1 << 0),
-    FOOTPATH_CONNECTED_MAP_EDGE_UNOWN = (1 << 5),
-    FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_NO_ENTRY = (1 << 7)
-};
-
-extern FootpathSelection gFootpathSelection;
-extern uint8_t gFootpathGroundFlags;
-
-// Given a direction, this will return how to increase/decrease the x and y coordinates.
-extern const std::array<CoordsXY, kNumOrthogonalDirections> DirectionOffsets;
-extern const std::array<CoordsXY, kNumOrthogonalDirections> BinUseOffsets;
-extern const std::array<CoordsXY, kNumOrthogonalDirections * 2> BenchUseOffsets;
-
-OpenRCT2::PathElement* MapGetFootpathElement(const CoordsXYZ& coords);
-void FootpathInterruptPeeps(const CoordsXYZ& footpathPos);
-void FootpathRemoveLitter(const CoordsXYZ& footpathPos);
-void FootpathConnectEdges(
-    const CoordsXY& footpathPos, OpenRCT2::TileElement* tileElement, OpenRCT2::GameActions::CommandFlags flags);
-void FootpathUpdateQueueChains();
-void FootpathChainRideQueue(
-    RideId rideIndex, StationIndex entranceIndex, const CoordsXY& footpathPos, OpenRCT2::TileElement* tileElement,
-    int32_t direction);
-void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos);
-bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position);
-
-bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const OpenRCT2::TileElement* elementToBeRemoved);
-
-int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
-void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, OpenRCT2::TileElement* tileElement);
-
-const OpenRCT2::FootpathObject* GetLegacyFootpathEntry(OpenRCT2::ObjectEntryIndex entryIndex);
-const OpenRCT2::FootpathSurfaceObject* GetPathSurfaceEntry(OpenRCT2::ObjectEntryIndex entryIndex);
-const OpenRCT2::FootpathRailingsObject* GetPathRailingsEntry(OpenRCT2::ObjectEntryIndex entryIndex);
-
-void FootpathQueueChainReset();
-void FootpathQueueChainPush(RideId rideIndex);
-int32_t FootpathQueueCountConnections(const CoordsXY& position, const OpenRCT2::PathElement& pathElement);
-bool FootpathIsZAndDirectionValid(const OpenRCT2::PathElement& tileElement, int32_t currentZ, int32_t currentDirection);
-
-FootpathPlacementResult FootpathGetOnTerrainPlacement(const TileCoordsXY& location);
-FootpathPlacementResult FootpathGetOnTerrainPlacement(const OpenRCT2::SurfaceElement& surfaceElement);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -68,2317 +68,2321 @@
 #include <iterator>
 #include <memory>
 
-using namespace OpenRCT2;
-
-/**
- * Replaces 0x00993CCC, 0x00993CCE
- */
-// clang-format off
-const std::array<CoordsXY, 8> CoordsDirectionDelta = {
-    CoordsXY{ -kCoordsXYStep, 0 },
-    CoordsXY{               0, +kCoordsXYStep },
-    CoordsXY{ +kCoordsXYStep, 0 },
-    CoordsXY{               0, -kCoordsXYStep },
-    CoordsXY{ -kCoordsXYStep, +kCoordsXYStep },
-    CoordsXY{ +kCoordsXYStep, +kCoordsXYStep },
-    CoordsXY{ +kCoordsXYStep, -kCoordsXYStep },
-    CoordsXY{ -kCoordsXYStep, -kCoordsXYStep }
-};
-// clang-format on
-
-const TileCoordsXY TileDirectionDelta[] = {
-    { -1, 0 }, { 0, +1 }, { +1, 0 }, { 0, -1 }, { -1, +1 }, { +1, +1 }, { +1, -1 }, { -1, -1 },
-};
-
-constexpr size_t MIN_TILE_ELEMENTS = 1024;
-
-uint32_t gLandRemainingOwnershipSales;
-uint32_t gLandRemainingConstructionSales;
-
-bool gMapLandRightsUpdateSuccess;
-
-static TilePointerIndex<TileElement> _tileIndex;
-static TilePointerIndex<TileElement> _tileIndexStash;
-static std::vector<TileElement> _tileElementsStash;
-static size_t _tileElementsInUse;
-static size_t _tileElementsInUseStash;
-static TileCoordsXY _mapSizeStash;
-
-void StashMap()
+namespace OpenRCT2
 {
-    auto& gameState = getGameState();
-    _tileIndexStash = std::move(_tileIndex);
-    _tileElementsStash = std::move(gameState.tileElements);
-    _mapSizeStash = gameState.mapSize;
-    _tileElementsInUseStash = _tileElementsInUse;
-}
+    /**
+     * Replaces 0x00993CCC, 0x00993CCE
+     */
+    // clang-format off
+    const std::array<CoordsXY, 8> CoordsDirectionDelta = {
+        CoordsXY{ -kCoordsXYStep, 0 },
+        CoordsXY{               0, +kCoordsXYStep },
+        CoordsXY{ +kCoordsXYStep, 0 },
+        CoordsXY{               0, -kCoordsXYStep },
+        CoordsXY{ -kCoordsXYStep, +kCoordsXYStep },
+        CoordsXY{ +kCoordsXYStep, +kCoordsXYStep },
+        CoordsXY{ +kCoordsXYStep, -kCoordsXYStep },
+        CoordsXY{ -kCoordsXYStep, -kCoordsXYStep }
+    };
+    // clang-format on
 
-void UnstashMap()
-{
-    auto& gameState = getGameState();
-    _tileIndex = std::move(_tileIndexStash);
-    gameState.tileElements = std::move(_tileElementsStash);
-    gameState.mapSize = _mapSizeStash;
-    _tileElementsInUse = _tileElementsInUseStash;
-}
+    const TileCoordsXY TileDirectionDelta[] = {
+        { -1, 0 }, { 0, +1 }, { +1, 0 }, { 0, -1 }, { -1, +1 }, { +1, +1 }, { +1, -1 }, { -1, -1 },
+    };
 
-CoordsXY GetMapSizeUnits()
-{
-    auto& gameState = getGameState();
-    return { (gameState.mapSize.x - 1) * kCoordsXYStep, (gameState.mapSize.y - 1) * kCoordsXYStep };
-}
-CoordsXY GetMapSizeMinus2()
-{
-    auto& gameState = getGameState();
-    return { (gameState.mapSize.x * kCoordsXYStep) + (8 * kCoordsXYStep - 2),
-             (gameState.mapSize.y * kCoordsXYStep) + (8 * kCoordsXYStep - 2) };
-}
-CoordsXY GetMapSizeMaxXY()
-{
-    return GetMapSizeUnits() - CoordsXY{ 1, 1 };
-}
+    constexpr size_t MIN_TILE_ELEMENTS = 1024;
 
-const std::vector<TileElement>& GetTileElements()
-{
-    return getGameState().tileElements;
-}
+    uint32_t gLandRemainingOwnershipSales;
+    uint32_t gLandRemainingConstructionSales;
 
-void SetTileElements(GameState_t& gameState, std::vector<TileElement>&& tileElements)
-{
-    gameState.tileElements = std::move(tileElements);
-    _tileIndex = TilePointerIndex<TileElement>(
-        kMaximumMapSizeTechnical, gameState.tileElements.data(), gameState.tileElements.size());
-    _tileElementsInUse = gameState.tileElements.size();
-}
+    bool gMapLandRightsUpdateSuccess;
 
-static TileElement GetDefaultSurfaceElement()
-{
-    TileElement el;
-    el.ClearAs(TileElementType::Surface);
-    el.SetLastForTile(true);
-    el.BaseHeight = 14;
-    el.ClearanceHeight = 14;
-    el.AsSurface()->SetWaterHeight(0);
-    el.AsSurface()->SetSlope(kTileSlopeFlat);
-    el.AsSurface()->SetGrassLength(GRASS_LENGTH_CLEAR_0);
-    el.AsSurface()->SetOwnership(OWNERSHIP_UNOWNED);
-    el.AsSurface()->SetParkFences(0);
-    el.AsSurface()->SetSurfaceObjectIndex(0);
-    el.AsSurface()->SetEdgeObjectIndex(0);
-    return el;
-}
+    static TilePointerIndex<TileElement> _tileIndex;
+    static TilePointerIndex<TileElement> _tileIndexStash;
+    static std::vector<TileElement> _tileElementsStash;
+    static size_t _tileElementsInUse;
+    static size_t _tileElementsInUseStash;
+    static TileCoordsXY _mapSizeStash;
 
-std::vector<TileElement> GetReorganisedTileElementsWithoutGhosts()
-{
-    std::vector<TileElement> newElements;
-    newElements.reserve(std::max(MIN_TILE_ELEMENTS, getGameState().tileElements.size()));
-    for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
+    void StashMap()
     {
-        for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
-        {
-            auto oldSize = newElements.size();
+        auto& gameState = getGameState();
+        _tileIndexStash = std::move(_tileIndex);
+        _tileElementsStash = std::move(gameState.tileElements);
+        _mapSizeStash = gameState.mapSize;
+        _tileElementsInUseStash = _tileElementsInUse;
+    }
 
-            // Add all non-ghost elements
-            const auto* element = MapGetFirstElementAt(TileCoordsXY{ x, y });
-            if (element != nullptr)
+    void UnstashMap()
+    {
+        auto& gameState = getGameState();
+        _tileIndex = std::move(_tileIndexStash);
+        gameState.tileElements = std::move(_tileElementsStash);
+        gameState.mapSize = _mapSizeStash;
+        _tileElementsInUse = _tileElementsInUseStash;
+    }
+
+    CoordsXY GetMapSizeUnits()
+    {
+        auto& gameState = getGameState();
+        return { (gameState.mapSize.x - 1) * kCoordsXYStep, (gameState.mapSize.y - 1) * kCoordsXYStep };
+    }
+    CoordsXY GetMapSizeMinus2()
+    {
+        auto& gameState = getGameState();
+        return { (gameState.mapSize.x * kCoordsXYStep) + (8 * kCoordsXYStep - 2),
+                 (gameState.mapSize.y * kCoordsXYStep) + (8 * kCoordsXYStep - 2) };
+    }
+    CoordsXY GetMapSizeMaxXY()
+    {
+        return GetMapSizeUnits() - CoordsXY{ 1, 1 };
+    }
+
+    const std::vector<TileElement>& GetTileElements()
+    {
+        return getGameState().tileElements;
+    }
+
+    void SetTileElements(GameState_t& gameState, std::vector<TileElement>&& tileElements)
+    {
+        gameState.tileElements = std::move(tileElements);
+        _tileIndex = TilePointerIndex<TileElement>(
+            kMaximumMapSizeTechnical, gameState.tileElements.data(), gameState.tileElements.size());
+        _tileElementsInUse = gameState.tileElements.size();
+    }
+
+    static TileElement GetDefaultSurfaceElement()
+    {
+        TileElement el;
+        el.ClearAs(TileElementType::Surface);
+        el.SetLastForTile(true);
+        el.BaseHeight = 14;
+        el.ClearanceHeight = 14;
+        el.AsSurface()->SetWaterHeight(0);
+        el.AsSurface()->SetSlope(kTileSlopeFlat);
+        el.AsSurface()->SetGrassLength(GRASS_LENGTH_CLEAR_0);
+        el.AsSurface()->SetOwnership(OWNERSHIP_UNOWNED);
+        el.AsSurface()->SetParkFences(0);
+        el.AsSurface()->SetSurfaceObjectIndex(0);
+        el.AsSurface()->SetEdgeObjectIndex(0);
+        return el;
+    }
+
+    std::vector<TileElement> GetReorganisedTileElementsWithoutGhosts()
+    {
+        std::vector<TileElement> newElements;
+        newElements.reserve(std::max(MIN_TILE_ELEMENTS, getGameState().tileElements.size()));
+        for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
+        {
+            for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
             {
-                do
+                auto oldSize = newElements.size();
+
+                // Add all non-ghost elements
+                const auto* element = MapGetFirstElementAt(TileCoordsXY{ x, y });
+                if (element != nullptr)
                 {
-                    if (!element->IsGhost())
+                    do
+                    {
+                        if (!element->IsGhost())
+                        {
+                            newElements.push_back(*element);
+                        }
+                    } while (!(element++)->IsLastForTile());
+                }
+
+                // Insert default surface element if no elements were added
+                auto newSize = newElements.size();
+                if (oldSize == newSize)
+                {
+                    newElements.push_back(GetDefaultSurfaceElement());
+                }
+
+                // Ensure last element of tile has last flag set
+                auto& lastEl = newElements.back();
+                lastEl.SetLastForTile(true);
+            }
+        }
+        return newElements;
+    }
+
+    static void ReorganiseTileElements(GameState_t& gameState, size_t capacity)
+    {
+        ContextSetCurrentCursor(CursorID::ZZZ);
+
+        std::vector<TileElement> newElements;
+        newElements.reserve(std::max(MIN_TILE_ELEMENTS, capacity));
+        for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
+        {
+            for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
+            {
+                const auto* element = MapGetFirstElementAt(TileCoordsXY{ x, y });
+                if (element == nullptr)
+                {
+                    newElements.push_back(GetDefaultSurfaceElement());
+                }
+                else
+                {
+                    do
                     {
                         newElements.push_back(*element);
-                    }
-                } while (!(element++)->IsLastForTile());
+                    } while (!(element++)->IsLastForTile());
+                }
             }
-
-            // Insert default surface element if no elements were added
-            auto newSize = newElements.size();
-            if (oldSize == newSize)
-            {
-                newElements.push_back(GetDefaultSurfaceElement());
-            }
-
-            // Ensure last element of tile has last flag set
-            auto& lastEl = newElements.back();
-            lastEl.SetLastForTile(true);
         }
+
+        SetTileElements(gameState, std::move(newElements));
     }
-    return newElements;
-}
 
-static void ReorganiseTileElements(GameState_t& gameState, size_t capacity)
-{
-    ContextSetCurrentCursor(CursorID::ZZZ);
-
-    std::vector<TileElement> newElements;
-    newElements.reserve(std::max(MIN_TILE_ELEMENTS, capacity));
-    for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
+    static void ReorganiseTileElements(size_t capacity)
     {
-        for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
+        auto& gameState = getGameState();
+        ReorganiseTileElements(gameState, capacity);
+    }
+
+    void ReorganiseTileElements()
+    {
+        auto& gameState = getGameState();
+        ReorganiseTileElements(gameState, gameState.tileElements.size());
+    }
+
+    static bool MapCheckFreeElementsAndReorganise(size_t numElementsOnTile, size_t numNewElements)
+    {
+        // Check hard cap on num in use tiles (this would be the size of _tileElements immediately after a reorg)
+        if (_tileElementsInUse + numNewElements > kMaxTileElements)
         {
-            const auto* element = MapGetFirstElementAt(TileCoordsXY{ x, y });
-            if (element == nullptr)
-            {
-                newElements.push_back(GetDefaultSurfaceElement());
-            }
-            else
-            {
-                do
-                {
-                    newElements.push_back(*element);
-                } while (!(element++)->IsLastForTile());
-            }
+            return false;
         }
-    }
 
-    SetTileElements(gameState, std::move(newElements));
-}
-
-static void ReorganiseTileElements(size_t capacity)
-{
-    auto& gameState = getGameState();
-    ReorganiseTileElements(gameState, capacity);
-}
-
-void ReorganiseTileElements()
-{
-    auto& gameState = getGameState();
-    ReorganiseTileElements(gameState, gameState.tileElements.size());
-}
-
-static bool MapCheckFreeElementsAndReorganise(size_t numElementsOnTile, size_t numNewElements)
-{
-    // Check hard cap on num in use tiles (this would be the size of _tileElements immediately after a reorg)
-    if (_tileElementsInUse + numNewElements > kMaxTileElements)
-    {
-        return false;
-    }
-
-    auto& gameState = getGameState();
-    auto totalElementsRequired = numElementsOnTile + numNewElements;
-    auto freeElements = gameState.tileElements.capacity() - gameState.tileElements.size();
-    if (freeElements >= totalElementsRequired)
-    {
-        return true;
-    }
-
-    // if space issue is due to fragmentation then Reorg Tiles without increasing capacity
-    if (gameState.tileElements.size() > totalElementsRequired + _tileElementsInUse)
-    {
-        ReorganiseTileElements();
-        // This check is not expected to fail
-        freeElements = gameState.tileElements.capacity() - gameState.tileElements.size();
+        auto& gameState = getGameState();
+        auto totalElementsRequired = numElementsOnTile + numNewElements;
+        auto freeElements = gameState.tileElements.capacity() - gameState.tileElements.size();
         if (freeElements >= totalElementsRequired)
         {
             return true;
         }
-    }
 
-    // Capacity must increase to handle the space (Note capacity can go above kMaxTileElements)
-    auto newCapacity = gameState.tileElements.capacity() * 2;
-    ReorganiseTileElements(newCapacity);
-    return true;
-}
-
-static size_t CountElementsOnTile(const CoordsXY& loc);
-
-bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements)
-{
-    auto numElementsOnTile = CountElementsOnTile(loc);
-    return MapCheckFreeElementsAndReorganise(numElementsOnTile, numElements);
-}
-
-static void ClearElementsAt(const CoordsXY& loc);
-
-void TileElementIteratorBegin(TileElementIterator* it)
-{
-    it->x = 1;
-    it->y = 1;
-    it->element = MapGetFirstElementAt(TileCoordsXY{ 1, 1 });
-}
-
-int32_t TileElementIteratorNext(TileElementIterator* it)
-{
-    if (it->element == nullptr)
-    {
-        it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        return it->element == nullptr ? 0 : 1;
-    }
-
-    if (!it->element->IsLastForTile())
-    {
-        it->element++;
-        return 1;
-    }
-
-    auto& gameState = getGameState();
-    if (it->y < (gameState.mapSize.y - 2))
-    {
-        it->y++;
-        it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        return it->element == nullptr ? 0 : 1;
-    }
-
-    if (it->x < (gameState.mapSize.x - 2))
-    {
-        it->y = 1;
-        it->x++;
-        it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
-        return it->element == nullptr ? 0 : 1;
-    }
-
-    return 0;
-}
-
-void TileElementIteratorRestartForTile(TileElementIterator* it)
-{
-    it->element = nullptr;
-}
-
-static bool IsTileLocationValid(const TileCoordsXY& coords)
-{
-    const bool is_x_valid = coords.x < kMaximumMapSizeTechnical && coords.x >= 0;
-    const bool is_y_valid = coords.y < kMaximumMapSizeTechnical && coords.y >= 0;
-    return is_x_valid && is_y_valid;
-}
-
-TileElement* MapGetFirstElementAt(const TileCoordsXY& tilePos)
-{
-    if (!IsTileLocationValid(tilePos))
-    {
-        LOG_VERBOSE("Trying to access element outside of range");
-        return nullptr;
-    }
-    return _tileIndex.GetFirstElementAt(tilePos);
-}
-
-TileElement* MapGetFirstElementAt(const CoordsXY& elementPos)
-{
-    return MapGetFirstElementAt(TileCoordsXY{ elementPos });
-}
-
-TileElement* MapGetNthElementAt(const CoordsXY& coords, int32_t n)
-{
-    TileElement* tileElement = MapGetFirstElementAt(coords);
-    if (tileElement == nullptr)
-    {
-        return nullptr;
-    }
-    // Iterate through elements on this tile. This has to be walked, rather than
-    // jumped directly to, because n may exceed element count for given tile,
-    // and the order of tiles (unlike elements) is not synced over multiplayer.
-    while (n >= 0)
-    {
-        if (n == 0)
+        // if space issue is due to fragmentation then Reorg Tiles without increasing capacity
+        if (gameState.tileElements.size() > totalElementsRequired + _tileElementsInUse)
         {
-            return tileElement;
-        }
-        if (tileElement->IsLastForTile())
-        {
-            break;
-        }
-        tileElement++;
-        n--;
-    }
-    // The element sought for is not within given tile.
-    return nullptr;
-}
-
-TileElement* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc, TileElementType type)
-{
-    TileElement* tileElement = MapGetFirstElementAt(loc);
-    if (tileElement == nullptr)
-        return nullptr;
-    do
-    {
-        if (tileElement->GetType() != type)
-            continue;
-        if (tileElement->BaseHeight >= loc.baseZ && tileElement->BaseHeight <= loc.clearanceZ)
-            return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-void MapSetTileElement(const TileCoordsXY& tilePos, TileElement* elements)
-{
-    if (!MapIsLocationValid(tilePos.ToCoordsXY()))
-    {
-        LOG_ERROR("Trying to access element outside of range");
-        return;
-    }
-    _tileIndex.SetTile(tilePos, elements);
-}
-
-SurfaceElement* MapGetSurfaceElementAt(const TileCoordsXY& coords)
-{
-    auto view = TileElementsView<SurfaceElement>(coords);
-
-    return *view.begin();
-}
-
-SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords)
-{
-    return MapGetSurfaceElementAt(TileCoordsXY{ coords });
-}
-
-PathElement* MapGetPathElementAt(const TileCoordsXYZ& loc)
-{
-    for (auto* element : TileElementsView<PathElement>(loc.ToCoordsXY()))
-    {
-        if (element->IsGhost())
-            continue;
-        if (element->BaseHeight != loc.z)
-            continue;
-        return element;
-    }
-    return nullptr;
-}
-
-BannerElement* MapGetBannerElementAt(const CoordsXYZ& bannerPos, uint8_t position)
-{
-    const auto bannerTilePos = TileCoordsXYZ{ bannerPos };
-    for (auto* element : TileElementsView<BannerElement>(bannerPos))
-    {
-        if (element->BaseHeight != bannerTilePos.z)
-            continue;
-        if (element->GetPosition() != position)
-            continue;
-        return element;
-    }
-    return nullptr;
-}
-
-/**
- *
- *  rct2: 0x0068AB4C
- */
-void MapInit(const TileCoordsXY& size)
-{
-    auto numTiles = kMaximumMapSizeTechnical * kMaximumMapSizeTechnical;
-
-    auto& gameState = getGameState();
-    SetTileElements(gameState, std::vector<TileElement>(numTiles, GetDefaultSurfaceElement()));
-
-    gameState.grassSceneryTileLoopPosition = 0;
-    gameState.widePathTileLoopPosition = {};
-    gameState.mapSize = size;
-    MapRemoveOutOfRangeElements();
-    MapAnimations::ClearAll();
-
-    auto intent = Intent(INTENT_ACTION_MAP);
-    ContextBroadcastIntent(&intent);
-}
-
-/**
- * Counts the number of surface tiles that offer land ownership rights for sale,
- * but haven't been bought yet. It updates gLandRemainingOwnershipSales and
- * gLandRemainingConstructionSales.
- */
-void MapCountRemainingLandRights()
-{
-    gLandRemainingOwnershipSales = 0;
-    gLandRemainingConstructionSales = 0;
-    auto& gameState = getGameState();
-
-    for (int32_t y = 0; y < gameState.mapSize.y; y++)
-    {
-        for (int32_t x = 0; x < gameState.mapSize.x; x++)
-        {
-            auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
-            // Surface elements are sometimes hacked out to save some space for other map elements
-            if (surfaceElement == nullptr)
-            {
-                continue;
-            }
-
-            uint8_t flags = surfaceElement->GetOwnership();
-
-            // Do not combine this condition with (flags & OWNERSHIP_AVAILABLE)
-            // As some RCT1 parks have owned tiles with the 'construction rights available' flag also set
-            if (!(flags & OWNERSHIP_OWNED))
-            {
-                if (flags & OWNERSHIP_AVAILABLE)
-                {
-                    gLandRemainingOwnershipSales++;
-                }
-                else if (
-                    (flags & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) && (flags & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED) == 0)
-                {
-                    gLandRemainingConstructionSales++;
-                }
-            }
-        }
-    }
-}
-
-/**
- * This is meant to strip TILE_ELEMENT_FLAG_GHOST flag from all elements when
- * importing a park.
- *
- * This can only exist in hacked parks, as we remove ghost elements while saving.
- *
- * This is less invasive than removing ghost elements themselves, as they can
- * contain valid data.
- */
-void MapStripGhostFlagFromElements()
-{
-    auto& gameState = getGameState();
-    for (auto& element : gameState.tileElements)
-    {
-        element.SetGhost(false);
-    }
-}
-
-/**
- * Return the absolute height of an element, given its (x,y) coordinates
- *
- * ax: x
- * cx: y
- * dx: return remember to & with 0xFFFF if you don't want water affecting results
- *  rct2: 0x00662783
- */
-int16_t TileElementHeight(const CoordsXY& loc)
-{
-    // Off the map
-    if (!MapIsLocationValid(loc))
-        return kMinimumLandZ;
-
-    // Get the surface element for the tile
-    auto surfaceElement = MapGetSurfaceElementAt(loc);
-
-    if (surfaceElement == nullptr)
-    {
-        return kMinimumLandZ;
-    }
-
-    auto height = surfaceElement->GetBaseZ();
-    auto slope = surfaceElement->GetSlope();
-
-    return TileElementHeight(CoordsXYZ{ loc, height }, slope);
-}
-
-int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope)
-{
-    // Off the map
-    if (!MapIsLocationValid(loc))
-        return kMinimumLandZ;
-
-    auto height = loc.z;
-
-    uint8_t extra_height = (slope & kTileSlopeDiagonalFlag) >> 4; // 0x10 is the 5th bit - sets slope to double height
-    // Remove the extra height bit
-    slope &= kTileSlopeRaisedCornersMask;
-
-    int8_t quad = 0, quad_extra = 0; // which quadrant the element is in?
-                                     // quad_extra is for extra height tiles
-
-    // coordinates across this tile
-    uint8_t xl = loc.x & 0x1f;
-    uint8_t yl = loc.y & 0x1f;
-
-    uint8_t TILE_SIZE = 32;
-
-    // Slope logic:
-    // Each of the four bits in slope represents that corner being raised
-    // slope == 15 (all four bits) is not used and slope == 0 is flat
-    // If the extra_height bit is set, then the slope goes up two z-levels
-
-    // We arbitrarily take the SW corner to be closest to the viewer
-
-    // One corner up
-    if (slope == kTileSlopeNCornerUp || slope == kTileSlopeECornerUp || slope == kTileSlopeSCornerUp
-        || slope == kTileSlopeWCornerUp)
-    {
-        switch (slope)
-        {
-            case kTileSlopeNCornerUp:
-                quad = xl + yl - TILE_SIZE;
-                break;
-            case kTileSlopeECornerUp:
-                quad = xl - yl;
-                break;
-            case kTileSlopeSCornerUp:
-                quad = TILE_SIZE - yl - xl;
-                break;
-            case kTileSlopeWCornerUp:
-                quad = yl - xl;
-                break;
-        }
-        // If the element is in the quadrant with the slope, raise its height
-        if (quad > 0)
-        {
-            height += quad / 2;
-        }
-    }
-
-    // One side up
-    switch (slope)
-    {
-        case kTileSlopeNESideUp:
-            height += xl / 2;
-            break;
-        case kTileSlopeSESideUp:
-            height += (TILE_SIZE - yl) / 2;
-            break;
-        case kTileSlopeNWSideUp:
-            height += yl / 2;
-            break;
-        case kTileSlopeSWSideUp:
-            height += (TILE_SIZE - xl) / 2;
-            break;
-    }
-
-    // One corner down
-    if ((slope == kTileSlopeWCornerDown) || (slope == kTileSlopeSCornerDown) || (slope == kTileSlopeECornerDown)
-        || (slope == kTileSlopeNCornerDown))
-    {
-        switch (slope)
-        {
-            case kTileSlopeWCornerDown:
-                quad_extra = xl + TILE_SIZE - yl;
-                quad = xl - yl;
-                break;
-            case kTileSlopeSCornerDown:
-                quad_extra = xl + yl;
-                quad = xl + yl - TILE_SIZE;
-                break;
-            case kTileSlopeECornerDown:
-                quad_extra = TILE_SIZE - xl + yl;
-                quad = yl - xl;
-                break;
-            case kTileSlopeNCornerDown:
-                quad_extra = (TILE_SIZE - xl) + (TILE_SIZE - yl);
-                quad = TILE_SIZE - yl - xl;
-                break;
-        }
-
-        if (extra_height)
-        {
-            height += quad_extra / 2;
-            return height;
-        }
-        // This tile is essentially at the next height level
-        height += kLandHeightStep;
-        // so we move *down* the slope
-        if (quad < 0)
-        {
-            height += quad / 2;
-        }
-    }
-
-    // Valleys
-    if ((slope == kTileSlopeWEValley) || (slope == kTileSlopeNSValley))
-    {
-        switch (slope)
-        {
-            case kTileSlopeWEValley:
-                quad = std::abs(xl - yl);
-                break;
-            case kTileSlopeNSValley:
-                quad = std::abs(xl + yl - TILE_SIZE);
-                break;
-        }
-        height += quad / 2;
-    }
-
-    return height;
-}
-
-int16_t TileElementWaterHeight(const CoordsXY& loc)
-{
-    // Off the map
-    if (!MapIsLocationValid(loc))
-        return 0;
-
-    // Get the surface element for the tile
-    auto surfaceElement = MapGetSurfaceElementAt(loc);
-
-    if (surfaceElement == nullptr)
-    {
-        return 0;
-    }
-
-    return surfaceElement->GetWaterHeight();
-}
-
-/**
- * Checks if the tile at coordinate at height counts as connected.
- * @return 1 if connected, 0 otherwise
- */
-bool MapCoordIsConnected(const TileCoordsXYZ& loc, uint8_t faceDirection)
-{
-    TileElement* tileElement = MapGetFirstElementAt(loc);
-
-    if (tileElement == nullptr)
-        return false;
-
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Path)
-            continue;
-
-        uint8_t slopeDirection = tileElement->AsPath()->GetSlopeDirection();
-
-        if (tileElement->AsPath()->IsSloped())
-        {
-            if (slopeDirection == faceDirection)
-            {
-                if (loc.z == tileElement->BaseHeight + 2)
-                    return true;
-            }
-            else if (DirectionReverse(slopeDirection) == faceDirection && loc.z == tileElement->BaseHeight)
+            ReorganiseTileElements();
+            // This check is not expected to fail
+            freeElements = gameState.tileElements.capacity() - gameState.tileElements.size();
+            if (freeElements >= totalElementsRequired)
             {
                 return true;
             }
+        }
+
+        // Capacity must increase to handle the space (Note capacity can go above kMaxTileElements)
+        auto newCapacity = gameState.tileElements.capacity() * 2;
+        ReorganiseTileElements(newCapacity);
+        return true;
+    }
+
+    static size_t CountElementsOnTile(const CoordsXY& loc);
+
+    bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements)
+    {
+        auto numElementsOnTile = CountElementsOnTile(loc);
+        return MapCheckFreeElementsAndReorganise(numElementsOnTile, numElements);
+    }
+
+    static void ClearElementsAt(const CoordsXY& loc);
+
+    void TileElementIteratorBegin(TileElementIterator* it)
+    {
+        it->x = 1;
+        it->y = 1;
+        it->element = MapGetFirstElementAt(TileCoordsXY{ 1, 1 });
+    }
+
+    int32_t TileElementIteratorNext(TileElementIterator* it)
+    {
+        if (it->element == nullptr)
+        {
+            it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
+            return it->element == nullptr ? 0 : 1;
+        }
+
+        if (!it->element->IsLastForTile())
+        {
+            it->element++;
+            return 1;
+        }
+
+        auto& gameState = getGameState();
+        if (it->y < (gameState.mapSize.y - 2))
+        {
+            it->y++;
+            it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
+            return it->element == nullptr ? 0 : 1;
+        }
+
+        if (it->x < (gameState.mapSize.x - 2))
+        {
+            it->y = 1;
+            it->x++;
+            it->element = MapGetFirstElementAt(TileCoordsXY{ it->x, it->y });
+            return it->element == nullptr ? 0 : 1;
+        }
+
+        return 0;
+    }
+
+    void TileElementIteratorRestartForTile(TileElementIterator* it)
+    {
+        it->element = nullptr;
+    }
+
+    static bool IsTileLocationValid(const TileCoordsXY& coords)
+    {
+        const bool is_x_valid = coords.x < kMaximumMapSizeTechnical && coords.x >= 0;
+        const bool is_y_valid = coords.y < kMaximumMapSizeTechnical && coords.y >= 0;
+        return is_x_valid && is_y_valid;
+    }
+
+    TileElement* MapGetFirstElementAt(const TileCoordsXY& tilePos)
+    {
+        if (!IsTileLocationValid(tilePos))
+        {
+            LOG_VERBOSE("Trying to access element outside of range");
+            return nullptr;
+        }
+        return _tileIndex.GetFirstElementAt(tilePos);
+    }
+
+    TileElement* MapGetFirstElementAt(const CoordsXY& elementPos)
+    {
+        return MapGetFirstElementAt(TileCoordsXY{ elementPos });
+    }
+
+    TileElement* MapGetNthElementAt(const CoordsXY& coords, int32_t n)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(coords);
+        if (tileElement == nullptr)
+        {
+            return nullptr;
+        }
+        // Iterate through elements on this tile. This has to be walked, rather than
+        // jumped directly to, because n may exceed element count for given tile,
+        // and the order of tiles (unlike elements) is not synced over multiplayer.
+        while (n >= 0)
+        {
+            if (n == 0)
+            {
+                return tileElement;
+            }
+            if (tileElement->IsLastForTile())
+            {
+                break;
+            }
+            tileElement++;
+            n--;
+        }
+        // The element sought for is not within given tile.
+        return nullptr;
+    }
+
+    TileElement* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc, TileElementType type)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(loc);
+        if (tileElement == nullptr)
+            return nullptr;
+        do
+        {
+            if (tileElement->GetType() != type)
+                continue;
+            if (tileElement->BaseHeight >= loc.baseZ && tileElement->BaseHeight <= loc.clearanceZ)
+                return tileElement;
+        } while (!(tileElement++)->IsLastForTile());
+
+        return nullptr;
+    }
+
+    void MapSetTileElement(const TileCoordsXY& tilePos, TileElement* elements)
+    {
+        if (!MapIsLocationValid(tilePos.ToCoordsXY()))
+        {
+            LOG_ERROR("Trying to access element outside of range");
+            return;
+        }
+        _tileIndex.SetTile(tilePos, elements);
+    }
+
+    SurfaceElement* MapGetSurfaceElementAt(const TileCoordsXY& coords)
+    {
+        auto view = TileElementsView<SurfaceElement>(coords);
+
+        return *view.begin();
+    }
+
+    SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords)
+    {
+        return MapGetSurfaceElementAt(TileCoordsXY{ coords });
+    }
+
+    PathElement* MapGetPathElementAt(const TileCoordsXYZ& loc)
+    {
+        for (auto* element : TileElementsView<PathElement>(loc.ToCoordsXY()))
+        {
+            if (element->IsGhost())
+                continue;
+            if (element->BaseHeight != loc.z)
+                continue;
+            return element;
+        }
+        return nullptr;
+    }
+
+    BannerElement* MapGetBannerElementAt(const CoordsXYZ& bannerPos, uint8_t position)
+    {
+        const auto bannerTilePos = TileCoordsXYZ{ bannerPos };
+        for (auto* element : TileElementsView<BannerElement>(bannerPos))
+        {
+            if (element->BaseHeight != bannerTilePos.z)
+                continue;
+            if (element->GetPosition() != position)
+                continue;
+            return element;
+        }
+        return nullptr;
+    }
+
+    /**
+     *
+     *  rct2: 0x0068AB4C
+     */
+    void MapInit(const TileCoordsXY& size)
+    {
+        auto numTiles = kMaximumMapSizeTechnical * kMaximumMapSizeTechnical;
+
+        auto& gameState = getGameState();
+        SetTileElements(gameState, std::vector<TileElement>(numTiles, GetDefaultSurfaceElement()));
+
+        gameState.grassSceneryTileLoopPosition = 0;
+        gameState.widePathTileLoopPosition = {};
+        gameState.mapSize = size;
+        MapRemoveOutOfRangeElements();
+        MapAnimations::ClearAll();
+
+        auto intent = Intent(INTENT_ACTION_MAP);
+        ContextBroadcastIntent(&intent);
+    }
+
+    /**
+     * Counts the number of surface tiles that offer land ownership rights for sale,
+     * but haven't been bought yet. It updates gLandRemainingOwnershipSales and
+     * gLandRemainingConstructionSales.
+     */
+    void MapCountRemainingLandRights()
+    {
+        gLandRemainingOwnershipSales = 0;
+        gLandRemainingConstructionSales = 0;
+        auto& gameState = getGameState();
+
+        for (int32_t y = 0; y < gameState.mapSize.y; y++)
+        {
+            for (int32_t x = 0; x < gameState.mapSize.x; x++)
+            {
+                auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
+                // Surface elements are sometimes hacked out to save some space for other map elements
+                if (surfaceElement == nullptr)
+                {
+                    continue;
+                }
+
+                uint8_t flags = surfaceElement->GetOwnership();
+
+                // Do not combine this condition with (flags & OWNERSHIP_AVAILABLE)
+                // As some RCT1 parks have owned tiles with the 'construction rights available' flag also set
+                if (!(flags & OWNERSHIP_OWNED))
+                {
+                    if (flags & OWNERSHIP_AVAILABLE)
+                    {
+                        gLandRemainingOwnershipSales++;
+                    }
+                    else if (
+                        (flags & OWNERSHIP_CONSTRUCTION_RIGHTS_AVAILABLE) && (flags & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED) == 0)
+                    {
+                        gLandRemainingConstructionSales++;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This is meant to strip TILE_ELEMENT_FLAG_GHOST flag from all elements when
+     * importing a park.
+     *
+     * This can only exist in hacked parks, as we remove ghost elements while saving.
+     *
+     * This is less invasive than removing ghost elements themselves, as they can
+     * contain valid data.
+     */
+    void MapStripGhostFlagFromElements()
+    {
+        auto& gameState = getGameState();
+        for (auto& element : gameState.tileElements)
+        {
+            element.SetGhost(false);
+        }
+    }
+
+    /**
+     * Return the absolute height of an element, given its (x,y) coordinates
+     *
+     * ax: x
+     * cx: y
+     * dx: return remember to & with 0xFFFF if you don't want water affecting results
+     *  rct2: 0x00662783
+     */
+    int16_t TileElementHeight(const CoordsXY& loc)
+    {
+        // Off the map
+        if (!MapIsLocationValid(loc))
+            return kMinimumLandZ;
+
+        // Get the surface element for the tile
+        auto surfaceElement = MapGetSurfaceElementAt(loc);
+
+        if (surfaceElement == nullptr)
+        {
+            return kMinimumLandZ;
+        }
+
+        auto height = surfaceElement->GetBaseZ();
+        auto slope = surfaceElement->GetSlope();
+
+        return TileElementHeight(CoordsXYZ{ loc, height }, slope);
+    }
+
+    int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope)
+    {
+        // Off the map
+        if (!MapIsLocationValid(loc))
+            return kMinimumLandZ;
+
+        auto height = loc.z;
+
+        uint8_t extra_height = (slope & kTileSlopeDiagonalFlag) >> 4; // 0x10 is the 5th bit - sets slope to double height
+        // Remove the extra height bit
+        slope &= kTileSlopeRaisedCornersMask;
+
+        int8_t quad = 0, quad_extra = 0; // which quadrant the element is in?
+                                         // quad_extra is for extra height tiles
+
+        // coordinates across this tile
+        uint8_t xl = loc.x & 0x1f;
+        uint8_t yl = loc.y & 0x1f;
+
+        uint8_t TILE_SIZE = 32;
+
+        // Slope logic:
+        // Each of the four bits in slope represents that corner being raised
+        // slope == 15 (all four bits) is not used and slope == 0 is flat
+        // If the extra_height bit is set, then the slope goes up two z-levels
+
+        // We arbitrarily take the SW corner to be closest to the viewer
+
+        // One corner up
+        if (slope == kTileSlopeNCornerUp || slope == kTileSlopeECornerUp || slope == kTileSlopeSCornerUp
+            || slope == kTileSlopeWCornerUp)
+        {
+            switch (slope)
+            {
+                case kTileSlopeNCornerUp:
+                    quad = xl + yl - TILE_SIZE;
+                    break;
+                case kTileSlopeECornerUp:
+                    quad = xl - yl;
+                    break;
+                case kTileSlopeSCornerUp:
+                    quad = TILE_SIZE - yl - xl;
+                    break;
+                case kTileSlopeWCornerUp:
+                    quad = yl - xl;
+                    break;
+            }
+            // If the element is in the quadrant with the slope, raise its height
+            if (quad > 0)
+            {
+                height += quad / 2;
+            }
+        }
+
+        // One side up
+        switch (slope)
+        {
+            case kTileSlopeNESideUp:
+                height += xl / 2;
+                break;
+            case kTileSlopeSESideUp:
+                height += (TILE_SIZE - yl) / 2;
+                break;
+            case kTileSlopeNWSideUp:
+                height += yl / 2;
+                break;
+            case kTileSlopeSWSideUp:
+                height += (TILE_SIZE - xl) / 2;
+                break;
+        }
+
+        // One corner down
+        if ((slope == kTileSlopeWCornerDown) || (slope == kTileSlopeSCornerDown) || (slope == kTileSlopeECornerDown)
+            || (slope == kTileSlopeNCornerDown))
+        {
+            switch (slope)
+            {
+                case kTileSlopeWCornerDown:
+                    quad_extra = xl + TILE_SIZE - yl;
+                    quad = xl - yl;
+                    break;
+                case kTileSlopeSCornerDown:
+                    quad_extra = xl + yl;
+                    quad = xl + yl - TILE_SIZE;
+                    break;
+                case kTileSlopeECornerDown:
+                    quad_extra = TILE_SIZE - xl + yl;
+                    quad = yl - xl;
+                    break;
+                case kTileSlopeNCornerDown:
+                    quad_extra = (TILE_SIZE - xl) + (TILE_SIZE - yl);
+                    quad = TILE_SIZE - yl - xl;
+                    break;
+            }
+
+            if (extra_height)
+            {
+                height += quad_extra / 2;
+                return height;
+            }
+            // This tile is essentially at the next height level
+            height += kLandHeightStep;
+            // so we move *down* the slope
+            if (quad < 0)
+            {
+                height += quad / 2;
+            }
+        }
+
+        // Valleys
+        if ((slope == kTileSlopeWEValley) || (slope == kTileSlopeNSValley))
+        {
+            switch (slope)
+            {
+                case kTileSlopeWEValley:
+                    quad = std::abs(xl - yl);
+                    break;
+                case kTileSlopeNSValley:
+                    quad = std::abs(xl + yl - TILE_SIZE);
+                    break;
+            }
+            height += quad / 2;
+        }
+
+        return height;
+    }
+
+    int16_t TileElementWaterHeight(const CoordsXY& loc)
+    {
+        // Off the map
+        if (!MapIsLocationValid(loc))
+            return 0;
+
+        // Get the surface element for the tile
+        auto surfaceElement = MapGetSurfaceElementAt(loc);
+
+        if (surfaceElement == nullptr)
+        {
+            return 0;
+        }
+
+        return surfaceElement->GetWaterHeight();
+    }
+
+    /**
+     * Checks if the tile at coordinate at height counts as connected.
+     * @return 1 if connected, 0 otherwise
+     */
+    bool MapCoordIsConnected(const TileCoordsXYZ& loc, uint8_t faceDirection)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(loc);
+
+        if (tileElement == nullptr)
+            return false;
+
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Path)
+                continue;
+
+            uint8_t slopeDirection = tileElement->AsPath()->GetSlopeDirection();
+
+            if (tileElement->AsPath()->IsSloped())
+            {
+                if (slopeDirection == faceDirection)
+                {
+                    if (loc.z == tileElement->BaseHeight + 2)
+                        return true;
+                }
+                else if (DirectionReverse(slopeDirection) == faceDirection && loc.z == tileElement->BaseHeight)
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                if (loc.z == tileElement->BaseHeight && (tileElement->AsPath()->GetEdges() & (1 << faceDirection)))
+                    return true;
+            }
+        } while (!(tileElement++)->IsLastForTile());
+
+        return false;
+    }
+
+    /**
+     *
+     *  rct2: 0x006A876D
+     */
+    void MapUpdatePathWideFlags()
+    {
+        PROFILED_FUNCTION();
+
+        if (isInTrackDesignerOrManager())
+        {
+            return;
+        }
+
+        const int32_t kPracticalMapSizeBigX = getGameState().mapSize.x * kCoordsXYStep;
+        const int32_t kPracticalMapSizeBigY = getGameState().mapSize.y * kCoordsXYStep;
+
+        // Presumably update_path_wide_flags is too computationally expensive to call for every
+        // tile every update, so gWidePathTileLoopX and gWidePathTileLoopY store the x and y
+        // progress. A maximum of 128 calls is done per update.
+        CoordsXY& loopPosition = getGameState().widePathTileLoopPosition;
+        for (int32_t i = 0; i < 128; i++)
+        {
+            FootpathUpdatePathWideFlags(loopPosition);
+
+            // Next x, y tile
+            loopPosition.x += kCoordsXYStep;
+            if (loopPosition.x >= kPracticalMapSizeBigX)
+            {
+                loopPosition.x = 0;
+                loopPosition.y += kCoordsXYStep;
+                if (loopPosition.y >= kPracticalMapSizeBigY)
+                {
+                    loopPosition.y = 0;
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006A7B84
+     */
+    int32_t MapHeightFromSlope(const CoordsXY& coords, int32_t slopeDirection, bool isSloped)
+    {
+        if (!isSloped)
+            return 0;
+
+        switch (slopeDirection % kNumOrthogonalDirections)
+        {
+            case TILE_ELEMENT_DIRECTION_WEST:
+                return (31 - (coords.x & 31)) / 2;
+            case TILE_ELEMENT_DIRECTION_NORTH:
+                return (coords.y & 31) / 2;
+            case TILE_ELEMENT_DIRECTION_EAST:
+                return (coords.x & 31) / 2;
+            case TILE_ELEMENT_DIRECTION_SOUTH:
+                return (31 - (coords.y & 31)) / 2;
+        }
+        return 0;
+    }
+
+    bool MapIsLocationValid(const CoordsXY& coords)
+    {
+        const bool is_x_valid = coords.x < kMaximumMapSizeBig && coords.x >= 0;
+        const bool is_y_valid = coords.y < kMaximumMapSizeBig && coords.y >= 0;
+        return is_x_valid && is_y_valid;
+    }
+
+    bool MapIsEdge(const CoordsXY& coords)
+    {
+        auto mapSizeUnits = GetMapSizeUnits();
+        return (coords.x < 32 || coords.y < 32 || coords.x >= mapSizeUnits.x || coords.y >= mapSizeUnits.y);
+    }
+
+    bool MapCanBuildAt(const CoordsXYZ& loc)
+    {
+        if (gLegacyScene == LegacyScene::scenarioEditor)
+            return true;
+        if (getGameState().cheats.sandboxMode)
+            return true;
+        if (MapIsLocationOwned(loc))
+            return true;
+        return false;
+    }
+
+    /**
+     *
+     *  rct2: 0x00664F72
+     */
+    bool MapIsLocationOwned(const CoordsXYZ& loc)
+    {
+        // This check is to avoid throwing lots of messages in logs.
+        if (MapIsLocationValid(loc))
+        {
+            auto* surfaceElement = MapGetSurfaceElementAt(loc);
+            if (surfaceElement != nullptr)
+            {
+                if (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
+                    return true;
+
+                if (surfaceElement->GetOwnership() & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
+                {
+                    if (loc.z < surfaceElement->GetBaseZ()
+                        || loc.z >= surfaceElement->GetBaseZ() + kConstructionRightsClearanceBig)
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     *
+     *  rct2: 0x00664F2C
+     */
+    bool MapIsLocationInPark(const CoordsXY& coords)
+    {
+        if (MapIsLocationValid(coords))
+        {
+            auto surfaceElement = MapGetSurfaceElementAt(coords);
+            if (surfaceElement == nullptr)
+                return false;
+            if (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
+                return true;
+        }
+        return false;
+    }
+
+    bool MapIsLocationOwnedOrHasRights(const CoordsXY& loc)
+    {
+        if (MapIsLocationValid(loc))
+        {
+            auto surfaceElement = MapGetSurfaceElementAt(loc);
+            if (surfaceElement == nullptr)
+            {
+                return false;
+            }
+            if (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
+                return true;
+            if (surfaceElement->GetOwnership() & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
+                return true;
+        }
+        return false;
+    }
+
+    int32_t MapGetCornerHeight(int32_t z, int32_t slope, int32_t direction)
+    {
+        switch (direction)
+        {
+            case 0:
+                if (slope & kTileSlopeNCornerUp)
+                {
+                    z += 2;
+                    if (slope == (kTileSlopeSCornerDown | kTileSlopeDiagonalFlag))
+                    {
+                        z += 2;
+                    }
+                }
+                break;
+            case 1:
+                if (slope & kTileSlopeECornerUp)
+                {
+                    z += 2;
+                    if (slope == (kTileSlopeWCornerDown | kTileSlopeDiagonalFlag))
+                    {
+                        z += 2;
+                    }
+                }
+                break;
+            case 2:
+                if (slope & kTileSlopeSCornerUp)
+                {
+                    z += 2;
+                    if (slope == (kTileSlopeNCornerDown | kTileSlopeDiagonalFlag))
+                    {
+                        z += 2;
+                    }
+                }
+                break;
+            case 3:
+                if (slope & kTileSlopeWCornerUp)
+                {
+                    z += 2;
+                    if (slope == (kTileSlopeECornerDown | kTileSlopeDiagonalFlag))
+                    {
+                        z += 2;
+                    }
+                }
+                break;
+        }
+        return z;
+    }
+
+    int32_t TileElementGetCornerHeight(const SurfaceElement* surfaceElement, int32_t direction)
+    {
+        int32_t z = surfaceElement->BaseHeight;
+        int32_t slope = surfaceElement->GetSlope();
+        return MapGetCornerHeight(z, slope, direction);
+    }
+
+    uint8_t MapGetLowestLandHeight(const MapRange& range)
+    {
+        auto mapSizeMax = GetMapSizeMaxXY();
+        MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
+                                std::min(range.GetY2(), mapSizeMax.y) };
+
+        uint8_t minHeight = 0xFF;
+        for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
+        {
+            for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
+            {
+                auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
+
+                if (surfaceElement != nullptr && minHeight > surfaceElement->BaseHeight)
+                {
+                    if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+                    {
+                        if (!MapIsLocationInPark(CoordsXY{ xi, yi }))
+                        {
+                            continue;
+                        }
+                    }
+
+                    minHeight = surfaceElement->BaseHeight;
+                }
+            }
+        }
+        return minHeight;
+    }
+
+    uint8_t MapGetHighestLandHeight(const MapRange& range)
+    {
+        auto mapSizeMax = GetMapSizeMaxXY();
+        MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
+                                std::min(range.GetY2(), mapSizeMax.y) };
+
+        uint8_t maxHeight = 0;
+        for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
+        {
+            for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
+            {
+                auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
+                if (surfaceElement != nullptr)
+                {
+                    if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+                    {
+                        if (!MapIsLocationInPark(CoordsXY{ xi, yi }))
+                        {
+                            continue;
+                        }
+                    }
+
+                    uint8_t BaseHeight = surfaceElement->BaseHeight;
+                    if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
+                        BaseHeight += 2;
+                    if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
+                        BaseHeight += 2;
+                    if (maxHeight < BaseHeight)
+                        maxHeight = BaseHeight;
+                }
+            }
+        }
+        return maxHeight;
+    }
+
+    /**
+     *
+     *  rct2: 0x0068B280
+     */
+    void TileElementRemove(TileElement* tileElement)
+    {
+        // Replace Nth element by (N+1)th element.
+        // This loop will make tileElement point to the old last element position,
+        // after copy it to it's new position
+        if (!tileElement->IsLastForTile())
+        {
+            do
+            {
+                *tileElement = *(tileElement + 1);
+            } while (!(++tileElement)->IsLastForTile());
+        }
+
+        // Mark the latest element with the last element flag.
+        (tileElement - 1)->SetLastForTile(true);
+        tileElement->BaseHeight = kMaxTileElementHeight;
+        _tileElementsInUse--;
+        auto& gameState = getGameState();
+        if (tileElement == &gameState.tileElements.back())
+        {
+            gameState.tileElements.pop_back();
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x00675A8E
+     */
+    void MapRemoveAllRides()
+    {
+        TileElementIterator it;
+
+        TileElementIteratorBegin(&it);
+        do
+        {
+            switch (it.element->GetType())
+            {
+                case TileElementType::Path:
+                    if (it.element->AsPath()->IsQueue())
+                    {
+                        it.element->AsPath()->SetHasQueueBanner(false);
+                        it.element->AsPath()->SetRideIndex(RideId::GetNull());
+                    }
+                    break;
+                case TileElementType::Entrance:
+                    if (it.element->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
+                        break;
+                    [[fallthrough]];
+                case TileElementType::Track:
+                    FootpathQueueChainReset();
+                    FootpathRemoveEdgesAt(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
+                    TileElementRemove(it.element);
+                    TileElementIteratorRestartForTile(&it);
+                    break;
+                default:
+                    break;
+            }
+        } while (TileElementIteratorNext(&it));
+    }
+
+    void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* top, int32_t* right, int32_t* bottom)
+    {
+        uint32_t rotation = GetCurrentRotation();
+        const std::array corners{
+            CoordsXY{ _range.GetX1(), _range.GetY1() },
+            CoordsXY{ _range.GetX2(), _range.GetY1() },
+            CoordsXY{ _range.GetX2(), _range.GetY2() },
+            CoordsXY{ _range.GetX1(), _range.GetY2() },
+        };
+
+        *left = std::numeric_limits<int32_t>::max();
+        *top = std::numeric_limits<int32_t>::max();
+        *right = std::numeric_limits<int32_t>::min();
+        *bottom = std::numeric_limits<int32_t>::min();
+
+        for (const auto& corner : corners)
+        {
+            auto screenCoord = Translate3DTo2DWithZ(rotation, CoordsXYZ{ corner, 0 });
+            if (screenCoord.x < *left)
+                *left = screenCoord.x;
+            if (screenCoord.x > *right)
+                *right = screenCoord.x;
+            if (screenCoord.y > *bottom)
+                *bottom = screenCoord.y;
+            if (screenCoord.y < *top)
+                *top = screenCoord.y;
+        }
+    }
+
+    static size_t CountElementsOnTile(const CoordsXY& loc)
+    {
+        size_t count = 0;
+        auto* element = _tileIndex.GetFirstElementAt(TileCoordsXY(loc));
+        do
+        {
+            count++;
+        } while (!(element++)->IsLastForTile());
+        return count;
+    }
+
+    static TileElement* AllocateTileElements(size_t numElementsOnTile, size_t numNewElements)
+    {
+        if (!MapCheckFreeElementsAndReorganise(numElementsOnTile, numNewElements))
+        {
+            LOG_ERROR("Cannot insert new element");
+            return nullptr;
+        }
+
+        auto& gameState = getGameState();
+        auto oldSize = gameState.tileElements.size();
+        gameState.tileElements.resize(gameState.tileElements.size() + numElementsOnTile + numNewElements);
+        _tileElementsInUse += numNewElements;
+        return &gameState.tileElements[oldSize];
+    }
+
+    /**
+     *
+     *  rct2: 0x0068B1F6
+     */
+    TileElement* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type)
+    {
+        const auto& tileLoc = TileCoordsXYZ(loc);
+
+        auto numElementsOnTileOld = CountElementsOnTile(loc);
+        auto* newTileElement = AllocateTileElements(numElementsOnTileOld, 1);
+        auto* originalTileElement = _tileIndex.GetFirstElementAt(tileLoc);
+        if (newTileElement == nullptr)
+        {
+            return nullptr;
+        }
+
+        // Set tile index pointer to point to new element block
+        _tileIndex.SetTile(tileLoc, newTileElement);
+
+        bool isLastForTile = false;
+        if (originalTileElement == nullptr)
+        {
+            isLastForTile = true;
         }
         else
         {
-            if (loc.z == tileElement->BaseHeight && (tileElement->AsPath()->GetEdges() & (1 << faceDirection)))
-                return true;
+            // Copy all elements that are below the insert height
+            while (loc.z >= originalTileElement->GetBaseZ())
+            {
+                // Copy over map element
+                *newTileElement = *originalTileElement;
+                originalTileElement->BaseHeight = kMaxTileElementHeight;
+                originalTileElement++;
+                newTileElement++;
+
+                if ((newTileElement - 1)->IsLastForTile())
+                {
+                    // No more elements above the insert element
+                    (newTileElement - 1)->SetLastForTile(false);
+                    isLastForTile = true;
+                    break;
+                }
+            }
         }
-    } while (!(tileElement++)->IsLastForTile());
 
-    return false;
-}
+        // Insert new map element
+        auto* insertedElement = newTileElement;
+        newTileElement->Type = 0;
+        newTileElement->SetType(type);
+        newTileElement->SetBaseZ(loc.z);
+        newTileElement->Flags = 0;
+        newTileElement->SetLastForTile(isLastForTile);
+        newTileElement->SetOccupiedQuadrants(occupiedQuadrants);
+        newTileElement->SetClearanceZ(loc.z);
+        newTileElement->Owner = 0;
+        std::memset(&newTileElement->Pad05, 0, sizeof(newTileElement->Pad05));
+        std::memset(&newTileElement->Pad08, 0, sizeof(newTileElement->Pad08));
+        newTileElement++;
 
-/**
- *
- *  rct2: 0x006A876D
- */
-void MapUpdatePathWideFlags()
-{
-    PROFILED_FUNCTION();
+        // Insert rest of map elements above insert height
+        if (!isLastForTile)
+        {
+            do
+            {
+                // Copy over map element
+                *newTileElement = *originalTileElement;
+                originalTileElement->BaseHeight = kMaxTileElementHeight;
+                originalTileElement++;
+                newTileElement++;
+            } while (!((newTileElement - 1)->IsLastForTile()));
+        }
 
-    if (isInTrackDesignerOrManager())
-    {
-        return;
+        return insertedElement;
     }
 
-    const int32_t kPracticalMapSizeBigX = getGameState().mapSize.x * kCoordsXYStep;
-    const int32_t kPracticalMapSizeBigY = getGameState().mapSize.y * kCoordsXYStep;
-
-    // Presumably update_path_wide_flags is too computationally expensive to call for every
-    // tile every update, so gWidePathTileLoopX and gWidePathTileLoopY store the x and y
-    // progress. A maximum of 128 calls is done per update.
-    CoordsXY& loopPosition = getGameState().widePathTileLoopPosition;
-    for (int32_t i = 0; i < 128; i++)
+    /**
+     * Updates grass length, scenery age and jumping fountains.
+     *
+     *  rct2: 0x006646E1
+     */
+    void MapUpdateTiles()
     {
-        FootpathUpdatePathWideFlags(loopPosition);
+        PROFILED_FUNCTION();
 
-        // Next x, y tile
-        loopPosition.x += kCoordsXYStep;
-        if (loopPosition.x >= kPracticalMapSizeBigX)
+        if (isInEditorMode())
+            return;
+
+        auto& gameState = getGameState();
+
+        // Update 43 more tiles (for each 256x256 block)
+        for (int32_t j = 0; j < 43; j++)
         {
-            loopPosition.x = 0;
-            loopPosition.y += kCoordsXYStep;
-            if (loopPosition.y >= kPracticalMapSizeBigY)
+            int32_t x = 0;
+            int32_t y = 0;
+
+            uint16_t interleaved_xy = gameState.grassSceneryTileLoopPosition;
+            for (int32_t i = 0; i < 8; i++)
             {
-                loopPosition.y = 0;
+                x = (x << 1) | (interleaved_xy & 1);
+                interleaved_xy >>= 1;
+                y = (y << 1) | (interleaved_xy & 1);
+                interleaved_xy >>= 1;
+            }
+
+            // Repeat for each 256x256 block on the map
+            for (int32_t blockY = 0; blockY < gameState.mapSize.y; blockY += 256)
+            {
+                for (int32_t blockX = 0; blockX < gameState.mapSize.x; blockX += 256)
+                {
+                    auto mapPos = TileCoordsXY{ blockX + x, blockY + y }.ToCoordsXY();
+                    if (MapIsEdge(mapPos))
+                        continue;
+
+                    auto* surfaceElement = MapGetSurfaceElementAt(mapPos);
+                    if (surfaceElement != nullptr)
+                    {
+                        surfaceElement->UpdateGrassLength(mapPos);
+                        SceneryUpdateTile(mapPos);
+                    }
+                }
+            }
+
+            gameState.grassSceneryTileLoopPosition++;
+        }
+    }
+
+    /**
+     * Removes elements that are out of the map size range and crops the park perimeter.
+     *  rct2: 0x0068ADBC
+     */
+    void MapRemoveOutOfRangeElements()
+    {
+        auto mapSizeMax = GetMapSizeMaxXY();
+
+        // Ensure that we can remove elements
+        //
+        // NOTE: This is only a workaround for non-networked games.
+        // Map resize has to become its own Game Action to properly solve this issue.
+        //
+        auto& gameState = getGameState();
+        bool buildState = gameState.cheats.buildInPauseMode;
+        gameState.cheats.buildInPauseMode = true;
+
+        for (int32_t y = kMaximumMapSizeBig - kCoordsXYStep; y >= 0; y -= kCoordsXYStep)
+        {
+            for (int32_t x = kMaximumMapSizeBig - kCoordsXYStep; x >= 0; x -= kCoordsXYStep)
+            {
+                if (x == 0 || y == 0 || x >= mapSizeMax.x || y >= mapSizeMax.y)
+                {
+                    // Note this purposely does not use LandSetRightsAction as X Y coordinates are outside of normal range.
+                    auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ x, y });
+                    if (surfaceElement != nullptr)
+                    {
+                        surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
+                        Park::UpdateFencesAroundTile({ x, y });
+                    }
+                    ClearElementsAt({ x, y });
+                }
+            }
+        }
+
+        // Reset cheat state
+        gameState.cheats.buildInPauseMode = buildState;
+    }
+
+    static void MapExtendBoundarySurfaceExtendTile(
+        const SurfaceElement& sourceTile, SurfaceElement& destTile, const Direction direction)
+    {
+        destTile.SetSurfaceObjectIndex(sourceTile.GetSurfaceObjectIndex());
+        destTile.SetEdgeObjectIndex(sourceTile.GetEdgeObjectIndex());
+        destTile.SetGrassLength(sourceTile.GetGrassLength());
+        destTile.SetOwnership(OWNERSHIP_UNOWNED);
+        destTile.SetWaterHeight(sourceTile.GetWaterHeight());
+
+        auto z = sourceTile.BaseHeight;
+        const auto originalSlope = Numerics::rol4(sourceTile.GetSlope(), direction)
+            | (sourceTile.GetSlope() & kTileSlopeDiagonalFlag);
+        auto slope = originalSlope & kTileSlopeNWSideUp;
+        if (slope == kTileSlopeNWSideUp)
+        {
+            z += 2;
+            slope = kTileSlopeFlat;
+            if (originalSlope & kTileSlopeDiagonalFlag)
+            {
+                slope = kTileSlopeNCornerUp;
+                if (originalSlope & kTileSlopeSCornerUp)
+                {
+                    slope = kTileSlopeWCornerUp;
+                    if (originalSlope & kTileSlopeECornerUp)
+                    {
+                        slope = kTileSlopeFlat;
+                    }
+                }
+            }
+        }
+        if (slope & kTileSlopeNCornerUp)
+            slope |= kTileSlopeECornerUp;
+        if (slope & kTileSlopeWCornerUp)
+            slope |= kTileSlopeSCornerUp;
+
+        destTile.SetSlope(Numerics::ror4(slope, direction));
+        destTile.BaseHeight = z;
+        destTile.ClearanceHeight = z;
+    }
+
+    /**
+     * Copies the terrain and slope from the Y edge of the map to the new tiles. Used when increasing the size of the map.
+     */
+    void MapExtendBoundarySurfaceY()
+    {
+        auto y = getGameState().mapSize.y - 2;
+        for (auto x = 0; x < kMaximumMapSizeTechnical; x++)
+        {
+            auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y - 1 });
+            auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
+
+            if (existingTileElement != nullptr && newTileElement != nullptr)
+            {
+                MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 0);
+            }
+
+            Park::UpdateFences({ x << 5, y << 5 });
+        }
+    }
+
+    /**
+     * Copies the terrain and slope from the X edge of the map to the new tiles. Used when increasing the size of the map.
+     */
+    void MapExtendBoundarySurfaceX()
+    {
+        auto x = getGameState().mapSize.x - 2;
+        for (auto y = 0; y < kMaximumMapSizeTechnical; y++)
+        {
+            auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y });
+            auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
+            if (existingTileElement != nullptr && newTileElement != nullptr)
+            {
+                MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 3);
+            }
+            Park::UpdateFences({ x << 5, y << 5 });
+        }
+    }
+
+    static void MapExtendBoundarySurfaceShiftX(const int32_t amount, const int32_t mapSizeY)
+    {
+        for (int32_t y = 1; y < mapSizeY - 1; y++)
+        {
+            for (int32_t x = amount; x > 0; x--)
+            {
+                const auto* const existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y });
+                auto* const newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
+                if (existingTileElement != nullptr && newTileElement != nullptr)
+                {
+                    MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 1);
+                }
+                Park::UpdateFences(TileCoordsXY{ x, y }.ToCoordsXY());
             }
         }
     }
-}
 
-/**
- *
- *  rct2: 0x006A7B84
- */
-int32_t MapHeightFromSlope(const CoordsXY& coords, int32_t slopeDirection, bool isSloped)
-{
-    if (!isSloped)
-        return 0;
-
-    switch (slopeDirection % kNumOrthogonalDirections)
+    static void MapExtendBoundarySurfaceShiftY(const int32_t amount, const int32_t mapSizeX)
     {
-        case TILE_ELEMENT_DIRECTION_WEST:
-            return (31 - (coords.x & 31)) / 2;
-        case TILE_ELEMENT_DIRECTION_NORTH:
-            return (coords.y & 31) / 2;
-        case TILE_ELEMENT_DIRECTION_EAST:
-            return (coords.x & 31) / 2;
-        case TILE_ELEMENT_DIRECTION_SOUTH:
-            return (31 - (coords.y & 31)) / 2;
-    }
-    return 0;
-}
-
-bool MapIsLocationValid(const CoordsXY& coords)
-{
-    const bool is_x_valid = coords.x < kMaximumMapSizeBig && coords.x >= 0;
-    const bool is_y_valid = coords.y < kMaximumMapSizeBig && coords.y >= 0;
-    return is_x_valid && is_y_valid;
-}
-
-bool MapIsEdge(const CoordsXY& coords)
-{
-    auto mapSizeUnits = GetMapSizeUnits();
-    return (coords.x < 32 || coords.y < 32 || coords.x >= mapSizeUnits.x || coords.y >= mapSizeUnits.y);
-}
-
-bool MapCanBuildAt(const CoordsXYZ& loc)
-{
-    if (gLegacyScene == LegacyScene::scenarioEditor)
-        return true;
-    if (getGameState().cheats.sandboxMode)
-        return true;
-    if (MapIsLocationOwned(loc))
-        return true;
-    return false;
-}
-
-/**
- *
- *  rct2: 0x00664F72
- */
-bool MapIsLocationOwned(const CoordsXYZ& loc)
-{
-    // This check is to avoid throwing lots of messages in logs.
-    if (MapIsLocationValid(loc))
-    {
-        auto* surfaceElement = MapGetSurfaceElementAt(loc);
-        if (surfaceElement != nullptr)
+        for (int32_t x = 1; x < mapSizeX - 1; x++)
         {
-            if (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
-                return true;
-
-            if (surfaceElement->GetOwnership() & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
+            for (int32_t y = amount; y > 0; y--)
             {
-                if (loc.z < surfaceElement->GetBaseZ() || loc.z >= surfaceElement->GetBaseZ() + kConstructionRightsClearanceBig)
-                    return true;
+                const auto* const existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y + 1 });
+                auto* const newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
+                if (existingTileElement != nullptr && newTileElement != nullptr)
+                {
+                    MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 2);
+                }
+                Park::UpdateFences(TileCoordsXY{ x, y }.ToCoordsXY());
             }
         }
     }
-    return false;
-}
 
-/**
- *
- *  rct2: 0x00664F2C
- */
-bool MapIsLocationInPark(const CoordsXY& coords)
-{
-    if (MapIsLocationValid(coords))
+    /**
+     * Clears the provided element properly from a certain tile, and updates
+     * the pointer (when needed) passed to this function to point to the next element.
+     */
+    void ClearElementAt(const CoordsXY& loc, TileElement** elementPtr)
     {
-        auto surfaceElement = MapGetSurfaceElementAt(coords);
-        if (surfaceElement == nullptr)
-            return false;
-        if (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
-            return true;
-    }
-    return false;
-}
+        auto& gameState = getGameState();
 
-bool MapIsLocationOwnedOrHasRights(const CoordsXY& loc)
-{
-    if (MapIsLocationValid(loc))
+        TileElement* element = *elementPtr;
+        switch (element->GetType())
+        {
+            case TileElementType::Surface:
+                element->BaseHeight = kMinimumLandHeight;
+                element->ClearanceHeight = kMinimumLandHeight;
+                element->Owner = 0;
+                element->AsSurface()->SetSlope(kTileSlopeFlat);
+                element->AsSurface()->SetSurfaceObjectIndex(0);
+                element->AsSurface()->SetEdgeObjectIndex(0);
+                element->AsSurface()->SetGrassLength(GRASS_LENGTH_CLEAR_0);
+                element->AsSurface()->SetOwnership(OWNERSHIP_UNOWNED);
+                element->AsSurface()->SetParkFences(0);
+                element->AsSurface()->SetWaterHeight(0);
+                // Because this element is not completely removed, the pointer must be updated manually
+                // The rest of the elements are removed from the array, so the pointer doesn't need to be updated.
+                (*elementPtr)++;
+                break;
+            case TileElementType::Entrance:
+            {
+                int32_t rotation = element->GetDirectionWithOffset(1);
+                auto seqLoc = loc;
+                switch (element->AsEntrance()->GetSequenceIndex())
+                {
+                    case 1:
+                        seqLoc += CoordsDirectionDelta[rotation];
+                        break;
+                    case 2:
+                        seqLoc -= CoordsDirectionDelta[rotation];
+                        break;
+                }
+                auto parkEntranceRemoveAction = GameActions::ParkEntranceRemoveAction(CoordsXYZ{ seqLoc, element->GetBaseZ() });
+                auto result = GameActions::ExecuteNested(&parkEntranceRemoveAction, gameState);
+                // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+                if (result.error != GameActions::Status::ok)
+                {
+                    TileElementRemove(element);
+                }
+                break;
+            }
+            case TileElementType::Wall:
+            {
+                CoordsXYZD wallLocation = { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() };
+                auto wallRemoveAction = GameActions::WallRemoveAction(wallLocation);
+                auto result = GameActions::ExecuteNested(&wallRemoveAction, gameState);
+                // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+                if (result.error != GameActions::Status::ok)
+                {
+                    TileElementRemove(element);
+                }
+            }
+            break;
+            case TileElementType::LargeScenery:
+            {
+                auto removeSceneryAction = GameActions::LargeSceneryRemoveAction(
+                    { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() },
+                    element->AsLargeScenery()->GetSequenceIndex());
+                auto result = GameActions::ExecuteNested(&removeSceneryAction, gameState);
+                // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+                if (result.error != GameActions::Status::ok)
+                {
+                    TileElementRemove(element);
+                }
+            }
+            break;
+            case TileElementType::Banner:
+            {
+                auto bannerRemoveAction = GameActions::BannerRemoveAction(
+                    { loc.x, loc.y, element->GetBaseZ(), element->AsBanner()->GetPosition() });
+                auto result = GameActions::ExecuteNested(&bannerRemoveAction, gameState);
+                // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
+                if (result.error != GameActions::Status::ok)
+                {
+                    TileElementRemove(element);
+                }
+                break;
+            }
+            default:
+                TileElementRemove(element);
+                break;
+        }
+    }
+
+    /**
+     * Clears all elements properly from a certain tile.
+     *  rct2: 0x0068AE2A
+     */
+    static void ClearElementsAt(const CoordsXY& loc)
+    {
+        auto& gameState = getGameState();
+        // Remove the spawn point (if there is one in the current tile)
+        gameState.peepSpawns.erase(
+            std::remove_if(
+                gameState.peepSpawns.begin(), gameState.peepSpawns.end(),
+                [loc](const CoordsXY& spawn) { return spawn.ToTileStart() == loc.ToTileStart(); }),
+            gameState.peepSpawns.end());
+
+        TileElement* tileElement = MapGetFirstElementAt(loc);
+        if (tileElement == nullptr)
+            return;
+
+        // Remove all elements except the last one
+        while (!tileElement->IsLastForTile())
+            ClearElementAt(loc, &tileElement);
+
+        // Remove the last element
+        ClearElementAt(loc, &tileElement);
+    }
+
+    int32_t MapGetHighestZ(const CoordsXY& loc)
     {
         auto surfaceElement = MapGetSurfaceElementAt(loc);
         if (surfaceElement == nullptr)
+            return -1;
+
+        auto z = surfaceElement->GetBaseZ();
+
+        // Raise z so that is above highest point of land and water on tile
+        if ((surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask) != kTileSlopeFlat)
+            z += kLandHeightStep;
+        if ((surfaceElement->GetSlope() & kTileSlopeDiagonalFlag) != 0)
+            z += kLandHeightStep;
+
+        z = std::max(z, surfaceElement->GetWaterHeight());
+        return z;
+    }
+
+    LargeSceneryElement* MapGetLargeScenerySegment(const CoordsXYZD& sceneryPos, int32_t sequence)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(sceneryPos);
+        if (tileElement == nullptr)
+        {
+            return nullptr;
+        }
+        auto sceneryTilePos = TileCoordsXYZ{ sceneryPos };
+        do
+        {
+            if (tileElement->GetType() != TileElementType::LargeScenery)
+                continue;
+            if (tileElement->BaseHeight != sceneryTilePos.z)
+                continue;
+            if (tileElement->AsLargeScenery()->GetSequenceIndex() != sequence)
+                continue;
+            if ((tileElement->GetDirection()) != sceneryPos.direction)
+                continue;
+
+            return tileElement->AsLargeScenery();
+        } while (!(tileElement++)->IsLastForTile());
+        return nullptr;
+    }
+
+    EntranceElement* MapGetParkEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost)
+    {
+        auto entranceTileCoords = TileCoordsXYZ(entranceCoords);
+        TileElement* tileElement = MapGetFirstElementAt(entranceCoords);
+        if (tileElement != nullptr)
+        {
+            do
+            {
+                if (tileElement->GetType() != TileElementType::Entrance)
+                    continue;
+
+                if (tileElement->BaseHeight != entranceTileCoords.z)
+                    continue;
+
+                if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
+                    continue;
+
+                if (!ghost && tileElement->IsGhost())
+                    continue;
+
+                return tileElement->AsEntrance();
+            } while (!(tileElement++)->IsLastForTile());
+        }
+        return nullptr;
+    }
+
+    EntranceElement* MapGetRideEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost)
+    {
+        auto entranceTileCoords = TileCoordsXYZ{ entranceCoords };
+        TileElement* tileElement = MapGetFirstElementAt(entranceCoords);
+        if (tileElement != nullptr)
+        {
+            do
+            {
+                if (tileElement->GetType() != TileElementType::Entrance)
+                    continue;
+
+                if (tileElement->BaseHeight != entranceTileCoords.z)
+                    continue;
+
+                if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
+                    continue;
+
+                if (!ghost && tileElement->IsGhost())
+                    continue;
+
+                return tileElement->AsEntrance();
+            } while (!(tileElement++)->IsLastForTile());
+        }
+        return nullptr;
+    }
+
+    EntranceElement* MapGetRideExitElementAt(const CoordsXYZ& exitCoords, bool ghost)
+    {
+        auto exitTileCoords = TileCoordsXYZ{ exitCoords };
+        TileElement* tileElement = MapGetFirstElementAt(exitCoords);
+        if (tileElement != nullptr)
+        {
+            do
+            {
+                if (tileElement->GetType() != TileElementType::Entrance)
+                    continue;
+
+                if (tileElement->BaseHeight != exitTileCoords.z)
+                    continue;
+
+                if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_EXIT)
+                    continue;
+
+                if (!ghost && tileElement->IsGhost())
+                    continue;
+
+                return tileElement->AsEntrance();
+            } while (!(tileElement++)->IsLastForTile());
+        }
+        return nullptr;
+    }
+
+    SmallSceneryElement* MapGetSmallSceneryElementAt(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant)
+    {
+        auto sceneryTileCoords = TileCoordsXYZ{ sceneryCoords };
+        TileElement* tileElement = MapGetFirstElementAt(sceneryCoords);
+        if (tileElement != nullptr)
+        {
+            do
+            {
+                if (tileElement->GetType() != TileElementType::SmallScenery)
+                    continue;
+                if (tileElement->AsSmallScenery()->GetSceneryQuadrant() != quadrant)
+                    continue;
+                if (tileElement->BaseHeight != sceneryTileCoords.z)
+                    continue;
+                if (tileElement->AsSmallScenery()->GetEntryIndex() != type)
+                    continue;
+
+                return tileElement->AsSmallScenery();
+            } while (!(tileElement++)->IsLastForTile());
+        }
+        return nullptr;
+    }
+
+    std::optional<CoordsXYZ> MapLargeSceneryGetOrigin(
+        const CoordsXYZD& sceneryPos, int32_t sequence, LargeSceneryElement** outElement)
+    {
+        auto tileElement = MapGetLargeScenerySegment(sceneryPos, sequence);
+        if (tileElement == nullptr)
+            return std::nullopt;
+
+        auto* sceneryEntry = tileElement->GetEntry();
+        auto& tile = sceneryEntry->tiles[sequence];
+
+        CoordsXY offsetPos{ tile.offset };
+        auto rotatedOffsetPos = offsetPos.Rotate(sceneryPos.direction);
+
+        auto origin = CoordsXYZ{ sceneryPos.x - rotatedOffsetPos.x, sceneryPos.y - rotatedOffsetPos.y,
+                                 sceneryPos.z - tile.offset.z };
+        if (outElement != nullptr)
+            *outElement = tileElement;
+        return origin;
+    }
+
+    /**
+     *
+     *  rct2: 0x006B9B05
+     */
+    bool MapLargeScenerySignSetColour(
+        const CoordsXYZD& signPos, int32_t sequence, Drawing::Colour mainColour, Drawing::Colour textColour)
+    {
+        LargeSceneryElement* tileElement;
+
+        auto sceneryOrigin = MapLargeSceneryGetOrigin(signPos, sequence, &tileElement);
+        if (!sceneryOrigin)
         {
             return false;
         }
-        if (surfaceElement->GetOwnership() & OWNERSHIP_OWNED)
+
+        auto* sceneryEntry = tileElement->GetEntry();
+
+        // Iterate through each tile of the large scenery element
+        for (auto& tile : sceneryEntry->tiles)
+        {
+            CoordsXY offsetPos{ tile.offset };
+            auto rotatedOffsetPos = offsetPos.Rotate(signPos.direction);
+
+            auto tmpSignPos = CoordsXYZD{ sceneryOrigin->x + rotatedOffsetPos.x, sceneryOrigin->y + rotatedOffsetPos.y,
+                                          sceneryOrigin->z + tile.offset.z, signPos.direction };
+            tileElement = MapGetLargeScenerySegment(tmpSignPos, tile.index);
+            if (tileElement != nullptr)
+            {
+                tileElement->SetPrimaryColour(mainColour);
+                tileElement->SetSecondaryColour(textColour);
+
+                MapInvalidateTile({ tmpSignPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+            }
+        }
+
+        return true;
+    }
+
+    static void MapInvalidateTileUnderZoom(int32_t x, int32_t y, int32_t z0, int32_t z1, ZoomLevel maxZoom)
+    {
+        if (gOpenRCT2Headless)
+            return;
+
+        ViewportsInvalidate(x, y, z0, z1, maxZoom);
+    }
+
+    /**
+     *
+     *  rct2: 0x006EC847
+     */
+    void MapInvalidateTile(const CoordsXYRangedZ& tilePos)
+    {
+        MapInvalidateTileUnderZoom(tilePos.x, tilePos.y, tilePos.baseZ, tilePos.clearanceZ, ZoomLevel{ -1 });
+    }
+
+    /**
+     *
+     *  rct2: 0x006ECB60
+     */
+    void MapInvalidateTileZoom1(const CoordsXYRangedZ& tilePos)
+    {
+        MapInvalidateTileUnderZoom(tilePos.x, tilePos.y, tilePos.baseZ, tilePos.clearanceZ, ZoomLevel{ 1 });
+    }
+
+    /**
+     *
+     *  rct2: 0x006EC9CE
+     */
+    void MapInvalidateTileZoom0(const CoordsXYRangedZ& tilePos)
+    {
+        MapInvalidateTileUnderZoom(tilePos.x, tilePos.y, tilePos.baseZ, tilePos.clearanceZ, ZoomLevel{ 0 });
+    }
+
+    /**
+     *
+     *  rct2: 0x006EC6D7
+     */
+    void MapInvalidateTileFull(const CoordsXY& tilePos)
+    {
+        MapInvalidateTile({ tilePos, 0, 2080 });
+    }
+
+    void MapInvalidateElement(const CoordsXY& elementPos, TileElement* tileElement)
+    {
+        MapInvalidateTile({ elementPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+    }
+
+    void MapInvalidateRegion(const CoordsXY& mins, const CoordsXY& maxs)
+    {
+        int32_t x0 = mins.x + 16;
+        int32_t y0 = mins.y + 16;
+        int32_t x1 = maxs.x + 16;
+        int32_t y1 = maxs.y + 16;
+        int32_t left, right, top, bottom;
+
+        MapGetBoundingBox({ x0, y0, x1, y1 }, &left, &top, &right, &bottom);
+
+        left -= 32;
+        right += 32;
+        bottom += 32;
+        top -= 32 + 2080;
+
+        ViewportsInvalidate({ { left, top }, { right, bottom } });
+    }
+
+    int32_t MapGetTileSide(const CoordsXY& mapPos)
+    {
+        int32_t subMapX = mapPos.x & (32 - 1);
+        int32_t subMapY = mapPos.y & (32 - 1);
+        return (subMapX < subMapY) ? ((subMapX + subMapY) < 32 ? 0 : 1) : ((subMapX + subMapY) < 32 ? 3 : 2);
+    }
+
+    int32_t MapGetTileQuadrant(const CoordsXY& mapPos)
+    {
+        int32_t subMapX = mapPos.x & (32 - 1);
+        int32_t subMapY = mapPos.y & (32 - 1);
+        return (subMapX > 16) ? (subMapY < 16 ? 1 : 0) : (subMapY < 16 ? 2 : 3);
+    }
+
+    /**
+     *
+     *  rct2: 0x00693BFF
+     */
+    bool MapSurfaceIsBlocked(const CoordsXY& mapCoords)
+    {
+        if (!MapIsLocationValid(mapCoords))
             return true;
-        if (surfaceElement->GetOwnership() & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
+
+        auto surfaceElement = MapGetSurfaceElementAt(mapCoords);
+
+        if (surfaceElement == nullptr)
+        {
             return true;
-    }
-    return false;
-}
-
-int32_t MapGetCornerHeight(int32_t z, int32_t slope, int32_t direction)
-{
-    switch (direction)
-    {
-        case 0:
-            if (slope & kTileSlopeNCornerUp)
-            {
-                z += 2;
-                if (slope == (kTileSlopeSCornerDown | kTileSlopeDiagonalFlag))
-                {
-                    z += 2;
-                }
-            }
-            break;
-        case 1:
-            if (slope & kTileSlopeECornerUp)
-            {
-                z += 2;
-                if (slope == (kTileSlopeWCornerDown | kTileSlopeDiagonalFlag))
-                {
-                    z += 2;
-                }
-            }
-            break;
-        case 2:
-            if (slope & kTileSlopeSCornerUp)
-            {
-                z += 2;
-                if (slope == (kTileSlopeNCornerDown | kTileSlopeDiagonalFlag))
-                {
-                    z += 2;
-                }
-            }
-            break;
-        case 3:
-            if (slope & kTileSlopeWCornerUp)
-            {
-                z += 2;
-                if (slope == (kTileSlopeECornerDown | kTileSlopeDiagonalFlag))
-                {
-                    z += 2;
-                }
-            }
-            break;
-    }
-    return z;
-}
-
-int32_t TileElementGetCornerHeight(const SurfaceElement* surfaceElement, int32_t direction)
-{
-    int32_t z = surfaceElement->BaseHeight;
-    int32_t slope = surfaceElement->GetSlope();
-    return MapGetCornerHeight(z, slope, direction);
-}
-
-uint8_t MapGetLowestLandHeight(const MapRange& range)
-{
-    auto mapSizeMax = GetMapSizeMaxXY();
-    MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
-                            std::min(range.GetY2(), mapSizeMax.y) };
-
-    uint8_t minHeight = 0xFF;
-    for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
-    {
-        for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
-        {
-            auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
-
-            if (surfaceElement != nullptr && minHeight > surfaceElement->BaseHeight)
-            {
-                if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
-                {
-                    if (!MapIsLocationInPark(CoordsXY{ xi, yi }))
-                    {
-                        continue;
-                    }
-                }
-
-                minHeight = surfaceElement->BaseHeight;
-            }
-        }
-    }
-    return minHeight;
-}
-
-uint8_t MapGetHighestLandHeight(const MapRange& range)
-{
-    auto mapSizeMax = GetMapSizeMaxXY();
-    MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
-                            std::min(range.GetY2(), mapSizeMax.y) };
-
-    uint8_t maxHeight = 0;
-    for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
-    {
-        for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
-        {
-            auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
-            if (surfaceElement != nullptr)
-            {
-                if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
-                {
-                    if (!MapIsLocationInPark(CoordsXY{ xi, yi }))
-                    {
-                        continue;
-                    }
-                }
-
-                uint8_t BaseHeight = surfaceElement->BaseHeight;
-                if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
-                    BaseHeight += 2;
-                if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
-                    BaseHeight += 2;
-                if (maxHeight < BaseHeight)
-                    maxHeight = BaseHeight;
-            }
-        }
-    }
-    return maxHeight;
-}
-
-/**
- *
- *  rct2: 0x0068B280
- */
-void TileElementRemove(TileElement* tileElement)
-{
-    // Replace Nth element by (N+1)th element.
-    // This loop will make tileElement point to the old last element position,
-    // after copy it to it's new position
-    if (!tileElement->IsLastForTile())
-    {
-        do
-        {
-            *tileElement = *(tileElement + 1);
-        } while (!(++tileElement)->IsLastForTile());
-    }
-
-    // Mark the latest element with the last element flag.
-    (tileElement - 1)->SetLastForTile(true);
-    tileElement->BaseHeight = kMaxTileElementHeight;
-    _tileElementsInUse--;
-    auto& gameState = getGameState();
-    if (tileElement == &gameState.tileElements.back())
-    {
-        gameState.tileElements.pop_back();
-    }
-}
-
-/**
- *
- *  rct2: 0x00675A8E
- */
-void MapRemoveAllRides()
-{
-    TileElementIterator it;
-
-    TileElementIteratorBegin(&it);
-    do
-    {
-        switch (it.element->GetType())
-        {
-            case TileElementType::Path:
-                if (it.element->AsPath()->IsQueue())
-                {
-                    it.element->AsPath()->SetHasQueueBanner(false);
-                    it.element->AsPath()->SetRideIndex(RideId::GetNull());
-                }
-                break;
-            case TileElementType::Entrance:
-                if (it.element->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE)
-                    break;
-                [[fallthrough]];
-            case TileElementType::Track:
-                FootpathQueueChainReset();
-                FootpathRemoveEdgesAt(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
-                TileElementRemove(it.element);
-                TileElementIteratorRestartForTile(&it);
-                break;
-            default:
-                break;
-        }
-    } while (TileElementIteratorNext(&it));
-}
-
-void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* top, int32_t* right, int32_t* bottom)
-{
-    uint32_t rotation = GetCurrentRotation();
-    const std::array corners{
-        CoordsXY{ _range.GetX1(), _range.GetY1() },
-        CoordsXY{ _range.GetX2(), _range.GetY1() },
-        CoordsXY{ _range.GetX2(), _range.GetY2() },
-        CoordsXY{ _range.GetX1(), _range.GetY2() },
-    };
-
-    *left = std::numeric_limits<int32_t>::max();
-    *top = std::numeric_limits<int32_t>::max();
-    *right = std::numeric_limits<int32_t>::min();
-    *bottom = std::numeric_limits<int32_t>::min();
-
-    for (const auto& corner : corners)
-    {
-        auto screenCoord = Translate3DTo2DWithZ(rotation, CoordsXYZ{ corner, 0 });
-        if (screenCoord.x < *left)
-            *left = screenCoord.x;
-        if (screenCoord.x > *right)
-            *right = screenCoord.x;
-        if (screenCoord.y > *bottom)
-            *bottom = screenCoord.y;
-        if (screenCoord.y < *top)
-            *top = screenCoord.y;
-    }
-}
-
-static size_t CountElementsOnTile(const CoordsXY& loc)
-{
-    size_t count = 0;
-    auto* element = _tileIndex.GetFirstElementAt(TileCoordsXY(loc));
-    do
-    {
-        count++;
-    } while (!(element++)->IsLastForTile());
-    return count;
-}
-
-static TileElement* AllocateTileElements(size_t numElementsOnTile, size_t numNewElements)
-{
-    if (!MapCheckFreeElementsAndReorganise(numElementsOnTile, numNewElements))
-    {
-        LOG_ERROR("Cannot insert new element");
-        return nullptr;
-    }
-
-    auto& gameState = getGameState();
-    auto oldSize = gameState.tileElements.size();
-    gameState.tileElements.resize(gameState.tileElements.size() + numElementsOnTile + numNewElements);
-    _tileElementsInUse += numNewElements;
-    return &gameState.tileElements[oldSize];
-}
-
-/**
- *
- *  rct2: 0x0068B1F6
- */
-TileElement* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type)
-{
-    const auto& tileLoc = TileCoordsXYZ(loc);
-
-    auto numElementsOnTileOld = CountElementsOnTile(loc);
-    auto* newTileElement = AllocateTileElements(numElementsOnTileOld, 1);
-    auto* originalTileElement = _tileIndex.GetFirstElementAt(tileLoc);
-    if (newTileElement == nullptr)
-    {
-        return nullptr;
-    }
-
-    // Set tile index pointer to point to new element block
-    _tileIndex.SetTile(tileLoc, newTileElement);
-
-    bool isLastForTile = false;
-    if (originalTileElement == nullptr)
-    {
-        isLastForTile = true;
-    }
-    else
-    {
-        // Copy all elements that are below the insert height
-        while (loc.z >= originalTileElement->GetBaseZ())
-        {
-            // Copy over map element
-            *newTileElement = *originalTileElement;
-            originalTileElement->BaseHeight = kMaxTileElementHeight;
-            originalTileElement++;
-            newTileElement++;
-
-            if ((newTileElement - 1)->IsLastForTile())
-            {
-                // No more elements above the insert element
-                (newTileElement - 1)->SetLastForTile(false);
-                isLastForTile = true;
-                break;
-            }
-        }
-    }
-
-    // Insert new map element
-    auto* insertedElement = newTileElement;
-    newTileElement->Type = 0;
-    newTileElement->SetType(type);
-    newTileElement->SetBaseZ(loc.z);
-    newTileElement->Flags = 0;
-    newTileElement->SetLastForTile(isLastForTile);
-    newTileElement->SetOccupiedQuadrants(occupiedQuadrants);
-    newTileElement->SetClearanceZ(loc.z);
-    newTileElement->Owner = 0;
-    std::memset(&newTileElement->Pad05, 0, sizeof(newTileElement->Pad05));
-    std::memset(&newTileElement->Pad08, 0, sizeof(newTileElement->Pad08));
-    newTileElement++;
-
-    // Insert rest of map elements above insert height
-    if (!isLastForTile)
-    {
-        do
-        {
-            // Copy over map element
-            *newTileElement = *originalTileElement;
-            originalTileElement->BaseHeight = kMaxTileElementHeight;
-            originalTileElement++;
-            newTileElement++;
-        } while (!((newTileElement - 1)->IsLastForTile()));
-    }
-
-    return insertedElement;
-}
-
-/**
- * Updates grass length, scenery age and jumping fountains.
- *
- *  rct2: 0x006646E1
- */
-void MapUpdateTiles()
-{
-    PROFILED_FUNCTION();
-
-    if (isInEditorMode())
-        return;
-
-    auto& gameState = getGameState();
-
-    // Update 43 more tiles (for each 256x256 block)
-    for (int32_t j = 0; j < 43; j++)
-    {
-        int32_t x = 0;
-        int32_t y = 0;
-
-        uint16_t interleaved_xy = gameState.grassSceneryTileLoopPosition;
-        for (int32_t i = 0; i < 8; i++)
-        {
-            x = (x << 1) | (interleaved_xy & 1);
-            interleaved_xy >>= 1;
-            y = (y << 1) | (interleaved_xy & 1);
-            interleaved_xy >>= 1;
         }
 
-        // Repeat for each 256x256 block on the map
-        for (int32_t blockY = 0; blockY < gameState.mapSize.y; blockY += 256)
-        {
-            for (int32_t blockX = 0; blockX < gameState.mapSize.x; blockX += 256)
-            {
-                auto mapPos = TileCoordsXY{ blockX + x, blockY + y }.ToCoordsXY();
-                if (MapIsEdge(mapPos))
-                    continue;
+        if (surfaceElement->GetWaterHeight() > surfaceElement->GetBaseZ())
+            return true;
 
-                auto* surfaceElement = MapGetSurfaceElementAt(mapPos);
-                if (surfaceElement != nullptr)
-                {
-                    surfaceElement->UpdateGrassLength(mapPos);
-                    SceneryUpdateTile(mapPos);
-                }
+        int16_t base_z = surfaceElement->BaseHeight;
+        int16_t clear_z = surfaceElement->BaseHeight + 2;
+        if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
+            clear_z += 2;
+
+        auto tileElement = reinterpret_cast<TileElement*>(surfaceElement);
+        while (!(tileElement++)->IsLastForTile())
+        {
+            if (clear_z >= tileElement->ClearanceHeight)
+                continue;
+
+            if (base_z < tileElement->BaseHeight)
+                continue;
+
+            if (tileElement->GetType() == TileElementType::Path || tileElement->GetType() == TileElementType::Wall)
+                continue;
+
+            if (tileElement->GetType() != TileElementType::SmallScenery)
+                return true;
+
+            auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
+            if (sceneryEntry == nullptr)
+            {
+                return false;
             }
+            if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_FULL_TILE))
+                return true;
         }
-
-        gameState.grassSceneryTileLoopPosition++;
+        return false;
     }
-}
 
-/**
- * Removes elements that are out of the map size range and crops the park perimeter.
- *  rct2: 0x0068ADBC
- */
-void MapRemoveOutOfRangeElements()
-{
-    auto mapSizeMax = GetMapSizeMaxXY();
-
-    // Ensure that we can remove elements
-    //
-    // NOTE: This is only a workaround for non-networked games.
-    // Map resize has to become its own Game Action to properly solve this issue.
-    //
-    auto& gameState = getGameState();
-    bool buildState = gameState.cheats.buildInPauseMode;
-    gameState.cheats.buildInPauseMode = true;
-
-    for (int32_t y = kMaximumMapSizeBig - kCoordsXYStep; y >= 0; y -= kCoordsXYStep)
+    /* Clears all map elements, to be used before generating a new map */
+    void MapClearAllElements()
     {
-        for (int32_t x = kMaximumMapSizeBig - kCoordsXYStep; x >= 0; x -= kCoordsXYStep)
+        for (int32_t y = 0; y < kMaximumMapSizeBig; y += kCoordsXYStep)
         {
-            if (x == 0 || y == 0 || x >= mapSizeMax.x || y >= mapSizeMax.y)
+            for (int32_t x = 0; x < kMaximumMapSizeBig; x += kCoordsXYStep)
             {
-                // Note this purposely does not use LandSetRightsAction as X Y coordinates are outside of normal range.
-                auto surfaceElement = MapGetSurfaceElementAt(CoordsXY{ x, y });
-                if (surfaceElement != nullptr)
-                {
-                    surfaceElement->SetOwnership(OWNERSHIP_UNOWNED);
-                    Park::UpdateFencesAroundTile({ x, y });
-                }
                 ClearElementsAt({ x, y });
             }
         }
     }
 
-    // Reset cheat state
-    gameState.cheats.buildInPauseMode = buildState;
-}
-
-static void MapExtendBoundarySurfaceExtendTile(
-    const SurfaceElement& sourceTile, SurfaceElement& destTile, const Direction direction)
-{
-    destTile.SetSurfaceObjectIndex(sourceTile.GetSurfaceObjectIndex());
-    destTile.SetEdgeObjectIndex(sourceTile.GetEdgeObjectIndex());
-    destTile.SetGrassLength(sourceTile.GetGrassLength());
-    destTile.SetOwnership(OWNERSHIP_UNOWNED);
-    destTile.SetWaterHeight(sourceTile.GetWaterHeight());
-
-    auto z = sourceTile.BaseHeight;
-    const auto originalSlope = Numerics::rol4(sourceTile.GetSlope(), direction)
-        | (sourceTile.GetSlope() & kTileSlopeDiagonalFlag);
-    auto slope = originalSlope & kTileSlopeNWSideUp;
-    if (slope == kTileSlopeNWSideUp)
+    /**
+     * Gets the track element at x, y, z.
+     * @param x x units, not tiles.
+     * @param y y units, not tiles.
+     * @param z Base height.
+     */
+    TrackElement* MapGetTrackElementAt(const CoordsXYZ& trackPos)
     {
-        z += 2;
-        slope = kTileSlopeFlat;
-        if (originalSlope & kTileSlopeDiagonalFlag)
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
+        if (tileElement == nullptr)
+            return nullptr;
+        do
         {
-            slope = kTileSlopeNCornerUp;
-            if (originalSlope & kTileSlopeSCornerUp)
-            {
-                slope = kTileSlopeWCornerUp;
-                if (originalSlope & kTileSlopeECornerUp)
-                {
-                    slope = kTileSlopeFlat;
-                }
-            }
-        }
-    }
-    if (slope & kTileSlopeNCornerUp)
-        slope |= kTileSlopeECornerUp;
-    if (slope & kTileSlopeWCornerUp)
-        slope |= kTileSlopeSCornerUp;
+            if (tileElement->GetType() != TileElementType::Track)
+                continue;
+            if (tileElement->GetBaseZ() != trackPos.z)
+                continue;
 
-    destTile.SetSlope(Numerics::ror4(slope, direction));
-    destTile.BaseHeight = z;
-    destTile.ClearanceHeight = z;
-}
+            return tileElement->AsTrack();
+        } while (!(tileElement++)->IsLastForTile());
 
-/**
- * Copies the terrain and slope from the Y edge of the map to the new tiles. Used when increasing the size of the map.
- */
-void MapExtendBoundarySurfaceY()
-{
-    auto y = getGameState().mapSize.y - 2;
-    for (auto x = 0; x < kMaximumMapSizeTechnical; x++)
-    {
-        auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y - 1 });
-        auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
-
-        if (existingTileElement != nullptr && newTileElement != nullptr)
-        {
-            MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 0);
-        }
-
-        Park::UpdateFences({ x << 5, y << 5 });
-    }
-}
-
-/**
- * Copies the terrain and slope from the X edge of the map to the new tiles. Used when increasing the size of the map.
- */
-void MapExtendBoundarySurfaceX()
-{
-    auto x = getGameState().mapSize.x - 2;
-    for (auto y = 0; y < kMaximumMapSizeTechnical; y++)
-    {
-        auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y });
-        auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
-        if (existingTileElement != nullptr && newTileElement != nullptr)
-        {
-            MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 3);
-        }
-        Park::UpdateFences({ x << 5, y << 5 });
-    }
-}
-
-static void MapExtendBoundarySurfaceShiftX(const int32_t amount, const int32_t mapSizeY)
-{
-    for (int32_t y = 1; y < mapSizeY - 1; y++)
-    {
-        for (int32_t x = amount; x > 0; x--)
-        {
-            const auto* const existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y });
-            auto* const newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
-            if (existingTileElement != nullptr && newTileElement != nullptr)
-            {
-                MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 1);
-            }
-            Park::UpdateFences(TileCoordsXY{ x, y }.ToCoordsXY());
-        }
-    }
-}
-
-static void MapExtendBoundarySurfaceShiftY(const int32_t amount, const int32_t mapSizeX)
-{
-    for (int32_t x = 1; x < mapSizeX - 1; x++)
-    {
-        for (int32_t y = amount; y > 0; y--)
-        {
-            const auto* const existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y + 1 });
-            auto* const newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
-            if (existingTileElement != nullptr && newTileElement != nullptr)
-            {
-                MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement, 2);
-            }
-            Park::UpdateFences(TileCoordsXY{ x, y }.ToCoordsXY());
-        }
-    }
-}
-
-/**
- * Clears the provided element properly from a certain tile, and updates
- * the pointer (when needed) passed to this function to point to the next element.
- */
-void ClearElementAt(const CoordsXY& loc, TileElement** elementPtr)
-{
-    auto& gameState = getGameState();
-
-    TileElement* element = *elementPtr;
-    switch (element->GetType())
-    {
-        case TileElementType::Surface:
-            element->BaseHeight = kMinimumLandHeight;
-            element->ClearanceHeight = kMinimumLandHeight;
-            element->Owner = 0;
-            element->AsSurface()->SetSlope(kTileSlopeFlat);
-            element->AsSurface()->SetSurfaceObjectIndex(0);
-            element->AsSurface()->SetEdgeObjectIndex(0);
-            element->AsSurface()->SetGrassLength(GRASS_LENGTH_CLEAR_0);
-            element->AsSurface()->SetOwnership(OWNERSHIP_UNOWNED);
-            element->AsSurface()->SetParkFences(0);
-            element->AsSurface()->SetWaterHeight(0);
-            // Because this element is not completely removed, the pointer must be updated manually
-            // The rest of the elements are removed from the array, so the pointer doesn't need to be updated.
-            (*elementPtr)++;
-            break;
-        case TileElementType::Entrance:
-        {
-            int32_t rotation = element->GetDirectionWithOffset(1);
-            auto seqLoc = loc;
-            switch (element->AsEntrance()->GetSequenceIndex())
-            {
-                case 1:
-                    seqLoc += CoordsDirectionDelta[rotation];
-                    break;
-                case 2:
-                    seqLoc -= CoordsDirectionDelta[rotation];
-                    break;
-            }
-            auto parkEntranceRemoveAction = GameActions::ParkEntranceRemoveAction(CoordsXYZ{ seqLoc, element->GetBaseZ() });
-            auto result = GameActions::ExecuteNested(&parkEntranceRemoveAction, gameState);
-            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
-            if (result.error != GameActions::Status::ok)
-            {
-                TileElementRemove(element);
-            }
-            break;
-        }
-        case TileElementType::Wall:
-        {
-            CoordsXYZD wallLocation = { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() };
-            auto wallRemoveAction = GameActions::WallRemoveAction(wallLocation);
-            auto result = GameActions::ExecuteNested(&wallRemoveAction, gameState);
-            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
-            if (result.error != GameActions::Status::ok)
-            {
-                TileElementRemove(element);
-            }
-        }
-        break;
-        case TileElementType::LargeScenery:
-        {
-            auto removeSceneryAction = GameActions::LargeSceneryRemoveAction(
-                { loc.x, loc.y, element->GetBaseZ(), element->GetDirection() }, element->AsLargeScenery()->GetSequenceIndex());
-            auto result = GameActions::ExecuteNested(&removeSceneryAction, gameState);
-            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
-            if (result.error != GameActions::Status::ok)
-            {
-                TileElementRemove(element);
-            }
-        }
-        break;
-        case TileElementType::Banner:
-        {
-            auto bannerRemoveAction = GameActions::BannerRemoveAction(
-                { loc.x, loc.y, element->GetBaseZ(), element->AsBanner()->GetPosition() });
-            auto result = GameActions::ExecuteNested(&bannerRemoveAction, gameState);
-            // If asking nicely did not work, forcibly remove this to avoid an infinite loop.
-            if (result.error != GameActions::Status::ok)
-            {
-                TileElementRemove(element);
-            }
-            break;
-        }
-        default:
-            TileElementRemove(element);
-            break;
-    }
-}
-
-/**
- * Clears all elements properly from a certain tile.
- *  rct2: 0x0068AE2A
- */
-static void ClearElementsAt(const CoordsXY& loc)
-{
-    auto& gameState = getGameState();
-    // Remove the spawn point (if there is one in the current tile)
-    gameState.peepSpawns.erase(
-        std::remove_if(
-            gameState.peepSpawns.begin(), gameState.peepSpawns.end(),
-            [loc](const CoordsXY& spawn) { return spawn.ToTileStart() == loc.ToTileStart(); }),
-        gameState.peepSpawns.end());
-
-    TileElement* tileElement = MapGetFirstElementAt(loc);
-    if (tileElement == nullptr)
-        return;
-
-    // Remove all elements except the last one
-    while (!tileElement->IsLastForTile())
-        ClearElementAt(loc, &tileElement);
-
-    // Remove the last element
-    ClearElementAt(loc, &tileElement);
-}
-
-int32_t MapGetHighestZ(const CoordsXY& loc)
-{
-    auto surfaceElement = MapGetSurfaceElementAt(loc);
-    if (surfaceElement == nullptr)
-        return -1;
-
-    auto z = surfaceElement->GetBaseZ();
-
-    // Raise z so that is above highest point of land and water on tile
-    if ((surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask) != kTileSlopeFlat)
-        z += kLandHeightStep;
-    if ((surfaceElement->GetSlope() & kTileSlopeDiagonalFlag) != 0)
-        z += kLandHeightStep;
-
-    z = std::max(z, surfaceElement->GetWaterHeight());
-    return z;
-}
-
-LargeSceneryElement* MapGetLargeScenerySegment(const CoordsXYZD& sceneryPos, int32_t sequence)
-{
-    TileElement* tileElement = MapGetFirstElementAt(sceneryPos);
-    if (tileElement == nullptr)
-    {
         return nullptr;
     }
-    auto sceneryTilePos = TileCoordsXYZ{ sceneryPos };
-    do
-    {
-        if (tileElement->GetType() != TileElementType::LargeScenery)
-            continue;
-        if (tileElement->BaseHeight != sceneryTilePos.z)
-            continue;
-        if (tileElement->AsLargeScenery()->GetSequenceIndex() != sequence)
-            continue;
-        if ((tileElement->GetDirection()) != sceneryPos.direction)
-            continue;
 
-        return tileElement->AsLargeScenery();
-    } while (!(tileElement++)->IsLastForTile());
-    return nullptr;
-}
-
-EntranceElement* MapGetParkEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost)
-{
-    auto entranceTileCoords = TileCoordsXYZ(entranceCoords);
-    TileElement* tileElement = MapGetFirstElementAt(entranceCoords);
-    if (tileElement != nullptr)
+    /**
+     * Gets the track element at x, y, z that is the given track type.
+     * @param x x units, not tiles.
+     * @param y y units, not tiles.
+     * @param z Base height.
+     */
+    TileElement* MapGetTrackElementAtOfType(const CoordsXYZ& trackPos, TrackElemType trackType)
     {
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
+        if (tileElement == nullptr)
+            return nullptr;
+        auto trackTilePos = TileCoordsXYZ{ trackPos };
         do
         {
-            if (tileElement->GetType() != TileElementType::Entrance)
+            if (tileElement->GetType() != TileElementType::Track)
+                continue;
+            if (tileElement->BaseHeight != trackTilePos.z)
+                continue;
+            if (tileElement->AsTrack()->GetTrackType() != trackType)
                 continue;
 
-            if (tileElement->BaseHeight != entranceTileCoords.z)
-                continue;
-
-            if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
-                continue;
-
-            if (!ghost && tileElement->IsGhost())
-                continue;
-
-            return tileElement->AsEntrance();
+            return tileElement;
         } while (!(tileElement++)->IsLastForTile());
-    }
-    return nullptr;
-}
 
-EntranceElement* MapGetRideEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost)
-{
-    auto entranceTileCoords = TileCoordsXYZ{ entranceCoords };
-    TileElement* tileElement = MapGetFirstElementAt(entranceCoords);
-    if (tileElement != nullptr)
+        return nullptr;
+    }
+
+    /**
+     * Gets the track element at x, y, z that is the given track type and sequence.
+     * @param x x units, not tiles.
+     * @param y y units, not tiles.
+     * @param z Base height.
+     */
+    TileElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZ& trackPos, TrackElemType trackType, int32_t sequence)
     {
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
+        auto trackTilePos = TileCoordsXYZ{ trackPos };
         do
         {
-            if (tileElement->GetType() != TileElementType::Entrance)
+            if (tileElement == nullptr)
+                break;
+            if (tileElement->GetType() != TileElementType::Track)
+                continue;
+            if (tileElement->BaseHeight != trackTilePos.z)
+                continue;
+            if (tileElement->AsTrack()->GetTrackType() != trackType)
+                continue;
+            if (tileElement->AsTrack()->GetSequenceIndex() != sequence)
                 continue;
 
-            if (tileElement->BaseHeight != entranceTileCoords.z)
-                continue;
-
-            if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_ENTRANCE)
-                continue;
-
-            if (!ghost && tileElement->IsGhost())
-                continue;
-
-            return tileElement->AsEntrance();
+            return tileElement;
         } while (!(tileElement++)->IsLastForTile());
-    }
-    return nullptr;
-}
 
-EntranceElement* MapGetRideExitElementAt(const CoordsXYZ& exitCoords, bool ghost)
-{
-    auto exitTileCoords = TileCoordsXYZ{ exitCoords };
-    TileElement* tileElement = MapGetFirstElementAt(exitCoords);
-    if (tileElement != nullptr)
-    {
-        do
-        {
-            if (tileElement->GetType() != TileElementType::Entrance)
-                continue;
-
-            if (tileElement->BaseHeight != exitTileCoords.z)
-                continue;
-
-            if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_RIDE_EXIT)
-                continue;
-
-            if (!ghost && tileElement->IsGhost())
-                continue;
-
-            return tileElement->AsEntrance();
-        } while (!(tileElement++)->IsLastForTile());
-    }
-    return nullptr;
-}
-
-SmallSceneryElement* MapGetSmallSceneryElementAt(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant)
-{
-    auto sceneryTileCoords = TileCoordsXYZ{ sceneryCoords };
-    TileElement* tileElement = MapGetFirstElementAt(sceneryCoords);
-    if (tileElement != nullptr)
-    {
-        do
-        {
-            if (tileElement->GetType() != TileElementType::SmallScenery)
-                continue;
-            if (tileElement->AsSmallScenery()->GetSceneryQuadrant() != quadrant)
-                continue;
-            if (tileElement->BaseHeight != sceneryTileCoords.z)
-                continue;
-            if (tileElement->AsSmallScenery()->GetEntryIndex() != type)
-                continue;
-
-            return tileElement->AsSmallScenery();
-        } while (!(tileElement++)->IsLastForTile());
-    }
-    return nullptr;
-}
-
-std::optional<CoordsXYZ> MapLargeSceneryGetOrigin(
-    const CoordsXYZD& sceneryPos, int32_t sequence, LargeSceneryElement** outElement)
-{
-    auto tileElement = MapGetLargeScenerySegment(sceneryPos, sequence);
-    if (tileElement == nullptr)
-        return std::nullopt;
-
-    auto* sceneryEntry = tileElement->GetEntry();
-    auto& tile = sceneryEntry->tiles[sequence];
-
-    CoordsXY offsetPos{ tile.offset };
-    auto rotatedOffsetPos = offsetPos.Rotate(sceneryPos.direction);
-
-    auto origin = CoordsXYZ{ sceneryPos.x - rotatedOffsetPos.x, sceneryPos.y - rotatedOffsetPos.y,
-                             sceneryPos.z - tile.offset.z };
-    if (outElement != nullptr)
-        *outElement = tileElement;
-    return origin;
-}
-
-/**
- *
- *  rct2: 0x006B9B05
- */
-bool MapLargeScenerySignSetColour(
-    const CoordsXYZD& signPos, int32_t sequence, Drawing::Colour mainColour, Drawing::Colour textColour)
-{
-    LargeSceneryElement* tileElement;
-
-    auto sceneryOrigin = MapLargeSceneryGetOrigin(signPos, sequence, &tileElement);
-    if (!sceneryOrigin)
-    {
-        return false;
+        return nullptr;
     }
 
-    auto* sceneryEntry = tileElement->GetEntry();
-
-    // Iterate through each tile of the large scenery element
-    for (auto& tile : sceneryEntry->tiles)
+    TrackElement* MapGetTrackElementAtOfType(const CoordsXYZD& location, TrackElemType trackType)
     {
-        CoordsXY offsetPos{ tile.offset };
-        auto rotatedOffsetPos = offsetPos.Rotate(signPos.direction);
-
-        auto tmpSignPos = CoordsXYZD{ sceneryOrigin->x + rotatedOffsetPos.x, sceneryOrigin->y + rotatedOffsetPos.y,
-                                      sceneryOrigin->z + tile.offset.z, signPos.direction };
-        tileElement = MapGetLargeScenerySegment(tmpSignPos, tile.index);
+        auto tileElement = MapGetFirstElementAt(location);
         if (tileElement != nullptr)
         {
-            tileElement->SetPrimaryColour(mainColour);
-            tileElement->SetSecondaryColour(textColour);
-
-            MapInvalidateTile({ tmpSignPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
+            do
+            {
+                auto trackElement = tileElement->AsTrack();
+                if (trackElement != nullptr)
+                {
+                    if (trackElement->GetBaseZ() != location.z)
+                        continue;
+                    if (trackElement->GetDirection() != location.direction)
+                        continue;
+                    if (trackElement->GetTrackType() != trackType)
+                        continue;
+                    return trackElement;
+                }
+            } while (!(tileElement++)->IsLastForTile());
         }
-    }
-
-    return true;
-}
-
-static void MapInvalidateTileUnderZoom(int32_t x, int32_t y, int32_t z0, int32_t z1, ZoomLevel maxZoom)
-{
-    if (gOpenRCT2Headless)
-        return;
-
-    ViewportsInvalidate(x, y, z0, z1, maxZoom);
-}
-
-/**
- *
- *  rct2: 0x006EC847
- */
-void MapInvalidateTile(const CoordsXYRangedZ& tilePos)
-{
-    MapInvalidateTileUnderZoom(tilePos.x, tilePos.y, tilePos.baseZ, tilePos.clearanceZ, ZoomLevel{ -1 });
-}
-
-/**
- *
- *  rct2: 0x006ECB60
- */
-void MapInvalidateTileZoom1(const CoordsXYRangedZ& tilePos)
-{
-    MapInvalidateTileUnderZoom(tilePos.x, tilePos.y, tilePos.baseZ, tilePos.clearanceZ, ZoomLevel{ 1 });
-}
-
-/**
- *
- *  rct2: 0x006EC9CE
- */
-void MapInvalidateTileZoom0(const CoordsXYRangedZ& tilePos)
-{
-    MapInvalidateTileUnderZoom(tilePos.x, tilePos.y, tilePos.baseZ, tilePos.clearanceZ, ZoomLevel{ 0 });
-}
-
-/**
- *
- *  rct2: 0x006EC6D7
- */
-void MapInvalidateTileFull(const CoordsXY& tilePos)
-{
-    MapInvalidateTile({ tilePos, 0, 2080 });
-}
-
-void MapInvalidateElement(const CoordsXY& elementPos, TileElement* tileElement)
-{
-    MapInvalidateTile({ elementPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
-}
-
-void MapInvalidateRegion(const CoordsXY& mins, const CoordsXY& maxs)
-{
-    int32_t x0 = mins.x + 16;
-    int32_t y0 = mins.y + 16;
-    int32_t x1 = maxs.x + 16;
-    int32_t y1 = maxs.y + 16;
-    int32_t left, right, top, bottom;
-
-    MapGetBoundingBox({ x0, y0, x1, y1 }, &left, &top, &right, &bottom);
-
-    left -= 32;
-    right += 32;
-    bottom += 32;
-    top -= 32 + 2080;
-
-    ViewportsInvalidate({ { left, top }, { right, bottom } });
-}
-
-int32_t MapGetTileSide(const CoordsXY& mapPos)
-{
-    int32_t subMapX = mapPos.x & (32 - 1);
-    int32_t subMapY = mapPos.y & (32 - 1);
-    return (subMapX < subMapY) ? ((subMapX + subMapY) < 32 ? 0 : 1) : ((subMapX + subMapY) < 32 ? 3 : 2);
-}
-
-int32_t MapGetTileQuadrant(const CoordsXY& mapPos)
-{
-    int32_t subMapX = mapPos.x & (32 - 1);
-    int32_t subMapY = mapPos.y & (32 - 1);
-    return (subMapX > 16) ? (subMapY < 16 ? 1 : 0) : (subMapY < 16 ? 2 : 3);
-}
-
-/**
- *
- *  rct2: 0x00693BFF
- */
-bool MapSurfaceIsBlocked(const CoordsXY& mapCoords)
-{
-    if (!MapIsLocationValid(mapCoords))
-        return true;
-
-    auto surfaceElement = MapGetSurfaceElementAt(mapCoords);
-
-    if (surfaceElement == nullptr)
-    {
-        return true;
-    }
-
-    if (surfaceElement->GetWaterHeight() > surfaceElement->GetBaseZ())
-        return true;
-
-    int16_t base_z = surfaceElement->BaseHeight;
-    int16_t clear_z = surfaceElement->BaseHeight + 2;
-    if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
-        clear_z += 2;
-
-    auto tileElement = reinterpret_cast<TileElement*>(surfaceElement);
-    while (!(tileElement++)->IsLastForTile())
-    {
-        if (clear_z >= tileElement->ClearanceHeight)
-            continue;
-
-        if (base_z < tileElement->BaseHeight)
-            continue;
-
-        if (tileElement->GetType() == TileElementType::Path || tileElement->GetType() == TileElementType::Wall)
-            continue;
-
-        if (tileElement->GetType() != TileElementType::SmallScenery)
-            return true;
-
-        auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
-        if (sceneryEntry == nullptr)
-        {
-            return false;
-        }
-        if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_FULL_TILE))
-            return true;
-    }
-    return false;
-}
-
-/* Clears all map elements, to be used before generating a new map */
-void MapClearAllElements()
-{
-    for (int32_t y = 0; y < kMaximumMapSizeBig; y += kCoordsXYStep)
-    {
-        for (int32_t x = 0; x < kMaximumMapSizeBig; x += kCoordsXYStep)
-        {
-            ClearElementsAt({ x, y });
-        }
-    }
-}
-
-/**
- * Gets the track element at x, y, z.
- * @param x x units, not tiles.
- * @param y y units, not tiles.
- * @param z Base height.
- */
-TrackElement* MapGetTrackElementAt(const CoordsXYZ& trackPos)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    if (tileElement == nullptr)
         return nullptr;
-    do
+    }
+
+    TrackElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZD& location, TrackElemType trackType, int32_t sequence)
     {
-        if (tileElement->GetType() != TileElementType::Track)
-            continue;
-        if (tileElement->GetBaseZ() != trackPos.z)
-            continue;
-
-        return tileElement->AsTrack();
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-/**
- * Gets the track element at x, y, z that is the given track type.
- * @param x x units, not tiles.
- * @param y y units, not tiles.
- * @param z Base height.
- */
-TileElement* MapGetTrackElementAtOfType(const CoordsXYZ& trackPos, TrackElemType trackType)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    if (tileElement == nullptr)
+        auto tileElement = MapGetFirstElementAt(location);
+        if (tileElement != nullptr)
+        {
+            do
+            {
+                auto trackElement = tileElement->AsTrack();
+                if (trackElement != nullptr)
+                {
+                    if (trackElement->GetBaseZ() != location.z)
+                        continue;
+                    if (trackElement->GetDirection() != location.direction)
+                        continue;
+                    if (trackElement->GetTrackType() != trackType)
+                        continue;
+                    if (trackElement->GetSequenceIndex() != sequence)
+                        continue;
+                    return trackElement;
+                }
+            } while (!(tileElement++)->IsLastForTile());
+        }
         return nullptr;
-    auto trackTilePos = TileCoordsXYZ{ trackPos };
-    do
+    }
+
+    /**
+     * Gets the track element at x, y, z that is the given track type and sequence.
+     * @param x x units, not tiles.
+     * @param y y units, not tiles.
+     * @param z Base height.
+     */
+    TileElement* MapGetTrackElementAtOfTypeFromRide(const CoordsXYZ& trackPos, TrackElemType trackType, RideId rideIndex)
     {
-        if (tileElement->GetType() != TileElementType::Track)
-            continue;
-        if (tileElement->BaseHeight != trackTilePos.z)
-            continue;
-        if (tileElement->AsTrack()->GetTrackType() != trackType)
-            continue;
-
-        return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-/**
- * Gets the track element at x, y, z that is the given track type and sequence.
- * @param x x units, not tiles.
- * @param y y units, not tiles.
- * @param z Base height.
- */
-TileElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZ& trackPos, TrackElemType trackType, int32_t sequence)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    auto trackTilePos = TileCoordsXYZ{ trackPos };
-    do
-    {
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
         if (tileElement == nullptr)
-            break;
-        if (tileElement->GetType() != TileElementType::Track)
-            continue;
-        if (tileElement->BaseHeight != trackTilePos.z)
-            continue;
-        if (tileElement->AsTrack()->GetTrackType() != trackType)
-            continue;
-        if (tileElement->AsTrack()->GetSequenceIndex() != sequence)
-            continue;
-
-        return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-TrackElement* MapGetTrackElementAtOfType(const CoordsXYZD& location, TrackElemType trackType)
-{
-    auto tileElement = MapGetFirstElementAt(location);
-    if (tileElement != nullptr)
-    {
-        do
-        {
-            auto trackElement = tileElement->AsTrack();
-            if (trackElement != nullptr)
-            {
-                if (trackElement->GetBaseZ() != location.z)
-                    continue;
-                if (trackElement->GetDirection() != location.direction)
-                    continue;
-                if (trackElement->GetTrackType() != trackType)
-                    continue;
-                return trackElement;
-            }
-        } while (!(tileElement++)->IsLastForTile());
-    }
-    return nullptr;
-}
-
-TrackElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZD& location, TrackElemType trackType, int32_t sequence)
-{
-    auto tileElement = MapGetFirstElementAt(location);
-    if (tileElement != nullptr)
-    {
-        do
-        {
-            auto trackElement = tileElement->AsTrack();
-            if (trackElement != nullptr)
-            {
-                if (trackElement->GetBaseZ() != location.z)
-                    continue;
-                if (trackElement->GetDirection() != location.direction)
-                    continue;
-                if (trackElement->GetTrackType() != trackType)
-                    continue;
-                if (trackElement->GetSequenceIndex() != sequence)
-                    continue;
-                return trackElement;
-            }
-        } while (!(tileElement++)->IsLastForTile());
-    }
-    return nullptr;
-}
-
-/**
- * Gets the track element at x, y, z that is the given track type and sequence.
- * @param x x units, not tiles.
- * @param y y units, not tiles.
- * @param z Base height.
- */
-TileElement* MapGetTrackElementAtOfTypeFromRide(const CoordsXYZ& trackPos, TrackElemType trackType, RideId rideIndex)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    if (tileElement == nullptr)
-        return nullptr;
-    auto trackTilePos = TileCoordsXYZ{ trackPos };
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Track)
-            continue;
-        if (tileElement->BaseHeight != trackTilePos.z)
-            continue;
-        if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
-            continue;
-        if (tileElement->AsTrack()->GetTrackType() != trackType)
-            continue;
-
-        return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-/**
- * Gets the track element at x, y, z that is the given track type and sequence.
- * @param x x units, not tiles.
- * @param y y units, not tiles.
- * @param z Base height.
- */
-TileElement* MapGetTrackElementAtFromRide(const CoordsXYZ& trackPos, RideId rideIndex)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    if (tileElement == nullptr)
-        return nullptr;
-    auto trackTilePos = TileCoordsXYZ{ trackPos };
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Track)
-            continue;
-        if (tileElement->BaseHeight != trackTilePos.z)
-            continue;
-        if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
-            continue;
-
-        return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-TileElement* MapGetTrackElementAtBeforeSurfaceFromRide(const CoordsXYZ& trackPos, const RideId rideIndex)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    if (tileElement == nullptr)
-        return nullptr;
-
-    do
-    {
-        if (tileElement->GetType() == TileElementType::Surface)
-        {
             return nullptr;
-        }
-
-        if (tileElement->GetType() == TileElementType::Track && tileElement->GetBaseZ() == trackPos.z
-            && tileElement->AsTrack()->GetRideIndex() == rideIndex)
-        {
-            return tileElement;
-        }
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-/**
- * Gets the track element at x, y, z that is the given track type and sequence.
- * @param x x units, not tiles.
- * @param y y units, not tiles.
- * @param z Base height.
- * @param direction The direction (0 - 3).
- */
-TileElement* MapGetTrackElementAtWithDirectionFromRide(const CoordsXYZD& trackPos, RideId rideIndex)
-{
-    TileElement* tileElement = MapGetFirstElementAt(trackPos);
-    if (tileElement == nullptr)
-        return nullptr;
-    auto trackTilePos = TileCoordsXYZ{ trackPos };
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Track)
-            continue;
-        if (tileElement->BaseHeight != trackTilePos.z)
-            continue;
-        if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
-            continue;
-        if (tileElement->GetDirection() != trackPos.direction)
-            continue;
-
-        return tileElement;
-    } while (!(tileElement++)->IsLastForTile());
-
-    return nullptr;
-}
-
-WallElement* MapGetWallElementAt(const CoordsXYRangedZ& coords)
-{
-    auto tileElement = MapGetFirstElementAt(coords);
-
-    if (tileElement != nullptr)
-    {
+        auto trackTilePos = TileCoordsXYZ{ trackPos };
         do
         {
-            if (tileElement->GetType() == TileElementType::Wall && coords.baseZ < tileElement->GetClearanceZ()
-                && coords.clearanceZ > tileElement->GetBaseZ())
+            if (tileElement->GetType() != TileElementType::Track)
+                continue;
+            if (tileElement->BaseHeight != trackTilePos.z)
+                continue;
+            if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
+                continue;
+            if (tileElement->AsTrack()->GetTrackType() != trackType)
+                continue;
+
+            return tileElement;
+        } while (!(tileElement++)->IsLastForTile());
+
+        return nullptr;
+    }
+
+    /**
+     * Gets the track element at x, y, z that is the given track type and sequence.
+     * @param x x units, not tiles.
+     * @param y y units, not tiles.
+     * @param z Base height.
+     */
+    TileElement* MapGetTrackElementAtFromRide(const CoordsXYZ& trackPos, RideId rideIndex)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
+        if (tileElement == nullptr)
+            return nullptr;
+        auto trackTilePos = TileCoordsXYZ{ trackPos };
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Track)
+                continue;
+            if (tileElement->BaseHeight != trackTilePos.z)
+                continue;
+            if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
+                continue;
+
+            return tileElement;
+        } while (!(tileElement++)->IsLastForTile());
+
+        return nullptr;
+    }
+
+    TileElement* MapGetTrackElementAtBeforeSurfaceFromRide(const CoordsXYZ& trackPos, const RideId rideIndex)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
+        if (tileElement == nullptr)
+            return nullptr;
+
+        do
+        {
+            if (tileElement->GetType() == TileElementType::Surface)
             {
-                return tileElement->AsWall();
+                return nullptr;
+            }
+
+            if (tileElement->GetType() == TileElementType::Track && tileElement->GetBaseZ() == trackPos.z
+                && tileElement->AsTrack()->GetRideIndex() == rideIndex)
+            {
+                return tileElement;
             }
         } while (!(tileElement++)->IsLastForTile());
-    }
 
-    return nullptr;
-}
-
-WallElement* MapGetWallElementAt(const CoordsXYZD& wallCoords)
-{
-    auto tileWallCoords = TileCoordsXYZ(wallCoords);
-    TileElement* tileElement = MapGetFirstElementAt(wallCoords);
-    if (tileElement == nullptr)
         return nullptr;
-    do
-    {
-        if (tileElement->GetType() != TileElementType::Wall)
-            continue;
-        if (tileElement->BaseHeight != tileWallCoords.z)
-            continue;
-        if (tileElement->GetDirection() != wallCoords.direction)
-            continue;
-
-        return tileElement->AsWall();
-    } while (!(tileElement++)->IsLastForTile());
-    return nullptr;
-}
-
-uint16_t CheckMaxAllowableLandRightsForTile(const CoordsXYZ& tileMapPos)
-{
-    TileElement* tileElement = MapGetFirstElementAt(tileMapPos);
-    uint16_t destOwnership = OWNERSHIP_OWNED;
-
-    // Sometimes done deliberately.
-    if (tileElement == nullptr)
-    {
-        return OWNERSHIP_OWNED;
     }
 
-    auto tilePos = TileCoordsXYZ{ tileMapPos };
-    do
+    /**
+     * Gets the track element at x, y, z that is the given track type and sequence.
+     * @param x x units, not tiles.
+     * @param y y units, not tiles.
+     * @param z Base height.
+     * @param direction The direction (0 - 3).
+     */
+    TileElement* MapGetTrackElementAtWithDirectionFromRide(const CoordsXYZD& trackPos, RideId rideIndex)
     {
-        auto type = tileElement->GetType();
-        if (type == TileElementType::Path
-            || (type == TileElementType::Entrance
-                && tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE))
+        TileElement* tileElement = MapGetFirstElementAt(trackPos);
+        if (tileElement == nullptr)
+            return nullptr;
+        auto trackTilePos = TileCoordsXYZ{ trackPos };
+        do
         {
-            destOwnership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;
-            // Do not own construction rights if too high/below surface
-            if (tileElement->BaseHeight - kConstructionRightsClearanceSmall > tilePos.z || tileElement->BaseHeight < tilePos.z)
-            {
-                destOwnership = OWNERSHIP_UNOWNED;
-                break;
-            }
-        }
-    } while (!(tileElement++)->IsLastForTile());
+            if (tileElement->GetType() != TileElementType::Track)
+                continue;
+            if (tileElement->BaseHeight != trackTilePos.z)
+                continue;
+            if (tileElement->AsTrack()->GetRideIndex() != rideIndex)
+                continue;
+            if (tileElement->GetDirection() != trackPos.direction)
+                continue;
 
-    return destOwnership;
-}
+            return tileElement;
+        } while (!(tileElement++)->IsLastForTile());
 
-void FixLandOwnershipTilesWithOwnership(std::vector<TileCoordsXY> tiles, uint8_t ownership)
-{
-    for (const auto& tile : tiles)
-    {
-        auto surfaceElement = MapGetSurfaceElementAt(tile);
-        if (surfaceElement != nullptr)
-        {
-            surfaceElement->SetOwnership(ownership);
-            Park::UpdateFencesAroundTile(tile.ToCoordsXY());
-        }
+        return nullptr;
     }
-}
 
-MapRange ClampRangeWithinMap(const MapRange& range)
-{
-    auto mapSizeMax = GetMapSizeMaxXY();
-    auto aX = std::max<decltype(range.GetX1())>(kCoordsXYStep, range.GetX1());
-    auto bX = std::min<decltype(range.GetX2())>(mapSizeMax.x, range.GetX2());
-    auto aY = std::max<decltype(range.GetY1())>(kCoordsXYStep, range.GetY1());
-    auto bY = std::min<decltype(range.GetY2())>(mapSizeMax.y, range.GetY2());
-    MapRange validRange = MapRange{ aX, aY, bX, bY };
-    return validRange;
-}
-
-static inline void shiftIfNotNull(TileCoordsXY& coords, const TileCoordsXY& amount)
-{
-    if (!coords.IsNull())
-        coords += amount;
-}
-
-static inline void shiftIfNotNull(CoordsXY& coords, const CoordsXY& amount)
-{
-    if (!coords.IsNull())
-        coords += amount;
-}
-
-void ShiftMap(const TileCoordsXY& amount)
-{
-    if (amount.x == 0 && amount.y == 0)
-        return;
-
-    auto amountToMove = amount.ToCoordsXY();
-    auto& gameState = getGameState();
-
-    // Tile elements
-    auto newElements = std::vector<TileElement>();
-    for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
+    WallElement* MapGetWallElementAt(const CoordsXYRangedZ& coords)
     {
-        for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
+        auto tileElement = MapGetFirstElementAt(coords);
+
+        if (tileElement != nullptr)
         {
-            auto srcX = x - amount.x;
-            auto srcY = y - amount.y;
-            if (x > 0 && y > 0 && x < gameState.mapSize.x - 1 && y < gameState.mapSize.y - 1 && srcX > 0 && srcY > 0
-                && srcX < gameState.mapSize.x - 1 && srcY < gameState.mapSize.y - 1)
+            do
             {
-                auto srcTile = _tileIndex.GetFirstElementAt(TileCoordsXY(srcX, srcY));
-                do
+                if (tileElement->GetType() == TileElementType::Wall && coords.baseZ < tileElement->GetClearanceZ()
+                    && coords.clearanceZ > tileElement->GetBaseZ())
                 {
-                    newElements.push_back(*srcTile);
-                } while (!(srcTile++)->IsLastForTile());
-            }
-            else if (x == 0 || y == 0 || x == gameState.mapSize.x - 1 || y == gameState.mapSize.y - 1)
+                    return tileElement->AsWall();
+                }
+            } while (!(tileElement++)->IsLastForTile());
+        }
+
+        return nullptr;
+    }
+
+    WallElement* MapGetWallElementAt(const CoordsXYZD& wallCoords)
+    {
+        auto tileWallCoords = TileCoordsXYZ(wallCoords);
+        TileElement* tileElement = MapGetFirstElementAt(wallCoords);
+        if (tileElement == nullptr)
+            return nullptr;
+        do
+        {
+            if (tileElement->GetType() != TileElementType::Wall)
+                continue;
+            if (tileElement->BaseHeight != tileWallCoords.z)
+                continue;
+            if (tileElement->GetDirection() != wallCoords.direction)
+                continue;
+
+            return tileElement->AsWall();
+        } while (!(tileElement++)->IsLastForTile());
+        return nullptr;
+    }
+
+    uint16_t CheckMaxAllowableLandRightsForTile(const CoordsXYZ& tileMapPos)
+    {
+        TileElement* tileElement = MapGetFirstElementAt(tileMapPos);
+        uint16_t destOwnership = OWNERSHIP_OWNED;
+
+        // Sometimes done deliberately.
+        if (tileElement == nullptr)
+        {
+            return OWNERSHIP_OWNED;
+        }
+
+        auto tilePos = TileCoordsXYZ{ tileMapPos };
+        do
+        {
+            auto type = tileElement->GetType();
+            if (type == TileElementType::Path
+                || (type == TileElementType::Entrance
+                    && tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_PARK_ENTRANCE))
             {
-                auto surface = GetDefaultSurfaceElement();
-                surface.SetBaseZ(kMinimumLandZ);
-                surface.SetClearanceZ(kMinimumLandZ);
-                surface.AsSurface()->SetSlope(0);
-                surface.AsSurface()->SetWaterHeight(0);
-                newElements.push_back(surface);
+                destOwnership = OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED;
+                // Do not own construction rights if too high/below surface
+                if (tileElement->BaseHeight - kConstructionRightsClearanceSmall > tilePos.z
+                    || tileElement->BaseHeight < tilePos.z)
+                {
+                    destOwnership = OWNERSHIP_UNOWNED;
+                    break;
+                }
             }
-            else
+        } while (!(tileElement++)->IsLastForTile());
+
+        return destOwnership;
+    }
+
+    void FixLandOwnershipTilesWithOwnership(std::vector<TileCoordsXY> tiles, uint8_t ownership)
+    {
+        for (const auto& tile : tiles)
+        {
+            auto surfaceElement = MapGetSurfaceElementAt(tile);
+            if (surfaceElement != nullptr)
             {
-                newElements.push_back(GetDefaultSurfaceElement());
+                surfaceElement->SetOwnership(ownership);
+                Park::UpdateFencesAroundTile(tile.ToCoordsXY());
             }
         }
     }
 
-    SetTileElements(gameState, std::move(newElements));
-    MapRemoveOutOfRangeElements();
-
-    MapExtendBoundarySurfaceShiftX(amount.x, gameState.mapSize.y);
-    MapExtendBoundarySurfaceShiftY(amount.y, gameState.mapSize.x);
-
-    for (auto& spawn : gameState.peepSpawns)
-        shiftIfNotNull(spawn, amountToMove);
-
-    for (auto& entrance : gameState.park.entrances)
-        shiftIfNotNull(entrance, amountToMove);
-
-    // Entities
-    auto& entityTweener = EntityTweener::Get();
-    for (auto i = 0; i < EnumValue(EntityType::count); i++)
+    MapRange ClampRangeWithinMap(const MapRange& range)
     {
-        auto entityType = static_cast<EntityType>(i);
-        auto& list = getGameState().entities.GetEntityList(entityType);
-        for (const auto& entityId : list)
+        auto mapSizeMax = GetMapSizeMaxXY();
+        auto aX = std::max<decltype(range.GetX1())>(kCoordsXYStep, range.GetX1());
+        auto bX = std::min<decltype(range.GetX2())>(mapSizeMax.x, range.GetX2());
+        auto aY = std::max<decltype(range.GetY1())>(kCoordsXYStep, range.GetY1());
+        auto bY = std::min<decltype(range.GetY2())>(mapSizeMax.y, range.GetY2());
+        MapRange validRange = MapRange{ aX, aY, bX, bY };
+        return validRange;
+    }
+
+    static inline void shiftIfNotNull(TileCoordsXY& coords, const TileCoordsXY& amount)
+    {
+        if (!coords.IsNull())
+            coords += amount;
+    }
+
+    static inline void shiftIfNotNull(CoordsXY& coords, const CoordsXY& amount)
+    {
+        if (!coords.IsNull())
+            coords += amount;
+    }
+
+    void ShiftMap(const TileCoordsXY& amount)
+    {
+        if (amount.x == 0 && amount.y == 0)
+            return;
+
+        auto amountToMove = amount.ToCoordsXY();
+        auto& gameState = getGameState();
+
+        // Tile elements
+        auto newElements = std::vector<TileElement>();
+        for (int32_t y = 0; y < kMaximumMapSizeTechnical; y++)
         {
-            auto entity = getGameState().entities.GetEntity(entityId);
-
-            // Do not tween the entity
-            entityTweener.RemoveEntity(entity);
-
-            auto location = entity->GetLocation();
-            shiftIfNotNull(location, amountToMove);
-            entity->MoveTo(location);
-
-            switch (entityType)
+            for (int32_t x = 0; x < kMaximumMapSizeTechnical; x++)
             {
-                case EntityType::guest:
-                case EntityType::staff:
+                auto srcX = x - amount.x;
+                auto srcY = y - amount.y;
+                if (x > 0 && y > 0 && x < gameState.mapSize.x - 1 && y < gameState.mapSize.y - 1 && srcX > 0 && srcY > 0
+                    && srcX < gameState.mapSize.x - 1 && srcY < gameState.mapSize.y - 1)
                 {
-                    auto peep = entity->As<Peep>();
-                    if (peep != nullptr)
+                    auto srcTile = _tileIndex.GetFirstElementAt(TileCoordsXY(srcX, srcY));
+                    do
                     {
-                        shiftIfNotNull(peep->NextLoc, amountToMove);
-                        peep->DestinationX += amountToMove.x;
-                        peep->DestinationY += amountToMove.y;
-                        shiftIfNotNull(peep->PathfindGoal, amount);
-                        for (auto& h : peep->PathfindHistory)
-                            shiftIfNotNull(h, amount);
-                    }
-                    break;
+                        newElements.push_back(*srcTile);
+                    } while (!(srcTile++)->IsLastForTile());
                 }
-                case EntityType::vehicle:
+                else if (x == 0 || y == 0 || x == gameState.mapSize.x - 1 || y == gameState.mapSize.y - 1)
                 {
-                    auto vehicle = entity->As<Vehicle>();
-                    if (vehicle != nullptr)
-                    {
-                        shiftIfNotNull(vehicle->TrackLocation, amountToMove);
-                        shiftIfNotNull(vehicle->BoatLocation, amountToMove);
-                    }
-                    break;
+                    auto surface = GetDefaultSurfaceElement();
+                    surface.SetBaseZ(kMinimumLandZ);
+                    surface.SetClearanceZ(kMinimumLandZ);
+                    surface.AsSurface()->SetSlope(0);
+                    surface.AsSurface()->SetWaterHeight(0);
+                    newElements.push_back(surface);
                 }
-                case EntityType::duck:
+                else
                 {
-                    auto duck = entity->As<Duck>();
-                    if (duck != nullptr)
-                    {
-                        duck->target_x += amountToMove.x;
-                        duck->target_y += amountToMove.y;
-                    }
-                    break;
-                }
-                case EntityType::jumpingFountain:
-                {
-                    auto fountain = entity->As<JumpingFountain>();
-                    if (fountain != nullptr)
-                    {
-                        fountain->TargetX += amountToMove.x;
-                        fountain->TargetY += amountToMove.y;
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-            if (entityType == EntityType::staff)
-            {
-                auto staff = entity->As<Staff>();
-                if (staff != nullptr)
-                {
-                    auto patrol = staff->PatrolInfo;
-                    if (patrol != nullptr)
-                    {
-                        auto positions = patrol->ToVector();
-                        for (auto& p : positions)
-                            shiftIfNotNull(p, amount);
-                        patrol->Clear();
-                        patrol->Union(positions);
-                    }
+                    newElements.push_back(GetDefaultSurfaceElement());
                 }
             }
         }
-    }
-    UpdateConsolidatedPatrolAreas();
 
-    // Rides
-    for (auto& ride : RideManager(gameState))
-    {
-        auto stations = ride.getStations();
-        for (auto& station : stations)
+        SetTileElements(gameState, std::move(newElements));
+        MapRemoveOutOfRangeElements();
+
+        MapExtendBoundarySurfaceShiftX(amount.x, gameState.mapSize.y);
+        MapExtendBoundarySurfaceShiftY(amount.y, gameState.mapSize.x);
+
+        for (auto& spawn : gameState.peepSpawns)
+            shiftIfNotNull(spawn, amountToMove);
+
+        for (auto& entrance : gameState.park.entrances)
+            shiftIfNotNull(entrance, amountToMove);
+
+        // Entities
+        auto& entityTweener = EntityTweener::Get();
+        for (auto i = 0; i < EnumValue(EntityType::count); i++)
         {
-            shiftIfNotNull(station.Start, amountToMove);
-            shiftIfNotNull(station.Entrance, amount);
-            shiftIfNotNull(station.Exit, amount);
+            auto entityType = static_cast<EntityType>(i);
+            auto& list = getGameState().entities.GetEntityList(entityType);
+            for (const auto& entityId : list)
+            {
+                auto entity = getGameState().entities.GetEntity(entityId);
+
+                // Do not tween the entity
+                entityTweener.RemoveEntity(entity);
+
+                auto location = entity->GetLocation();
+                shiftIfNotNull(location, amountToMove);
+                entity->MoveTo(location);
+
+                switch (entityType)
+                {
+                    case EntityType::guest:
+                    case EntityType::staff:
+                    {
+                        auto peep = entity->As<Peep>();
+                        if (peep != nullptr)
+                        {
+                            shiftIfNotNull(peep->NextLoc, amountToMove);
+                            peep->DestinationX += amountToMove.x;
+                            peep->DestinationY += amountToMove.y;
+                            shiftIfNotNull(peep->PathfindGoal, amount);
+                            for (auto& h : peep->PathfindHistory)
+                                shiftIfNotNull(h, amount);
+                        }
+                        break;
+                    }
+                    case EntityType::vehicle:
+                    {
+                        auto vehicle = entity->As<Vehicle>();
+                        if (vehicle != nullptr)
+                        {
+                            shiftIfNotNull(vehicle->TrackLocation, amountToMove);
+                            shiftIfNotNull(vehicle->BoatLocation, amountToMove);
+                        }
+                        break;
+                    }
+                    case EntityType::duck:
+                    {
+                        auto duck = entity->As<Duck>();
+                        if (duck != nullptr)
+                        {
+                            duck->target_x += amountToMove.x;
+                            duck->target_y += amountToMove.y;
+                        }
+                        break;
+                    }
+                    case EntityType::jumpingFountain:
+                    {
+                        auto fountain = entity->As<JumpingFountain>();
+                        if (fountain != nullptr)
+                        {
+                            fountain->TargetX += amountToMove.x;
+                            fountain->TargetY += amountToMove.y;
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+                if (entityType == EntityType::staff)
+                {
+                    auto staff = entity->As<Staff>();
+                    if (staff != nullptr)
+                    {
+                        auto patrol = staff->PatrolInfo;
+                        if (patrol != nullptr)
+                        {
+                            auto positions = patrol->ToVector();
+                            for (auto& p : positions)
+                                shiftIfNotNull(p, amount);
+                            patrol->Clear();
+                            patrol->Union(positions);
+                        }
+                    }
+                }
+            }
+        }
+        UpdateConsolidatedPatrolAreas();
+
+        // Rides
+        for (auto& ride : RideManager(gameState))
+        {
+            auto stations = ride.getStations();
+            for (auto& station : stations)
+            {
+                shiftIfNotNull(station.Start, amountToMove);
+                shiftIfNotNull(station.Entrance, amount);
+                shiftIfNotNull(station.Exit, amount);
+            }
+
+            shiftIfNotNull(ride.overallView, amountToMove);
+            shiftIfNotNull(ride.boatHireReturnPosition, amount);
+            shiftIfNotNull(ride.curTestTrackLocation, amount);
+            shiftIfNotNull(ride.chairliftBullwheelLocation[0], amount);
+            shiftIfNotNull(ride.chairliftBullwheelLocation[1], amount);
+            shiftIfNotNull(ride.cableLiftLoc, amountToMove);
         }
 
-        shiftIfNotNull(ride.overallView, amountToMove);
-        shiftIfNotNull(ride.boatHireReturnPosition, amount);
-        shiftIfNotNull(ride.curTestTrackLocation, amount);
-        shiftIfNotNull(ride.chairliftBullwheelLocation[0], amount);
-        shiftIfNotNull(ride.chairliftBullwheelLocation[1], amount);
-        shiftIfNotNull(ride.cableLiftLoc, amountToMove);
-    }
-
-    // Banners
-    auto numBanners = GetNumBanners();
-    auto id = BannerIndex::FromUnderlying(0);
-    size_t count = 0;
-    while (count < numBanners)
-    {
-        auto* banner = GetBanner(id);
-        if (banner != nullptr)
+        // Banners
+        auto numBanners = GetNumBanners();
+        auto id = BannerIndex::FromUnderlying(0);
+        size_t count = 0;
+        while (count < numBanners)
         {
-            shiftIfNotNull(banner->position, amount);
-            count++;
+            auto* banner = GetBanner(id);
+            if (banner != nullptr)
+            {
+                shiftIfNotNull(banner->position, amount);
+                count++;
+            }
+            id = BannerIndex::FromUnderlying(id.ToUnderlying() + 1);
         }
-        id = BannerIndex::FromUnderlying(id.ToUnderlying() + 1);
-    }
 
-    MapAnimations::ShiftAll(amount);
-}
+        MapAnimations::ShiftAll(amount);
+    }
+} // namespace OpenRCT2

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -17,7 +17,10 @@
 #include <optional>
 #include <vector>
 
-constexpr TileCoordsXY kDefaultMapSize = { 150, 150 };
+namespace OpenRCT2::Drawing
+{
+    enum class Colour : uint8_t;
+}
 
 namespace OpenRCT2
 {
@@ -33,152 +36,140 @@ namespace OpenRCT2
 
     enum class TileElementType : uint8_t;
     enum class TrackElemType : uint16_t;
-} // namespace OpenRCT2
 
-namespace OpenRCT2::Drawing
-{
-    enum class Colour : uint8_t;
-}
-
-extern const std::array<CoordsXY, 8> CoordsDirectionDelta;
-extern const TileCoordsXY TileDirectionDelta[];
-
-CoordsXY GetMapSizeUnits();
-CoordsXY GetMapSizeMinus2();
-CoordsXY GetMapSizeMaxXY();
-
-extern uint32_t gLandRemainingOwnershipSales;
-extern uint32_t gLandRemainingConstructionSales;
-
-extern bool gMapLandRightsUpdateSuccess;
-
-namespace OpenRCT2
-{
     struct GameState_t;
-}
 
-void ReorganiseTileElements();
-const std::vector<OpenRCT2::TileElement>& GetTileElements();
-void SetTileElements(OpenRCT2::GameState_t& gameState, std::vector<OpenRCT2::TileElement>&& tileElements);
-void StashMap();
-void UnstashMap();
-std::vector<OpenRCT2::TileElement> GetReorganisedTileElementsWithoutGhosts();
+    constexpr TileCoordsXY kDefaultMapSize = { 150, 150 };
 
-void MapInit(const TileCoordsXY& size);
+    extern const std::array<CoordsXY, 8> CoordsDirectionDelta;
+    extern const TileCoordsXY TileDirectionDelta[];
 
-void MapCountRemainingLandRights();
-void MapStripGhostFlagFromElements();
-OpenRCT2::TileElement* MapGetFirstElementAt(const CoordsXY& elementPos);
-OpenRCT2::TileElement* MapGetFirstElementAt(const TileCoordsXY& tilePos);
-OpenRCT2::TileElement* MapGetNthElementAt(const CoordsXY& coords, int32_t n);
-OpenRCT2::TileElement* MapGetFirstTileElementWithBaseHeightBetween(
-    const TileCoordsXYRangedZ& loc, OpenRCT2::TileElementType type);
-void MapSetTileElement(const TileCoordsXY& tilePos, OpenRCT2::TileElement* elements);
-int32_t MapHeightFromSlope(const CoordsXY& coords, int32_t slopeDirection, bool isSloped);
-OpenRCT2::BannerElement* MapGetBannerElementAt(const CoordsXYZ& bannerPos, uint8_t position);
-OpenRCT2::SurfaceElement* MapGetSurfaceElementAt(const TileCoordsXY& coords);
-OpenRCT2::SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords);
-OpenRCT2::PathElement* MapGetPathElementAt(const TileCoordsXYZ& loc);
-OpenRCT2::WallElement* MapGetWallElementAt(const CoordsXYZD& wallCoords);
-OpenRCT2::WallElement* MapGetWallElementAt(const CoordsXYRangedZ& coords);
-OpenRCT2::SmallSceneryElement* MapGetSmallSceneryElementAt(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant);
-OpenRCT2::EntranceElement* MapGetParkEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost);
-OpenRCT2::EntranceElement* MapGetRideEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost);
-OpenRCT2::EntranceElement* MapGetRideExitElementAt(const CoordsXYZ& exitCoords, bool ghost);
-uint8_t MapGetHighestLandHeight(const MapRange& range);
-uint8_t MapGetLowestLandHeight(const MapRange& range);
-bool MapCoordIsConnected(const TileCoordsXYZ& loc, uint8_t faceDirection);
-void MapUpdatePathWideFlags();
-bool MapIsLocationValid(const CoordsXY& coords);
-bool MapIsEdge(const CoordsXY& coords);
-bool MapCanBuildAt(const CoordsXYZ& loc);
-bool MapIsLocationOwned(const CoordsXYZ& loc);
-bool MapIsLocationInPark(const CoordsXY& coords);
-bool MapIsLocationOwnedOrHasRights(const CoordsXY& loc);
-bool MapSurfaceIsBlocked(const CoordsXY& mapCoords);
-void MapRemoveAllRides();
-void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* top, int32_t* right, int32_t* bottom);
-bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements = 1);
-int16_t TileElementHeight(const CoordsXY& loc);
-int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope);
-int16_t TileElementWaterHeight(const CoordsXY& loc);
-void TileElementRemove(OpenRCT2::TileElement* tileElement);
-OpenRCT2::TileElement* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants, OpenRCT2::TileElementType type);
+    CoordsXY GetMapSizeUnits();
+    CoordsXY GetMapSizeMinus2();
+    CoordsXY GetMapSizeMaxXY();
 
-template<typename T = OpenRCT2::TileElement>
-T* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc)
-{
-    auto* element = MapGetFirstTileElementWithBaseHeightBetween(loc, T::kElementType);
-    return element != nullptr ? element->template as<T>() : nullptr;
-}
+    extern uint32_t gLandRemainingOwnershipSales;
+    extern uint32_t gLandRemainingConstructionSales;
 
-template<typename T>
-T* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants)
-{
-    auto* element = TileElementInsert(loc, occupiedQuadrants, T::kElementType);
-    return (element != nullptr) ? element->template as<T>() : nullptr;
-}
+    extern bool gMapLandRightsUpdateSuccess;
 
-struct TileElementIterator
-{
-    int32_t x;
-    int32_t y;
-    OpenRCT2::TileElement* element;
-};
+    void ReorganiseTileElements();
+    const std::vector<TileElement>& GetTileElements();
+    void SetTileElements(GameState_t& gameState, std::vector<TileElement>&& tileElements);
+    void StashMap();
+    void UnstashMap();
+    std::vector<TileElement> GetReorganisedTileElementsWithoutGhosts();
+
+    void MapInit(const TileCoordsXY& size);
+
+    void MapCountRemainingLandRights();
+    void MapStripGhostFlagFromElements();
+    TileElement* MapGetFirstElementAt(const CoordsXY& elementPos);
+    TileElement* MapGetFirstElementAt(const TileCoordsXY& tilePos);
+    TileElement* MapGetNthElementAt(const CoordsXY& coords, int32_t n);
+    TileElement* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc, TileElementType type);
+    void MapSetTileElement(const TileCoordsXY& tilePos, TileElement* elements);
+    int32_t MapHeightFromSlope(const CoordsXY& coords, int32_t slopeDirection, bool isSloped);
+    BannerElement* MapGetBannerElementAt(const CoordsXYZ& bannerPos, uint8_t position);
+    SurfaceElement* MapGetSurfaceElementAt(const TileCoordsXY& coords);
+    SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords);
+    PathElement* MapGetPathElementAt(const TileCoordsXYZ& loc);
+    WallElement* MapGetWallElementAt(const CoordsXYZD& wallCoords);
+    WallElement* MapGetWallElementAt(const CoordsXYRangedZ& coords);
+    SmallSceneryElement* MapGetSmallSceneryElementAt(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant);
+    EntranceElement* MapGetParkEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost);
+    EntranceElement* MapGetRideEntranceElementAt(const CoordsXYZ& entranceCoords, bool ghost);
+    EntranceElement* MapGetRideExitElementAt(const CoordsXYZ& exitCoords, bool ghost);
+    uint8_t MapGetHighestLandHeight(const MapRange& range);
+    uint8_t MapGetLowestLandHeight(const MapRange& range);
+    bool MapCoordIsConnected(const TileCoordsXYZ& loc, uint8_t faceDirection);
+    void MapUpdatePathWideFlags();
+    bool MapIsLocationValid(const CoordsXY& coords);
+    bool MapIsEdge(const CoordsXY& coords);
+    bool MapCanBuildAt(const CoordsXYZ& loc);
+    bool MapIsLocationOwned(const CoordsXYZ& loc);
+    bool MapIsLocationInPark(const CoordsXY& coords);
+    bool MapIsLocationOwnedOrHasRights(const CoordsXY& loc);
+    bool MapSurfaceIsBlocked(const CoordsXY& mapCoords);
+    void MapRemoveAllRides();
+    void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* top, int32_t* right, int32_t* bottom);
+    bool MapCheckCapacityAndReorganise(const CoordsXY& loc, size_t numElements = 1);
+    int16_t TileElementHeight(const CoordsXY& loc);
+    int16_t TileElementHeight(const CoordsXYZ& loc, uint8_t slope);
+    int16_t TileElementWaterHeight(const CoordsXY& loc);
+    void TileElementRemove(TileElement* tileElement);
+    TileElement* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants, TileElementType type);
+
+    template<typename T = TileElement>
+    T* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc)
+    {
+        auto* element = MapGetFirstTileElementWithBaseHeightBetween(loc, T::kElementType);
+        return element != nullptr ? element->template as<T>() : nullptr;
+    }
+
+    template<typename T>
+    T* TileElementInsert(const CoordsXYZ& loc, int32_t occupiedQuadrants)
+    {
+        auto* element = TileElementInsert(loc, occupiedQuadrants, T::kElementType);
+        return (element != nullptr) ? element->template as<T>() : nullptr;
+    }
+
+    struct TileElementIterator
+    {
+        int32_t x;
+        int32_t y;
+        TileElement* element;
+    };
 #ifdef PLATFORM_32BIT
-static_assert(sizeof(TileElementIterator) == 12);
+    static_assert(sizeof(TileElementIterator) == 12);
 #endif
 
-void TileElementIteratorBegin(TileElementIterator* it);
-int32_t TileElementIteratorNext(TileElementIterator* it);
-void TileElementIteratorRestartForTile(TileElementIterator* it);
+    void TileElementIteratorBegin(TileElementIterator* it);
+    int32_t TileElementIteratorNext(TileElementIterator* it);
+    void TileElementIteratorRestartForTile(TileElementIterator* it);
 
-void MapUpdateTiles();
-int32_t MapGetHighestZ(const CoordsXY& loc);
+    void MapUpdateTiles();
+    int32_t MapGetHighestZ(const CoordsXY& loc);
 
-bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const OpenRCT2::TileElement* elementToBeRemoved);
+    void MapRemoveOutOfRangeElements();
+    void MapExtendBoundarySurfaceX();
+    void MapExtendBoundarySurfaceY();
 
-void MapRemoveOutOfRangeElements();
-void MapExtendBoundarySurfaceX();
-void MapExtendBoundarySurfaceY();
+    bool MapLargeScenerySignSetColour(
+        const CoordsXYZD& signPos, int32_t sequence, Drawing::Colour mainColour, Drawing::Colour textColour);
 
-bool MapLargeScenerySignSetColour(
-    const CoordsXYZD& signPos, int32_t sequence, OpenRCT2::Drawing::Colour mainColour, OpenRCT2::Drawing::Colour textColour);
+    void MapInvalidateTile(const CoordsXYRangedZ& tilePos);
+    void MapInvalidateTileZoom1(const CoordsXYRangedZ& tilePos);
+    void MapInvalidateTileZoom0(const CoordsXYRangedZ& tilePos);
+    void MapInvalidateTileFull(const CoordsXY& tilePos);
+    void MapInvalidateElement(const CoordsXY& elementPos, TileElement* tileElement);
+    void MapInvalidateRegion(const CoordsXY& mins, const CoordsXY& maxs);
 
-void MapInvalidateTile(const CoordsXYRangedZ& tilePos);
-void MapInvalidateTileZoom1(const CoordsXYRangedZ& tilePos);
-void MapInvalidateTileZoom0(const CoordsXYRangedZ& tilePos);
-void MapInvalidateTileFull(const CoordsXY& tilePos);
-void MapInvalidateElement(const CoordsXY& elementPos, OpenRCT2::TileElement* tileElement);
-void MapInvalidateRegion(const CoordsXY& mins, const CoordsXY& maxs);
+    int32_t MapGetTileSide(const CoordsXY& mapPos);
+    int32_t MapGetTileQuadrant(const CoordsXY& mapPos);
+    int32_t MapGetCornerHeight(int32_t z, int32_t slope, int32_t direction);
+    int32_t TileElementGetCornerHeight(const SurfaceElement* surfaceElement, int32_t direction);
 
-int32_t MapGetTileSide(const CoordsXY& mapPos);
-int32_t MapGetTileQuadrant(const CoordsXY& mapPos);
-int32_t MapGetCornerHeight(int32_t z, int32_t slope, int32_t direction);
-int32_t TileElementGetCornerHeight(const OpenRCT2::SurfaceElement* surfaceElement, int32_t direction);
+    void MapClearAllElements();
+    void ClearElementAt(const CoordsXY& loc, TileElement** elementPtr);
 
-void MapClearAllElements();
-void ClearElementAt(const CoordsXY& loc, OpenRCT2::TileElement** elementPtr);
+    LargeSceneryElement* MapGetLargeScenerySegment(const CoordsXYZD& sceneryPos, int32_t sequence);
+    std::optional<CoordsXYZ> MapLargeSceneryGetOrigin(
+        const CoordsXYZD& sceneryPos, int32_t sequence, LargeSceneryElement** outElement);
 
-OpenRCT2::LargeSceneryElement* MapGetLargeScenerySegment(const CoordsXYZD& sceneryPos, int32_t sequence);
-std::optional<CoordsXYZ> MapLargeSceneryGetOrigin(
-    const CoordsXYZD& sceneryPos, int32_t sequence, OpenRCT2::LargeSceneryElement** outElement);
+    TrackElement* MapGetTrackElementAt(const CoordsXYZ& trackPos);
+    TileElement* MapGetTrackElementAtOfType(const CoordsXYZ& trackPos, TrackElemType trackType);
+    TileElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZ& trackPos, TrackElemType trackType, int32_t sequence);
+    TrackElement* MapGetTrackElementAtOfType(const CoordsXYZD& location, TrackElemType trackType);
+    TrackElement* MapGetTrackElementAtOfTypeSeq(const CoordsXYZD& location, TrackElemType trackType, int32_t sequence);
+    TileElement* MapGetTrackElementAtOfTypeFromRide(const CoordsXYZ& trackPos, TrackElemType trackType, RideId rideIndex);
+    TileElement* MapGetTrackElementAtFromRide(const CoordsXYZ& trackPos, RideId rideIndex);
+    TileElement* MapGetTrackElementAtWithDirectionFromRide(const CoordsXYZD& trackPos, RideId rideIndex);
+    TileElement* MapGetTrackElementAtBeforeSurfaceFromRide(const CoordsXYZ& trackPos, RideId rideIndex);
 
-OpenRCT2::TrackElement* MapGetTrackElementAt(const CoordsXYZ& trackPos);
-OpenRCT2::TileElement* MapGetTrackElementAtOfType(const CoordsXYZ& trackPos, OpenRCT2::TrackElemType trackType);
-OpenRCT2::TileElement* MapGetTrackElementAtOfTypeSeq(
-    const CoordsXYZ& trackPos, OpenRCT2::TrackElemType trackType, int32_t sequence);
-OpenRCT2::TrackElement* MapGetTrackElementAtOfType(const CoordsXYZD& location, OpenRCT2::TrackElemType trackType);
-OpenRCT2::TrackElement* MapGetTrackElementAtOfTypeSeq(
-    const CoordsXYZD& location, OpenRCT2::TrackElemType trackType, int32_t sequence);
-OpenRCT2::TileElement* MapGetTrackElementAtOfTypeFromRide(
-    const CoordsXYZ& trackPos, OpenRCT2::TrackElemType trackType, RideId rideIndex);
-OpenRCT2::TileElement* MapGetTrackElementAtFromRide(const CoordsXYZ& trackPos, RideId rideIndex);
-OpenRCT2::TileElement* MapGetTrackElementAtWithDirectionFromRide(const CoordsXYZD& trackPos, RideId rideIndex);
-OpenRCT2::TileElement* MapGetTrackElementAtBeforeSurfaceFromRide(const CoordsXYZ& trackPos, RideId rideIndex);
+    uint16_t CheckMaxAllowableLandRightsForTile(const CoordsXYZ& tileMapPos);
 
-uint16_t CheckMaxAllowableLandRightsForTile(const CoordsXYZ& tileMapPos);
-
-void FixLandOwnershipTilesWithOwnership(std::vector<TileCoordsXY> tiles, uint8_t ownership);
-MapRange ClampRangeWithinMap(const MapRange& range);
-void ShiftMap(const TileCoordsXY& amount);
+    void FixLandOwnershipTilesWithOwnership(std::vector<TileCoordsXY> tiles, uint8_t ownership);
+    MapRange ClampRangeWithinMap(const MapRange& range);
+    void ShiftMap(const TileCoordsXY& amount);
+} // namespace OpenRCT2

--- a/src/openrct2/world/tile_element/PathElement.h
+++ b/src/openrct2/world/tile_element/PathElement.h
@@ -12,15 +12,14 @@
 #include "../../Identifiers.h"
 #include "TileElementBase.h"
 
-struct PathRailingsDescriptor;
-struct PathSurfaceDescriptor;
-
 namespace OpenRCT2
 {
     class FootpathObject;
     class FootpathRailingsObject;
     class FootpathSurfaceObject;
     struct PathAdditionEntry;
+    struct PathRailingsDescriptor;
+    struct PathSurfaceDescriptor;
 
     using ObjectEntryIndex = uint16_t;
 


### PR DESCRIPTION
Before reworking/splitting these headers further, let's first move them into namespaces to minimise conflicts down the line.

(Suggest reviewing these without whitespace changes.)