### PR TITLE
Add reversed sequence and rotation to ted and use in trackPaintGeneric

### DIFF
--- a/src/openrct2/paint/track_pieces/QuarterHelix.h
+++ b/src/openrct2/paint/track_pieces/QuarterHelix.h
@@ -116,8 +116,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
             kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, false,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, 0, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -132,8 +131,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
             kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, false,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, 0, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -148,8 +146,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
             kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, true,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, 1, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -164,8 +161,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
             kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, true,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, -1, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -180,8 +176,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
             kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, false,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, 0, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -196,8 +191,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
             kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, false,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, 0, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -212,8 +206,7 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
             kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, true,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, 1, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -228,7 +221,6 @@ namespace OpenRCT2
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
             kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
             blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, true,
-            kMapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles, -1, trackSupportColours>(
-            session, ride, trackSequence, direction, height, trackElement, supportType);
+            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -1737,12 +1737,14 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = 2,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq0.blockedSegments,
+        .reversedTrackSequence = 6,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq1 = {
         .clearance = { 0, -32, 0, 16, { 0b1000, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b1100,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq1.blockedSegments,
+        .reversedTrackSequence = 4,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq2 = {
@@ -1750,18 +1752,21 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0011,
         .woodenSupports = { WoodenSupportSubType::corner3 },
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq2.blockedSegments,
+        .reversedTrackSequence = 5,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq3 = {
         .clearance = { -32, -32, 0, 16, { 0b1101, 0 }, {} },
         .woodenSupports = { WoodenSupportSubType::corner1 },
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq3.blockedSegments,
+        .reversedTrackSequence = 3,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq4 = {
         .clearance = { -32, -64, 0, 8, { 0b1000, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b1100,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq4.blockedSegments,
+        .reversedTrackSequence = 1,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq5 = {
@@ -1770,6 +1775,7 @@ namespace OpenRCT2::TrackMetadata
         .woodenSupports = { WoodenSupportSubType::corner0 },
         .extraSupportRotation = -1,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq5.blockedSegments,
+        .reversedTrackSequence = 2,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq6 = {
@@ -1780,6 +1786,7 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = -1,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq6.blockedSegments,
+        .reversedTrackSequence = 0,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq0 = {
@@ -1790,12 +1797,14 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = 2,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq0.blockedSegments,
+        .reversedTrackSequence = 6,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq1 = {
         .clearance = { 0, 32, 0, 16, { 0b0100, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b0110,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq1.blockedSegments,
+        .reversedTrackSequence = 4,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq2 = {
@@ -1803,18 +1812,21 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b1001,
         .woodenSupports = { WoodenSupportSubType::corner2 },
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq2.blockedSegments,
+        .reversedTrackSequence = 5,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq3 = {
         .clearance = { -32, 32, 0, 16, { 0b1110, 0 }, {} },
         .woodenSupports = { WoodenSupportSubType::corner0 },
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq3.blockedSegments,
+        .reversedTrackSequence = 3,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq4 = {
         .clearance = { -32, 64, 0, 8, { 0b0100, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b0110,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq4.blockedSegments,
+        .reversedTrackSequence = 1,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq5 = {
@@ -1823,6 +1835,7 @@ namespace OpenRCT2::TrackMetadata
         .woodenSupports = { WoodenSupportSubType::corner1 },
         .extraSupportRotation = 1,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq5.blockedSegments,
+        .reversedTrackSequence = 2,
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeDownSeq6 = {
@@ -1833,6 +1846,7 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = 1,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq6.blockedSegments,
+        .reversedTrackSequence = 0,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeUpSeq0 = {
@@ -1957,12 +1971,14 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = 2,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq0.blockedSegments,
+        .reversedTrackSequence = 6,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq1 = {
         .clearance = { 0, -32, 0, 16, { 0b1000, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b1100,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq1.blockedSegments,
+        .reversedTrackSequence = 4,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq2 = {
@@ -1970,18 +1986,21 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0011,
         .woodenSupports = { WoodenSupportSubType::corner3 },
         .blockedSegments = kLeftQuarterHelixLargeUpSeq2.blockedSegments,
+        .reversedTrackSequence = 5,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq3 = {
         .clearance = { -32, -32, 0, 16, { 0b1101, 0 }, {} },
         .woodenSupports = { WoodenSupportSubType::corner1 },
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq3.blockedSegments,
+        .reversedTrackSequence = 3,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq4 = {
         .clearance = { -32, -64, 0, 8, { 0b1000, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b1100,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq4.blockedSegments,
+        .reversedTrackSequence = 1,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq5 = {
@@ -1990,6 +2009,7 @@ namespace OpenRCT2::TrackMetadata
         .woodenSupports = { WoodenSupportSubType::corner0 },
         .extraSupportRotation = -1,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq5.blockedSegments,
+        .reversedTrackSequence = 2,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq6 = {
@@ -2000,6 +2020,7 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = -1,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq6.blockedSegments,
+        .reversedTrackSequence = 0,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq0 = {
@@ -2010,12 +2031,14 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = 2,
         .blockedSegments = kRightQuarterHelixLargeUpSeq0.blockedSegments,
+        .reversedTrackSequence = 6,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq1 = {
         .clearance = { 0, 32, 0, 16, { 0b0100, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b0110,
         .blockedSegments = kRightQuarterHelixLargeUpSeq1.blockedSegments,
+        .reversedTrackSequence = 4,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq2 = {
@@ -2023,18 +2046,21 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b1001,
         .woodenSupports = { WoodenSupportSubType::corner2 },
         .blockedSegments = kRightQuarterHelixLargeUpSeq2.blockedSegments,
+        .reversedTrackSequence = 5,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq3 = {
         .clearance = { -32, 32, 0, 16, { 0b1110, 0 }, {} },
         .woodenSupports = { WoodenSupportSubType::corner0 },
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq3.blockedSegments,
+        .reversedTrackSequence = 3,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq4 = {
         .clearance = { -32, 64, 0, 8, { 0b0100, 0 }, { ClearanceFlag::flag0 } },
         .allowedWallEdges = 0b0110,
         .blockedSegments = kRightQuarterHelixLargeUpSeq4.blockedSegments,
+        .reversedTrackSequence = 1,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq5 = {
@@ -2043,6 +2069,7 @@ namespace OpenRCT2::TrackMetadata
         .woodenSupports = { WoodenSupportSubType::corner1 },
         .extraSupportRotation = 1,
         .blockedSegments = kRightQuarterHelixLargeUpSeq5.blockedSegments,
+        .reversedTrackSequence = 2,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeDownSeq6 = {
@@ -2053,6 +2080,7 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .extraSupportRotation = 1,
         .blockedSegments = kRightQuarterHelixLargeUpSeq6.blockedSegments,
+        .reversedTrackSequence = 0,
     };
 
     static constexpr SequenceDescriptor kUp25LeftBankedSeq0 = {
@@ -7677,6 +7705,7 @@ namespace OpenRCT2::TrackMetadata
         .spinFunction = SpinFunction::l8,
         .verticalFactor = EvaluatorConst<200>,
         .lateralFactor = EvaluatorConst<160>,
+        .reversedRotationOffset = 1,
         .sequenceData = { 7,
                           { kLeftQuarterBankedHelixLargeDownSeq0, kLeftQuarterBankedHelixLargeDownSeq1,
                             kLeftQuarterBankedHelixLargeDownSeq2, kLeftQuarterBankedHelixLargeDownSeq3,
@@ -7697,6 +7726,7 @@ namespace OpenRCT2::TrackMetadata
         .spinFunction = SpinFunction::r8,
         .verticalFactor = EvaluatorConst<200>,
         .lateralFactor = EvaluatorConst<-160>,
+        .reversedRotationOffset = 3,
         .sequenceData = { 7,
                           { kRightQuarterBankedHelixLargeDownSeq0, kRightQuarterBankedHelixLargeDownSeq1,
                             kRightQuarterBankedHelixLargeDownSeq2, kRightQuarterBankedHelixLargeDownSeq3,
@@ -7752,6 +7782,7 @@ namespace OpenRCT2::TrackMetadata
                         TrackRoll::none, 0 },
         .spinFunction = SpinFunction::l8,
         .lateralFactor = EvaluatorConst<98>,
+        .reversedRotationOffset = 1,
         .sequenceData = { 7,
                           { kLeftQuarterHelixLargeDownSeq0, kLeftQuarterHelixLargeDownSeq1, kLeftQuarterHelixLargeDownSeq2,
                             kLeftQuarterHelixLargeDownSeq3, kLeftQuarterHelixLargeDownSeq4, kLeftQuarterHelixLargeDownSeq5,
@@ -7770,6 +7801,7 @@ namespace OpenRCT2::TrackMetadata
                         TrackRoll::none, 0 },
         .spinFunction = SpinFunction::r8,
         .lateralFactor = EvaluatorConst<-98>,
+        .reversedRotationOffset = 3,
         .sequenceData = { 7,
                           { kRightQuarterHelixLargeDownSeq0, kRightQuarterHelixLargeDownSeq1, kRightQuarterHelixLargeDownSeq2,
                             kRightQuarterHelixLargeDownSeq3, kRightQuarterHelixLargeDownSeq4, kRightQuarterHelixLargeDownSeq5,

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -598,17 +598,20 @@ namespace OpenRCT2
         const std::array<std::array<int8_t, kNumOrthogonalDirections>, sequenceCount>& supportHeightExtras,
         const OpenRCT2::BlockedSegmentsType blockedSegmentsType, const TunnelGroup tunnelGroup,
         const std::array<int8_t, sequenceCount>& generalSupportHeights, const auto tunnelPaintFunction, const bool down,
-        const uint8_t trackSequenceMap[sequenceCount], const int8_t directionOffset, const bool trackSupportColours>
+        const bool trackSupportColours>
     void trackPaintGeneric(
         PaintSession& session, const Ride& ride, const uint8_t trackSequence, const Direction direction, const int32_t height,
         const OpenRCT2::TrackElement& trackElement, const SupportType supportType)
     {
+        const auto& ted = OpenRCT2::TrackMetadata::GetTrackElementDescriptor(trackElement.GetTrackType());
+        const auto& sequenceDescriptor = ted.sequenceData.sequences[trackSequence];
+
         uint8_t modifiedTrackSequence = trackSequence;
         Direction modifiedDirection = direction;
         if constexpr (down)
         {
-            modifiedTrackSequence = trackSequenceMap[trackSequence];
-            modifiedDirection = (direction + directionOffset) & 3;
+            modifiedTrackSequence = sequenceDescriptor.reversedTrackSequence;
+            modifiedDirection = (direction + ted.reversedRotationOffset) & 3;
         }
 
         ImageId imageId = trackSupportColours ? getPrimaryTrackColourWithSecondarySupportColour(session) : session.TrackColours;
@@ -625,9 +628,6 @@ namespace OpenRCT2
                 session, modifiedDirection, sequenceCount, modifiedTrackSequence, mapSpriteCount, 1, spriteMap, imageId, height,
                 &boundingBoxes[0][0][0]);
         }
-
-        const auto& ted = OpenRCT2::TrackMetadata::GetTrackElementDescriptor(trackElement.GetTrackType());
-        const auto& sequenceDescriptor = ted.sequenceData.sequences[trackSequence];
 
         if constexpr (woodenSupports)
         {

--- a/src/openrct2/ride/ted/TrackElementDescriptor.h
+++ b/src/openrct2/ride/ted/TrackElementDescriptor.h
@@ -233,6 +233,7 @@ namespace OpenRCT2::TrackMetadata
         int8_t extraSupportRotation = 0;
         bool invertSegmentBlocking = false;
         BlockedSegmentsPerType blockedSegments{ kSegmentsNone, kSegmentsNone, kSegmentsNone };
+        uint8_t reversedTrackSequence = 0;
 
         constexpr uint8_t getEntranceConnectionSides() const
         {
@@ -278,6 +279,8 @@ namespace OpenRCT2::TrackMetadata
 
         TrackComputeFunction verticalFactor = EvaluatorConst<0>;
         TrackComputeFunction lateralFactor = EvaluatorConst<0>;
+
+        int8_t reversedRotationOffset = 0;
 
         SequenceTable sequenceData;
     };


### PR DESCRIPTION
This adds a reversed track sequence and a rotation offset to the track element descriptor.
This is then used in the `trackPaintGeneric` function from the quarter helix PR.
Actual track element descriptor data is only filled out for the quarter helices so far.

This is to replace these ad hoc arrays like:
https://github.com/OpenRCT2/OpenRCT2/blob/892d60cbde2e2de9711d2eccd5343708321b8d68/src/openrct2/ride/TrackPaint.cpp#L1238-L1240
Which are used to map the track sequence of mirrored/down pieces to their up equivalent. Used like so:
https://github.com/OpenRCT2/OpenRCT2/blob/892d60cbde2e2de9711d2eccd5343708321b8d68/src/openrct2/paint/track/coaster/LatticeTriangleTrack.cpp#L1040-L1046