### PR TITLE
MSVC 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
             tracks.dat
   windows:
     name: Windows
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     needs: [check-code-formatting, build_variables, g2dat]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,20 @@ jobs:
             tracks.dat
   windows:
     name: Windows
-    runs-on: windows-2025-vs2026
+    runs-on: ${{ matrix.runs_on }}
     needs: [check-code-formatting, build_variables, g2dat]
     strategy:
       fail-fast: false
       matrix:
-        platform: [win32, x64, arm64]
+        include:
+          - platform: win32
+            runs_on: windows-2025-vs2026
+          - platform: x64
+            runs_on: windows-2025-vs2026
+          # keep arm64 on vs2022 for now. VS2026 is a bit slower and we can maintain
+          # compatibility with vs2022
+          - platform: arm64
+            runs_on: windows-latest
     env:
       PLATFORM: ${{ matrix.platform }}
       DISTANCE_FROM_TAG: ${{ needs.build_variables.outputs.distance }}

--- a/scripts/vstool.cmd
+++ b/scripts/vstool.cmd
@@ -3,20 +3,49 @@
 rem Invokes a tool within a Visual Studio prompt
 rem Uses %PLATFORM% to set architecture of prompt
 
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise"
-if exist "%vspath%" goto found
-set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community"
-if exist "%vspath%" goto found
+set "vspath="
 
-:notfound
-echo Visual Studio directory not found
-exit /b 1
+rem Try to use vswhere to find the latest Visual Studio
+set "vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%vswhere%" set "vswhere=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
 
-:found
+if exist "%vswhere%" (
+    for /f "usebackq tokens=*" %%i in (`"%vswhere%" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+        set "vspath=%%i"
+    )
+)
+
+if not defined vspath (
+    rem Fallback to searching common paths
+    if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Enterprise"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Community" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Community"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2026\Professional" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2026\Professional"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\18\Enterprise" (
+        rem Visual Studio 2026 changed its installation path to use "18" instead of "2026"
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\18\Enterprise"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\18\Community" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\18\Community"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\18\Professional" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\18\Professional"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise"
+    ) else if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community" (
+        set "vspath=%ProgramFiles%\Microsoft Visual Studio\2022\Community"
+    ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise" (
+        set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise"
+    ) else if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community" (
+        set "vspath=%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community"
+    )
+)
+
+if not defined vspath goto notfound
+if not exist "%vspath%" goto notfound
+
+echo Using Visual Studio from %vspath%
+
 if "%platform%"=="x64" (
     call "%vspath%\Common7\Tools\VsDevCmd.bat" -no_logo -arch=x64
 ) else (
@@ -25,3 +54,7 @@ if "%platform%"=="x64" (
 
 %*
 exit /b %errorlevel%
+
+:notfound
+echo Visual Studio directory not found
+exit /b 1


### PR DESCRIPTION
This changes our CI image to VS 2026. For whatever reason, the version is now 2004 numbers behind 2022, i.e. `18` instead of the expected `2026`, so deal with that as well.

VS 2026 offers significantly shorter build times for x86 and amd64, but arm64 is tiny bit longer.

Dependencies stays on 2022 for now.