### PR TITLE
Fix misaligned sprites of Steeplechase large left turn angle 2

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#26128] The loan spinner widget does not appear on the same baseline as the text around it.
 - Fix: [#26140] The time a guest has spent in a queue overflows back to 0 after it reaches 65535 (about a year).
 - Fix: [#26159] The map generator window is not resized correctly in Enlarged UI mode.
+- Fix: [#26196] The sprites of one angle of the Steeplechase left large turn are misaligned (original bug).
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -302,6 +302,12 @@ static void OverrideElementOffsets(size_t index, G1Element& element)
         case 25802:
             element.yOffset += 2;
             break;
+        case 28733:
+        case 28734:
+        case 28735:
+        case 28736:
+            element.xOffset -= 1; // Steeplechase leftEighthToDiag angle 2
+            break;
     }
 }
 


### PR DESCRIPTION
Fixes this sprite misalignment. Most of the time the actual sprites just don't fit together, but this seems to be unambiguously a simple offset error. This adds these sprites to the offset override function.

<img width="531" height="258" alt="steeplechaseleftlargeturnbug" src="https://github.com/user-attachments/assets/d492237e-e701-4245-914b-9ecf580a0421" />
<img width="531" height="258" alt="steeplechaseleftlargeturnfix" src="https://github.com/user-attachments/assets/014898cb-f455-416a-ae02-7225a392a733" />
