### PR TITLE
DrawText* refactor

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -38,9 +38,9 @@ namespace OpenRCT2::Graph
             // Draw Y label text
             char buffer[64]{};
             FormatStringToBuffer(buffer, sizeof(buffer), fmt, curLabel);
-            DrawText(
-                rt, { internalBounds.GetLeft() - kYTickMarkPadding, curScreenPos }, { FontStyle::small, TextAlignment::right },
-                buffer);
+            DrawTextBasic(
+                rt, { internalBounds.GetLeft() - kYTickMarkPadding, curScreenPos }, buffer,
+                { FontStyle::small, TextAlignment::right });
             // Draw Y label tick mark
             Rectangle::fill(
                 rt, { { internalBounds.GetLeft() - 5, curScreenPos + 5 }, { internalBounds.GetLeft(), curScreenPos + 5 } },
@@ -102,7 +102,7 @@ namespace OpenRCT2::Graph
             kDashLength, PaletteIndex::pi10);
         GfxDrawDashedLine(rt, { { bounds.GetLeft(), coords.y }, coords }, kDashLength, PaletteIndex::pi10);
 
-        DrawText(rt, coords - ScreenCoordsXY{ 0, 16 }, { textCol, TextAlignment::centre }, text);
+        DrawTextBasic(rt, coords - ScreenCoordsXY{ 0, 16 }, text, { textCol, TextAlignment::centre });
 
         Rectangle::fill(rt, { { coords - ScreenCoordsXY{ 2, 2 } }, coords + ScreenCoordsXY{ 2, 2 } }, PaletteIndex::pi10);
         Rectangle::fill(rt, { { coords - ScreenCoordsXY{ 1, 1 } }, { coords + ScreenCoordsXY{ 1, 1 } } }, PaletteIndex::pi21);

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -342,19 +342,19 @@ void InGameConsole::Draw(RenderTarget& rt) const
             // as opposed to a desaturated grey
             if (textColour.colour == OpenRCT2::Drawing::Colour::black)
             {
-                DrawText(rt, screenCoords, { textColour, style }, "{BLACK}");
-                DrawText(rt, screenCoords, { OpenRCT2::Drawing::kColourNull, style }, _consoleLines[index].first.c_str(), true);
+                DrawTextBasic(rt, screenCoords, "{BLACK}", { textColour, style });
+                DrawTextNoFormatting(rt, screenCoords, _consoleLines[index].first, { kColourNull, style });
             }
             else
             {
-                DrawText(rt, screenCoords, { textColour, style }, _consoleLines[index].first.c_str(), true);
+                DrawTextNoFormatting(rt, screenCoords, _consoleLines[index].first, { textColour, style });
             }
         }
         else
         {
             std::string lineColour = FormatTokenToStringWithBraces(_consoleLines[index].second);
-            DrawText(rt, screenCoords, { textColour, style }, lineColour.c_str());
-            DrawText(rt, screenCoords, { OpenRCT2::Drawing::kColourNull, style }, _consoleLines[index].first.c_str(), true);
+            DrawTextBasic(rt, screenCoords, lineColour, { textColour, style });
+            DrawTextNoFormatting(rt, screenCoords, _consoleLines[index].first, { OpenRCT2::Drawing::kColourNull, style });
         }
 
         screenCoords.y += lineHeight;
@@ -365,12 +365,12 @@ void InGameConsole::Draw(RenderTarget& rt) const
     // Draw current line
     if (textColour.colour == OpenRCT2::Drawing::Colour::black)
     {
-        DrawText(rt, screenCoords, { textColour, style }, "{BLACK}");
-        DrawText(rt, screenCoords, { OpenRCT2::Drawing::kColourNull, style }, _consoleCurrentLine.c_str(), true);
+        DrawTextBasic(rt, screenCoords, "{BLACK}", { textColour, style });
+        DrawTextNoFormatting(rt, screenCoords, _consoleCurrentLine, { OpenRCT2::Drawing::kColourNull, style });
     }
     else
     {
-        DrawText(rt, screenCoords, { textColour, style }, _consoleCurrentLine.c_str(), true);
+        DrawTextNoFormatting(rt, screenCoords, _consoleCurrentLine, { textColour, style });
     }
 
     // Draw caret

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -647,7 +647,7 @@ namespace OpenRCT2::Ui
         if (widgetIsDisabled(w, widgetIndex))
             colour.flags.set(ColourFlag::inset, true);
 
