### PR TITLE
Fix incorrect diagUp25 sprite in Alpine, Hybrid and Single Rail tracks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#26140] The time a guest has spent in a queue overflows back to 0 after it reaches 65535 (about a year).
 - Fix: [#26159] The map generator window is not resized correctly in Enlarged UI mode.
 - Fix: [#26196] The sprites of one angle of the Steeplechase left large turn are misaligned (original bug).
+- Fix: [#26214] The wrong sprite is used for one angle of the gentle diagonal slope of Alpine, Hybrid and Single Rail tracks.
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/AlpineCoaster.cpp
@@ -1231,7 +1231,7 @@ namespace OpenRCT2::AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours.WithIndex((SPR_TRACKS_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
+                                session.TrackColours.WithIndex((SPR_TRACKS_ALPINE_LIFT_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                             break;
                     }
@@ -1243,7 +1243,7 @@ namespace OpenRCT2::AlpineRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours.WithIndex((SPR_TRACKS_ALPINE_TRACK_GENTLE_DIAGONAL + 1)),
+                                session.TrackColours.WithIndex((SPR_TRACKS_ALPINE_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                             break;
                     }

--- a/src/openrct2/paint/track/coaster/HybridCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/HybridCoaster.cpp
@@ -1768,7 +1768,7 @@ namespace OpenRCT2::HybridRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_GENTLE_DIAGONAL + 1),
+                                GetTrackColour(session).WithIndex(SPR_TRACKS_HYBRID_TRACK_GENTLE_DIAGONAL + 9),
                                 { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                             break;
                     }

--- a/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/SingleRailRollerCoaster.cpp
@@ -1891,7 +1891,7 @@ namespace OpenRCT2::SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours.WithIndex((SPR_TRACKS_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 1)),
+                                session.TrackColours.WithIndex((SPR_TRACKS_SINGLE_RAIL_LIFT_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                             MetalBSupportsPaintSetup(
                                 session, supportType.metal, MetalSupportPlace::topCorner, 9, height, session.SupportColours);
@@ -1917,7 +1917,7 @@ namespace OpenRCT2::SingleRailRC
                         case 1:
                             PaintAddImageAsParentRotated(
                                 session, direction,
-                                session.TrackColours.WithIndex((SPR_TRACKS_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 1)),
+                                session.TrackColours.WithIndex((SPR_TRACKS_SINGLE_RAIL_TRACK_GENTLE_DIAGONAL + 9)),
                                 { -16, -16, height }, { { -16, -16, height }, { 32, 32, 3 } });
                             MetalBSupportsPaintSetup(
                                 session, supportType.metal, MetalSupportPlace::topCorner, 9, height, session.SupportColours);


### PR DESCRIPTION
This fixes an incorrect sprite used in diagUp25 of these 3 tracks. They were using the sprite from diagFlatToUp25 by mistake. The down equivalents are already correct. The hybrid chain sprite is already correct too.

<img width="532" height="279" alt="diagup25bug" src="https://github.com/user-attachments/assets/30e3180a-bb7d-4499-874b-e4ccd165a2d7" />
<img width="532" height="279" alt="diagup25fix" src="https://github.com/user-attachments/assets/7b6e014d-ec84-4f7e-9552-3a7f67c5b146" />

Save:
[alpinehybridsingleraildiagup25.zip](https://github.com/user-attachments/files/26085494/alpinehybridsingleraildiagup25.zip)
