### PR TITLE
Refactor a few drawText* calls

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -27,6 +27,7 @@
 #include <openrct2/interface/ColourWithFlags.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Formatting.h>
+#include <openrct2/localisation/Language.h>
 #include <openrct2/localisation/StringIds.h>
 
 using namespace OpenRCT2;
@@ -485,34 +486,20 @@ namespace OpenRCT2::Ui
         auto textRight = l;
 
         // Text
-        auto stringId = widget.text;
-        auto rawFt = Formatter();
-        if (widget.flags.has(WidgetFlag::textIsString))
-        {
-            if (widget.string != nullptr && widget.string[0] != '\0')
-            {
-                stringId = STR_STRING;
-                rawFt.Add<utf8*>(widget.string);
-            }
-            else
-            {
-                stringId = kStringIdNone;
-            }
-        }
+        u8string groupCaption{};
+        if (widget.flags.has(WidgetFlag::textIsString) && widget.string != nullptr)
+            groupCaption = widget.string;
+        else
+            groupCaption = LanguageGetString(widget.text);
 
-        if (stringId != kStringIdNone)
+        if (!groupCaption.empty())
         {
             auto colour = w.colours[widget.colour].withFlag(ColourFlag::translucent, false);
             if (widgetIsDisabled(w, widgetIndex))
                 colour.flags.set(ColourFlag::inset, true);
 
-            utf8 buffer[512] = { 0 };
-            FormatStringLegacy(buffer, sizeof(buffer), stringId, rawFt.Data());
-
-            auto ft = Formatter();
-            ft.Add<utf8*>(buffer);
-            drawText(rt, { l, t }, STR_STRING, ft, { colour });
-            textRight = l + getStringWidth(buffer, FontStyle::medium) + 1;
+            drawText(rt, { l, t }, groupCaption, { colour });
+            textRight = l + getStringWidth(groupCaption, FontStyle::medium) + 1;
         }
 
         // Border

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -777,7 +777,7 @@ void CustomListView::PaintCell(
     auto ft = Formatter();
     ft.Add<StringId>(STR_STRING);
     ft.Add<const char*>(text);
-    drawTextEllipsised(rt, pos, size.width, stringId, ft, {});
+    drawTextEllipsised(rt, pos, size.width, stringId, ft);
 }
 
 std::optional<RowColumn> CustomListView::GetItemIndexAt(const ScreenCoordsXY& pos)

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -726,14 +726,10 @@ void CustomListView::PaintSeparator(RenderTarget& rt, const ScreenCoordsXY& pos,
     if (hasText)
     {
         // Draw string
-        Formatter ft;
-        ft.Add<const char*>(text);
-        drawText(rt, { centreX, pos.y }, STR_STRING, ft, { baseColour, TextAlignment::centre });
+        drawText(rt, { centreX, pos.y }, text, { baseColour, TextAlignment::centre });
 
         // Get string dimensions
-        utf8 stringBuffer[512]{};
-        FormatStringLegacy(stringBuffer, sizeof(stringBuffer), STR_STRING, ft.Data());
-        int32_t categoryStringHalfWidth = (getStringWidth(stringBuffer, FontStyle::medium) / 2) + 4;
+        int32_t categoryStringHalfWidth = (getStringWidth(text, FontStyle::medium) / 2) + 4;
         int32_t strLeft = centreX - categoryStringHalfWidth;
         int32_t strRight = centreX + categoryStringHalfWidth;
 

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -228,15 +228,11 @@ namespace OpenRCT2::Ui::Windows
             auto logoCoords = windowPos + ScreenCoordsXY(logoWidget.left, logoWidget.top);
             GfxDrawSprite(rt, ImageId(SPR_G2_LOGO), logoCoords);
 
-            u8string versionInfo = gVersionInfoFull;
-            auto ft = Formatter();
-            ft.Add<const char*>(versionInfo.c_str());
-
             const auto& versionWidget = widgets[WIDX_VERSION];
             auto centreX = versionWidget.midX();
             auto centreY = versionWidget.midY() - FontGetLineHeight(FontStyle::medium) / 2;
             auto centrePos = windowPos + ScreenCoordsXY(centreX, centreY);
-            drawTextWrapped(rt, centrePos, versionWidget.width() - 1, STR_STRING, ft, { colours[1], TextAlignment::centre });
+            drawTextWrapped(rt, centrePos, versionWidget.width() - 1, gVersionInfoFull, { colours[1], TextAlignment::centre });
 
             // Shows the update available button
             if (GetContext()->HasNewVersionInfo())

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -249,7 +249,7 @@ namespace OpenRCT2::Ui::Windows
             auto textCoords = windowPos + ScreenCoordsXY((width / 2) - 1, 240);
             auto textWidth = kWindowSize.width - (kPadding * 2);
             for (auto stringId : _OpenRCT2InfoStrings)
-                textCoords.y += drawTextWrapped(rt, textCoords, textWidth, stringId, {}, tp) + 5;
+                textCoords.y += drawTextWrapped(rt, textCoords, textWidth, stringId, tp) + 5;
 
             return textCoords.y - windowPos.y;
         }
@@ -270,7 +270,7 @@ namespace OpenRCT2::Ui::Windows
                     continue;
                 }
 