-        DrawText(rt, crossMidPoint, { colour, TextAlignment::centre }, widget.string);
+        DrawTextBasic(rt, crossMidPoint, widget.string, { colour, TextAlignment::centre });
     }
 
     /**
@@ -679,9 +679,9 @@ namespace OpenRCT2::Ui
         // fill it when checkbox is pressed
         if (widgetIsPressed(w, widgetIndex))
         {
-            DrawText(
-                rt, { midLeft - ScreenCoordsXY{ 0, 5 } }, { colour.withFlag(ColourFlag::translucent, false) },
-                kCheckMarkString);
+            DrawTextBasic(
+                rt, { midLeft - ScreenCoordsXY{ 0, 5 } }, kCheckMarkString,
+                { colour.withFlag(ColourFlag::translucent, false) });
         }
 
         // draw the text
@@ -804,7 +804,7 @@ namespace OpenRCT2::Ui
                                                                         : Rectangle::BorderStyle::outset;
 
             Rectangle::fillInset(rt, { { l, t }, { l + (kScrollBarWidth - 1), b } }, colour, borderStyle);
-            DrawText(rt, { l + 1, t }, {}, kBlackLeftArrowString);
+            DrawTextBasic(rt, { l + 1, t }, kBlackLeftArrowString);
         }
 
         // Thumb
@@ -823,7 +823,7 @@ namespace OpenRCT2::Ui
                                                                          : Rectangle::BorderStyle::outset;
 
             Rectangle::fillInset(rt, { { r - (kScrollBarWidth - 1), t }, { r, b } }, colour, borderStyle);
-            DrawText(rt, { r - 6, t }, {}, kBlackRightArrowString);
+            DrawTextBasic(rt, { r - 6, t }, kBlackRightArrowString);
         }
     }
 
@@ -849,7 +849,7 @@ namespace OpenRCT2::Ui
         Rectangle::fillInset(
             rt, { { l, t }, { r, t + (kScrollBarWidth - 1) } }, colour,
             ((scroll.flags & VSCROLLBAR_UP_PRESSED) ? Rectangle::BorderStyle::inset : Rectangle::BorderStyle::outset));
-        DrawText(rt, { l + 1, t - 1 }, {}, kBlackUpArrowString);
+        DrawTextBasic(rt, { l + 1, t - 1 }, kBlackUpArrowString);
 
         // Thumb
         Rectangle::fillInset(
@@ -863,7 +863,7 @@ namespace OpenRCT2::Ui
         Rectangle::fillInset(
             rt, { { l, b - (kScrollBarWidth - 1) }, { r, b } }, colour,
             ((scroll.flags & VSCROLLBAR_DOWN_PRESSED) ? Rectangle::BorderStyle::inset : Rectangle::BorderStyle::outset));
-        DrawText(rt, { l + 1, b - (kScrollBarWidth - 1) }, {}, kBlackDownArrowString);
+        DrawTextBasic(rt, { l + 1, b - (kScrollBarWidth - 1) }, kBlackDownArrowString);
     }
 
     /**
@@ -1195,7 +1195,7 @@ namespace OpenRCT2::Ui
             {
                 u8string wrappedString;
                 GfxWrapString(widget.string, bottomRight.x - topLeft.x - 5, FontStyle::medium, &wrappedString, nullptr);
-                DrawText(rt, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
+                DrawTextNoFormatting(rt, { topLeft.x + 2, topLeft.y }, wrappedString, { w.colours[1] });
             }
             return;
         }
@@ -1205,7 +1205,7 @@ namespace OpenRCT2::Ui
         u8string wrappedString;
         GfxWrapString(*textInput->Buffer, bottomRight.x - topLeft.x - 5 - 6, FontStyle::medium, &wrappedString, nullptr);
 
-        DrawText(rt, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
+        DrawTextNoFormatting(rt, { topLeft.x + 2, topLeft.y }, wrappedString, { w.colours[1] });
 
         // Make a trimmed view of the string for measuring the width.
         int32_t curX = topLeft.x

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -239,7 +239,7 @@ namespace OpenRCT2::Scripting
 
         void text(const std::string& text, int32_t x, int32_t y)
         {
-            DrawText(_rt, { x, y }, { static_cast<Drawing::Colour>(_colour.value_or(0)) }, text.c_str());
+            DrawTextBasic(_rt, { x, y }, text, { static_cast<Drawing::Colour>(_colour.value_or(0)) });
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -187,7 +187,7 @@ namespace OpenRCT2::Ui::Windows
                 if (screenCoords.y + lineHeight < rt.y || screenCoords.y >= rt.y + rt.height)
                     continue;
 
-                DrawText(rt, screenCoords, { colours[0] }, line.c_str());
+                DrawTextBasic(rt, screenCoords, line, { colours[0] });
             }
         }
 

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -210,7 +210,8 @@ namespace OpenRCT2::Ui::Windows
 
             screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_SYMBOL_TEXT].left + 1, widgets[WIDX_SYMBOL_TEXT].top };
 
-            DrawText(rt, screenCoords, { colours[1] }, CurrencyDescriptors[EnumValue(CurrencyType::custom)].symbol_unicode);
+            DrawTextBasic(
+                rt, screenCoords, CurrencyDescriptors[EnumValue(CurrencyType::custom)].symbol_unicode, { colours[1] });
 
             auto drawPos = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_AFFIX_DROPDOWN].left + 1, widgets[WIDX_AFFIX_DROPDOWN].top };

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -764,7 +764,7 @@ namespace OpenRCT2::Ui::Windows
                         if (*listItem.flags & (ObjectSelectionFlags::InUse | ObjectSelectionFlags::AlwaysRequired))
                             colour2.flags.set(ColourFlag::inset, true);
 
-                        DrawText(rt, screenCoords, { colour2, FontStyle::medium, darkness }, kCheckMarkString);
+                        DrawTextBasic(rt, screenCoords, kCheckMarkString, { colour2, FontStyle::medium, darkness });
                     }
 
                     screenCoords.x = gLegacyScene == LegacyScene::trackDesignsManager ? 0 : 15;

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -2371,9 +2371,9 @@ namespace OpenRCT2::Ui::Windows
                     if (currentRide->flags.has(RideFlag::indestructible))
                     {
                         auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::extraDark : TextDarkness::dark;
-                        DrawText(
-                            rt, { 2, y }, { colours[1].withFlag(ColourFlag::translucent, false), FontStyle::medium, darkness },
-                            kCheckMarkString);
+                        DrawTextBasic(
+                            rt, { 2, y }, kCheckMarkString,
+                            { colours[1].withFlag(ColourFlag::translucent, false), FontStyle::medium, darkness });
                     }
 
                     // Ride name

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1875,7 +1875,7 @@ namespace OpenRCT2::Ui::Windows
                     FormatStringLegacy(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SLOPE, ft2.Data());
                     String::safeConcat(buffer, buffer2, sizeof(buffer));
                 }
-                DrawText(rt, screenCoords, {}, buffer);
+                DrawTextBasic(rt, screenCoords, buffer);
             }
             screenCoords.y += kListRowHeight;
             {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -691,7 +691,7 @@ namespace OpenRCT2::Ui::Windows
                         Rectangle::fill(
                             rt, { screenCoords + ScreenCoordsXY{ 0, 2 }, screenCoords + ScreenCoordsXY{ 6, 8 } },
                             kRideKeyColours[i].b);
-                        DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ kListRowHeight, 0 }, MapLabels[i], {});
+                        DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ kListRowHeight, 0 }, MapLabels[i]);
                         screenCoords.y += kListRowHeight;
                         if (i == 3)
                         {

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -292,8 +292,7 @@ namespace OpenRCT2::Ui::Windows
                         _buffer += Network::GetPlayerName(player);
                     }
                     screenCoords.x = 0;
-                    GfxClipString(_buffer.data(), 230, FontStyle::medium);
-                    DrawText(rt, screenCoords, { colour }, _buffer.c_str());
+                    DrawTextEllipsised(rt, screenCoords, 230, _buffer, { colour });
 
                     // Draw group name
                     _buffer.resize(0);
@@ -303,8 +302,7 @@ namespace OpenRCT2::Ui::Windows
                         _buffer += "{BLACK}";
                         screenCoords.x = 173;
                         _buffer += Network::GetGroupName(group);
-                        GfxClipString(_buffer.data(), 80, FontStyle::medium);
-                        DrawText(rt, screenCoords, { colour }, _buffer.c_str());
+                        DrawTextEllipsised(rt, screenCoords, 80, _buffer, { colour });
                     }
 
                     // Draw last action
@@ -341,7 +339,7 @@ namespace OpenRCT2::Ui::Windows
                     _buffer += pingBuffer;
 
                     screenCoords.x = 356;
-                    DrawText(rt, screenCoords, { colour }, _buffer.c_str());
+                    DrawTextBasic(rt, screenCoords, _buffer, { colour });
                 }
                 screenCoords.y += kScrollableRowHeight;
                 listPosition++;
@@ -421,7 +419,7 @@ namespace OpenRCT2::Ui::Windows
                         if (Network::CanPerformAction(groupindex, static_cast<Network::Permission>(i)))
                         {
                             screenCoords.x = 0;
-                            DrawText(rt, screenCoords, {}, u8"{WINDOW_COLOUR_2}✓");
+                            DrawTextBasic(rt, screenCoords, u8"{WINDOW_COLOUR_2}✓");
                         }
                     }
 

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2::Ui::Windows
 
             ScreenCoordsXY screenCoords(windowPos.x + (width / 2), windowPos.y + (height / 2));
             screenCoords.x -= GfxGetStringWidth(_buffer, FontStyle::medium) / 2;
-            DrawText(rt, screenCoords, { Drawing::Colour::black }, _buffer.c_str());
+            DrawTextBasic(rt, screenCoords, _buffer, { Drawing::Colour::black });
         }
 
         void setCloseCallBack(CloseCallback callback)

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -544,10 +544,7 @@ namespace OpenRCT2::Ui::Windows
 
                 const auto& entry = _invalidEntries[i];
 
-                auto name = entry.GetName();
-                char buffer[256];
-                String::set(buffer, sizeof(buffer), name.data(), name.size());
-                DrawText(rt, screenCoords, { Drawing::Colour::darkGreen }, buffer);
+                DrawTextBasic(rt, screenCoords, entry.GetName(), { Colour::darkGreen });
 
                 if (entry.Generation == ObjectGeneration::DAT)
                 {

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -451,7 +451,7 @@ namespace OpenRCT2::Ui::Windows
             DrawTextBasic(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
             char ping[64];
             snprintf(ping, 64, "%d ms", Network::GetPlayerPing(player));
-            DrawText(rt, screenCoords + ScreenCoordsXY(30, 0), { colours[2] }, ping);
+            DrawTextBasic(rt, screenCoords + ScreenCoordsXY(30, 0), ping, { colours[2] });
 
             // Draw last action
             screenCoords = windowPos + ScreenCoordsXY{ width / 2, height - 13 };

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -418,7 +418,7 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw number of players
                 screenCoords.x = right - numPlayersStringWidth;
-                DrawText(rt, screenCoords + ScreenCoordsXY{ 0, 3 }, { colours[1] }, players);
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY{ 0, 3 }, players, { colours[1] });
 
                 screenCoords.y += kItemHeight;
             }

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -244,7 +244,7 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t line = 0; line <= no_lines; line++)
             {
                 screenCoords.x = windowPos.x + 12;
-                DrawText(rt, screenCoords, { colours[1], FontStyle::medium, TextAlignment::left }, wrapPointer, true);
+                DrawTextNoFormatting(rt, screenCoords, wrapPointer, { colours[1], FontStyle::medium, TextAlignment::left });
 
                 size_t string_length = GetStringSize(wrapPointer) - 1;
                 if (!cur_drawn && (textInput->SelectionStart <= char_count + string_length))

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -802,8 +802,8 @@ namespace OpenRCT2::Ui::Windows
                             Rectangle::FillBrightness::dark, Rectangle::FillMode::dontLightenWhenInset);
                         if (colour.flags.has(ColourFlag::translucent))
                         {
-                            DrawText(
-                                rt, topLeft, { colours[1].colour, FontStyle::medium, TextDarkness::dark }, kCheckMarkString);
+                            DrawTextBasic(
+                                rt, topLeft, kCheckMarkString, { colours[1].colour, FontStyle::medium, TextDarkness::dark });
                         }
                     }
                 }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1070,8 +1070,8 @@ static uint64_t PageDisabledWidgets[] = {
             }
             else
             {
-                DrawText(rt, screenCoords + ScreenCoordsXY(43 - 7, yOffset), { colours[1] }, "-");
-                DrawText(rt, screenCoords + ScreenCoordsXY(113 - 7, yOffset), { colours[1] }, "-");
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY(43 - 7, yOffset), "-", { colours[1] });
+                DrawTextBasic(rt, screenCoords + ScreenCoordsXY(113 - 7, yOffset), "-", { colours[1] });
             }
 
             if (windowTileInspectorSelectedIndex != -1)

--- a/src/openrct2-ui/windows/TitleVersion.cpp
+++ b/src/openrct2-ui/windows/TitleVersion.cpp
@@ -27,12 +27,12 @@ namespace OpenRCT2::Ui::Windows
         {
             // Write name and version information
             const auto whiteOutline = ColourWithFlags{ Drawing::Colour::white }.withFlag(ColourFlag::withOutline, true);
-            DrawText(rt, windowPos, { whiteOutline }, gVersionInfoFull);
+            DrawTextBasic(rt, windowPos, gVersionInfoFull, { whiteOutline });
             width = GfxGetStringWidth(gVersionInfoFull, FontStyle::medium);
 
             // Write platform information
             constexpr const char platformInfo[] = OPENRCT2_PLATFORM " (" OPENRCT2_ARCHITECTURE ")";
-            DrawText(rt, windowPos + ScreenCoordsXY(0, kListRowHeight), { whiteOutline }, platformInfo);
+            DrawTextBasic(rt, windowPos + ScreenCoordsXY(0, kListRowHeight), platformInfo, { whiteOutline });
             width = std::max<int16_t>(width, GfxGetStringWidth(platformInfo, FontStyle::medium)) + kTextOffset;
         }
     };

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -462,8 +462,7 @@ void DrawNewsTicker(
         }
 
         screenCoords = { coords.x - halfWidth, lineY };
-        DrawTextBasic(rt, screenCoords, buffer, kColourNull, FontStyle::small
-    });
+        DrawTextBasic(rt, screenCoords, buffer, { kColourNull, FontStyle::small });
 
         if (numCharactersDrawn > numCharactersToDraw)
         {

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -783,12 +783,9 @@ static void TTFProcessInitialColour(ColourWithFlags colour, TextDrawInfo* info)
 }
 
 void TTFDrawString(
-    RenderTarget& rt, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
+    RenderTarget& rt, u8string_view text, ColourWithFlags colour, const ScreenCoordsXY& coords, bool noFormatting,
     FontStyle fontStyle, TextDarkness darkness)
 {
-    if (text == nullptr)
-        return;
-
     TextDrawInfo info{};
     info.fontStyle = fontStyle;
     info.startX = coords.x;

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -271,7 +271,7 @@ void GfxDrawStringLeftCentred(
     auto bufferPtr = buffer;
     FormatStringLegacy(bufferPtr, sizeof(buffer), format, args);
     int32_t height = StringGetHeightRaw(bufferPtr, FontStyle::medium);
-    DrawText(rt, coords - ScreenCoordsXY{ 0, (height / 2) }, { colour }, bufferPtr);
+    DrawTextBasic(rt, coords - ScreenCoordsXY{ 0, (height / 2) }, bufferPtr, { colour });
 }
 
 /**
@@ -325,13 +325,13 @@ void DrawStringCentredRaw(
     RenderTarget& rt, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle)
 {
     ScreenCoordsXY screenCoords(rt.x, rt.y);
-    DrawText(rt, screenCoords, { OpenRCT2::Drawing::Colour::black, fontStyle }, "");
+    DrawTextBasic(rt, screenCoords, "", { Colour::black, fontStyle });
     screenCoords = coords;
 
     for (int32_t i = 0; i <= numLines; i++)
     {
         int32_t width = GfxGetStringWidth(text, fontStyle);
-        DrawText(rt, screenCoords - ScreenCoordsXY{ width / 2, 0 }, { OpenRCT2::Drawing::kColourNull, fontStyle }, text);
+        DrawTextBasic(rt, screenCoords - ScreenCoordsXY{ width / 2, 0 }, text, { kColourNull, fontStyle });
 
         const utf8* ch = text;
         const utf8* nextCh = nullptr;
@@ -423,7 +423,7 @@ void DrawNewsTicker(
     int32_t numLines, lineHeight, lineY;
     ScreenCoordsXY screenCoords(rt.x, rt.y);
 
-    DrawText(rt, screenCoords, { colour }, "");
+    DrawTextBasic(rt, screenCoords, "", { colour });
 
     u8string wrappedString;
     GfxWrapString(FormatStringID(format, args), width, FontStyle::small, &wrappedString, &numLines);
@@ -462,7 +462,8 @@ void DrawNewsTicker(
         }
 
         screenCoords = { coords.x - halfWidth, lineY };
-        DrawText(rt, screenCoords, { OpenRCT2::Drawing::kColourNull, FontStyle::small }, buffer);
+        DrawTextBasic(rt, screenCoords, buffer, kColourNull, FontStyle::small
+    });
 
         if (numCharactersDrawn > numCharactersToDraw)
         {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -935,8 +935,8 @@ void DebugRT(RenderTarget& rt)
     GfxDrawLine(rt, { topLeft, topLeft + ScreenCoordsXY{ 4, 0 } }, PaletteIndex::pi136);
 
     const auto str = std::to_string(rt.x);
-    DrawText(rt, ScreenCoordsXY{ rt.x, rt.y }, { Colour::white, FontStyle::tiny }, str.c_str());
+    DrawTextBasic(rt, ScreenCoordsXY{ rt.x, rt.y }, str, { Colour::white, FontStyle::tiny });
 
     const auto str2 = std::to_string(rt.y);
-    DrawText(rt, ScreenCoordsXY{ rt.x, rt.y + 6 }, { Colour::white, FontStyle::tiny }, str2.c_str());
+    DrawTextBasic(rt, ScreenCoordsXY{ rt.x, rt.y + 6 }, str2, { Colour::white, FontStyle::tiny });
 }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -126,7 +126,7 @@ int32_t StringGetHeightRaw(std::string_view text, FontStyle fontStyle);
 int32_t GfxClipString(char* buffer, int32_t width, FontStyle fontStyle);
 u8string ShortenPath(const u8string& path, int32_t availableWidth, FontStyle fontStyle);
 void TTFDrawString(
-    OpenRCT2::Drawing::RenderTarget& rt, const_utf8string text, ColourWithFlags colour, const ScreenCoordsXY& coords,
+    OpenRCT2::Drawing::RenderTarget& rt, u8string_view text, ColourWithFlags colour, const ScreenCoordsXY& coords,
     bool noFormatting, FontStyle fontStyle, TextDarkness darkness);
 
 void MaskSse4_1(

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -56,7 +56,7 @@ public:
         const utf8* buffer = Buffer.data();
         for (int32_t line = 0; line < LineCount; ++line)
         {
-            DrawText(rt, lineCoords, tempPaint, buffer);
+            DrawTextBasic(rt, lineCoords, buffer, tempPaint);
             tempPaint.Colour = OpenRCT2::Drawing::kColourNull;
             buffer = GetStringEnd(buffer) + 1;
             lineCoords.y += LineHeight;
@@ -79,7 +79,8 @@ public:
     }
 };
 
-void DrawText(RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, u8string_view text, bool noFormatting)
+static void DrawText(
+    RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, u8string_view text, bool noFormatting = false)
 {
     int32_t width = noFormatting ? GfxGetStringWidthNoFormatting(text, paint.FontStyle)
                                  : GfxGetStringWidth(text, paint.FontStyle);
@@ -111,6 +112,11 @@ void DrawText(RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& p
                 gTextPalette.sunnyOutline);
         }
     }
+}
+
+void DrawTextNoFormatting(RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint)
+{
+    DrawText(rt, coords, textPaint, string, true);
 }
 
 void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, TextPaint textPaint)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -13,6 +13,7 @@
 #include "../drawing/Rectangle.h"
 #include "../localisation/Formatter.h"
 #include "../localisation/Formatting.h"
+#include "../localisation/Language.h"
 #include "Drawing.h"
 
 using namespace OpenRCT2;
@@ -112,11 +113,9 @@ void DrawText(RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& p
     }
 }
 
-void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format)
+void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, TextPaint textPaint)
 {
-    Formatter ft{};
-    TextPaint textPaint{};
-    DrawTextBasic(rt, coords, format, ft, textPaint);
+    DrawTextBasic(rt, coords, LanguageGetString(format), textPaint);
 }
 
 void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
@@ -126,11 +125,14 @@ void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId form
     DrawText(rt, coords, textPaint, buffer);
 }
 
-void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format)
+void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint)
 {
-    Formatter ft{};
-    TextPaint textPaint{};
-    DrawTextEllipsised(rt, coords, width, format, ft, textPaint);
+    DrawText(rt, coords, textPaint, string);
+}
+
+void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, TextPaint textPaint)
+{
+    DrawTextEllipsised(rt, coords, width, LanguageGetString(format), textPaint);
 }
 
 void DrawTextEllipsised(
@@ -138,24 +140,31 @@ void DrawTextEllipsised(
 {
     utf8 buffer[512];
     FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
-    GfxClipString(buffer, width, textPaint.FontStyle);
-
-    DrawText(rt, coords, textPaint, buffer);
+    DrawTextEllipsised(rt, coords, width, buffer, textPaint);
 }
 
-int32_t DrawTextWrapped(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format)
+void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string string, TextPaint textPaint)
 {
-    Formatter ft{};
-    TextPaint textPaint{};
-    return DrawTextWrapped(rt, coords, width, format, ft, textPaint);
+    GfxClipString(const_cast<utf8*>(string.c_str()), width, textPaint.FontStyle);
+    DrawText(rt, coords, textPaint, string);
+}
+
+int32_t DrawTextWrapped(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, TextPaint textPaint)
+{
+    return DrawTextWrapped(rt, coords, width, LanguageGetString(format), textPaint);
 }
 
 int32_t DrawTextWrapped(
     RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
-    const void* args = ft.Data();
+    auto formatted = FormatStringIDLegacy(format, ft.Data());
+    return DrawTextWrapped(rt, coords, width, formatted, textPaint);
+}
 
-    StaticLayout layout(FormatStringIDLegacy(format, args), textPaint, width);
+int32_t DrawTextWrapped(
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string_view string, TextPaint textPaint)
+{
+    StaticLayout layout(string, textPaint, width);
 
     if (textPaint.Alignment == TextAlignment::centre)
     {

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -80,7 +80,7 @@ public:
 };
 
 static void DrawText(
-    RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, u8string_view text, bool noFormatting = false)
+    RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view text, const TextPaint& paint, bool noFormatting = false)
 {
     int32_t width = noFormatting ? GfxGetStringWidthNoFormatting(text, paint.FontStyle)
                                  : GfxGetStringWidth(text, paint.FontStyle);
@@ -116,7 +116,7 @@ static void DrawText(
 
 void DrawTextNoFormatting(RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint)
 {
-    DrawText(rt, coords, textPaint, string, true);
+    DrawText(rt, coords, string, textPaint, true);
 }
 
 void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, TextPaint textPaint)
@@ -128,12 +128,12 @@ void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, StringId form
 {
     utf8 buffer[512];
     FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
-    DrawText(rt, coords, textPaint, buffer);
+    DrawText(rt, coords, buffer, textPaint);
 }
 
 void DrawTextBasic(RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint)
 {
-    DrawText(rt, coords, textPaint, string);
+    DrawText(rt, coords, string, textPaint);
 }
 
 void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, TextPaint textPaint)
@@ -152,7 +152,7 @@ void DrawTextEllipsised(
 void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string string, TextPaint textPaint)
 {
     GfxClipString(const_cast<utf8*>(string.c_str()), width, textPaint.FontStyle);
-    DrawText(rt, coords, textPaint, string);
+    DrawText(rt, coords, string, textPaint);
 }
 
 int32_t DrawTextWrapped(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format, TextPaint textPaint)

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -78,7 +78,7 @@ public:
     }
 };
 
-void DrawText(RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
+void DrawText(RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, u8string_view text, bool noFormatting)
 {
     int32_t width = noFormatting ? GfxGetStringWidthNoFormatting(text, paint.FontStyle)
                                  : GfxGetStringWidth(text, paint.FontStyle);

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -215,7 +215,7 @@ void DrawTextEllipsised(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsX
 int32_t DrawTextWrapped(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
 
 void DrawText(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text,
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, u8string_view text,
     bool noFormatting = false);
 void DrawTextBasic(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const OpenRCT2::Formatter& ft,

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -210,7 +210,8 @@ struct TextPaint
     }
 };
 
-void DrawTextNoFormatting(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint = {});
+void DrawTextNoFormatting(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint = {});
 
 void DrawTextBasic(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, TextPaint textPaint = {});

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -210,6 +210,8 @@ struct TextPaint
     }
 };
 
+void DrawTextNoFormatting(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint = {});
+
 void DrawTextBasic(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, TextPaint textPaint = {});
 void DrawTextBasic(

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -210,19 +210,30 @@ struct TextPaint
     }
 };
 
-void DrawTextBasic(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, StringId format);
-void DrawTextEllipsised(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
-int32_t DrawTextWrapped(OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format);
-
-void DrawText(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, const TextPaint& paint, u8string_view text,
-    bool noFormatting = false);
+void DrawTextBasic(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, TextPaint textPaint = {});
 void DrawTextBasic(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, StringId format, const OpenRCT2::Formatter& ft,
+    TextPaint textPaint = {});
+void DrawTextBasic(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, u8string_view string, TextPaint textPaint = {});
+
+void DrawTextEllipsised(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format,
     TextPaint textPaint = {});
 void DrawTextEllipsised(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format,
     const OpenRCT2::Formatter& ft, TextPaint textPaint = {});
+void DrawTextEllipsised(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string string,
+    TextPaint textPaint = {});
+
+int32_t DrawTextWrapped(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format,
+    TextPaint textPaint = {});
 int32_t DrawTextWrapped(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format,
     const OpenRCT2::Formatter& ft, TextPaint textPaint = {});
+int32_t DrawTextWrapped(
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string_view string,
+    TextPaint textPaint = {});

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -306,7 +306,7 @@ static int32_t ChatHistoryDrawString(RenderTarget& rt, const char* text, const S
     int32_t lineY = screenCoords.y;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        DrawText(rt, { screenCoords.x, lineY - (numLines * lineHeight) }, { OpenRCT2::Drawing::kColourNull }, bufferPtr);
+        DrawTextBasic(rt, { screenCoords.x, lineY - (numLines * lineHeight) }, bufferPtr, { OpenRCT2::Drawing::kColourNull });
         bufferPtr = GetStringEnd(bufferPtr) + 1;
         lineY += lineHeight;
     }

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -95,7 +95,7 @@ void Painter::PaintReplayNotice(RenderTarget& rt, const char* text)
     screenCoords.x = screenCoords.x - stringWidth;
 
     if (((getGameState().currentTicks >> 1) & 0xF) > 4)
-        DrawText(rt, screenCoords, { OpenRCT2::Drawing::Colour::saturatedRed }, buffer);
+        DrawTextBasic(rt, screenCoords, buffer, { OpenRCT2::Drawing::Colour::saturatedRed });
 
     // Make area dirty so the text doesn't get drawn over the last
     GfxSetDirtyBlocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
@@ -132,7 +132,7 @@ void Painter::PaintFPS(RenderTarget& rt)
         screenCoords.y = kTopToolbarHeight + 3;
     }
 
-    DrawText(rt, screenCoords, { OpenRCT2::Drawing::Colour::white }, buffer);
+    DrawTextBasic(rt, screenCoords, buffer, { OpenRCT2::Drawing::Colour::white });
 
     // Make area dirty so the text doesn't get drawn over the last
     GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { rt.lastStringPos.x + 16, screenCoords.y + 16 } });


### PR DESCRIPTION
This changes the DrawText* functions to be more consistent and allow passing a string directly, rather than having to wrap it in a formatter together with `STR_STRING`.

The PR is intended to be one out of many.