### PR TITLE
Increase dropdown limit from 512 to 1024

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#26159] The map generator window is not resized correctly in Enlarged UI mode.
 - Fix: [#26196] The sprites of one angle of the Steeplechase left large turn are misaligned (original bug).
 - Fix: [#26214] The wrong sprite is used for one angle of the gentle diagonal slope of Alpine, Hybrid and Single Rail tracks.
+- Fix: [#26243] Increase max dropdown size from 512 to 1024 to accommodate parks with more than 512 rides.
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -12,10 +12,10 @@
 #include <array>
 #include <functional>
 #include <openrct2-ui/UiStringIds.h>
+#include <openrct2/Limits.h>
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/core/StringTypes.h>
 #include <openrct2/interface/Window.h>
-#include <openrct2/Limits.h>
 #include <optional>
 #include <span>
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -15,6 +15,7 @@
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/core/StringTypes.h>
 #include <openrct2/interface/Window.h>
+#include <openrct2/limits.h>
 #include <optional>
 #include <span>
 
@@ -32,6 +33,7 @@ namespace OpenRCT2::Dropdown
 
     constexpr StringId kSeparatorString = 0;
     constexpr int32_t kItemsMaxSize = 1024;
+    static_assert(kItemsMaxSize >= Limits::kMaxRidesInPark);
 
     struct DropdownState;
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -15,7 +15,7 @@
 #include <openrct2/core/EnumUtils.hpp>
 #include <openrct2/core/StringTypes.h>
 #include <openrct2/interface/Window.h>
-#include <openrct2/limits.h>
+#include <openrct2/Limits.h>
 #include <optional>
 #include <span>
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -31,7 +31,7 @@ namespace OpenRCT2::Dropdown
     struct Item;
 
     constexpr StringId kSeparatorString = 0;
-    constexpr int32_t kItemsMaxSize = 512;
+    constexpr int32_t kItemsMaxSize = 1024;
 
     struct DropdownState;
 


### PR DESCRIPTION
This is to accommodate parks with more than 512 rides. For example: currently not all rides will show up if you're selecting a ride to advertise for.