### PR TITLE
Fix DrawTextEllipsised()

### DIFF
--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -146,12 +146,16 @@ void DrawTextEllipsised(
 {
     utf8 buffer[512];
     FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
-    DrawTextEllipsised(rt, coords, width, buffer, textPaint);
+    GfxClipString(buffer, width, textPaint.FontStyle);
+    DrawText(rt, coords, buffer, textPaint);
 }
 
-void DrawTextEllipsised(RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string string, TextPaint textPaint)
+void DrawTextEllipsised(
+    RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string_view string, TextPaint textPaint)
 {
-    GfxClipString(const_cast<utf8*>(string.c_str()), width, textPaint.FontStyle);
+    utf8 buffer[512]{};
+    string.copy(buffer, std::min(string.length(), sizeof(buffer) - 1));
+    GfxClipString(buffer, width, textPaint.FontStyle);
     DrawText(rt, coords, string, textPaint);
 }
 

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -228,7 +228,7 @@ void DrawTextEllipsised(
     OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, StringId format,
     const OpenRCT2::Formatter& ft, TextPaint textPaint = {});
 void DrawTextEllipsised(
-    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string string,
+    OpenRCT2::Drawing::RenderTarget& rt, const ScreenCoordsXY& coords, int32_t width, u8string_view string,
     TextPaint textPaint = {});
 
 int32_t DrawTextWrapped(


### PR DESCRIPTION
Mistake introduced in the previous commit. It caused characters that were supposed to be cut off to remain in the string. To fix this, this PR mostly revert to the old method of using a local char buffer.