-                textCoords.y += drawTextWrapped(rt, textCoords, textWidth, stringId, {}, tp);
+                textCoords.y += drawTextWrapped(rt, textCoords, textWidth, stringId, tp);
                 if (stringId == STR_COPYRIGHT_CS)
                     textCoords.y += 74;
             }

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -197,7 +197,7 @@ namespace OpenRCT2::Ui::Windows
 
             auto screenCoords = windowPos + ScreenCoordsXY{ 10, 18 + widgets[WIDX_TITLE].height() - 1 };
 
-            drawText(rt, screenCoords, STR_RATE, {}, { colours[1] });
+            drawText(rt, screenCoords, STR_RATE, { colours[1] });
 
             int32_t baseExchange = CurrencyDescriptors[EnumValue(CurrencyType::pounds)].rate;
             auto ft = Formatter();
@@ -206,7 +206,7 @@ namespace OpenRCT2::Ui::Windows
 
             screenCoords.y += 20;
 
-            drawText(rt, screenCoords, STR_CURRENCY_SYMBOL_TEXT, {}, { colours[1] });
+            drawText(rt, screenCoords, STR_CURRENCY_SYMBOL_TEXT, { colours[1] });
 
             screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_SYMBOL_TEXT].left + 1, widgets[WIDX_SYMBOL_TEXT].top };
 
@@ -217,7 +217,7 @@ namespace OpenRCT2::Ui::Windows
             StringId stringId = (CurrencyDescriptors[EnumValue(CurrencyType::custom)].affix_unicode == CurrencyAffix::prefix)
                 ? STR_PREFIX
                 : STR_SUFFIX;
-            drawText(rt, drawPos, stringId, {}, { colours[1] });
+            drawText(rt, drawPos, stringId, { colours[1] });
         }
     };
 

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -372,8 +372,8 @@ namespace OpenRCT2::Ui::Windows
             if (gLegacyScene == LegacyScene::trackDesigner)
                 stringId = STR_EDITOR_STEP_OBJECT_SELECTION;
 
-            drawText(rt, { textX, textY }, STR_BACK_TO_PREVIOUS_STEP, {}, { textColour, TextAlignment::centre });
-            drawText(rt, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::centre });
+            drawText(rt, { textX, textY }, STR_BACK_TO_PREVIOUS_STEP, { textColour, TextAlignment::centre });
+            drawText(rt, { textX, textY + 10 }, stringId, { textColour, TextAlignment::centre });
         }
 
         void DrawRightButtonBack(RenderTarget& rt)
@@ -413,8 +413,8 @@ namespace OpenRCT2::Ui::Windows
             if (gLegacyScene == LegacyScene::trackDesigner)
                 stringId = STR_EDITOR_STEP_ROLLERCOASTER_DESIGNER;
 
-            drawText(rt, { textX, textY }, STR_FORWARD_TO_NEXT_STEP, {}, { textColour, TextAlignment::centre });
-            drawText(rt, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::centre });
+            drawText(rt, { textX, textY }, STR_FORWARD_TO_NEXT_STEP, { textColour, TextAlignment::centre });
+            drawText(rt, { textX, textY + 10 }, stringId, { textColour, TextAlignment::centre });
         }
 
         void DrawStepText(RenderTarget& rt)
@@ -423,7 +423,7 @@ namespace OpenRCT2::Ui::Windows
             int16_t stateY = height - 0x0C + windowPos.y;
             auto colour = colours[2].withFlag(ColourFlag::translucent, false).withFlag(ColourFlag::withOutline, true);
             drawText(
-                rt, { stateX, stateY }, kEditorStepNames[EnumValue(getGameState().editorStep)], {},
+                rt, { stateX, stateY }, kEditorStepNames[EnumValue(getGameState().editorStep)],
                 { colour, TextAlignment::centre });
         }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -790,10 +790,8 @@ namespace OpenRCT2::Ui::Windows
                         // Draw ride type
                         StringId rideTypeStringId = GetRideTypeStringId(listItem.repositoryItem);
                         String::safeUtf8Copy(buffer, LanguageGetString(rideTypeStringId), 256 - (buffer - bufferWithColour));
-                        auto ft = Formatter();
-                        ft.Add<const char*>(itemBuffer);
                         drawTextEllipsised(
-                            rt, screenCoords, width_limit - 15, STR_STRING, ft, { colour, FontStyle::medium, darkness });
+                            rt, screenCoords, width_limit - 15, itemBuffer, { colour, FontStyle::medium, darkness });
                         screenCoords.x = widgets[WIDX_LIST_SORT_RIDE].left - widgets[WIDX_LIST].left;
                     }
 
@@ -806,9 +804,7 @@ namespace OpenRCT2::Ui::Windows
 
                         *buffer = 0;
                     }
