### PR TITLE
Fix #26216: Previously saved inverted flying quarter helices invisible

### DIFF
--- a/src/openrct2/park/Legacy.cpp
+++ b/src/openrct2/park/Legacy.cpp
@@ -22,6 +22,7 @@
 #include "../rct2/RCT2.h"
 #include "../ride/Ride.h"
 #include "../ride/ted/TrackElemType.h"
+#include "../world/tile_element/TrackElement.h"
 #include "ParkFile.h"
 
 #include <array>
@@ -2388,8 +2389,12 @@ std::string_view GetClimateObjectIdFromLegacyClimateType(RCT12::ClimateType clim
     return kClimateObjectIdsByLegacyClimateType[EnumValue(climate)];
 }
 
-bool TrackTypeMustBeMadeInvisible(ride_type_t rideType, TrackElemType trackType, int32_t parkFileVersion)
+bool TrackTypeMustBeMadeInvisible(const OpenRCT2::TrackElement& trackElement, const int32_t parkFileVersion)
 {
+    const auto rideType = trackElement.GetRideType();
+    const auto trackType = trackElement.GetTrackType();
+    const auto isInverted = trackElement.IsInverted();
+
     // Lots of Log Flumes exist where the downward slopes are simulated by using other track
     // types like the Splash Boats, but not actually made invisible, because they never needed
     // to be.
@@ -2988,7 +2993,7 @@ bool TrackTypeMustBeMadeInvisible(ride_type_t rideType, TrackElemType trackType,
             || rideType == RIDE_TYPE_CORKSCREW_ROLLER_COASTER || rideType == RIDE_TYPE_HYPERCOASTER
             || rideType == RIDE_TYPE_LAY_DOWN_ROLLER_COASTER || rideType == RIDE_TYPE_TWISTER_ROLLER_COASTER
             || rideType == RIDE_TYPE_HYPER_TWISTER || rideType == RIDE_TYPE_VERTICAL_DROP_ROLLER_COASTER
-            || rideType == RIDE_TYPE_FLYING_ROLLER_COASTER || rideType == RIDE_TYPE_GIGA_COASTER
+            || (rideType == RIDE_TYPE_FLYING_ROLLER_COASTER && !isInverted) || rideType == RIDE_TYPE_GIGA_COASTER
             || rideType == RIDE_TYPE_LSM_LAUNCHED_ROLLER_COASTER || rideType == RIDE_TYPE_SINGLE_RAIL_ROLLER_COASTER
             || rideType == RIDE_TYPE_LOOPING_ROLLER_COASTER || rideType == RIDE_TYPE_LIM_LAUNCHED_ROLLER_COASTER
             || rideType == RIDE_TYPE_ALPINE_COASTER || rideType == RIDE_TYPE_MINI_ROLLER_COASTER

--- a/src/openrct2/park/Legacy.h
+++ b/src/openrct2/park/Legacy.h
@@ -21,7 +21,7 @@ namespace OpenRCT2
 {
     struct GameState_t;
 
-    enum class TrackElemType : uint16_t;
+    struct TrackElement;
 
     namespace RCT12
     {
@@ -60,12 +60,11 @@ std::string_view GetClimateObjectIdFromLegacyClimateType(OpenRCT2::RCT12::Climat
  * To avoid this, this function will return true if the piece is question was added after the park was created,
  * so that import code can properly set the visibility.
  *
- * @param rideType The OpenRCT2 ride type
- * @param trackType The OpenRCT2 track type
+ * @param trackElement The track element
  * @param parkFileVersion The current park file version. Pass -1 when converting S4 or S6.
  * @return
  */
-bool TrackTypeMustBeMadeInvisible(ride_type_t rideType, OpenRCT2::TrackElemType trackType, int32_t parkFileVersion = -1);
+bool TrackTypeMustBeMadeInvisible(const OpenRCT2::TrackElement& trackElement, int32_t parkFileVersion = -1);
 
 std::pair<uint8_t, SpecialElements> splitCombinedHelicesAndSpecialElements(uint8_t combinedValue);
 std::pair<uint8_t, uint8_t> splitCombinedNumDropsPoweredLifts(uint8_t combinedValue);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1231,8 +1231,7 @@ namespace OpenRCT2
                                 {
                                     auto* trackElement = it.element->AsTrack();
                                     auto trackType = trackElement->GetTrackType();
-                                    if (TrackTypeMustBeMadeInvisible(
-                                            trackElement->GetRideType(), trackType, os.getHeader().targetVersion))
+                                    if (TrackTypeMustBeMadeInvisible(*trackElement, os.getHeader().targetVersion))
                                     {
                                         it.element->SetInvisible(true);
                                     }

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1771,7 +1771,7 @@ namespace OpenRCT2::RCT1
                         dst2->SetMazeEntry(src2->GetMazeEntry());
                     }
 
-                    if (TrackTypeMustBeMadeInvisible(rideType, trackType))
+                    if (TrackTypeMustBeMadeInvisible(*dst2))
                     {
                         dst->SetInvisible(true);
                     }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1441,7 +1441,7 @@ namespace OpenRCT2::RCT2
                         dst2->SetSeatRotation(src2->GetSeatRotation());
                     }
 
-                    if (TrackTypeMustBeMadeInvisible(rideType, dst2->GetTrackType()))
+                    if (TrackTypeMustBeMadeInvisible(*dst2))
                     {
                         dst->SetInvisible(true);
                     }


### PR DESCRIPTION
Fixes #26216.

Sorry for not catching this one.
This checks for the flying coaster pieces being inverted in `TrackTypeMustBeMadeInvisible`.

Quick test save:
[flyingrollercoasterinvertedquarterhelices.zip](https://github.com/user-attachments/files/26115222/flyingrollercoasterinvertedquarterhelices.zip)
