### PR TITLE
Fix entrance dropdown caption not being drawn

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5020,14 +5020,12 @@ namespace OpenRCT2::Ui::Windows
 
             const auto clipScreenPos = windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
             RenderTarget clippedRT;
-            if (!ClipRenderTarget(clippedRT, rt, clipScreenPos, widget.width() - 1, widget.height() - 1))
+            if (ClipRenderTarget(clippedRT, rt, clipScreenPos, widget.width() - 1, widget.height() - 1))
             {
-                return;
+                GfxClear(clippedRT, PaletteIndex::pi12);
+                ColourOnDrawEntrancePreview(clippedRT, ride, widget);
             }
 
-            GfxClear(clippedRT, PaletteIndex::pi12);
-
-            ColourOnDrawEntrancePreview(clippedRT, ride, widget);
             colourOnDrawEntranceDropdownCaption(rt, ride);
         }
 


### PR DESCRIPTION
The entrance style dropdown caption would not be drawn under particular circumstances. Determining whether it needed drawing was being lumped together with the checks for the entrance *preview*! This caused the intermittent flickering described in #26184.

Fortunately, the fix was easy enough, once the cause was finally identified. Just glad we caught it before the release. (No changelog necessary.)