-                    auto ft = Formatter();
-                    ft.Add<const char*>(itemBuffer);
-                    drawTextEllipsised(rt, screenCoords, width_limit, STR_STRING, ft, { colour, FontStyle::medium, darkness });
+                    drawTextEllipsised(rt, screenCoords, width_limit, itemBuffer, { colour, FontStyle::medium, darkness });
                 }
                 screenCoords.y += kScrollableRowHeight;
             }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1277,7 +1277,7 @@ namespace OpenRCT2::Ui::Windows
             if (_loadedObject->IsCompatibilityObject())
             {
                 screenPos.y += drawTextWrapped(
-                                   rt, screenPos, descriptionWidth, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION, {},
+                                   rt, screenPos, descriptionWidth, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION,
                                    { Drawing::Colour::brightRed })
                     + kListRowHeight;
             }
@@ -1368,7 +1368,7 @@ namespace OpenRCT2::Ui::Windows
             // Draw fallback image warning
             if (_loadedObject && _loadedObject->UsesFallbackImages())
             {
-                drawText(rt, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { Drawing::Colour::white, TextAlignment::right });
+                drawText(rt, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, { Drawing::Colour::white, TextAlignment::right });
             }
             screenPos.y += kListRowHeight;
 
@@ -1376,7 +1376,7 @@ namespace OpenRCT2::Ui::Windows
             if (GetSelectedObjectType() == ObjectType::ride)
             {
                 auto stringId = GetRideTypeStringId(listItem->repositoryItem);
-                drawText(rt, screenPos, stringId, {}, { Drawing::Colour::white, TextAlignment::right });
+                drawText(rt, screenPos, stringId, { Drawing::Colour::white, TextAlignment::right });
             }
 
             // Draw peep animation object type
@@ -1384,14 +1384,14 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto* animObj = reinterpret_cast<PeepAnimationsObject*>(_loadedObject.get());
                 auto stringId = GetAnimationPeepTypeStringId(animObj->GetPeepType());
-                drawText(rt, screenPos, stringId, {}, { Drawing::Colour::white, TextAlignment::right });
+                drawText(rt, screenPos, stringId, { Drawing::Colour::white, TextAlignment::right });
             }
 
             screenPos.y += kListRowHeight;
 
             // Draw object source
             auto stringId = ObjectManagerGetSourceGameString(listItem->repositoryItem->GetFirstSourceGame());
-            drawText(rt, screenPos, stringId, {}, { Drawing::Colour::white, TextAlignment::right });
+            drawText(rt, screenPos, stringId, { Drawing::Colour::white, TextAlignment::right });
             screenPos.y += kListRowHeight;
 
             // Draw object filename

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -597,7 +597,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Expenditure / Income heading
             drawText(
-                rt, screenCoords, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME, {},
+                rt, screenCoords, STR_FINANCES_SUMMARY_EXPENDITURE_INCOME,
                 { Drawing::Colour::black, { TextPaintFlag::underline }, TextAlignment::left });
             screenCoords.y += 14;
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -607,7 +607,7 @@ namespace OpenRCT2::Ui::Windows
                 // Draw build this... label
                 screenCoords = this->windowPos
                     + ScreenCoordsXY{ widgets[WIDX_CONSTRUCT].midX(), widgets[WIDX_CONSTRUCT].bottom - 23 };
-                drawText(rt, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::centre });
+                drawText(rt, screenCoords, STR_BUILD_THIS, { TextAlignment::centre });
             }
 
             // Draw cost

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -180,7 +180,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Scenery not available
                     drawTextEllipsised(
-                        rt, screenPos, 308, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::centre });
+                        rt, screenPos, 308, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, { TextAlignment::centre });
                     screenPos.y -= kListRowHeight;
                 }
             }

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -754,13 +754,8 @@ namespace OpenRCT2::Ui::Windows
 
                 // Draw path text
                 const auto normalisedPath = Platform::StrDecompToPrecomp(buffer.data());
-                const auto* normalisedPathC = normalisedPath.c_str();
-
-                auto ft = Formatter();
-                ft.Add<const char*>(normalisedPathC);
-
                 auto pathPos = windowPos + ScreenCoordsXY{ 4, widget.top + 4 };
-                drawTextEllipsised(rt, pathPos, pathWidth, STR_STRING, ft);
+                drawTextEllipsised(rt, pathPos, pathWidth, normalisedPath);
             }
 
             const auto drawButtonCaption =

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -479,7 +479,7 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 drawText(
-                    rt, textPos, previewText, {},
+                    rt, textPos, previewText,
                     { ColourWithFlags{ Drawing::Colour::white }.withFlag(ColourFlag::withOutline, true),
                       TextAlignment::centre });
                 return;
