### PR TITLE
Fix alignment for ride view dropdown text

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2717,7 +2717,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto* widget = &widgets[WIDX_VIEW];
             DrawTextBasic(
-                rt, { windowPos.x + (widget->left + widget->right - 11) / 2, windowPos.y + widget->top },
+                rt, { windowPos.x + (widget->left + widget->right - 11) / 2, windowPos.y + widget->textTop() },
                 STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::centre });
 
             // Status


### PR DESCRIPTION
Not sure what introduced this. It seems like a regression; it's probably due to the recent resizing of the dropdown widgets.

Before:
<img width="316" height="208" alt="Forest Frontiers 2026-03-25 14-32-27" src="https://github.com/user-attachments/assets/ef530800-0feb-4586-95cf-4a14ea2d4b9c" />

After:
<img width="316" height="208" alt="Forest Frontiers 2026-03-25 14-30-10" src="https://github.com/user-attachments/assets/e3e2ab6d-04df-4d87-b569-540ab708e772" />
