### PR TITLE
Add support height to TED and use in trackPaintGeneric

### DIFF
--- a/src/openrct2/paint/track/TrackPaintGeneric.h
+++ b/src/openrct2/paint/track/TrackPaintGeneric.h
@@ -56,7 +56,7 @@ namespace OpenRCT2
         const uint64_t spriteMap,
         const std::array<std::array<std::array<BoundBoxXYZ, mapSpriteCount>, sequenceCount>, kNumOrthogonalDirections>&
             boundingBoxes,
-        const bool woodenSupports, const std::array<int8_t, sequenceCount>& supportHeights,
+        const bool woodenSupports,
         const std::array<std::array<int8_t, kNumOrthogonalDirections>, sequenceCount>& supportHeightExtras,
         const OpenRCT2::BlockedSegmentsType blockedSegmentsType, const TunnelGroup tunnelGroup,
         const std::array<int8_t, sequenceCount>& generalSupportHeights, const auto tunnelPaintFunction, const bool down,
@@ -97,8 +97,9 @@ namespace OpenRCT2
             {
                 const Direction supportRotation = (direction + sequenceDescriptor.extraSupportRotation) & 3;
                 WoodenASupportsPaintSetupRotated(
-                    session, supportType.wooden, sequenceDescriptor.woodenSupports.subType, supportRotation, height,
-                    session.SupportColours, sequenceDescriptor.woodenSupports.transitionType);
+                    session, supportType.wooden, sequenceDescriptor.woodenSupports.subType, supportRotation,
+                    height + sequenceDescriptor.woodenSupports.height, session.SupportColours,
+                    sequenceDescriptor.woodenSupports.transitionType);
             }
         }
         else
@@ -109,7 +110,7 @@ namespace OpenRCT2
                 MetalASupportsPaintSetupRotated(
                     session, supportType.metal, sequenceDescriptor.metalSupports.place, supportRotation,
                     supportHeightExtras[modifiedTrackSequence][modifiedDirection],
-                    height + supportHeights[modifiedTrackSequence], session.SupportColours);
+                    height + sequenceDescriptor.metalSupports.height, session.SupportColours);
             }
         }
 

--- a/src/openrct2/paint/track_pieces/QuarterHelix.cpp
+++ b/src/openrct2/paint/track_pieces/QuarterHelix.cpp
@@ -53,7 +53,6 @@ namespace OpenRCT2
         kLeftQuarterHelixLargeUpBoundingBoxes);
 
     const std::array<int8_t, kQuarterHelixSequenceCount> kQuarterHelixGeneralSupportHeights = { 32, 32, 32, 48, 48, 48, 48 };
-    const std::array<int8_t, kQuarterHelixSequenceCount> kQuarterHelixSupportHeights = { 0, 0, 0, 0, 0, 0, kCoordsZStep };
 
     void trackPaintLeftQuarterHelixTunnels(
         PaintSession& session, const uint8_t trackSequence, const Direction direction, const int32_t height,

--- a/src/openrct2/paint/track_pieces/QuarterHelix.h
+++ b/src/openrct2/paint/track_pieces/QuarterHelix.h
@@ -95,7 +95,6 @@ namespace OpenRCT2
     extern const QuarterHelixBoundingBoxes kRightQuarterHelixLargeUpBoundingBoxes;
 
     extern const std::array<int8_t, kQuarterHelixSequenceCount> kQuarterHelixGeneralSupportHeights;
-    extern const std::array<int8_t, kQuarterHelixSequenceCount> kQuarterHelixSupportHeights;
 
     void trackPaintLeftQuarterHelixTunnels(
         PaintSession& session, const uint8_t trackSequence, const Direction direction, const int32_t height,
@@ -114,9 +113,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, false,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, false, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -129,9 +128,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, false,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, false, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -144,9 +143,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, true,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, true, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -159,9 +158,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, true,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, true, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -174,9 +173,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, false,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, false, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -189,9 +188,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, false,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, false, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -204,9 +203,9 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, true,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintRightQuarterHelixTunnels, true, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
     template<
@@ -219,8 +218,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, kQuarterHelixSupportHeights, supportHeightExtras,
-            blockedSegmentsType, tunnelGroup, kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, true,
-            trackSupportColours>(session, ride, trackSequence, direction, height, trackElement, supportType);
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            kQuarterHelixGeneralSupportHeights, trackPaintLeftQuarterHelixTunnels, true, trackSupportColours>(
+            session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -1667,7 +1667,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0001,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = -1,
         .blockedSegments = { {
             EnumsToFlags(PS::bottom, PS::centre, PS::topLeft, PS::bottomRight, PS::bottomLeft, PS::left), // narrow
@@ -1724,7 +1724,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0001,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = 1,
         .blockedSegments = blockedSegmentsFlipXAxis(kLeftQuarterBankedHelixLargeUpSeq6.blockedSegments),
     };
@@ -1734,7 +1734,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0010,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = 2,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq0.blockedSegments,
         .reversedTrackSequence = 6,
@@ -1794,7 +1794,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b1000,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = 2,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq0.blockedSegments,
         .reversedTrackSequence = 6,
@@ -1901,7 +1901,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0001,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = -1,
         .blockedSegments = { {
             EnumsToFlags(PS::bottom, PS::centre, PS::topLeft, PS::bottomRight, PS::bottomLeft), // narrow
@@ -1958,7 +1958,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0001,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = 1,
         .blockedSegments = blockedSegmentsFlipXAxis(kLeftQuarterHelixLargeUpSeq6.blockedSegments),
     };
@@ -1968,7 +1968,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b0010,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = 2,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq0.blockedSegments,
         .reversedTrackSequence = 6,
@@ -2028,7 +2028,7 @@ namespace OpenRCT2::TrackMetadata
         .allowedWallEdges = 0b1000,
         .flags = { SequenceFlag::hasHeightMarker },
         .woodenSupports = { WoodenSupportSubType::neSw, WoodenSupportTransitionType::up25even },
-        .metalSupports = { MetalSupportPlace::centre },
+        .metalSupports = { MetalSupportPlace::centre, false, kCoordsZStep },
         .extraSupportRotation = 2,
         .blockedSegments = kRightQuarterHelixLargeUpSeq0.blockedSegments,
         .reversedTrackSequence = 6,

--- a/src/openrct2/ride/ted/TrackElementDescriptor.h
+++ b/src/openrct2/ride/ted/TrackElementDescriptor.h
@@ -206,12 +206,14 @@ namespace OpenRCT2::TrackMetadata
     {
         WoodenSupportSubType subType = WoodenSupportSubType::null;
         WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::none;
+        int8_t height = 0;
     };
 
     struct SequenceMetalSupport
     {
         MetalSupportPlace place = MetalSupportPlace::none;
         uint8_t alternates = false;
+        int8_t height = 0;
     };
 
     using BlockedSegmentsPerType = std::array<uint16_t, kBlockedSegmentsTypeCount>;


### PR DESCRIPTION
This adds base support heights for wooden and metal supports to the track sequence data, then uses it in `trackPaintGeneric`.
Only the data for the quarter helix pieces is filled in.
Removes the need for separate arrays of heights and removes another template argument.