@@ -797,8 +797,7 @@ namespace OpenRCT2::Ui::Windows
             if (action == LoadSaveAction::save)
             {
                 auto& widget = widgets[WIDX_FILENAME_TEXTBOX];
-                drawText(
-                    rt, windowPos + ScreenCoordsXY{ 5, widget.top + 2 }, STR_FILENAME_LABEL, {}, { Drawing::Colour::grey });
+                drawText(rt, windowPos + ScreenCoordsXY{ 5, widget.top + 2 }, STR_FILENAME_LABEL, { Drawing::Colour::grey });
             }
         }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -705,7 +705,7 @@ namespace OpenRCT2::Ui::Windows
             else if (!isToolActive(*this, WIDX_SET_LAND_RIGHTS))
             {
                 drawText(
-                    rt, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_MAP_SIZE_SPINNER_Y].top + 1 }, STR_MAP_SIZE, {},
+                    rt, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_MAP_SIZE_SPINNER_Y].top + 1 }, STR_MAP_SIZE,
                     { colours[1] });
             }
         }

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -620,14 +620,13 @@ namespace OpenRCT2::Ui::Windows
 
             {
                 auto textColour = isWidgetDisabled(WIDX_MAP_SIZE_Y) ? disabledColour : enabledColour;
-                drawText(
-                    rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_MAP_SIZE_Y].top + 1 }, STR_MAP_SIZE, {}, { textColour });
+                drawText(rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_MAP_SIZE_Y].top + 1 }, STR_MAP_SIZE, { textColour });
             }
 
             {
                 auto textColour = enabledColour;
                 drawText(
-                    rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_SOURCE].top + 1 }, STR_HEIGHTMAP_SOURCE, {},
+                    rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_SOURCE].top + 1 }, STR_HEIGHTMAP_SOURCE,
                     { textColour });
             }
         }
@@ -778,7 +777,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Tree to land ratio, label and value
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_LAND_RATIO].top + 1 }, STR_MAPGEN_TREE_TO_LAND_RATIO, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_LAND_RATIO].top + 1 }, STR_MAPGEN_TREE_TO_LAND_RATIO,
                 { textColour });
 
             auto ft = Formatter();
@@ -789,7 +788,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Minimum tree altitude, label and value
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 }, STR_MAPGEN_TREE_MIN_ALTITUDE, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MIN].top + 1 }, STR_MAPGEN_TREE_MIN_ALTITUDE,
                 { textColour });
 
             ft = Formatter();
@@ -804,7 +803,7 @@ namespace OpenRCT2::Ui::Windows
             const auto maxTreeTextColour = _settings.trees && !isFlatland ? enabledColour : disabledColour;
 
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 }, STR_MAPGEN_TREE_MAX_ALTITUDE, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TREE_ALTITUDE_MAX].top + 1 }, STR_MAPGEN_TREE_MAX_ALTITUDE,
                 { maxTreeTextColour });
 
             ft = Formatter();
@@ -879,7 +878,7 @@ namespace OpenRCT2::Ui::Windows
 
             drawText(
                 rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SIMPLEX_BASE_FREQ].top + 1 },
-                STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, {}, { textColour });
+                STR_MAPGEN_SIMPLEX_NOISE_BASE_FREQUENCY, { textColour });
             drawText(
                 rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SIMPLEX_OCTAVES].top + 1 }, STR_MAPGEN_SIMPLEX_NOISE_OCTAVES,
                 {}, { textColour });
@@ -991,7 +990,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Smooth strength label
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 }, STR_MAPGEN_SMOOTH_STRENGTH, {},
+                rt, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_HEIGHTMAP_STRENGTH].top + 1 }, STR_MAPGEN_SMOOTH_STRENGTH,
                 { strengthColour });
 
             // Smooth strength value
@@ -1241,12 +1240,12 @@ namespace OpenRCT2::Ui::Windows
 
             // Floor texture label
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_FLOOR_TEXTURE].top + 1 }, STR_TERRAIN_LABEL, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_FLOOR_TEXTURE].top + 1 }, STR_TERRAIN_LABEL,
                 { enabledColour });
 
             // Minimum land height label and value
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_LOW].top + 1 }, STR_MAPGEN_MIN_LAND_HEIGHT, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_LOW].top + 1 }, STR_MAPGEN_MIN_LAND_HEIGHT,
                 { enabledColour });
 
             auto ft = Formatter();
@@ -1259,7 +1258,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Maximum land height label and value
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_HIGH].top + 1 }, STR_MAPGEN_MAX_LAND_HEIGHT, {},
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHTMAP_HIGH].top + 1 }, STR_MAPGEN_MAX_LAND_HEIGHT,
                 { maxLandColour });
 
             ft = Formatter();
@@ -1349,8 +1348,7 @@ namespace OpenRCT2::Ui::Windows
             const auto textColour = colours[1];
 
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, {},
-                { textColour });
+                rt, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_WATER_LEVEL].top + 1 }, STR_WATER_LEVEL_LABEL, { textColour });
 
             auto ft = Formatter();
             ft.Add<int32_t>(BaseZToMetres(_settings.waterLevel));

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -197,18 +197,14 @@ namespace OpenRCT2::Ui::Windows
 
                 const auto& name = Network::GetServerName();
                 {
-                    auto ft = Formatter();
-                    ft.Add<const char*>(name.c_str());
-                    screenCoords.y += drawTextWrapped(clippedRT, screenCoords, newWidth, STR_STRING, ft, { colours[1] });
+                    screenCoords.y += drawTextWrapped(clippedRT, screenCoords, newWidth, name, { colours[1] });
                     screenCoords.y += kListRowHeight / 2;
                 }
 
                 const auto& description = Network::GetServerDescription();
                 if (!description.empty())
                 {
-                    auto ft = Formatter();
-                    ft.Add<const char*>(description.c_str());
-                    screenCoords.y += drawTextWrapped(clippedRT, screenCoords, newWidth, STR_STRING, ft, { colours[1] });
+                    screenCoords.y += drawTextWrapped(clippedRT, screenCoords, newWidth, description, { colours[1] });
                     screenCoords.y += kListRowHeight / 2;
                 }
 
