### PR TITLE
Modify CI workflow to adjust Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,14 +194,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Keep win32 on vs2022 for Windows 7 compatibility.
+          # See https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners
           - platform: win32
-            runs_on: windows-2025-vs2026
+            runs_on: windows-2025
           - platform: x64
             runs_on: windows-2025-vs2026
-          # keep arm64 on vs2022 for now. VS2026 is a bit slower and we can maintain
-          # compatibility with vs2022
           - platform: arm64
-            runs_on: windows-latest
+            runs_on: windows-2025-vs2026
     env:
       PLATFORM: ${{ matrix.platform }}
       DISTANCE_FROM_TAG: ${{ needs.build_variables.outputs.distance }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,14 +194,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # keep win32 on vs2022 for now. So we can maintain compatibility with vs2022
           - platform: win32
-            runs_on: windows-2025-vs2026
+            runs_on: windows-latest
           - platform: x64
             runs_on: windows-2025-vs2026
-          # keep arm64 on vs2022 for now. VS2026 is a bit slower and we can maintain
-          # compatibility with vs2022
           - platform: arm64
-            runs_on: windows-latest
+            runs_on: windows-2025-vs2026
     env:
       PLATFORM: ${{ matrix.platform }}
       DISTANCE_FROM_TAG: ${{ needs.build_variables.outputs.distance }}


### PR DESCRIPTION
Updated CI configuration to use 'windows-latest' for win32 and 'windows-2025-vs2026' for arm64.