@@ -383,10 +379,8 @@ namespace OpenRCT2::Ui::Windows
             {
                 _buffer.assign("{WINDOW_COLOUR_2}");
                 _buffer += Network::GetGroupName(group);
-                auto ft = Formatter();
-                ft.Add<const char*>(_buffer.c_str());
                 drawTextEllipsised(
-                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, _buffer,
                     { TextAlignment::centre });
             }
         }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -369,7 +369,7 @@ namespace OpenRCT2::Ui::Windows
             auto screenPos = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_CONTENT_PANEL].left + 4, widgets[WIDX_CONTENT_PANEL].top + 4 };
 
-            drawText(rt, screenPos, STR_DEFAULT_GROUP, {}, { colours[2] });
+            drawText(rt, screenPos, STR_DEFAULT_GROUP, { colours[2] });
 
             screenPos.y += 20;
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -551,12 +551,12 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // ... source game ...
                     const auto sourceStringId = ObjectManagerGetSourceGameString(entry.Entry.GetSourceGame());
-                    drawText(rt, { kSourceColLeft - 3, screenCoords.y }, sourceStringId, {}, { Drawing::Colour::darkGreen });
+                    drawText(rt, { kSourceColLeft - 3, screenCoords.y }, sourceStringId, { Drawing::Colour::darkGreen });
                 }
 
                 // ... and type
                 const auto type = GetStringFromObjectType(entry.GetType());
-                drawText(rt, { kTypeColLeft - 3, screenCoords.y }, type, {}, { Drawing::Colour::darkGreen });
+                drawText(rt, { kTypeColLeft - 3, screenCoords.y }, type, { Drawing::Colour::darkGreen });
             }
         }
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -436,11 +436,9 @@ namespace OpenRCT2::Ui::Windows
                 thread_local std::string _buffer;
                 _buffer.assign("{WINDOW_COLOUR_2}");
                 _buffer += Network::GetGroupName(groupindex);
-                auto ft = Formatter();
-                ft.Add<const char*>(_buffer.c_str());
 
                 drawTextEllipsised(
-                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 9, _buffer,
                     { TextAlignment::centre });
             }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4200,7 +4200,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     if (stringId == STR_CALLING_MECHANIC || stringId == STR_NO_MECHANICS_ARE_HIRED_MESSAGE)
                     {
-                        drawTextWrapped(rt, screenCoords, 280, stringId, {}, { TextAlignment::left });
+                        drawTextWrapped(rt, screenCoords, 280, stringId, { TextAlignment::left });
                     }
                     else
                     {
@@ -5388,7 +5388,7 @@ namespace OpenRCT2::Ui::Windows
 
             // 'Tracks' caption
             auto trackLabelPos = windowPos + ScreenCoordsXY{ widgets[WIDX_MUSIC_DATA].left, widgets[WIDX_MUSIC_DATA].top - 13 };
-            drawTextWrapped(rt, trackLabelPos, width, STR_MUSIC_OBJECT_TRACK_HEADER, {}, { TextAlignment::left });
+            drawTextWrapped(rt, trackLabelPos, width, STR_MUSIC_OBJECT_TRACK_HEADER, { TextAlignment::left });
 
             // Do we have a preview image to draw?
             auto musicObj = ride->getMusicObject();
@@ -5759,8 +5759,7 @@ namespace OpenRCT2::Ui::Windows
                 Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
                 ScreenCoordsXY widgetCoords(windowPos.x + widget->midX(), windowPos.y + widget->top + 40);
-                drawTextWrapped(
-                    rt, widgetCoords, width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::centre });
+                drawTextWrapped(rt, widgetCoords, width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, { TextAlignment::centre });
 
                 widgetCoords.x = windowPos.x + 4;
                 widgetCoords.y = windowPos.y + widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1722,7 +1722,7 @@ namespace OpenRCT2::Ui::Windows
             // Draw cost
             screenCoords = { windowPos.x + widget->midX(), windowPos.y + widget->bottom - 23 };
             if (_rideConstructionState != RideConstructionState::Place)
-                drawText(rt, screenCoords, STR_BUILD_THIS, {}, { TextAlignment::centre });
+                drawText(rt, screenCoords, STR_BUILD_THIS, { TextAlignment::centre });
 
             screenCoords.y += 11;
             if (_currentTrackPrice != kMoney64Undefined && !(getGameState().park.flags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -365,10 +365,7 @@ namespace OpenRCT2::Ui::Windows
             if (Config::Get().general.debuggingTools)
             {
                 const auto shortPath = shortenPath(scenario->Path, width - 6 - kTabWidth, FontStyle::medium);
-
-                auto ft = Formatter();
-                ft.Add<utf8*>(shortPath.c_str());
-                drawText(rt, windowPos + ScreenCoordsXY{ kTabWidth + 3, height - 3 - 11 }, STR_STRING, ft, { colours[1] });
+                drawText(rt, windowPos + ScreenCoordsXY{ kTabWidth + 3, height - 3 - 11 }, shortPath, { colours[1] });
             }
 
             // Scenario name

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -345,7 +345,7 @@ namespace OpenRCT2::Ui::Windows
                     auto screenPos = windowPos
                         + ScreenCoordsXY{ widgets[WIDX_SCENARIOLIST].right + 4, widgets[WIDX_TABCONTENT].top + 5 };
                     drawTextEllipsised(
-                        rt, screenPos + ScreenCoordsXY{ previewPaneWidth / 2, 0 }, previewPaneWidth, STR_SCENARIO_LOCKED, {},
+                        rt, screenPos + ScreenCoordsXY{ previewPaneWidth / 2, 0 }, previewPaneWidth, STR_SCENARIO_LOCKED,
                         { TextAlignment::centre });
 
                     drawTextWrapped(rt, screenPos + ScreenCoordsXY{ 0, 15 }, previewPaneWidth, STR_SCENARIO_LOCKED_DESC);
@@ -648,7 +648,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw string
             int32_t centreX = (left + right) / 2;
-            drawText(rt, { centreX, y }, stringId, {}, { baseColour, TextAlignment::centre });
+            drawText(rt, { centreX, y }, stringId, { baseColour, TextAlignment::centre });
 
             // Get string dimensions
             utf8 buffer[512];

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -312,7 +312,7 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
 
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PLAYER_NAME_INPUT].top }, STR_PLAYER_NAME, {},
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PLAYER_NAME_INPUT].top }, STR_PLAYER_NAME,
                 { Drawing::Colour::white });
 
             // Draw version number

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -386,10 +386,8 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Finally, draw the server information.
-                auto ft = Formatter();
-                ft.Add<const char*>(serverInfoToShow);
                 drawTextEllipsised(
-                    rt, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, STR_STRING, ft, { colour });
+                    rt, screenCoords + ScreenCoordsXY{ 0, 3 }, spaceAvailableForInfo, serverInfoToShow, { colour });
 
                 int32_t right = listWidgetWidth - 7 - kScrollBarWidth;
 

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -237,15 +237,15 @@ namespace OpenRCT2::Ui::Windows
         void onDraw(Drawing::RenderTarget& rt) override
         {
             drawWidgets(rt);
-            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PORT_INPUT].top }, STR_PORT, {}, { colours[1] });
-            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_NAME_INPUT].top }, STR_SERVER_NAME, {}, { colours[1] });
+            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PORT_INPUT].top }, STR_PORT, { colours[1] });
+            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_NAME_INPUT].top }, STR_SERVER_NAME, { colours[1] });
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_DESCRIPTION_INPUT].top }, STR_SERVER_DESCRIPTION, {},
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_DESCRIPTION_INPUT].top }, STR_SERVER_DESCRIPTION,
                 { colours[1] });
             drawText(
-                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, {}, { colours[1] });
-            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PASSWORD_INPUT].top }, STR_PASSWORD, {}, { colours[1] });
-            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_MAXPLAYERS].top }, STR_MAX_PLAYERS, {}, { colours[1] });
+                rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_GREETING_INPUT].top }, STR_SERVER_GREETING, { colours[1] });
+            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PASSWORD_INPUT].top }, STR_PASSWORD, { colours[1] });
+            drawText(rt, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_MAXPLAYERS].top }, STR_MAX_PLAYERS, { colours[1] });
         }
 
     private:

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -207,9 +207,7 @@ namespace OpenRCT2::Ui::Windows
 
             if (_descriptionStringId == kStringIdNone)
             {
-                auto ft = Formatter();
-                ft.Add<const char*>(_description.c_str());
-                drawTextWrapped(rt, screenCoords, kWindowSize.width, STR_STRING, ft, { colours[1], TextAlignment::centre });
+                drawTextWrapped(rt, screenCoords, kWindowSize.width, _description, { colours[1], TextAlignment::centre });
             }
             else
             {

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -405,15 +405,13 @@ namespace OpenRCT2::Ui::Windows
 
                 size_t activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
                 const utf8* activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
-                auto ft = Formatter();
-                ft.Add<const utf8*>(activeThemeName);
 
                 auto screenPos = windowPos
                     + ScreenCoordsXY{ widgets[WIDX_THEMES_PRESETS].left + 1, widgets[WIDX_THEMES_PRESETS].top };
                 auto newWidth = windowPos.x + widgets[WIDX_THEMES_PRESETS_DROPDOWN].left - widgets[WIDX_THEMES_PRESETS].left
                     - 4;
 
-                drawTextEllipsised(rt, screenPos, newWidth, STR_STRING, ft, { colours[1] });
+                drawTextEllipsised(rt, screenPos, newWidth, activeThemeName, { colours[1] });
             }
         }
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -782,7 +782,7 @@ namespace OpenRCT2::Ui::Windows
                     for (uint8_t j = 0; j < numColours; j++)
                     {
                         drawTextWrapped(
-                            rt, { 2, screenCoords.y + 4 }, kWindowHeaderWidth, ThemeDescGetName(wc), {}, { colours[1] });
+                            rt, { 2, screenCoords.y + 4 }, kWindowHeaderWidth, ThemeDescGetName(wc), { colours[1] });
 
                         // Don't draw the empty row
                         if (emptyRow && j == 1)

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1141,7 +1141,7 @@ static uint64_t PageDisabledWidgets[] = {
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                               widgets[WIDX_SURFACE_SPINNER_HEIGHT].top };
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_SURFACE_SPINNER_HEIGHT].left + 3;
@@ -1153,7 +1153,7 @@ static uint64_t PageDisabledWidgets[] = {
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                               widgets[WIDX_SURFACE_CHECK_CORNER_E].top };
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_SURFACE_CORNERS, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_SURFACE_CORNERS, { colours[1] });
                         break;
                     }
                     case TileElementType::Path:
@@ -1209,7 +1209,7 @@ static uint64_t PageDisabledWidgets[] = {
                         else
                         {
                             drawText(
-                                rt, screenCoords + ScreenCoordsXY{ 0, 2 * 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS_NONE, {},
+                                rt, screenCoords + ScreenCoordsXY{ 0, 2 * 11 }, STR_TILE_INSPECTOR_PATH_ADDITIONS_NONE,
                                 { Drawing::Colour::white });
                         }
 
@@ -1217,7 +1217,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Raise / lower label
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7, widgets[WIDX_PATH_SPINNER_HEIGHT].top };
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_PATH_SPINNER_HEIGHT].left + 3;
@@ -1228,7 +1228,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Path connections
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7, widgets[WIDX_PATH_CHECK_EDGE_W].top };
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_PATH_CONNECTED_EDGES, { colours[1] });
                         break;
                     }
 
@@ -1299,7 +1299,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_TRACK_SPINNER_HEIGHT].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_TRACK_SPINNER_HEIGHT].left + 3;
@@ -1345,7 +1345,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Properties
                         // Raise / Lower
                         screenCoords.y = windowPos.y + widgets[WIDX_SCENERY_SPINNER_HEIGHT].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_SCENERY_SPINNER_HEIGHT].left + 3;
@@ -1357,11 +1357,11 @@ static uint64_t PageDisabledWidgets[] = {
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7,
                                               widgets[WIDX_SCENERY_CHECK_QUARTER_E].top };
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_SCENERY_QUADRANT_LABEL, { colours[1] });
 
                         // Collision
                         screenCoords.y = windowPos.y + widgets[WIDX_SCENERY_CHECK_COLLISION_E].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_COLLISSION, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_COLLISSION, { colours[1] });
                         break;
                     }
 
@@ -1432,7 +1432,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Properties
                         // Raise / Lower
                         screenCoords.y = windowPos.y + widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_ENTRANCE_SPINNER_HEIGHT].left + 3;
@@ -1463,14 +1463,14 @@ static uint64_t PageDisabledWidgets[] = {
                         else
                         {
                             drawText(
-                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
+                                rt, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE,
                                 { colours[1] });
                         }
 
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_WALL_SPINNER_HEIGHT].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_WALL_SPINNER_HEIGHT].left + 3;
@@ -1481,11 +1481,11 @@ static uint64_t PageDisabledWidgets[] = {
                         // Slope label
                         screenCoords = windowPos
                             + ScreenCoordsXY{ widgets[WIDX_GROUPBOX_DETAILS].left + 7, widgets[WIDX_WALL_DROPDOWN_SLOPE].top };
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_WALL_SLOPE, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_WALL_SLOPE, { colours[1] });
 
                         // Animation frame label
                         screenCoords.y = windowPos.y + widgets[WIDX_WALL_SPINNER_ANIMATION_FRAME].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME, { colours[1] });
 
                         // Current animation frame
                         auto colour = colours[1];
@@ -1535,14 +1535,14 @@ static uint64_t PageDisabledWidgets[] = {
                         else
                         {
                             drawText(
-                                rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE, {},
+                                rt, screenCoords + ScreenCoordsXY{ 0, 22 }, STR_TILE_INSPECTOR_ENTRY_BANNER_NONE,
                                 { colours[1] });
                         }
 
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_LARGE_SCENERY_SPINNER_HEIGHT].left + 3;
@@ -1567,7 +1567,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Properties
                         // Raise / lower label
                         screenCoords.y = windowPos.y + widgets[WIDX_BANNER_SPINNER_HEIGHT].top;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BASE_HEIGHT_FULL, { colours[1] });
 
                         // Current base height
                         screenCoords.x = windowPos.x + widgets[WIDX_BANNER_SPINNER_HEIGHT].left + 3;
@@ -1578,7 +1578,7 @@ static uint64_t PageDisabledWidgets[] = {
                         // Blocked paths
                         screenCoords.y += 28;
                         screenCoords.x = windowPos.x + widgets[WIDX_GROUPBOX_DETAILS].left + 7;
-                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, {}, { colours[1] });
+                        drawText(rt, screenCoords, STR_TILE_INSPECTOR_BANNER_BLOCKED_PATHS, { colours[1] });
                         break;
                     }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1425,7 +1425,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     auto colour = ColourWithFlags{ Drawing::Colour::darkOrange }.withFlag(ColourFlag::withOutline, true);
                     drawText(
-                        rt, screenPos + ScreenCoordsXY{ 26, 2 }, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED, {},
+                        rt, screenPos + ScreenCoordsXY{ 26, 2 }, STR_OVERLAY_CLEARANCE_CHECKS_DISABLED,
                         { colour, TextAlignment::right });
                 }
             }

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -482,10 +482,8 @@ namespace OpenRCT2::Ui::Windows
             if (Config::Get().general.debuggingTools)
             {
                 const auto shortPath = shortenPath(path, width, FontStyle::medium);
-                auto ft = Formatter();
-                ft.Add<utf8*>(shortPath.c_str());
                 drawText(
-                    rt, windowPos + ScreenCoordsXY{ 0, height - kDebugPathHeight - 3 }, STR_STRING, ft,
+                    rt, windowPos + ScreenCoordsXY{ 0, height - kDebugPathHeight - 3 }, shortPath,
                     { colours[1] }); // TODO Check dpi
             }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -529,7 +529,7 @@ namespace OpenRCT2::Ui::Windows
                 && gLegacyScene != LegacyScene::trackDesignsManager)
             {
                 // Vehicle design not available
-                drawTextEllipsised(rt, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, {}, { TextAlignment::centre });
+                drawTextEllipsised(rt, screenPos, 368, STR_VEHICLE_DESIGN_UNAVAILABLE, { TextAlignment::centre });
                 screenPos.y -= kScrollableRowHeight;
             }
 
@@ -539,7 +539,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Scenery not available
                     drawTextEllipsised(
-                        rt, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, {}, { TextAlignment::centre });
+                        rt, screenPos, 368, STR_DESIGN_INCLUDES_SCENERY_WHICH_IS_UNAVAILABLE, { TextAlignment::centre });
                     screenPos.y -= kScrollableRowHeight;
                 }
             }

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -295,7 +295,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Clip height value
             auto screenCoords = this->windowPos + ScreenCoordsXY{ 8, this->widgets[WIDX_CLIP_HEIGHT_VALUE].top };
-            drawText(rt, screenCoords, STR_VIEW_CLIPPING_HEIGHT_VALUE, {}, { this->colours[0] });
+            drawText(rt, screenCoords, STR_VIEW_CLIPPING_HEIGHT_VALUE, { this->colours[0] });
 
             screenCoords = this->windowPos
                 + ScreenCoordsXY{ this->widgets[WIDX_CLIP_HEIGHT_VALUE].left + 1, this->widgets[WIDX_CLIP_HEIGHT_VALUE].top };

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -192,11 +192,8 @@ void ChatDraw(RenderTarget& rt, ColourWithFlags chatBackgroundColor)
 
         screenCoords.y = _chatBottom - inputLineHeight - 5;
 
-        auto lineCh = lineBuffer.c_str();
-        auto ft = Formatter();
-        ft.Add<const char*>(lineCh);
         inputLineHeight = drawTextWrapped(
-            rt, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING, ft, { OpenRCT2::Drawing::kColourNull });
+            rt, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, lineBuffer, { OpenRCT2::Drawing::kColourNull });
         GfxSetDirtyBlocks({ screenCoords, { screenCoords + ScreenCoordsXY{ _chatWidth, inputLineHeight + 15 } } });
 
         // TODO: Show caret if the input text has multiple lines

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -97,7 +97,7 @@ namespace OpenRCT2
         if (_hasPreview)
             GfxDrawSprite(rt, ImageId(_previewImageId), { 0, 0 });
         else
-            drawText(rt, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::centre });
+            drawText(rt, { x, y }, STR_WINDOW_NO_IMAGE, { TextAlignment::centre });
     }
 
     bool MusicObject::HasPreview() const

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -63,7 +63,7 @@ namespace OpenRCT2
     {
         // Write (no image)
         auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-        drawText(rt, screenCoords, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::centre });
+        drawText(rt, screenCoords, STR_WINDOW_NO_IMAGE, { TextAlignment::centre });
     }
 
     void WaterObject::ReadJson([[maybe_unused]] IReadObjectContext* context, json_t& root)


### PR DESCRIPTION
- Replace calls with a string ID and an empty formatter with calls with just the string ID. This avoids an unnecessary run through the formatter.
- Replace calls with STR_STRING and a formatter with just a string with calls that pass the string directly.