### PR TITLE
Start reworking widgets into their own subtypes

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -48,7 +48,6 @@ namespace OpenRCT2::Ui
     static void WidgetProgressBarDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHorizontalSeparatorDraw(RenderTarget& rt, WindowBase& w, const Widget& widget);
     static void WidgetGroupboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCaptionDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetCheckboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetCloseboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetScrollDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
@@ -68,6 +67,12 @@ namespace OpenRCT2::Ui
         if (widget == nullptr)
         {
             LOG_ERROR("Tried drawing an out-of-bounds widget index!");
+            return;
+        }
+
+        if (widget->events.draw != nullptr)
+        {
+            widget->events.draw(rt, *widget, widgetIndex, w);
             return;
         }
 
@@ -108,9 +113,6 @@ namespace OpenRCT2::Ui
                 break;
             case WidgetType::groupbox:
                 WidgetGroupboxDraw(rt, w, widgetIndex);
-                break;
-            case WidgetType::caption:
-                WidgetCaptionDraw(rt, w, widgetIndex);
                 break;
             case WidgetType::closeBox:
                 WidgetCloseboxDraw(rt, w, widgetIndex);
@@ -530,74 +532,6 @@ namespace OpenRCT2::Ui
         // Border left
         Rectangle::fill(rt, { { l, t + 1 }, { l, b - 2 } }, getColourMap(colour).midDark);
         Rectangle::fill(rt, { { l + 1, t + 2 }, { l + 1, b - 2 } }, getColourMap(colour).lighter);
-    }
-
-    /**
-     *
-     *  rct2: 0x006EB2F9
-     */
-    static void WidgetCaptionDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
-    {
-        // Get the widget
-        const auto* widget = &w.widgets[widgetIndex];
-
-        // Resolve the absolute ltrb
-        auto topLeft = w.windowPos + ScreenCoordsXY{ widget->left, widget->top };
-        auto bottomRight = w.windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
-
-        auto colour = w.colours[widget->colour];
-
-        auto brightness = Rectangle::FillBrightness::light;
-        if (w.flags.has(WindowFlag::higherContrastOnPress))
-            brightness = Rectangle::FillBrightness::dark;
-
-        Rectangle::fillInset(
-            rt, { topLeft, bottomRight }, colour, Rectangle::BorderStyle::inset, brightness,
-            Rectangle::FillMode::dontLightenWhenInset);
-
-        // Black caption bars look slightly green, this fixes that
-        if (colour.colour == Drawing::Colour::black)
-            Rectangle::fill(
-                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
-                getColourMap(colour.colour).dark);
-        else
-            Rectangle::filter(
-                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
-                FilterPaletteID::paletteDarken3);
-
-        // Draw text
-        if (!widget->flags.has(WidgetFlag::textIsString) && widget->text == kStringIdNone)
-            return;
-
-        topLeft = w.windowPos + ScreenCoordsXY{ widget->left + 2, widget->top + 1 };
-        int32_t width = widget->width() - 5;
-
-        if (static_cast<size_t>(widgetIndex + 1) < w.widgets.size()
-            && (w.widgets[widgetIndex + 1]).type == WidgetType::closeBox)
-        {
-            width -= kCloseButtonSize;
-            if (static_cast<size_t>(widgetIndex + 2) < w.widgets.size()
-                && (w.widgets[widgetIndex + 2]).type == WidgetType::closeBox)
-                width -= kCloseButtonSize;
-        }
-        topLeft.x += width / 2;
-        if (Config::Get().interface.windowButtonsOnTheLeft)
-            topLeft.x += kCloseButtonSize;
-        if (Config::Get().interface.enlargedUi)
-            topLeft.y += kTitleHeightLarge / 4;
-
-        Formatter ft{};
-        bool hasStringPtr = widget->flags.has(WidgetFlag::textIsString);
-        auto formatString = widget->text;
-        if (hasStringPtr)
-        {
-            formatString = STR_STRING;
-            ft.Add<const utf8*>(widget->string);
-        }
-
-        drawTextEllipsised(
-            rt, topLeft, width, formatString, ft,
-            { ColourWithFlags{ Drawing::Colour::white }.withFlag(ColourFlag::withOutline, true), TextAlignment::centre });
     }
 
     /**

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -48,7 +48,6 @@ namespace OpenRCT2::Ui
     static void WidgetProgressBarDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHorizontalSeparatorDraw(RenderTarget& rt, WindowBase& w, const Widget& widget);
     static void WidgetGroupboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCheckboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetCloseboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetScrollDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHScrollbarDraw(
@@ -122,9 +121,6 @@ namespace OpenRCT2::Ui
                 break;
             case WidgetType::scroll:
                 WidgetScrollDraw(rt, w, widgetIndex);
-                break;
-            case WidgetType::checkbox:
-                WidgetCheckboxDraw(rt, w, widgetIndex);
                 break;
             case WidgetType::textBox:
                 WidgetTextBoxDraw(rt, w, widgetIndex);
@@ -555,56 +551,6 @@ namespace OpenRCT2::Ui
             colour.flags.set(ColourFlag::inset, true);
 
         drawText(rt, crossMidPoint, widget.string, { colour, TextAlignment::centre });
-    }
-
-    /**
-     *
-     *  rct2: 0x006EBAD9
-     */
-    static void WidgetCheckboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
-    {
-        // Get the widget
-        const auto& widget = w.widgets[widgetIndex];
-
-        // Resolve the absolute ltb
-        ScreenCoordsXY topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
-        ScreenCoordsXY bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
-        ScreenCoordsXY midLeft = { topLeft.x, (topLeft.y + bottomRight.y) / 2 };
-
-        auto colour = w.colours[widget.colour];
-
-        // checkbox
-        Rectangle::fillInset(
-            rt, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, Rectangle::BorderStyle::inset,
-            Rectangle::FillBrightness::light, Rectangle::FillMode::dontLightenWhenInset);
-
-        if (widgetIsDisabled(w, widgetIndex))
-        {
-            colour.flags.set(ColourFlag::inset, true);
-        }
-
-        // fill it when checkbox is pressed
-        if (widgetIsPressed(w, widgetIndex))
-        {
-            drawText(
-                rt, { midLeft - ScreenCoordsXY{ 0, 5 } }, kCheckMarkString,
-                { colour.withFlag(ColourFlag::translucent, false) });
-        }
-
-        // draw the text
-        if (widget.text == kStringIdNone)
-            return;
-
-        auto stringId = widget.text;
-        auto ft = Formatter();
-        if (widget.flags.has(WidgetFlag::textIsString))
-        {
-            stringId = STR_STRING;
-            ft.Add<utf8*>(widget.string);
-        }
-
-        drawTextEllipsised(
-            rt, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 15, stringId, ft, colour);
     }
 
     /**

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -54,7 +54,6 @@ namespace OpenRCT2::Ui
         RenderTarget& rt, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
     static void WidgetVScrollbarDraw(
         RenderTarget& rt, const ScrollArea& scroll, int32_t l, int32_t t, int32_t r, int32_t b, ColourWithFlags colour);
-    static void WidgetDrawImage(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
 
     /**
      *
@@ -62,7 +61,7 @@ namespace OpenRCT2::Ui
      */
     void widgetDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
     {
-        const auto* widget = getWidgetByIndex(w, widgetIndex);
+        auto* widget = getWidgetByIndex(w, widgetIndex);
         if (widget == nullptr)
         {
             LOG_ERROR("Tried drawing an out-of-bounds widget index!");
@@ -91,7 +90,6 @@ namespace OpenRCT2::Ui
                 break;
             case WidgetType::colourBtn:
             case WidgetType::trnBtn:
-            case WidgetType::tab:
                 WidgetTabDraw(rt, w, widgetIndex);
                 break;
             case WidgetType::flatBtn:
@@ -727,7 +725,7 @@ namespace OpenRCT2::Ui
      *
      *  rct2: 0x006EB951
      */
-    static void WidgetDrawImage(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
+    void WidgetDrawImage(RenderTarget& rt, const WindowBase& w, WidgetIndex widgetIndex)
     {
         // Get the widget
         const auto& widget = w.widgets[widgetIndex];
@@ -741,8 +739,10 @@ namespace OpenRCT2::Ui
         auto screenCoords = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
         if (widget.type == WidgetType::colourBtn || widget.type == WidgetType::trnBtn || widget.type == WidgetType::tab)
+        {
             if (widgetIsPressed(w, widgetIndex) || isToolActive(w, widgetIndex))
                 image = image.WithIndexOffset(1);
+        }
 
         const auto colour = w.colours[widget.colour].colour;
         if (widgetIsDisabled(w, widgetIndex))

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -48,7 +48,6 @@ namespace OpenRCT2::Ui
     static void WidgetProgressBarDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetHorizontalSeparatorDraw(RenderTarget& rt, WindowBase& w, const Widget& widget);
     static void WidgetGroupboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
-    static void WidgetCaptionDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetCheckboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetCloseboxDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
     static void WidgetScrollDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
@@ -73,6 +72,12 @@ namespace OpenRCT2::Ui
 
         if (!widget->isVisible())
             return;
+
+        if (widget->events.draw != nullptr)
+        {
+            widget->events.draw(rt, *widget, widgetIndex, w);
+            return;
+        }
 
         switch (widget->type)
         {
@@ -111,9 +116,6 @@ namespace OpenRCT2::Ui
                 break;
             case WidgetType::groupbox:
                 WidgetGroupboxDraw(rt, w, widgetIndex);
-                break;
-            case WidgetType::caption:
-                WidgetCaptionDraw(rt, w, widgetIndex);
                 break;
             case WidgetType::closeBox:
                 WidgetCloseboxDraw(rt, w, widgetIndex);
@@ -515,74 +517,6 @@ namespace OpenRCT2::Ui
         // Border left
         Rectangle::fill(rt, { { l, t + 1 }, { l, b - 2 } }, getColourMap(colour).midDark);
         Rectangle::fill(rt, { { l + 1, t + 2 }, { l + 1, b - 2 } }, getColourMap(colour).lighter);
-    }
-
-    /**
-     *
-     *  rct2: 0x006EB2F9
-     */
-    static void WidgetCaptionDraw(RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex)
-    {
-        // Get the widget
-        const auto* widget = &w.widgets[widgetIndex];
-
-        // Resolve the absolute ltrb
-        auto topLeft = w.windowPos + ScreenCoordsXY{ widget->left, widget->top };
-        auto bottomRight = w.windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
-
-        auto colour = w.colours[widget->colour];
-
-        auto brightness = Rectangle::FillBrightness::light;
-        if (w.flags.has(WindowFlag::higherContrastOnPress))
-            brightness = Rectangle::FillBrightness::dark;
-
-        Rectangle::fillInset(
-            rt, { topLeft, bottomRight }, colour, Rectangle::BorderStyle::inset, brightness,
-            Rectangle::FillMode::dontLightenWhenInset);
-
-        // Black caption bars look slightly green, this fixes that
-        if (colour.colour == Drawing::Colour::black)
-            Rectangle::fill(
-                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
-                getColourMap(colour.colour).dark);
-        else
-            Rectangle::filter(
-                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
-                FilterPaletteID::paletteDarken3);
-
-        // Draw text
-        if (!widget->flags.has(WidgetFlag::textIsString) && widget->text == kStringIdNone)
-            return;
-
-        topLeft = w.windowPos + ScreenCoordsXY{ widget->left + 2, widget->top + 1 };
-        int32_t width = widget->width() - 5;
-
-        if (static_cast<size_t>(widgetIndex + 1) < w.widgets.size()
-            && (w.widgets[widgetIndex + 1]).type == WidgetType::closeBox)
-        {
-            width -= kCloseButtonSize.width;
-            if (static_cast<size_t>(widgetIndex + 2) < w.widgets.size()
-                && (w.widgets[widgetIndex + 2]).type == WidgetType::closeBox)
-                width -= kCloseButtonSize.width;
-        }
-        topLeft.x += width / 2;
-        if (Config::Get().interface.windowButtonsOnTheLeft)
-            topLeft.x += kCloseButtonSize.width;
-        if (Config::Get().interface.enlargedUi)
-            topLeft.y += kTitleHeightLarge / 4;
-
-        Formatter ft{};
-        bool hasStringPtr = widget->flags.has(WidgetFlag::textIsString);
-        auto formatString = widget->text;
-        if (hasStringPtr)
-        {
-            formatString = STR_STRING;
-            ft.Add<const utf8*>(widget->string);
-        }
-
-        drawTextEllipsised(
-            rt, topLeft, width, formatString, ft,
-            { ColourWithFlags{ Drawing::Colour::white }.withFlag(ColourFlag::withOutline, true), TextAlignment::centre });
     }
 
     /**

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -12,6 +12,7 @@
 #include "Window.h"
 
 #include <openrct2-ui/UiStringIds.h>
+#include <openrct2-ui/widget/CaptionWidget.h>
 #include <openrct2/drawing/FilterPaletteIds.h>
 #include <openrct2/interface/Widget.h>
 
@@ -31,14 +32,6 @@ namespace OpenRCT2::Ui
     constexpr const char* kBlackRightArrowString = u8"{BLACK}▶";
     constexpr const char* kCheckMarkString = u8"✓";
     constexpr const char* kEyeString = u8"👁";
-
-    enum class WindowColour : uint8_t
-    {
-        primary,
-        secondary,
-        tertiary,
-        quaternary,
-    };
 
     constexpr Widget makeWidget(
         const ScreenCoordsXY& origin, const ScreenSize& size, WidgetType type, WindowColour colour,
@@ -175,11 +168,11 @@ namespace OpenRCT2::Ui
     constexpr std::array<Widget, 3> makeWindowShim(StringId title, ScreenSize size)
     {
         // clang-format off
-        std::array<Widget, 3> out = {
+        auto out = makeWidgets(
             makeWidget({ 0, 0 }, { size.width, size.height }, WidgetType::frame, WindowColour::primary),
-            makeWidget({ 1, 1 }, { size.width - 1, kTitleHeightNormal }, WidgetType::caption, WindowColour::primary, title, STR_WINDOW_TITLE_TIP),
-            makeWidget({ size.width - 12, 2 }, { 11, 11 }, WidgetType::closeBox, WindowColour::primary, kWidgetContentEmpty, STR_CLOSE_WINDOW_TIP),
-        };
+            OpenRCT2::Ui::Widgets::Caption({ 1, 1 }, { size.width - 1, kTitleHeightNormal }, WindowColour::primary, title),
+            makeWidget({ size.width - 12, 2 }, { 11, 11 }, WidgetType::closeBox, WindowColour::primary, kWidgetContentEmpty, STR_CLOSE_WINDOW_TIP)
+        );
         // clang-format on
 
         out[2].string = kCloseBoxStringBlackNormal;

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -24,7 +24,6 @@ namespace OpenRCT2::Ui
     constexpr uint32_t kWidgetContentEmpty = 0xFFFFFFFF;
     constexpr auto kBarBlink = (1u << 31);
     constexpr uint8_t kScrollBarWidth = 10;
-    constexpr ScreenSize kTabSize = { 31, 27 };
 
     constexpr const char* kBlackUpArrowString = u8"{BLACK}▲";
     constexpr const char* kBlackDownArrowString = u8"{BLACK}▼";
@@ -72,16 +71,6 @@ namespace OpenRCT2::Ui
         StringId tooltip = kStringIdNone)
     {
         return makeWidget(origin, size, type, colour, ImageId(content, Drawing::FilterPaletteID::paletteNull), tooltip);
-    }
-
-    constexpr Widget makeTab(const ScreenCoordsXY& origin, StringId tooltip = kStringIdNone)
-    {
-        const ScreenSize size = kTabSize;
-        const WidgetType type = WidgetType::tab;
-        const WindowColour colour = WindowColour::secondary;
-        const auto content = ImageId(kImageIndexUndefined);
-
-        return makeWidget(origin, size, type, colour, content, tooltip);
     }
 
     constexpr Widget withFlag(Widget w, WidgetFlag flag)
@@ -265,6 +254,7 @@ namespace OpenRCT2::Ui
     };
 
     void widgetDraw(Drawing::RenderTarget& rt, WindowBase& w, WidgetIndex widgetIndex);
+    void WidgetDrawImage(Drawing::RenderTarget& rt, const WindowBase& w, WidgetIndex widgetIndex);
 
     bool widgetIsDisabled(const WindowBase& w, WidgetIndex widgetIndex);
     bool widgetIsHoldable(const WindowBase& w, WidgetIndex widgetIndex);

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -11,6 +11,7 @@
 
 #include <initializer_list>
 #include <openrct2-ui/UiStringIds.h>
+#include <openrct2-ui/widget/CaptionWidget.h>
 #include <openrct2/drawing/FilterPaletteIds.h>
 #include <openrct2/interface/Widget.h>
 #include <openrct2/interface/WindowBase.h>
@@ -31,14 +32,6 @@ namespace OpenRCT2::Ui
     constexpr const char* kBlackRightArrowString = u8"{BLACK}▶";
     constexpr const char* kCheckMarkString = u8"✓";
     constexpr const char* kEyeString = u8"👁";
-
-    enum class WindowColour : uint8_t
-    {
-        primary,
-        secondary,
-        tertiary,
-        quaternary,
-    };
 
     constexpr Widget makeWidget(
         const ScreenCoordsXY& origin, const ScreenSize& size, WidgetType type, WindowColour colour,
@@ -188,11 +181,11 @@ namespace OpenRCT2::Ui
     constexpr std::array<Widget, 3> makeWindowShim(StringId title, ScreenSize size)
     {
         // clang-format off
-        std::array<Widget, 3> out = {
+        auto out = makeWidgets(
             makeWidget({ 0, 0 }, { size.width, size.height }, WidgetType::frame, WindowColour::primary),
-            makeWidget({ 1, 1 }, { size.width - 1, kTitleHeightNormal }, WidgetType::caption, WindowColour::primary, title, STR_WINDOW_TITLE_TIP),
-            makeWidget({ size.width - kCloseButtonSize.width, 2 }, kCloseButtonSize, WidgetType::closeBox, WindowColour::primary, kWidgetContentEmpty, STR_CLOSE_WINDOW_TIP),
-        };
+            Widgets::Caption({ 1, 1 }, { size.width - 1, kTitleHeightNormal }, WindowColour::primary, title, STR_WINDOW_TITLE_TIP),
+            makeWidget({ size.width - kCloseButtonSize.width, 2 }, kCloseButtonSize, WidgetType::closeBox, WindowColour::primary, kWidgetContentEmpty, STR_CLOSE_WINDOW_TIP)
+        );
         // clang-format on
 
         out[2].string = kCloseBoxStringBlackNormal;

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -96,6 +96,7 @@
     <ClInclude Include="scripting\ScWidget.hpp" />
     <ClInclude Include="scripting\ScWindow.hpp" />
     <ClInclude Include="scripting\UiExtensions.h" />
+    <ClInclude Include="widget\CaptionWidget.h" />
     <ClInclude Include="ProvisionalElements.h" />
     <ClInclude Include="SDLException.h" />
     <ClInclude Include="TextComposition.h" />
@@ -166,6 +167,7 @@
     <ClCompile Include="UiContext.Linux.cpp" />
     <ClCompile Include="UiContext.Win32.cpp" />
     <ClCompile Include="WindowManager.cpp" />
+    <ClCompile Include="widget\CaptionWidget.cpp" />
     <ClCompile Include="windows\About.cpp" />
     <ClCompile Include="windows\AssetPacks.cpp" />
     <ClCompile Include="windows\Banner.cpp" />

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -98,6 +98,7 @@
     <ClInclude Include="scripting\UiExtensions.h" />
     <ClInclude Include="widget\CaptionWidget.h" />
     <ClInclude Include="widget\CheckboxWidget.h" />
+    <ClInclude Include="widget\TabWidget.h" />
     <ClInclude Include="ProvisionalElements.h" />
     <ClInclude Include="SDLException.h" />
     <ClInclude Include="TextComposition.h" />
@@ -171,6 +172,7 @@
     <ClCompile Include="WindowManager.cpp" />
     <ClCompile Include="widget\CaptionWidget.cpp" />
     <ClCompile Include="widget\CheckboxWidget.cpp" />
+    <ClCompile Include="widget\TabWidget.cpp" />
     <ClCompile Include="windows\About.cpp" />
     <ClCompile Include="windows\AssetPacks.cpp" />
     <ClCompile Include="windows\Banner.cpp" />

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -96,6 +96,7 @@
     <ClInclude Include="scripting\ScWindow.h" />
     <ClInclude Include="scripting\ScWindow.hpp" />
     <ClInclude Include="scripting\UiExtensions.h" />
+    <ClInclude Include="widget\CaptionWidget.h" />
     <ClInclude Include="ProvisionalElements.h" />
     <ClInclude Include="SDLException.h" />
     <ClInclude Include="TextComposition.h" />
@@ -167,6 +168,7 @@
     <ClCompile Include="UiContext.Linux.cpp" />
     <ClCompile Include="UiContext.Win32.cpp" />
     <ClCompile Include="WindowManager.cpp" />
+    <ClCompile Include="widget\CaptionWidget.cpp" />
     <ClCompile Include="windows\About.cpp" />
     <ClCompile Include="windows\AssetPacks.cpp" />
     <ClCompile Include="windows\Banner.cpp" />

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -97,6 +97,7 @@
     <ClInclude Include="scripting\ScWindow.hpp" />
     <ClInclude Include="scripting\UiExtensions.h" />
     <ClInclude Include="widget\CaptionWidget.h" />
+    <ClInclude Include="widget\CheckboxWidget.h" />
     <ClInclude Include="ProvisionalElements.h" />
     <ClInclude Include="SDLException.h" />
     <ClInclude Include="TextComposition.h" />
@@ -169,6 +170,7 @@
     <ClCompile Include="UiContext.Win32.cpp" />
     <ClCompile Include="WindowManager.cpp" />
     <ClCompile Include="widget\CaptionWidget.cpp" />
+    <ClCompile Include="widget\CheckboxWidget.cpp" />
     <ClCompile Include="windows\About.cpp" />
     <ClCompile Include="windows\AssetPacks.cpp" />
     <ClCompile Include="windows\Banner.cpp" />

--- a/src/openrct2-ui/widget/CaptionWidget.cpp
+++ b/src/openrct2-ui/widget/CaptionWidget.cpp
@@ -1,0 +1,82 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "CaptionWidget.h"
+
+#include <openrct2/config/Config.h>
+#include <openrct2/drawing/ColourMap.h>
+#include <openrct2/drawing/Rectangle.h>
+#include <openrct2/drawing/Text.h>
+#include <openrct2/localisation/StringIds.h>
+
+using namespace OpenRCT2::Drawing;
+
+namespace OpenRCT2::Ui::Widgets
+{
+    void Caption::draw(Drawing::RenderTarget& rt, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
+    {
+        // Resolve the absolute ltrb
+        auto topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+        auto bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
+
+        auto colour = w.colours[widget.colour];
+
+        auto brightness = Drawing::Rectangle::FillBrightness::light;
+        if (w.flags.has(WindowFlag::higherContrastOnPress))
+            brightness = Rectangle::FillBrightness::dark;
+
+        Rectangle::fillInset(
+            rt, { topLeft, bottomRight }, colour, Rectangle::BorderStyle::inset, brightness,
+            Rectangle::FillMode::dontLightenWhenInset);
+
+        // Black caption bars look slightly green, this fixes that
+        if (colour.colour == Drawing::Colour::black)
+            Rectangle::fill(
+                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+                getColourMap(colour.colour).dark);
+        else
+            Rectangle::filter(
+                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+                FilterPaletteID::paletteDarken3);
+
+        // Draw text
+        if (!widget.flags.has(WidgetFlag::textIsString) && widget.text == kStringIdNone)
+            return;
+
+        topLeft = w.windowPos + ScreenCoordsXY{ widget.left + 2, widget.top + 1 };
+        int32_t width = widget.width() - 5;
+
+        if (static_cast<size_t>(widgetIndex + 1) < w.widgets.size()
+            && (w.widgets[widgetIndex + 1]).type == WidgetType::closeBox)
+        {
+            width -= kCloseButtonSize;
+            if (static_cast<size_t>(widgetIndex + 2) < w.widgets.size()
+                && (w.widgets[widgetIndex + 2]).type == WidgetType::closeBox)
+                width -= kCloseButtonSize;
+        }
+        topLeft.x += width / 2;
+        if (Config::Get().interface.windowButtonsOnTheLeft)
+            topLeft.x += kCloseButtonSize;
+        if (Config::Get().interface.enlargedUi)
+            topLeft.y += kTitleHeightLarge / 4;
+
+        Formatter ft{};
+        bool hasStringPtr = widget.flags.has(WidgetFlag::textIsString);
+        auto formatString = widget.text;
+        if (hasStringPtr)
+        {
+            formatString = STR_STRING;
+            ft.Add<const utf8*>(widget.string);
+        }
+
+        drawTextEllipsised(
+            rt, topLeft, width, formatString, ft,
+            { ColourWithFlags{ Drawing::Colour::white }.withFlag(ColourFlag::withOutline, true), TextAlignment::centre });
+    }
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/CaptionWidget.cpp
+++ b/src/openrct2-ui/widget/CaptionWidget.cpp
@@ -20,7 +20,7 @@ using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2::Ui::Widgets
 {
-    void Caption::draw(Drawing::RenderTarget& rt, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
+    void Caption::draw(Drawing::RenderTarget& rt, Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
     {
         // Resolve the absolute ltrb
         auto topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };

--- a/src/openrct2-ui/widget/CaptionWidget.cpp
+++ b/src/openrct2-ui/widget/CaptionWidget.cpp
@@ -1,0 +1,83 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "CaptionWidget.h"
+
+#include <openrct2/config/Config.h>
+#include <openrct2/drawing/ColourMap.h>
+#include <openrct2/drawing/FilterPaletteIds.h>
+#include <openrct2/drawing/Rectangle.h>
+#include <openrct2/drawing/Text.h>
+#include <openrct2/localisation/StringIds.h>
+
+using namespace OpenRCT2::Drawing;
+
+namespace OpenRCT2::Ui::Widgets
+{
+    void Caption::draw(Drawing::RenderTarget& rt, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
+    {
+        // Resolve the absolute ltrb
+        auto topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+        auto bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
+
+        auto colour = w.colours[widget.colour];
+
+        auto brightness = Rectangle::FillBrightness::light;
+        if (w.flags.has(WindowFlag::higherContrastOnPress))
+            brightness = Rectangle::FillBrightness::dark;
+
+        Rectangle::fillInset(
+            rt, { topLeft, bottomRight }, colour, Rectangle::BorderStyle::inset, brightness,
+            Rectangle::FillMode::dontLightenWhenInset);
+
+        // Black caption bars look slightly green, this fixes that
+        if (colour.colour == Drawing::Colour::black)
+            Rectangle::fill(
+                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+                getColourMap(colour.colour).dark);
+        else
+            Rectangle::filter(
+                rt, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+                FilterPaletteID::paletteDarken3);
+
+        // Draw text
+        if (!widget.flags.has(WidgetFlag::textIsString) && widget.text == kStringIdNone)
+            return;
+
+        topLeft = w.windowPos + ScreenCoordsXY{ widget.left + 2, widget.top + 1 };
+        int32_t width = widget.width() - 5;
+
+        if (static_cast<size_t>(widgetIndex + 1) < w.widgets.size()
+            && (w.widgets[widgetIndex + 1]).type == WidgetType::closeBox)
+        {
+            width -= kCloseButtonSize.width;
+            if (static_cast<size_t>(widgetIndex + 2) < w.widgets.size()
+                && (w.widgets[widgetIndex + 2]).type == WidgetType::closeBox)
+                width -= kCloseButtonSize.width;
+        }
+        topLeft.x += width / 2;
+        if (Config::Get().interface.windowButtonsOnTheLeft)
+            topLeft.x += kCloseButtonSize.width;
+        if (Config::Get().interface.enlargedUi)
+            topLeft.y += kTitleHeightLarge / 4;
+
+        Formatter ft{};
+        bool hasStringPtr = widget.flags.has(WidgetFlag::textIsString);
+        auto formatString = widget.text;
+        if (hasStringPtr)
+        {
+            formatString = STR_STRING;
+            ft.Add<const utf8*>(widget.string);
+        }
+
+        drawTextEllipsised(
+            rt, topLeft, width, formatString, ft,
+            { ColourWithFlags{ Drawing::Colour::white }.withFlag(ColourFlag::withOutline, true), TextAlignment::centre });
+    }
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/CaptionWidget.h
+++ b/src/openrct2-ui/widget/CaptionWidget.h
@@ -1,0 +1,34 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <openrct2-ui/interface/Window.h>
+#include <openrct2/drawing/FilterPaletteIds.h>
+#include <openrct2/interface/Widget.h>
+
+namespace OpenRCT2::Ui::Widgets
+{
+    struct Caption : Widget
+    {
+        static constexpr auto kWidgetType = WidgetType::caption;
+
+        constexpr Caption(
+            ScreenCoordsXY origin, ScreenSize size, WindowColour colour, StringId content = kStringIdNone,
+            StringId tooltip = kStringIdNone)
+            : Widget(origin, size, kWidgetType, colour, content, tooltip)
+        {
+            events.draw = &draw;
+        }
+
+        static void draw(
+            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window);
+    };
+
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/CaptionWidget.h
+++ b/src/openrct2-ui/widget/CaptionWidget.h
@@ -20,9 +20,9 @@ namespace OpenRCT2::Ui::Widgets
         static constexpr auto kWidgetType = WidgetType::caption;
 
         constexpr Caption(
-            ScreenCoordsXY origin, ScreenSize size, WindowColour colour, StringId content = kStringIdNone,
-            StringId tooltip = kStringIdNone)
-            : Widget(origin, size, kWidgetType, colour, content, tooltip)
+            ScreenCoordsXY origin, ScreenSize size, WindowColour colour_, StringId content_ = kStringIdNone,
+            StringId tooltip_ = kStringIdNone)
+            : Widget(origin, size, kWidgetType, colour_, content_, tooltip_)
         {
             events.draw = &draw;
         }

--- a/src/openrct2-ui/widget/CaptionWidget.h
+++ b/src/openrct2-ui/widget/CaptionWidget.h
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <openrct2-ui/interface/Window.h>
+
+namespace OpenRCT2::Ui::Widgets
+{
+    struct Caption : Widget
+    {
+        static constexpr auto kWidgetType = WidgetType::caption;
+
+        constexpr Caption(
+            ScreenCoordsXY origin, ScreenSize size, WindowColour colour_, StringId content_ = kStringIdNone,
+            StringId tooltip_ = kStringIdNone)
+            : Widget(origin, size, kWidgetType, colour_, content_, tooltip_)
+        {
+            events.draw = &draw;
+        }
+
+        static void draw(
+            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window);
+    };
+
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/CaptionWidget.h
+++ b/src/openrct2-ui/widget/CaptionWidget.h
@@ -26,7 +26,7 @@ namespace OpenRCT2::Ui::Widgets
         }
 
         static void draw(
-            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window);
+            Drawing::RenderTarget& RenderTarget, Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window);
     };
 
 } // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/CheckboxWidget.cpp
+++ b/src/openrct2-ui/widget/CheckboxWidget.cpp
@@ -20,7 +20,7 @@ using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2::Ui::Widgets
 {
-    void Checkbox::draw(Drawing::RenderTarget& rt, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
+    void Checkbox::draw(Drawing::RenderTarget& rt, Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
     {
         // Resolve the absolute ltb
         ScreenCoordsXY topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };

--- a/src/openrct2-ui/widget/CheckboxWidget.cpp
+++ b/src/openrct2-ui/widget/CheckboxWidget.cpp
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "CheckboxWidget.h"
+
+#include <openrct2-ui/interface/Widget.h>
+#include <openrct2/config/Config.h>
+#include <openrct2/drawing/ColourMap.h>
+#include <openrct2/drawing/Rectangle.h>
+#include <openrct2/drawing/Text.h>
+#include <openrct2/localisation/StringIds.h>
+
+using namespace OpenRCT2::Drawing;
+
+namespace OpenRCT2::Ui::Widgets
+{
+    void Checkbox::draw(Drawing::RenderTarget& rt, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
+    {
+        // Resolve the absolute ltb
+        ScreenCoordsXY topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+        ScreenCoordsXY bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
+        ScreenCoordsXY midLeft = { topLeft.x, (topLeft.y + bottomRight.y) / 2 };
+
+        auto colour = w.colours[widget.colour];
+
+        // checkbox
+        Rectangle::fillInset(
+            rt, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, Rectangle::BorderStyle::inset,
+            Rectangle::FillBrightness::light, Rectangle::FillMode::dontLightenWhenInset);
+
+        if (widgetIsDisabled(w, widgetIndex))
+        {
+            colour.flags.set(ColourFlag::inset, true);
+        }
+
+        // fill it when checkbox is pressed
+        if (widgetIsPressed(w, widgetIndex))
+        {
+            drawText(
+                rt, { midLeft - ScreenCoordsXY{ 0, 5 } }, kCheckMarkString,
+                { colour.withFlag(ColourFlag::translucent, false) });
+        }
+
+        // draw the text
+        if (widget.text == kStringIdNone)
+            return;
+
+        auto stringId = widget.text;
+        auto ft = Formatter();
+        if (widget.flags.has(WidgetFlag::textIsString))
+        {
+            stringId = STR_STRING;
+            ft.Add<utf8*>(widget.string);
+        }
+
+        drawTextEllipsised(
+            rt, w.windowPos + ScreenCoordsXY{ widget.left + 14, widget.textTop() }, widget.width() - 15, stringId, ft, colour);
+    }
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/CheckboxWidget.h
+++ b/src/openrct2-ui/widget/CheckboxWidget.h
@@ -1,0 +1,34 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <openrct2-ui/interface/Window.h>
+#include <openrct2/drawing/FilterPaletteIds.h>
+#include <openrct2/interface/Widget.h>
+
+namespace OpenRCT2::Ui::Widgets
+{
+    struct Checkbox : Widget
+    {
+        static constexpr auto kWidgetType = WidgetType::checkbox;
+
+        constexpr Checkbox(
+            ScreenCoordsXY origin, ScreenSize size, WindowColour colour_, StringId content_ = kStringIdNone,
+            StringId tooltip_ = kStringIdNone)
+            : Widget(origin, size, kWidgetType, colour_, content_, tooltip_)
+        {
+            events.draw = &draw;
+        }
+
+        static void draw(
+            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window);
+    };
+
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/TabWidget.cpp
+++ b/src/openrct2-ui/widget/TabWidget.cpp
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "TabWidget.h"
+
+#include <openrct2-ui/interface/Widget.h>
+#include <openrct2/SpriteIds.h>
+#include <openrct2/drawing/ColourMap.h>
+#include <openrct2/drawing/Drawing.h>
+#include <openrct2/drawing/FilterPaletteIds.h>
+#include <openrct2/localisation/StringIds.h>
+
+using namespace OpenRCT2::Drawing;
+
+namespace OpenRCT2::Ui::Widgets
+{
+    void Tab::draw(Drawing::RenderTarget& rt, Widget& widget, const WidgetIndex widgetIndex, const WindowBase& w)
+    {
+        if (widgetIsDisabled(w, widgetIndex))
+            return;
+
+        // TODO: old hack, remove
+        if (widget.image.GetIndex() == kImageIndexUndefined)
+        {
+            // Set standard tab sprite to use.
+            widget.image = ImageId(SPR_TAB, FilterPaletteID::paletteNull);
+        }
+
+        WidgetDrawImage(rt, w, widgetIndex);
+    }
+} // namespace OpenRCT2::Ui::Widgets

--- a/src/openrct2-ui/widget/TabWidget.h
+++ b/src/openrct2-ui/widget/TabWidget.h
@@ -13,14 +13,14 @@
 
 namespace OpenRCT2::Ui::Widgets
 {
-    struct Checkbox : Widget
-    {
-        static constexpr auto kWidgetType = WidgetType::checkbox;
+    constexpr ScreenSize kTabSize = { 31, 27 };
 
-        constexpr Checkbox(
-            ScreenCoordsXY origin, ScreenSize size, WindowColour colour_, StringId content_ = kStringIdNone,
-            StringId tooltip_ = kStringIdNone)
-            : Widget(origin, size, kWidgetType, colour_, content_, tooltip_)
+    struct Tab : Widget
+    {
+        static constexpr auto kWidgetType = WidgetType::tab;
+
+        constexpr Tab(ScreenCoordsXY origin, StringId tooltip_ = kStringIdNone)
+            : Widget(origin, kTabSize, kWidgetType, WindowColour::secondary, kImageIndexUndefined, tooltip_)
         {
             events.draw = &draw;
         }

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -222,13 +223,13 @@ static constexpr int32_t kTabStart = 3;
 static constexpr auto kMainCheatWidgets = makeWidgets(
     makeWindowShim(kWindowTitle, kWindowSize),
     makeWidget({  0, 43}, {kWindowSize.width, 257}, WidgetType::resize, WindowColour::secondary), /* tab content panel */
-    makeTab   ({  3, 17}, STR_FINANCIAL_CHEATS_TIP                      ), /* tab 1 */
-    makeTab   ({ 34, 17}, STR_DATE_CHEATS_TIP                           ), /* tab 2 */
-    makeTab   ({ 65, 17}, STR_GUEST_CHEATS_TIP                          ), /* tab 3 */
-    makeTab   ({ 96, 17}, STR_STAFF_CHEATS_TIP                          ), /* tab 5 */
-    makeTab   ({127, 17}, STR_PARK_CHEATS_TIP                           ), /* tab 6 */
-    makeTab   ({158, 17}, STR_RIDE_CHEATS_TIP                           ), /* tab 4 */
-    makeTab   ({189, 17}, STR_WEATHER_NATURE_CHEATS_TIP                 )  /* tab 7 */
+    Widgets::Tab({  3, 17}, STR_FINANCIAL_CHEATS_TIP                      ), /* tab 1 */
+    Widgets::Tab({ 34, 17}, STR_DATE_CHEATS_TIP                           ), /* tab 2 */
+    Widgets::Tab({ 65, 17}, STR_GUEST_CHEATS_TIP                          ), /* tab 3 */
+    Widgets::Tab({ 96, 17}, STR_STAFF_CHEATS_TIP                          ), /* tab 5 */
+    Widgets::Tab({127, 17}, STR_PARK_CHEATS_TIP                           ), /* tab 6 */
+    Widgets::Tab({158, 17}, STR_RIDE_CHEATS_TIP                           ), /* tab 4 */
+    Widgets::Tab({189, 17}, STR_WEATHER_NATURE_CHEATS_TIP                 )  /* tab 7 */
 );
 
 static constexpr auto window_cheats_money_widgets = makeWidgets(

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -232,7 +233,7 @@ static constexpr auto kMainCheatWidgets = makeWidgets(
 
 static constexpr auto window_cheats_money_widgets = makeWidgets(
     kMainCheatWidgets,
-    makeWidget                ({ 11,  48}, kCheatButtonSize,  WidgetType::checkbox, WindowColour::secondary, STR_MAKE_PARK_NO_MONEY), // No money
+    Widgets::Checkbox         ({ 11,  48}, kCheatButtonSize,                        WindowColour::secondary, STR_MAKE_PARK_NO_MONEY), // No money
     makeWidget                ({  5,  69}, {238, 69},         WidgetType::groupbox, WindowColour::secondary, STR_ADD_SET_MONEY     ), // add / set money group frame
     makeHoldableSpinnerWidgets({ 11,  92}, kCheatSpinnerSize, WidgetType::spinner,  WindowColour::secondary                ), // money value
     makeHoldableWidget        ({ 11, 111}, kCheatButtonSize,  WidgetType::button,   WindowColour::secondary, STR_ADD_MONEY         ), // add money
@@ -279,11 +280,11 @@ static constexpr auto window_cheats_guests_widgets = makeWidgets(
     makeWidget({ 11, 300+15+6-3}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_SHOP_ITEM_PLURAL_BALLOON                                    ), // give guests balloons
     makeWidget({127, 300+15+6-3}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_SHOP_ITEM_PLURAL_UMBRELLA                                   ), // give guests umbrellas
 
-    makeWidget({  5, 342+6}, {238,  85},        WidgetType::groupbox, WindowColour::secondary, STR_GUEST_BEHAVIOUR                                             ), // Guests behaviour group frame
-    makeWidget({ 11, 363+1}, kCheatCheckSize,   WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_IGNORE_INTENSITY,      STR_CHEAT_IGNORE_INTENSITY_TIP ), // guests ignore intensity
-    makeWidget({ 11, 380+1}, kCheatCheckSize,   WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_IGNORE_PRICE,          STR_CHEAT_IGNORE_PRICE_TIP     ), // guests ignore price
-    makeWidget({ 11, 397+1}, kCheatCheckSize,   WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_VANDALISM,     STR_CHEAT_DISABLE_VANDALISM_TIP), // disable vandalism
-    makeWidget({ 11, 414+1}, kCheatCheckSize,   WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_LITTERING,     STR_CHEAT_DISABLE_LITTERING_TIP)  // disable littering
+    makeWidget({  5, 342+6}, {238,  85},             WidgetType::groupbox, WindowColour::secondary, STR_GUEST_BEHAVIOUR                                             ), // Guests behaviour group frame
+    Widgets::Checkbox({ 11, 363+1}, kCheatCheckSize,                       WindowColour::secondary, STR_CHEAT_IGNORE_INTENSITY,      STR_CHEAT_IGNORE_INTENSITY_TIP ), // guests ignore intensity
+    Widgets::Checkbox({ 11, 380+1}, kCheatCheckSize,                       WindowColour::secondary, STR_CHEAT_IGNORE_PRICE,          STR_CHEAT_IGNORE_PRICE_TIP     ), // guests ignore price
+    Widgets::Checkbox({ 11, 397+1}, kCheatCheckSize,                       WindowColour::secondary, STR_CHEAT_DISABLE_VANDALISM,     STR_CHEAT_DISABLE_VANDALISM_TIP), // disable vandalism
+    Widgets::Checkbox({ 11, 414+1}, kCheatCheckSize,                       WindowColour::secondary, STR_CHEAT_DISABLE_LITTERING,     STR_CHEAT_DISABLE_LITTERING_TIP)  // disable littering
 );
 
 static constexpr auto window_cheats_staff_widgets = makeWidgets(
@@ -298,8 +299,8 @@ static constexpr auto window_cheats_staff_widgets = makeWidgets(
     makeWidget                ({ 11, 292-168}, kCheatButtonSize, WidgetType::button,       WindowColour::secondary, STR_CHEAT_CLEAR_GRASS                                           ), // Clear grass
     makeWidget                ({127, 292-168}, kCheatButtonSize, WidgetType::button,       WindowColour::secondary, STR_CHEAT_MOWED_GRASS                                           ), // Mowed grass
     makeWidget                ({ 11, 313-168}, kCheatButtonSize, WidgetType::button,       WindowColour::secondary, STR_CHEAT_WATER_PLANTS                                          ), // Water plants
-    makeWidget                ({ 11, 334-164}, kCheatCheckSize,  WidgetType::checkbox,     WindowColour::secondary, STR_CHEAT_DISABLE_PLANT_AGING, STR_CHEAT_DISABLE_PLANT_AGING_TIP),  // Disable plant ageing
-    makeWidget                ({ 11, 351-164}, kCheatCheckSize,  WidgetType::checkbox,     WindowColour::secondary, STR_CHEAT_DISABLE_GRASS_GROWING, STR_CHEAT_DISABLE_GRASS_GROWING_TIP)  // Disable grass growing
+    Widgets::Checkbox         ({ 11, 334-164}, kCheatCheckSize,                            WindowColour::secondary, STR_CHEAT_DISABLE_PLANT_AGING, STR_CHEAT_DISABLE_PLANT_AGING_TIP),  // Disable plant ageing
+    Widgets::Checkbox         ({ 11, 351-164}, kCheatCheckSize,                            WindowColour::secondary, STR_CHEAT_DISABLE_GRASS_GROWING, STR_CHEAT_DISABLE_GRASS_GROWING_TIP)  // Disable grass growing
 );
 
 static constexpr auto window_cheats_park_widgets = makeWidgets(
@@ -310,16 +311,16 @@ static constexpr auto window_cheats_park_widgets = makeWidgets(
     makeWidget                ({ 11,  83}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_CHEAT_OPEN_PARK,                    STR_CHEAT_OPEN_PARK_TIP                   ), // open / close park
 
     makeWidget                ({  5, 113}, {238,  75},       WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_OBJECTIVE_GROUP                                                         ), // Objective group
-    makeWidget                ({ 11, 128}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_NEVERENDING_MARKETING,        STR_CHEAT_NEVERENDING_MARKETING_TIP       ), // never ending marketing campaigns
-    makeWidget                ({ 11, 145}, {281,  12},       WidgetType::checkbox, WindowColour::secondary, STR_FORCE_PARK_RATING                                                             ), // Force park rating
+    Widgets::Checkbox         ({ 11, 128}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_NEVERENDING_MARKETING,        STR_CHEAT_NEVERENDING_MARKETING_TIP       ), // never ending marketing campaigns
+    Widgets::Checkbox         ({ 11, 145}, {281,  12},                             WindowColour::secondary, STR_FORCE_PARK_RATING                                                             ), // Force park rating
     makeHoldableSpinnerWidgets({156, 143}, { 81,  14},       WidgetType::spinner,  WindowColour::secondary                                                                            ), // park rating (3 widgets)
     makeWidget                ({ 11, 163}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_CHEAT_WIN_SCENARIO                                                            ), // Win scenario
     makeWidget                ({127, 163}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_CHEAT_HAVE_FUN                                                                ), // Have fun!
 
     makeWidget                ({  5, 192}, {238,  68},       WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_CONSTRUCTION                                                      ), // Construction group
-    makeWidget                ({ 11, 207}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_BUILD_IN_PAUSE_MODE,          STR_CHEAT_BUILD_IN_PAUSE_MODE_TIP         ), // Build in pause mode
-    makeWidget                ({ 11, 224}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ALLOW_PATH_AS_QUEUE,          STR_CHEAT_ALLOW_PATH_AS_QUEUE_TIP         ), // Allow regular footpaths as queue path
-    makeWidget                ({ 11, 241}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES, STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES_TIP)  // Allow special colours in dropdown
+    Widgets::Checkbox         ({ 11, 207}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_BUILD_IN_PAUSE_MODE,          STR_CHEAT_BUILD_IN_PAUSE_MODE_TIP         ), // Build in pause mode
+    Widgets::Checkbox         ({ 11, 224}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_ALLOW_PATH_AS_QUEUE,          STR_CHEAT_ALLOW_PATH_AS_QUEUE_TIP         ), // Allow regular footpaths as queue path
+    Widgets::Checkbox         ({ 11, 241}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES, STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES_TIP)  // Allow special colours in dropdown
 );
 
 static constexpr auto window_cheats_rides_widgets = makeWidgets(
@@ -329,24 +330,24 @@ static constexpr auto window_cheats_rides_widgets = makeWidgets(
     makeWidget({127,  69}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_CHEAT_RESET_CRASH_STATUS,                   STR_CHEAT_RESET_CRASH_STATUS_TIP               ), // Reset crash status
     makeWidget({ 11,  69}, kCheatButtonSize, WidgetType::button,   WindowColour::secondary, STR_CHEAT_10_MINUTE_INSPECTIONS,                STR_CHEAT_10_MINUTE_INSPECTIONS_TIP            ), // 10 minute inspections
 
-    makeWidget({  5, 95},  {238, 87},        WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_CONSTRUCTION                                                                   ), // Construction group
-    makeWidget({ 11, 111}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES,     STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES_TIP ), // Show all drawable track pieces
-    makeWidget({ 11, 128}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,       STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP   ), // Enable chain lift on all track
-    makeWidget({ 11, 145}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS,    STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS_TIP), // Allow track place at invalid heights
-    makeWidget({ 11, 162}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_MAKE_DESTRUCTABLE,                    STR_CHEAT_MAKE_DESTRUCTABLE_TIP                ), // All destructible
+    makeWidget       ({  5, 95},  {238, 87},        WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_CONSTRUCTION                                                                   ), // Construction group
+    Widgets::Checkbox({ 11, 111}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES,     STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES_TIP ), // Show all drawable track pieces
+    Widgets::Checkbox({ 11, 128}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,       STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP   ), // Enable chain lift on all track
+    Widgets::Checkbox({ 11, 145}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS,    STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS_TIP), // Allow track place at invalid heights
+    Widgets::Checkbox({ 11, 162}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_MAKE_DESTRUCTABLE,                    STR_CHEAT_MAKE_DESTRUCTABLE_TIP                ), // All destructible
 
-    makeWidget({  5, 186}, {238, 102},       WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_OPERATION                                                                      ), // Operation group
-    makeWidget({ 11, 201}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_SHOW_ALL_OPERATING_MODES                                                             ), // Show all operating modes
-    makeWidget({ 11, 218}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_UNLOCK_OPERATING_LIMITS,              STR_CHEAT_UNLOCK_OPERATING_LIMITS_TIP          ), // 410 km/h lift hill etc.
-    makeWidget({ 11, 235}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_BRAKES_FAILURE,               STR_CHEAT_DISABLE_BRAKES_FAILURE_TIP           ), // Disable brakes failure
-    makeWidget({ 11, 252}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_BREAKDOWNS,                   STR_CHEAT_DISABLE_BREAKDOWNS_TIP               ), // Disable all breakdowns
-    makeWidget({ 11, 269}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_RIDE_VALUE_AGING,             STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP         ), // Disable ride ageing
+    makeWidget       ({  5, 186}, {238, 102},       WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_OPERATION                                                                      ), // Operation group
+    Widgets::Checkbox({ 11, 201}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_SHOW_ALL_OPERATING_MODES                                                             ), // Show all operating modes
+    Widgets::Checkbox({ 11, 218}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_UNLOCK_OPERATING_LIMITS,              STR_CHEAT_UNLOCK_OPERATING_LIMITS_TIP          ), // 410 km/h lift hill etc.
+    Widgets::Checkbox({ 11, 235}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_DISABLE_BRAKES_FAILURE,               STR_CHEAT_DISABLE_BRAKES_FAILURE_TIP           ), // Disable brakes failure
+    Widgets::Checkbox({ 11, 252}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_DISABLE_BREAKDOWNS,                   STR_CHEAT_DISABLE_BREAKDOWNS_TIP               ), // Disable all breakdowns
+    Widgets::Checkbox({ 11, 269}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_DISABLE_RIDE_VALUE_AGING,             STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP         ), // Disable ride ageing
 
-    makeWidget({  5, 292}, {238, 86},        WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_AVAILABILITY                                                                   ), // Availability group
-    makeWidget({ 11, 308}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,    STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES_TIP), // Allow arbitrary ride type changes
-    makeWidget({ 11, 325}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES                                                 ), // Show vehicles from other track types
-    makeWidget({ 11, 342}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT,           STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT_TIP       ), // Disable train length limits
-    makeWidget({ 11, 359}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_IGNORE_RESEARCH_STATUS,               STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP           )  // Ignore Research Status
+    makeWidget       ({  5, 292}, {238, 86},        WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_AVAILABILITY                                                                   ), // Availability group
+    Widgets::Checkbox({ 11, 308}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,    STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES_TIP), // Allow arbitrary ride type changes
+    Widgets::Checkbox({ 11, 325}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES                                                 ), // Show vehicles from other track types
+    Widgets::Checkbox({ 11, 342}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT,           STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT_TIP       ), // Disable train length limits
+    Widgets::Checkbox({ 11, 359}, kCheatCheckSize,                        WindowColour::secondary, STR_CHEAT_IGNORE_RESEARCH_STATUS,               STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP           )  // Ignore Research Status
 );
 
 static constexpr auto window_cheats_weather_widgets = makeWidgets(
@@ -354,7 +355,7 @@ static constexpr auto window_cheats_weather_widgets = makeWidgets(
     makeWidget                ({  5,  48}, {238,  50},       WidgetType::groupbox,     WindowColour::secondary, STR_CHEAT_WEATHER_GROUP                                      ), // Weather group
     makeWidget                ({126,  62}, {111,  14},       WidgetType::dropdownMenu, WindowColour::secondary, kStringIdEmpty,                  STR_CHANGE_WEATHER_TOOLTIP  ), // Force weather
     makeWidget                ({225,  63}, { 11,  12},       WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,              STR_CHANGE_WEATHER_TOOLTIP  ), // Force weather
-    makeWidget                ({ 11,  80}, kCheatCheckSize,  WidgetType::checkbox,     WindowColour::secondary, STR_CHEAT_FREEZE_WEATHER,        STR_CHEAT_FREEZE_WEATHER_TIP), // Freeze weather
+    Widgets::Checkbox         ({ 11,  80}, kCheatCheckSize,                            WindowColour::secondary, STR_CHEAT_FREEZE_WEATHER,        STR_CHEAT_FREEZE_WEATHER_TIP), // Freeze weather
     makeWidget                ({  5, 102}, {238,  37},       WidgetType::groupbox,     WindowColour::secondary, STR_FAUNA                                                    ), // Fauna group
     makeWidget                ({ 11, 115}, kCheatButtonSize, WidgetType::button,       WindowColour::secondary, STR_CREATE_DUCKS,                STR_CREATE_DUCKS_TIP        ), // Create ducks
     makeWidget                ({127, 115}, kCheatButtonSize, WidgetType::button,       WindowColour::secondary, STR_REMOVE_DUCKS,                STR_REMOVE_DUCKS_TIP        )  // Remove ducks

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -9,6 +9,7 @@
 
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/core/Guard.hpp>
@@ -40,15 +41,15 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize kWindowSize = { 200, 8 + (15 * 7) + 8 };
 
     // clang-format off
-    static constexpr Widget window_debug_paint_widgets[] = {
-        makeWidget({0,          0}, kWindowSize,                   WidgetType::frame,    WindowColour::primary                                        ),
-        makeWidget({8, 8 + 15 * 0}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_WIDE_PATHS     ),
-        makeWidget({8, 8 + 15 * 1}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_BLOCKED_TILES  ),
-        makeWidget({8, 8 + 15 * 2}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS),
-        makeWidget({8, 8 + 15 * 3}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_BOUND_BOXES    ),
-        makeWidget({8, 8 + 15 * 4}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS  ),
-        makeWidget({8, 8 + 15 * 5}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_STABLE_SORT  ),
-        makeWidget({8, 8 + 15 * 6}, {         185,            12}, WidgetType::checkbox, WindowColour::secondary, STR_DEBUG_PAINT_FORCE_REDRAW  ),
+    static constexpr Widget kWidgets[] = {
+        makeWidget({0, 0}, kWindowSize, WidgetType::frame, WindowColour::primary ),
+        Widgets::Checkbox({8, 8 + 15 * 0}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_WIDE_PATHS     ),
+        Widgets::Checkbox({8, 8 + 15 * 1}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_BLOCKED_TILES  ),
+        Widgets::Checkbox({8, 8 + 15 * 2}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_SEGMENT_HEIGHTS),
+        Widgets::Checkbox({8, 8 + 15 * 3}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_BOUND_BOXES    ),
+        Widgets::Checkbox({8, 8 + 15 * 4}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_SHOW_DIRTY_VISUALS  ),
+        Widgets::Checkbox({8, 8 + 15 * 5}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_STABLE_SORT         ),
+        Widgets::Checkbox({8, 8 + 15 * 6}, { 185, 12}, WindowColour::secondary, STR_DEBUG_PAINT_FORCE_REDRAW        ),
     };
     // clang-format on
 
@@ -60,7 +61,7 @@ namespace OpenRCT2::Ui::Windows
     public:
         void onOpen() override
         {
-            setWidgets(window_debug_paint_widgets);
+            setWidgets(kWidgets);
 
             initScrollWidgets();
             WindowPushOthersBelow(*this);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/Input.h>
@@ -57,7 +58,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto _inventionListWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({  0,  43}, {600, 357}, WidgetType::resize,  WindowColour::secondary                                             ),
-        makeTab   ({  3,  17}                                                                                                       ),
+        Widgets::Tab({  3,  17}                                                                                                       ),
         makeWidget({  4,  56}, {368, 161}, WidgetType::scroll,  WindowColour::secondary, SCROLL_VERTICAL                            ),
         makeWidget({  4, 231}, {368, 157}, WidgetType::scroll,  WindowColour::secondary, SCROLL_VERTICAL                            ),
         makeWidget({431, 106}, {114, 114}, WidgetType::flatBtn, WindowColour::secondary                                             ),

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/Diagnostic.h>
@@ -235,17 +236,17 @@ namespace OpenRCT2::Ui::Windows
         makeWidget         ({  4, 45}, {              211,  14}, WidgetType::textBox,      WindowColour::secondary                                                                 ),
         makeWidget         ({218, 45}, {               70,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR                                        ),
         makeWidget         ({  3, 73}, {              285,   4}, WidgetType::imgBtn,       WindowColour::secondary                                                                 ),
-        makeTab            ({  3, 47}                                                                                                                                              ),
-        makeTab            ({ 34, 47}                                                                                                                                              ),
-        makeTab            ({ 65, 47}                                                                                                                                              ),
-        makeTab            ({ 96, 47}                                                                                                                                              ),
-        makeTab            ({127, 47}                                                                                                                                              ),
-        makeTab            ({158, 47}                                                                                                                                              ),
-        makeTab            ({189, 47}                                                                                                                                              ),
+        Widgets::Tab({  3, 47}),
+        Widgets::Tab({ 34, 47}),
+        Widgets::Tab({ 65, 47}),
+        Widgets::Tab({ 96, 47}),
+        Widgets::Tab({127, 47}),
+        Widgets::Tab({158, 47}),
+        Widgets::Tab({189, 47}),
         makeWidget         ({  4, 80}, {              145,  14}, WidgetType::tableHeader, WindowColour::secondary                                                                  ),
         makeWidget         ({149, 80}, {              143,  14}, WidgetType::tableHeader, WindowColour::secondary                                                                  ),
         makeWidget         ({700, 50}, {               24,  24}, WidgetType::imgBtn,      WindowColour::secondary,  SPR_G2_RELOAD,                STR_RELOAD_OBJECT_TIP            ),
-        makeTab            ({  3, 17},                                                                                                            STR_STRING_DEFINED_TOOLTIP       )
+        Widgets::Tab({  3, 17},                                                                                                            STR_STRING_DEFINED_TOOLTIP       )
         // Copied object type times...
     );
     // clang-format on

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/ViewportInteraction.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -74,7 +75,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto _widgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget     ({                      0, 43 }, { kWindowSize.width, kWindowSize.height - 43 }, WidgetType::resize,  WindowColour::secondary                                                   ),
-        makeTab        ({                      3, 17 },                                                                                               kStringIdNone                                    ),
+        Widgets::Tab({ 3, 17 }),
         makeWidget     ({                      2, 45 }, {      kScrollWidth,           kScrollHeight }, WidgetType::scroll,  WindowColour::secondary, SCROLL_VERTICAL                                  ),
         makeWidget     ({ kWindowSize.width - 26, 59 }, {                24,                      24 }, WidgetType::flatBtn, WindowColour::secondary, ImageId(SPR_ROTATE_ARROW), STR_ROTATE_OBJECTS_90 )
     );

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
@@ -206,12 +207,12 @@ namespace OpenRCT2::Ui::Windows
         return makeWidgets(
             makeWindowShim(title, size),
             makeWidget({  0, 43}, { size.width, 106 }, WidgetType::resize, WindowColour::secondary),
-            makeTab   ({  3, 17}, STR_SCENARIO_OPTIONS_OBJECTIVE_TIP             ),
-            makeTab   ({ 34, 17}, STR_SCENARIO_OPTIONS_SCENARIO_DETAILS_TIP      ),
-            makeTab   ({ 65, 17}, STR_SCENARIO_OPTIONS_FINANCIAL_TIP             ),
-            makeTab   ({ 96, 17}, STR_SCENARIO_OPTIONS_GUESTS_TIP                ),
-            makeTab   ({127, 17}, STR_SCENARIO_OPTIONS_LAND_RESTRICTIONS_TIP     ),
-            makeTab   ({158, 17}, STR_SCENARIO_OPTIONS_PRESERVED_RIDES_TIP       )
+            Widgets::Tab({  3, 17}, STR_SCENARIO_OPTIONS_OBJECTIVE_TIP             ),
+            Widgets::Tab({ 34, 17}, STR_SCENARIO_OPTIONS_SCENARIO_DETAILS_TIP      ),
+            Widgets::Tab({ 65, 17}, STR_SCENARIO_OPTIONS_FINANCIAL_TIP             ),
+            Widgets::Tab({ 96, 17}, STR_SCENARIO_OPTIONS_GUESTS_TIP                ),
+            Widgets::Tab({127, 17}, STR_SCENARIO_OPTIONS_LAND_RESTRICTIONS_TIP     ),
+            Widgets::Tab({158, 17}, STR_SCENARIO_OPTIONS_PRESERVED_RIDES_TIP       )
         );
     };
 

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -14,6 +14,7 @@
 #include "Windows.h"
 
 #include <algorithm>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
@@ -223,7 +224,7 @@ namespace OpenRCT2::Ui::Windows
         makeHoldableSpinnerWidgets({158,  65}, {120,  14}, WidgetType::spinner,      WindowColour::secondary                                                                          ), // NB: 3 widgets
         makeWidget                ({ 28,  85}, {140,  12}, WidgetType::label,        WindowColour::secondary, STR_WINDOW_OBJECTIVE_DATE                                               ),
         makeHoldableSpinnerWidgets({158,  84}, {120,  14}, WidgetType::spinner,      WindowColour::secondary                                                                          ), // NB: 3 widgets
-        makeWidget        ({ 14, 103}, {340,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP                  )
+        Widgets::Checkbox         ({ 14, 103}, {340,  12},                           WindowColour::secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP                  )
     );
 
     static constexpr auto window_editor_scenario_options_scenario_details_widgets = makeWidgets(
@@ -237,7 +238,7 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr auto window_editor_scenario_options_financial_widgets = makeWidgets(
         makeOptionsWidgets(STR_SCENARIO_OPTIONS_FINANCIAL, kSizeFinancial),
-        makeWidget        ({  8,  48}, {kSizeFinancial.width - 16, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_MAKE_PARK_NO_MONEY,   STR_MAKE_PARK_NO_MONEY_TIP        ),
+        Widgets::Checkbox         ({  8,  48}, {kSizeFinancial.width - 16, 12},                           WindowColour::secondary, STR_MAKE_PARK_NO_MONEY,   STR_MAKE_PARK_NO_MONEY_TIP        ),
 
         makeWidget                ({  5,  63}, {kSizeFinancial.width - 10, 72}, WidgetType::groupbox,     WindowColour::secondary, STR_GROUP_LOAN_OPTIONS                                      ),
         makeWidget                ({  9,  78}, {                      250, 12}, WidgetType::label,        WindowColour::secondary, STR_INIT_LOAN_LABEL                                         ),
@@ -246,7 +247,7 @@ namespace OpenRCT2::Ui::Windows
         makeHoldableSpinnerWidgets({268,  96}, {                      100, 14}, WidgetType::spinner,      WindowColour::secondary                                                              ), // NB: 3 widgets
         makeWidget                ({  9, 116}, {                      280, 12}, WidgetType::label,        WindowColour::secondary, STR_INTEREST_RATE_LABEL                                     ),
         makeHoldableSpinnerWidgets({298, 115}, {                       70, 14}, WidgetType::spinner,      WindowColour::secondary                                                              ), // NB: 3 widgets
-        makeWidget                ({ 10, 115}, {kSizeFinancial.width - 16, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_RCT1_INTEREST,        STR_RCT1_INTEREST_TIP             ),
+        Widgets::Checkbox         ({ 10, 115}, {kSizeFinancial.width - 16, 12},                           WindowColour::secondary, STR_RCT1_INTEREST,        STR_RCT1_INTEREST_TIP             ),
 
         makeWidget                ({  5, 137}, {kSizeFinancial.width - 10, 89}, WidgetType::groupbox,     WindowColour::secondary, STR_GROUP_BUSINESS_MODEL                                    ),
         makeWidget                ({  9, 155}, {                      250, 12}, WidgetType::label,        WindowColour::secondary, STR_INIT_CASH_LABEL                                         ),
@@ -256,7 +257,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget                ({356, 173}, {                       11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,       STR_PAY_FOR_PARK_PAY_FOR_RIDES_TIP),
         makeWidget                ({  9, 191}, {                      280, 12}, WidgetType::label,        WindowColour::secondary, STR_ENTRY_PRICE_LABEL                                       ),
         makeHoldableSpinnerWidgets({298, 190}, {                       70, 14}, WidgetType::spinner,      WindowColour::secondary                                                              ), // NB: 3 widgets
-        makeWidget                ({ 10, 208}, {kSizeFinancial.width - 16, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_FORBID_MARKETING,     STR_FORBID_MARKETING_TIP          )
+        Widgets::Checkbox         ({ 10, 208}, {kSizeFinancial.width - 16, 12},                           WindowColour::secondary, STR_FORBID_MARKETING,     STR_FORBID_MARKETING_TIP          )
     );
 
     static constexpr auto window_editor_scenario_options_guests_widgets = makeWidgets(
@@ -272,7 +273,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget                ({  8, 124}, {      180,  12}, WidgetType::label,        WindowColour::secondary, STR_GUESTS_PREFER_INTENSITY_LABEL                                       ),
         makeWidget                ({198, 123}, {      170,  14}, WidgetType::dropdownMenu, WindowColour::secondary, kStringIdNone,                        STR_GUESTS_PREFER_INTENSITY_TIP   ),
         makeWidget                ({357, 124}, {       11,  12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,                   STR_GUESTS_PREFER_INTENSITY_TIP   ),
-        makeWidget                ({  8, 143}, {      350,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_HARD_GUEST_GENERATION,            STR_HARD_GUEST_GENERATION_TIP     )
+        Widgets::Checkbox         ({  8, 143}, {      350,  12},                           WindowColour::secondary, STR_HARD_GUEST_GENERATION,            STR_HARD_GUEST_GENERATION_TIP     )
     );
 
     static constexpr auto window_editor_scenario_options_land_widgets = makeWidgets(
@@ -281,9 +282,9 @@ namespace OpenRCT2::Ui::Windows
         makeHoldableSpinnerWidgets({188,  48}, {                  70,  14}, WidgetType::spinner,  WindowColour::secondary                                                                  ), // NB: 3 widgets
         makeWidget                ({  8,  66}, {                 170,  12}, WidgetType::label,    WindowColour::secondary, STR_RIGHTS_COST_LABEL                                           ),
         makeHoldableSpinnerWidgets({188,  65}, {                  70,  14}, WidgetType::spinner,  WindowColour::secondary                                                                  ), // NB: 3 widgets
-        makeWidget        ({  8,  82}, {kSizeLand.width - 16,  12}, WidgetType::checkbox, WindowColour::secondary, STR_FORBID_TREE_REMOVAL,      STR_FORBID_TREE_REMOVAL_TIP       ),
-        makeWidget        ({  8,  99}, {kSizeLand.width - 16,  12}, WidgetType::checkbox, WindowColour::secondary, STR_FORBID_LANDSCAPE_CHANGES, STR_FORBID_LANDSCAPE_CHANGES_TIP  ),
-        makeWidget        ({  8, 116}, {kSizeLand.width - 16,  12}, WidgetType::checkbox, WindowColour::secondary, STR_FORBID_HIGH_CONSTRUCTION, STR_FORBID_HIGH_CONSTRUCTION_TIP  )
+        Widgets::Checkbox         ({  8,  82}, {kSizeLand.width - 16,  12},                       WindowColour::secondary, STR_FORBID_TREE_REMOVAL,      STR_FORBID_TREE_REMOVAL_TIP       ),
+        Widgets::Checkbox         ({  8,  99}, {kSizeLand.width - 16,  12},                       WindowColour::secondary, STR_FORBID_LANDSCAPE_CHANGES, STR_FORBID_LANDSCAPE_CHANGES_TIP  ),
+        Widgets::Checkbox         ({  8, 116}, {kSizeLand.width - 16,  12},                       WindowColour::secondary, STR_FORBID_HIGH_CONSTRUCTION, STR_FORBID_HIGH_CONSTRUCTION_TIP  )
     );
 
     static constexpr auto window_editor_scenario_options_rides_widgets = makeWidgets(

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -108,12 +109,12 @@ namespace OpenRCT2::Ui::Windows
         return makeWidgets(
             makeWindowShim(title, frameSize),
             makeWidget({   0, 43 }, resizeSize, WidgetType::resize, WindowColour::secondary),
-            makeTab   ({   3, 17 }, STR_FINANCES_SHOW_SUMMARY_TAB_TIP),
-            makeTab   ({  34, 17 }, STR_FINANCES_SHOW_CASH_TAB_TIP),
-            makeTab   ({  65, 17 }, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP),
-            makeTab   ({  96, 17 }, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP),
-            makeTab   ({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP),
-            makeTab   ({ 158, 17 }, STR_FINANCES_RESEARCH_TIP)
+            Widgets::Tab({   3, 17 }, STR_FINANCES_SHOW_SUMMARY_TAB_TIP),
+            Widgets::Tab({  34, 17 }, STR_FINANCES_SHOW_CASH_TAB_TIP),
+            Widgets::Tab({  65, 17 }, STR_FINANCES_SHOW_PARK_VALUE_TAB_TIP),
+            Widgets::Tab({  96, 17 }, STR_FINANCES_SHOW_WEEKLY_PROFIT_TAB_TIP),
+            Widgets::Tab({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP),
+            Widgets::Tab({ 158, 17 }, STR_FINANCES_RESEARCH_TIP)
         );
     };
 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/Graph.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -148,17 +149,17 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr auto _windowFinancesResearchWidgets = makeWidgets(
         makeFinancesWidgets(STR_RESEARCH_FUNDING, kTabContentSizeResearch, kWindowSizeResearch),
-        makeWidget({  3,  47}, { kWindowSizeResearch.width - 6,  45}, WidgetType::groupbox,     WindowColour::tertiary, STR_RESEARCH_FUNDING_                                                             ),
-        makeWidget({  8,  59}, {                           160,  14}, WidgetType::dropdownMenu, WindowColour::tertiary, 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
-        makeWidget({156,  60}, {                            11,  12}, WidgetType::button,       WindowColour::tertiary, STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
-        makeWidget({  3,  96}, {kWindowSizeResearch.width -  6, 107}, WidgetType::groupbox,     WindowColour::tertiary, STR_RESEARCH_PRIORITIES                                                           ),
-        makeWidget({  8, 108}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
-        makeWidget({  8, 121}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
-        makeWidget({  8, 134}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
-        makeWidget({  8, 147}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
-        makeWidget({  8, 160}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
-        makeWidget({  8, 173}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
-        makeWidget({  8, 186}, {kWindowSizeResearch.width - 14,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    )
+        makeWidget       ({  3,  47}, { kWindowSizeResearch.width - 6,  45}, WidgetType::groupbox,     WindowColour::tertiary, STR_RESEARCH_FUNDING_                                                             ),
+        makeWidget       ({  8,  59}, {                           160,  14}, WidgetType::dropdownMenu, WindowColour::tertiary, 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
+        makeWidget       ({156,  60}, {                            11,  12}, WidgetType::button,       WindowColour::tertiary, STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
+        makeWidget       ({  3,  96}, {kWindowSizeResearch.width -  6, 107}, WidgetType::groupbox,     WindowColour::tertiary, STR_RESEARCH_PRIORITIES                                                           ),
+        Widgets::Checkbox({  8, 108}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
+        Widgets::Checkbox({  8, 121}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
+        Widgets::Checkbox({  8, 134}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
+        Widgets::Checkbox({  8, 147}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
+        Widgets::Checkbox({  8, 160}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
+        Widgets::Checkbox({  8, 173}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
+        Widgets::Checkbox({  8, 186}, {kWindowSizeResearch.width - 14,  12},                           WindowColour::tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    )
     );
     // clang-format on
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -120,13 +121,13 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kMainGuestWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({ 0, 43 }, { 192, 114 }, WidgetType::resize, WindowColour::secondary), /* Resize */
-        makeTab({ 3, 17 }, STR_SHOW_GUEST_VIEW_TIP),                                      /* Tab 1 */
-        makeTab({ 34, 17 }, STR_SHOW_GUEST_NEEDS_TIP),                                    /* Tab 2 */
-        makeTab({ 65, 17 }, STR_SHOW_GUEST_VISITED_RIDES_TIP),                            /* Tab 3 */
-        makeTab({ 96, 17 }, STR_SHOW_GUEST_FINANCE_TIP),                                  /* Tab 4 */
-        makeTab({ 127, 17 }, STR_SHOW_GUEST_THOUGHTS_TIP),                                /* Tab 5 */
-        makeTab({ 158, 17 }, STR_SHOW_GUEST_ITEMS_TIP),                                   /* Tab 6 */
-        makeTab({ 189, 17 }, STR_DEBUG_TIP)                                               /* Tab 7 */
+        Widgets::Tab({ 3, 17 }, STR_SHOW_GUEST_VIEW_TIP),           /* Tab 1 */
+        Widgets::Tab({ 34, 17 }, STR_SHOW_GUEST_NEEDS_TIP),         /* Tab 2 */
+        Widgets::Tab({ 65, 17 }, STR_SHOW_GUEST_VISITED_RIDES_TIP), /* Tab 3 */
+        Widgets::Tab({ 96, 17 }, STR_SHOW_GUEST_FINANCE_TIP),       /* Tab 4 */
+        Widgets::Tab({ 127, 17 }, STR_SHOW_GUEST_THOUGHTS_TIP),     /* Tab 5 */
+        Widgets::Tab({ 158, 17 }, STR_SHOW_GUEST_ITEMS_TIP),        /* Tab 6 */
+        Widgets::Tab({ 189, 17 }, STR_DEBUG_TIP)                    /* Tab 7 */
     );
 
     static constexpr auto _guestWindowWidgetsOverview = makeWidgets(

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -68,8 +69,8 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({273, 46}, { 24,  24}, WidgetType::flatBtn,      WindowColour::secondary, ImageId(SPR_MAP),        STR_SHOW_GUESTS_ON_MAP_TIP   ), // map
         makeWidget({297, 46}, { 24,  24}, WidgetType::flatBtn,      WindowColour::secondary, ImageId(SPR_G2_SEARCH),  STR_GUESTS_FILTER_BY_NAME_TIP), // filter by name
         makeWidget({321, 46}, { 24,  24}, WidgetType::flatBtn,      WindowColour::secondary, ImageId(SPR_TRACK_PEEP), STR_TRACKED_GUESTS_ONLY_TIP  ), // tracking
-        makeTab   ({  3, 17},                                                                                         STR_INDIVIDUAL_GUESTS_TIP    ), // tab 1
-        makeTab   ({ 34, 17},                                                                                         STR_SUMMARISED_GUESTS_TIP    ), // tab 2
+        Widgets::Tab({  3, 17},                                                                                       STR_INDIVIDUAL_GUESTS_TIP    ), // tab 1
+        Widgets::Tab({ 34, 17},                                                                                       STR_SUMMARISED_GUESTS_TIP    ), // tab 2
         makeWidget({  3, 72}, {344, 255}, WidgetType::scroll,       WindowColour::secondary, SCROLL_BOTH                                           ) // guest list
     );
     // clang-format on

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/SpriteIds.h>
@@ -123,10 +124,10 @@ namespace OpenRCT2::Ui::Windows
         return makeWidgets(
             makeWindowShim(title, kWindowSize),
             makeWidget({   0, 43 }, { kWindowSize.width, 177 }, WidgetType::resize, WindowColour::secondary),
-            makeTab   ({   3, 17 }),
-            makeTab   ({  34, 17 }),
-            makeTab   ({  65, 17 }),
-            makeTab   ({  96, 17 }),
+            Widgets::Tab({  3, 17 }),
+            Widgets::Tab({ 34, 17 }),
+            Widgets::Tab({ 65, 17 }),
+            Widgets::Tab({ 96, 17 }),
             makeWidget({ 185, 200 }, { 109, 14 }, WidgetType::button, WindowColour::secondary, STR_MAPGEN_ACTION_GENERATE)
         );
     };

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/SpriteIds.h>
@@ -143,8 +144,8 @@ namespace OpenRCT2::Ui::Windows
 
         makeWidget                ({  5,  90+8}, {290, 88}, WidgetType::groupbox, WindowColour::secondary, STR_MAPGEN_SELECT_HEIGHTMAP), // WIDX_HEIGHTMAP_GROUP
         makeWidget                ({223, 107+8}, { 65, 14}, WidgetType::button,   WindowColour::secondary, STR_BROWSE                 ), // WIDX_HEIGHTMAP_BROWSE
-        makeWidget                ({ 10, 125+8}, {150, 12}, WidgetType::checkbox, WindowColour::secondary, STR_MAPGEN_NORMALIZE       ), // WIDX_HEIGHTMAP_NORMALIZE
-        makeWidget                ({ 10, 141+8}, {150, 12}, WidgetType::checkbox, WindowColour::secondary, STR_MAPGEN_SMOOTH_HEIGHTMAP), // WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP
+        Widgets::Checkbox         ({ 10, 125+8}, {150, 12},                       WindowColour::secondary, STR_MAPGEN_NORMALIZE       ), // WIDX_HEIGHTMAP_NORMALIZE
+        Widgets::Checkbox         ({ 10, 141+8}, {150, 12},                       WindowColour::secondary, STR_MAPGEN_SMOOTH_HEIGHTMAP), // WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP
         makeHoldableSpinnerWidgets({179, 157+8}, {109, 14}, WidgetType::spinner,  WindowColour::secondary                             )  // WIDX_HEIGHTMAP_STRENGTH{,_UP,_DOWN}
     );
 
@@ -154,19 +155,19 @@ namespace OpenRCT2::Ui::Windows
         makeHoldableSpinnerWidgets({179,  70}, {109, 14}, WidgetType::spinner,  WindowColour::secondary                                  ), // WIDX_HEIGHTMAP_HIGH{,_UP,_DOWN}
         makeWidget        ({179,  88}, { 47, 36}, WidgetType::flatBtn,  WindowColour::secondary, 0xFFFFFFFF, STR_CHANGE_BASE_LAND_TIP    ),
         makeWidget        ({236,  88}, { 47, 36}, WidgetType::flatBtn,  WindowColour::secondary, 0xFFFFFFFF, STR_CHANGE_VERTICAL_LAND_TIP),
-        makeWidget        ({ 10, 106}, {150, 12}, WidgetType::checkbox, WindowColour::secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN        ),
-        makeWidget        ({ 10, 122}, {150, 12}, WidgetType::checkbox, WindowColour::secondary, STR_MAPGEN_SMOOTH_TILE                  )  // WIDX_HEIGHTMAP_SMOOTH_TILE_EDGES
+        Widgets::Checkbox ({ 10, 106}, {150, 12},                       WindowColour::secondary, STR_MAPGEN_OPTION_RANDOM_TERRAIN        ),
+        Widgets::Checkbox ({ 10, 122}, {150, 12},                       WindowColour::secondary, STR_MAPGEN_SMOOTH_TILE                  )  // WIDX_HEIGHTMAP_SMOOTH_TILE_EDGES
     );
 
     static constexpr auto kWaterWidgets = makeWidgets(
         makeMapGenWidgets(STR_MAPGEN_CAPTION_WATER),
         makeHoldableSpinnerWidgets({179,  52}, {109, 14}, WidgetType::spinner,  WindowColour::secondary                          ), // NB: 3 widgets
-        makeWidget                ({ 10,  70}, {255, 12}, WidgetType::checkbox, WindowColour::secondary, STR_BEACHES_WATER_BODIES)
+        Widgets::Checkbox         ({ 10,  70}, {255, 12},                       WindowColour::secondary, STR_BEACHES_WATER_BODIES)
     );
 
     static constexpr auto kForestsWidgets = makeWidgets(
         makeMapGenWidgets(STR_MAPGEN_CAPTION_FORESTS),
-        makeWidget                ({ 10,  52}, {255, 12}, WidgetType::checkbox, WindowColour::secondary, STR_MAPGEN_OPTION_PLACE_TREES),
+        Widgets::Checkbox         ({ 10,  52}, {255, 12},                       WindowColour::secondary, STR_MAPGEN_OPTION_PLACE_TREES),
         makeHoldableSpinnerWidgets({179,  70}, {109, 14}, WidgetType::spinner,  WindowColour::secondary                               ), // WIDX_TREE_LAND_RATIO{,_UP,_DOWN}
         makeHoldableSpinnerWidgets({179,  88}, {109, 14}, WidgetType::spinner,  WindowColour::secondary                               ), // WIDX_TREE_ALTITUDE_MIN{,_UP,_DOWN}
         makeHoldableSpinnerWidgets({179, 106}, {109, 14}, WidgetType::spinner,  WindowColour::secondary                               )  // WIDX_TREE_ALTITUDE_MAX{,_UP,_DOWN}

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -77,10 +78,10 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kMainMultiplayerWidgets = makeWidgets(
         makeWindowShim(kStringIdNone, kWindowSize),
         makeWidget({  0, 43}, {340, 197}, WidgetType::resize, WindowColour::secondary                          ),
-        makeTab   ({  3, 17},                                                          STR_SHOW_SERVER_INFO_TIP),
-        makeTab   ({ 34, 17},                                                          STR_PLAYERS_TIP         ),
-        makeTab   ({ 65, 17},                                                          STR_GROUPS_TIP          ),
-        makeTab   ({ 96, 17},                                                          STR_OPTIONS_TIP         )
+        Widgets::Tab({  3, 17}, STR_SHOW_SERVER_INFO_TIP),
+        Widgets::Tab({ 34, 17}, STR_PLAYERS_TIP         ),
+        Widgets::Tab({ 65, 17}, STR_GROUPS_TIP          ),
+        Widgets::Tab({ 96, 17}, STR_OPTIONS_TIP         )
     );
 
     static constexpr auto window_multiplayer_information_widgets = makeWidgets(

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -109,9 +110,9 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr auto window_multiplayer_options_widgets = makeWidgets(
         kMainMultiplayerWidgets,
-        makeWidget({3, 50}, {295, 12}, WidgetType::checkbox, WindowColour::secondary, STR_LOG_CHAT,              STR_LOG_CHAT_TIP             ),
-        makeWidget({3, 64}, {295, 12}, WidgetType::checkbox, WindowColour::secondary, STR_LOG_SERVER_ACTIONS,    STR_LOG_SERVER_ACTIONS_TIP   ),
-        makeWidget({3, 78}, {295, 12}, WidgetType::checkbox, WindowColour::secondary, STR_ALLOW_KNOWN_KEYS_ONLY, STR_ALLOW_KNOWN_KEYS_ONLY_TIP)
+        Widgets::Checkbox({3, 50}, {295, 12}, WindowColour::secondary, STR_LOG_CHAT,              STR_LOG_CHAT_TIP             ),
+        Widgets::Checkbox({3, 64}, {295, 12}, WindowColour::secondary, STR_LOG_SERVER_ACTIONS,    STR_LOG_SERVER_ACTIONS_TIP   ),
+        Widgets::Checkbox({3, 78}, {295, 12}, WindowColour::secondary, STR_ALLOW_KNOWN_KEYS_ONLY, STR_ALLOW_KNOWN_KEYS_ONLY_TIP)
     );
 
     static std::span<const Widget> window_multiplayer_page_widgets[] = {

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/ride/Construction.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -216,8 +217,8 @@ namespace OpenRCT2::Ui::Windows
         WIDX_GROUP_BY_TRACK_TYPE,
     };
 
-    static constexpr ScreenCoordsXY GroupByTrackTypeOrigin{ kWindowSize.width - 8 - GroupByTrackTypeWidth, 47 };
-    static constexpr ScreenSize GroupTrackTypeSize{ GroupByTrackTypeWidth, 14 };
+    static constexpr ScreenCoordsXY kGroupByTrackTypeOrigin{ kWindowSize.width - 8 - GroupByTrackTypeWidth, 47 };
+    static constexpr ScreenSize kGroupTrackTypeSize{ GroupByTrackTypeWidth, 14 };
 
     // clang-format off
     static constexpr auto window_new_ride_widgets = makeWidgets(
@@ -237,7 +238,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({265,  68},             { 24,  24},         WidgetType::flatBtn,  WindowColour::tertiary,  ImageId(SPR_FINANCE),             STR_FINANCES_RESEARCH_TIP    ),
         makeWidget({  4,  46},             {211, 14},          WidgetType::textBox,  WindowColour::secondary                                                                 ),
         makeWidget({218,  46},             { 70, 14},          WidgetType::button,   WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR                                        ),
-        makeWidget(GroupByTrackTypeOrigin, GroupTrackTypeSize, WidgetType::checkbox, WindowColour::secondary, STR_GROUP_BY_TRACK_TYPE,          STR_GROUP_BY_TRACK_TYPE_TIP  )
+        Widgets::Checkbox(kGroupByTrackTypeOrigin, kGroupTrackTypeSize, WindowColour::secondary, STR_GROUP_BY_TRACK_TYPE,          STR_GROUP_BY_TRACK_TYPE_TIP  )
     );
     // clang-format on
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/ride/Construction.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -224,13 +225,13 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto window_new_ride_widgets = makeWidgets(
         makeWindowShim(WindowTitle, kWindowSize),
         makeWidget({  0,  43},             {601, 339},         WidgetType::resize,   WindowColour::secondary                                                                 ),
-        makeTab   ({  3,  17},                                                                                STR_TRANSPORT_RIDES_TIP                                        ),
-        makeTab   ({ 34,  17},                                                                                STR_GENTLE_RIDES_TIP                                           ),
-        makeTab   ({ 65,  17},                                                                                STR_ROLLER_COASTERS_TIP                                        ),
-        makeTab   ({ 96,  17},                                                                                STR_THRILL_RIDES_TIP                                           ),
-        makeTab   ({127,  17},                                                                                STR_WATER_RIDES_TIP                                            ),
-        makeTab   ({158,  17},                                                                                STR_SHOPS_STALLS_TIP                                           ),
-        makeTab   ({189,  17},                                                                                STR_RESEARCH_AND_DEVELOPMENT_TIP                               ),
+        Widgets::Tab(                      {  3,  17},                                                        STR_TRANSPORT_RIDES_TIP                                        ),
+        Widgets::Tab(                      { 34,  17},                                                        STR_GENTLE_RIDES_TIP                                           ),
+        Widgets::Tab(                      { 65,  17},                                                        STR_ROLLER_COASTERS_TIP                                        ),
+        Widgets::Tab(                      { 96,  17},                                                        STR_THRILL_RIDES_TIP                                           ),
+        Widgets::Tab(                      {127,  17},                                                        STR_WATER_RIDES_TIP                                            ),
+        Widgets::Tab(                      {158,  17},                                                        STR_SHOPS_STALLS_TIP                                           ),
+        Widgets::Tab(                      {189,  17},                                                        STR_RESEARCH_AND_DEVELOPMENT_TIP                               ),
         makeWidget({  3,  62},             {595, 256},         WidgetType::scroll,   WindowColour::secondary, SCROLL_VERTICAL                                                ),
         makeWidget({  3,  47},             {290,  70},         WidgetType::groupbox, WindowColour::tertiary,  STR_CURRENTLY_IN_DEVELOPMENT                                   ),
         makeWidget({  3, 124},             {290,  65},         WidgetType::groupbox, WindowColour::tertiary,  STR_LAST_DEVELOPMENT                                           ),

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -168,15 +168,9 @@ namespace OpenRCT2::Ui::Windows
                         y += 7;
                     }
 
-                    Widget groupWidget = {
-                        .type = WidgetType::groupbox,
-                        .colour = EnumValue(colours[1].colour),
-                        .left = static_cast<int16_t>(baseCheckBox.left - 5),
-                        .right = static_cast<int16_t>(baseCheckBox.right + 5),
-                        .top = y,
-                        .bottom = static_cast<int16_t>(y + kListRowHeight),
-                        .text = def.group,
-                    };
+                    Widget groupWidget = makeWidget(
+                        { baseCheckBox.left - 5, y }, { baseCheckBox.width() + 10, kListRowHeight }, WidgetType::groupbox,
+                        WindowColour::secondary, def.group);
 
                     groupWidgetsToInsert.emplace_back(groupWidget);
                     lastGroup = def.group;
@@ -184,15 +178,9 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Create checkbox widgets
-                Widget checkboxWidget = {
-                    .type = WidgetType::checkbox,
-                    .colour = EnumValue(colours[1].colour),
-                    .left = baseCheckBox.left,
-                    .right = baseCheckBox.right,
-                    .top = y,
-                    .bottom = static_cast<int16_t>(y + kListRowHeight + 3),
-                    .text = def.caption,
-                };
+                Widget checkboxWidget = makeWidget(
+                    { baseCheckBox.left, y }, { baseCheckBox.width(), kListRowHeight + 3 }, WidgetType::checkbox,
+                    WindowColour::secondary, def.caption);
 
                 checkboxWidgetsToInsert.emplace_back(checkboxWidget);
                 numGroupElements++;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -64,8 +65,8 @@ namespace OpenRCT2::Ui::Windows
         return makeWidgets(
             makeWindowShim(title, kWindowSize),
             makeWidget({  0, 43 }, { kWindowSize.width, 257 }, WidgetType::resize, WindowColour::secondary),
-            makeTab   ({  3, 17 }, STR_RECENT_MESSAGES),
-            makeTab   ({ 34, 17 }, STR_NOTIFICATION_SETTINGS)
+            Widgets::Tab({  3, 17 }, STR_RECENT_MESSAGES),
+            Widgets::Tab({ 34, 17 }, STR_NOTIFICATION_SETTINGS)
         );
     };
 

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -170,15 +170,9 @@ namespace OpenRCT2::Ui::Windows
                         y += 7;
                     }
 
-                    Widget groupWidget = {
-                        .type = WidgetType::groupbox,
-                        .colour = EnumValue(colours[1].colour),
-                        .left = static_cast<int16_t>(baseCheckBox.left - 5),
-                        .right = static_cast<int16_t>(baseCheckBox.right + 5),
-                        .top = y,
-                        .bottom = static_cast<int16_t>(y + kListRowHeight),
-                        .text = def.group,
-                    };
+                    Widget groupWidget = makeWidget(
+                        { baseCheckBox.left - 5, y }, { baseCheckBox.width() + 10, kListRowHeight }, WidgetType::groupbox,
+                        WindowColour::secondary, def.group);
 
                     groupWidgetsToInsert.emplace_back(groupWidget);
                     lastGroup = def.group;
@@ -186,15 +180,9 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Create checkbox widgets
-                Widget checkboxWidget = {
-                    .type = WidgetType::checkbox,
-                    .colour = EnumValue(colours[1].colour),
-                    .left = baseCheckBox.left,
-                    .right = baseCheckBox.right,
-                    .top = y,
-                    .bottom = static_cast<int16_t>(y + kListRowHeight + 3),
-                    .text = def.caption,
-                };
+                Widget checkboxWidget = makeWidget(
+                    { baseCheckBox.left, y }, { baseCheckBox.width(), kListRowHeight + 3 }, WidgetType::checkbox,
+                    WindowColour::secondary, def.caption);
 
                 checkboxWidgetsToInsert.emplace_back(checkboxWidget);
                 numGroupElements++;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -9,6 +9,7 @@
 
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -75,7 +76,7 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr auto kOptionsTabWidgets = makeWidgets(
         makeNewsWidgets(STR_NOTIFICATION_SETTINGS),
-        makeWidget({ 10, 49 }, { 380,  14 }, WidgetType::checkbox, WindowColour::secondary)
+        Widgets::Checkbox({ 10, 49 }, { 380,  14 }, WindowColour::secondary)
     );
     // clang-format on
 
@@ -180,9 +181,9 @@ namespace OpenRCT2::Ui::Windows
                 }
 
                 // Create checkbox widgets
-                Widget checkboxWidget = makeWidget(
-                    { baseCheckBox.left, y }, { baseCheckBox.width(), kListRowHeight + 3 }, WidgetType::checkbox,
-                    WindowColour::secondary, def.caption);
+                Widget checkboxWidget = Widgets::Checkbox(
+                    { baseCheckBox.left, y }, { baseCheckBox.width(), kListRowHeight + 3 }, WindowColour::secondary,
+                    def.caption);
 
                 checkboxWidgetsToInsert.emplace_back(checkboxWidget);
                 numGroupElements++;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -18,6 +18,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/GameState.h>
@@ -270,14 +271,14 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kMainOptionsWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({   0, 43 }, { kWindowSize.width, 289 }, WidgetType::resize, WindowColour::secondary),
-        makeTab   ({   3, 17 }, STR_OPTIONS_DISPLAY_TIP),
-        makeTab   ({  34, 17 }, STR_OPTIONS_RENDERING_TIP),
-        makeTab   ({  65, 17 }, STR_OPTIONS_CULTURE_TIP),
-        makeTab   ({  96, 17 }, STR_OPTIONS_AUDIO_TIP),
-        makeTab   ({ 127, 17 }, STR_OPTIONS_INTERFACE_TIP),
-        makeTab   ({ 158, 17 }, STR_OPTIONS_CONTROLS_TIP),
-        makeTab   ({ 189, 17 }, STR_OPTIONS_MISCELLANEOUS_TIP),
-        makeTab   ({ 220, 17 }, STR_OPTIONS_ADVANCED)
+        Widgets::Tab({   3, 17 }, STR_OPTIONS_DISPLAY_TIP),
+        Widgets::Tab({  34, 17 }, STR_OPTIONS_RENDERING_TIP),
+        Widgets::Tab({  65, 17 }, STR_OPTIONS_CULTURE_TIP),
+        Widgets::Tab({  96, 17 }, STR_OPTIONS_AUDIO_TIP),
+        Widgets::Tab({ 127, 17 }, STR_OPTIONS_INTERFACE_TIP),
+        Widgets::Tab({ 158, 17 }, STR_OPTIONS_CONTROLS_TIP),
+        Widgets::Tab({ 189, 17 }, STR_OPTIONS_MISCELLANEOUS_TIP),
+        Widgets::Tab({ 220, 17 }, STR_OPTIONS_ADVANCED)
     );
 
     static constexpr auto window_options_display_widgets = makeWidgets(

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -17,6 +17,7 @@
 #include <openrct2-ui/interface/Theme.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/GameState.h>
@@ -298,12 +299,12 @@ namespace OpenRCT2::Ui::Windows
         makeWidget        ({ 10, 161}, {145,  12}, WidgetType::label,        WindowColour::secondary, STR_FRAME_RATE_LIMIT_LABEL                                                      ), // Frame rate limit (label)
         makeWidget        ({155, 160}, {145,  14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                                  ), // Frame rate limit (dropdown label)
         makeWidget        ({288, 161}, { 11,  12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                                              ), // Frame rate limit (chevron)
-        makeWidget        ({ 11, 178}, {136,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_SHOW_FPS,                          STR_SHOW_FPS_TIP                         ), // Show fps
-        makeWidget        ({155, 178}, {136,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_MULTITHREADING,                    STR_MULTITHREADING_TIP                   ), // Multithreading
+        Widgets::Checkbox ({ 11, 178}, {136,  12},                           WindowColour::secondary, STR_SHOW_FPS,                          STR_SHOW_FPS_TIP                         ), // Show fps
+        Widgets::Checkbox ({155, 178}, {136,  12},                           WindowColour::secondary, STR_MULTITHREADING,                    STR_MULTITHREADING_TIP                   ), // Multithreading
 
         makeWidget        ({  5, 200}, {300,  49}, WidgetType::groupbox,     WindowColour::secondary, STR_GROUP_BEHAVIOUR                                                             ), // Behaviour group
-        makeWidget        ({ 11, 215}, {280,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS_TIP), // Minimise fullscreen focus loss
-        makeWidget        ({ 11, 230}, {280,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_DISABLE_SCREENSAVER,               STR_DISABLE_SCREENSAVER_TIP              )  // Disable screensaver
+        Widgets::Checkbox ({ 11, 215}, {280,  12},                           WindowColour::secondary, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS, STR_MINIMISE_FULLSCREEN_ON_FOCUS_LOSS_TIP), // Minimise fullscreen focus loss
+        Widgets::Checkbox ({ 11, 230}, {280,  12},                           WindowColour::secondary, STR_DISABLE_SCREENSAVER,               STR_DISABLE_SCREENSAVER_TIP              )  // Disable screensaver
     );
 
     constexpr int32_t kFrameRenderingStart = 53;
@@ -312,21 +313,21 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto window_options_rendering_widgets = makeWidgets(
         kMainOptionsWidgets,
         makeWidget({  5,  kFrameRenderingStart + 0}, {300, 110}, WidgetType::groupbox,     WindowColour::secondary, STR_RENDERING_GROUP                                       ), // Rendering group
-        makeWidget({ 10, kFrameRenderingStart + 15}, {281,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_TILE_SMOOTHING,         STR_TILE_SMOOTHING_TIP        ), // Landscape smoothing
-        makeWidget({ 10, kFrameRenderingStart + 30}, {281,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_GRIDLINES,              STR_GRIDLINES_TIP             ), // Gridlines
-        makeWidget({ 10, kFrameRenderingStart + 45}, {281,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_UPPERCASE_BANNERS,      STR_UPPERCASE_BANNERS_TIP     ), // Uppercase banners
-        makeWidget({ 10, kFrameRenderingStart + 60}, {281,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_SHOW_GUEST_PURCHASES,   STR_SHOW_GUEST_PURCHASES_TIP  ), // Guest purchases
-        makeWidget({ 10, kFrameRenderingStart + 75}, {281,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_TRANSPARENT_SCREENSHOT, STR_TRANSPARENT_SCREENSHOT_TIP), // Transparent screenshot
+        Widgets::Checkbox({ 10, kFrameRenderingStart + 15}, {281,  12},                           WindowColour::secondary, STR_TILE_SMOOTHING,         STR_TILE_SMOOTHING_TIP        ), // Landscape smoothing
+        Widgets::Checkbox({ 10, kFrameRenderingStart + 30}, {281,  12},                           WindowColour::secondary, STR_GRIDLINES,              STR_GRIDLINES_TIP             ), // Gridlines
+        Widgets::Checkbox({ 10, kFrameRenderingStart + 45}, {281,  12},                           WindowColour::secondary, STR_UPPERCASE_BANNERS,      STR_UPPERCASE_BANNERS_TIP     ), // Uppercase banners
+        Widgets::Checkbox({ 10, kFrameRenderingStart + 60}, {281,  12},                           WindowColour::secondary, STR_SHOW_GUEST_PURCHASES,   STR_SHOW_GUEST_PURCHASES_TIP  ), // Guest purchases
+        Widgets::Checkbox({ 10, kFrameRenderingStart + 75}, {281,  12},                           WindowColour::secondary, STR_TRANSPARENT_SCREENSHOT, STR_TRANSPARENT_SCREENSHOT_TIP), // Transparent screenshot
         makeWidget({ 10, kFrameRenderingStart + 91}, {281,  12}, WidgetType::label,        WindowColour::secondary, STR_VIRTUAL_FLOOR_STYLE,    STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor
         makeWidget({155, kFrameRenderingStart + 90}, {145,  14}, WidgetType::dropdownMenu, WindowColour::secondary, kStringIdNone,              STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor dropdown
         makeWidget({288, kFrameRenderingStart + 91}, { 11,  12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,         STR_VIRTUAL_FLOOR_STYLE_TIP   ), // Virtual floor dropdown
 
         makeWidget({ 5,  kFrameEffectStart + 0}, {300, 94}, WidgetType::groupbox, WindowColour::secondary, STR_EFFECTS_GROUP                                             ), // Rendering group
-        makeWidget({10, kFrameEffectStart + 15}, {281, 12}, WidgetType::checkbox, WindowColour::secondary, STR_CYCLE_DAY_NIGHT,          STR_CYCLE_DAY_NIGHT_TIP         ), // Cycle day-night
-        makeWidget({25, kFrameEffectStart + 30}, {266, 12}, WidgetType::checkbox, WindowColour::secondary, STR_ENABLE_LIGHTING_EFFECTS,  STR_ENABLE_LIGHTING_EFFECTS_TIP ), // Enable light fx
-        makeWidget({40, kFrameEffectStart + 45}, {251, 12}, WidgetType::checkbox, WindowColour::secondary, STR_ENABLE_LIGHTING_VEHICLES, STR_ENABLE_LIGHTING_VEHICLES_TIP), // Enable light fx for vehicles
-        makeWidget({10, kFrameEffectStart + 60}, {281, 12}, WidgetType::checkbox, WindowColour::secondary, STR_RENDER_WEATHER_EFFECTS,   STR_RENDER_WEATHER_EFFECTS_TIP  ), // Render weather effects
-        makeWidget({25, kFrameEffectStart + 75}, {266, 12}, WidgetType::checkbox, WindowColour::secondary, STR_DISABLE_LIGHTNING_EFFECT, STR_DISABLE_LIGHTNING_EFFECT_TIP)  // Disable lightning effect
+        Widgets::Checkbox({10, kFrameEffectStart + 15}, {281, 12},                       WindowColour::secondary, STR_CYCLE_DAY_NIGHT,          STR_CYCLE_DAY_NIGHT_TIP         ), // Cycle day-night
+        Widgets::Checkbox({25, kFrameEffectStart + 30}, {266, 12},                       WindowColour::secondary, STR_ENABLE_LIGHTING_EFFECTS,  STR_ENABLE_LIGHTING_EFFECTS_TIP ), // Enable light fx
+        Widgets::Checkbox({40, kFrameEffectStart + 45}, {251, 12},                       WindowColour::secondary, STR_ENABLE_LIGHTING_VEHICLES, STR_ENABLE_LIGHTING_VEHICLES_TIP), // Enable light fx for vehicles
+        Widgets::Checkbox({10, kFrameEffectStart + 60}, {281, 12},                       WindowColour::secondary, STR_RENDER_WEATHER_EFFECTS,   STR_RENDER_WEATHER_EFFECTS_TIP  ), // Render weather effects
+        Widgets::Checkbox({25, kFrameEffectStart + 75}, {266, 12},                       WindowColour::secondary, STR_DISABLE_LIGHTNING_EFFECT, STR_DISABLE_LIGHTNING_EFFECT_TIP)  // Disable lightning effect
     );
 
     static constexpr auto window_options_culture_widgets = makeWidgets(
@@ -355,10 +356,10 @@ namespace OpenRCT2::Ui::Windows
         kMainOptionsWidgets,
         makeWidget({ 10,  53}, {290, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                ), // Audio device
         makeWidget({288,  54}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,      STR_AUDIO_DEVICE_TIP ),
-        makeWidget({ 10,  71}, {220, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_MASTER_VOLUME,       STR_MASTER_VOLUME_TIP), // Enable / disable master sound
-        makeWidget({ 10,  86}, {220, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_SOUND_EFFECTS,       STR_SOUND_EFFECTS_TIP), // Enable / disable sound effects
-        makeWidget({ 10, 101}, {220, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_RIDE_MUSIC,          STR_RIDE_MUSIC_TIP   ), // Enable / disable ride music
-        makeWidget({ 10, 115}, {290, 13}, WidgetType::checkbox,     WindowColour::secondary, STR_AUDIO_FOCUS,         STR_AUDIO_FOCUS_TIP  ), // Enable / disable audio disabled on focus lost
+        Widgets::Checkbox({ 10,  71}, {220, 12},                    WindowColour::secondary, STR_MASTER_VOLUME,       STR_MASTER_VOLUME_TIP), // Enable / disable master sound
+        Widgets::Checkbox({ 10,  86}, {220, 12},                    WindowColour::secondary, STR_SOUND_EFFECTS,       STR_SOUND_EFFECTS_TIP), // Enable / disable sound effects
+        Widgets::Checkbox({ 10, 101}, {220, 12},                    WindowColour::secondary, STR_RIDE_MUSIC,          STR_RIDE_MUSIC_TIP   ), // Enable / disable ride music
+        Widgets::Checkbox({ 10, 115}, {290, 13},                    WindowColour::secondary, STR_AUDIO_FOCUS,         STR_AUDIO_FOCUS_TIP  ), // Enable / disable audio disabled on focus lost
         makeWidget({ 10, 130}, {145, 12}, WidgetType::label,        WindowColour::secondary, STR_OPTIONS_MUSIC_LABEL, STR_TITLE_MUSIC_TIP  ), // Title music label
         makeWidget({155, 129}, {145, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                ), // Title music
         makeWidget({288, 130}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,      STR_TITLE_MUSIC_TIP  ),
@@ -373,13 +374,13 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto window_options_controls_widgets = makeWidgets(
         kMainOptionsWidgets,
         makeWidget({  5, kControlsGroupStart +  0},  {300,139}, WidgetType::groupbox, WindowColour::secondary, STR_CONTROLS_GROUP                                                ), // Controls group
-        makeWidget({ 10, kControlsGroupStart + 13},  {290, 14}, WidgetType::checkbox, WindowColour::tertiary,  STR_SCREEN_EDGE_SCROLLING,      STR_SCREEN_EDGE_SCROLLING_TIP     ), // Edge scrolling
-        makeWidget({ 10, kControlsGroupStart + 30},  {290, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_TRAP_MOUSE,                 STR_TRAP_MOUSE_TIP                ), // Trap mouse
-        makeWidget({ 10, kControlsGroupStart + 45},  {290, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_INVERT_RIGHT_MOUSE_DRAG,    STR_INVERT_RIGHT_MOUSE_DRAG_TIP   ), // Invert right mouse dragging
-        makeWidget({ 10, kControlsGroupStart + 60},  {290, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_ZOOM_TO_CURSOR,             STR_ZOOM_TO_CURSOR_TIP            ), // Zoom to cursor
-        makeWidget({ 10, kControlsGroupStart + 75},  {290, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_WINDOW_BUTTONS_ON_THE_LEFT, STR_WINDOW_BUTTONS_ON_THE_LEFT_TIP), // Window buttons on the left
-        makeWidget({ 10, kControlsGroupStart + 90},  {290, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_ENLARGED_UI,                STR_ENLARGED_UI_TIP               ),
-        makeWidget({ 25, kControlsGroupStart + 105}, {275, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_TOUCH_ENHANCEMENTS,         STR_TOUCH_ENHANCEMENTS_TIP        ),
+        Widgets::Checkbox({ 10, kControlsGroupStart + 13},  {290, 14},                WindowColour::tertiary,  STR_SCREEN_EDGE_SCROLLING,      STR_SCREEN_EDGE_SCROLLING_TIP     ), // Edge scrolling
+        Widgets::Checkbox({ 10, kControlsGroupStart + 30},  {290, 12},                WindowColour::tertiary,  STR_TRAP_MOUSE,                 STR_TRAP_MOUSE_TIP                ), // Trap mouse
+        Widgets::Checkbox({ 10, kControlsGroupStart + 45},  {290, 12},                WindowColour::tertiary,  STR_INVERT_RIGHT_MOUSE_DRAG,    STR_INVERT_RIGHT_MOUSE_DRAG_TIP   ), // Invert right mouse dragging
+        Widgets::Checkbox({ 10, kControlsGroupStart + 60},  {290, 12},                WindowColour::tertiary,  STR_ZOOM_TO_CURSOR,             STR_ZOOM_TO_CURSOR_TIP            ), // Zoom to cursor
+        Widgets::Checkbox({ 10, kControlsGroupStart + 75},  {290, 12},                WindowColour::tertiary,  STR_WINDOW_BUTTONS_ON_THE_LEFT, STR_WINDOW_BUTTONS_ON_THE_LEFT_TIP), // Window buttons on the left
+        Widgets::Checkbox({ 10, kControlsGroupStart + 90},  {290, 12},                WindowColour::tertiary,  STR_ENLARGED_UI,                STR_ENLARGED_UI_TIP               ),
+        Widgets::Checkbox({ 25, kControlsGroupStart + 105}, {275, 12},                WindowColour::tertiary,  STR_TOUCH_ENHANCEMENTS,         STR_TOUCH_ENHANCEMENTS_TIP        ),
         makeWidget({155, kControlsGroupStart + 120}, {144, 13}, WidgetType::button,   WindowColour::secondary, STR_HOTKEY,                     STR_HOTKEY_TIP                    ), // Set hotkeys buttons
 
         // Gamepad group
@@ -402,16 +403,16 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({155, kThemesGroupStart + 30}, {145, 14}, WidgetType::button,       WindowColour::secondary, STR_EDIT_THEMES_BUTTON,         STR_EDIT_THEMES_BUTTON_TIP), // Themes button
 
         makeWidget({  5, kToolbarGroupStart +  0}, {300,107}, WidgetType::groupbox, WindowColour::secondary, STR_TOOLBAR_BUTTONS_GROUP                                                         ), // Toolbar buttons group
-        makeWidget({ 10, kToolbarGroupStart + 14}, {280, 12}, WidgetType::checkbox, WindowColour::tertiary,  STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED, STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED_TIP      ),
+        Widgets::Checkbox({ 10, kToolbarGroupStart + 14}, {280, 12},                WindowColour::tertiary,  STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED, STR_OPTIONS_TOOLBAR_BUTTONS_CENTRED_TIP      ),
         makeWidget({ 10, kToolbarGroupStart + 31}, {280, 12}, WidgetType::label,    WindowColour::secondary, STR_SHOW_TOOLBAR_BUTTONS_FOR                                                      ),
-        makeWidget({ 24, kToolbarGroupStart + 46}, {122, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_FINANCES_BUTTON_ON_TOOLBAR,      STR_FINANCES_BUTTON_ON_TOOLBAR_TIP           ), // Finances
-        makeWidget({ 24, kToolbarGroupStart + 61}, {122, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_RESEARCH_BUTTON_ON_TOOLBAR,      STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP           ), // Research
-        makeWidget({155, kToolbarGroupStart + 46}, {145, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_CHEATS_BUTTON_ON_TOOLBAR,        STR_CHEATS_BUTTON_ON_TOOLBAR_TIP             ), // Cheats
-        makeWidget({155, kToolbarGroupStart + 61}, {145, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR, STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP      ), // Recent messages
-        makeWidget({ 24, kToolbarGroupStart + 76}, {162, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP               ), // Mute
-        makeWidget({155, kToolbarGroupStart + 76}, {145, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP               ), // Chat
-        makeWidget({ 24, kToolbarGroupStart + 91}, {122, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP               ), // Zoom
-        makeWidget({155, kToolbarGroupStart + 91}, {145, 12}, WidgetType::checkbox, WindowColour::tertiary , STR_ROTATE_ANTI_CLOCKWISE,           STR_ROTATE_VIEW_ANTI_CLOCKWISE_IN_TOOLBAR_TIP)  // Rotate anti-clockwise
+        Widgets::Checkbox({ 24, kToolbarGroupStart + 46}, {122, 12},                WindowColour::tertiary , STR_FINANCES_BUTTON_ON_TOOLBAR,      STR_FINANCES_BUTTON_ON_TOOLBAR_TIP           ), // Finances
+        Widgets::Checkbox({ 24, kToolbarGroupStart + 61}, {122, 12},                WindowColour::tertiary , STR_RESEARCH_BUTTON_ON_TOOLBAR,      STR_RESEARCH_BUTTON_ON_TOOLBAR_TIP           ), // Research
+        Widgets::Checkbox({155, kToolbarGroupStart + 46}, {145, 12},                WindowColour::tertiary , STR_CHEATS_BUTTON_ON_TOOLBAR,        STR_CHEATS_BUTTON_ON_TOOLBAR_TIP             ), // Cheats
+        Widgets::Checkbox({155, kToolbarGroupStart + 61}, {145, 12},                WindowColour::tertiary , STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR, STR_SHOW_RECENT_MESSAGES_ON_TOOLBAR_TIP      ), // Recent messages
+        Widgets::Checkbox({ 24, kToolbarGroupStart + 76}, {162, 12},                WindowColour::tertiary , STR_MUTE_BUTTON_ON_TOOLBAR,          STR_MUTE_BUTTON_ON_TOOLBAR_TIP               ), // Mute
+        Widgets::Checkbox({155, kToolbarGroupStart + 76}, {145, 12},                WindowColour::tertiary , STR_CHAT_BUTTON_ON_TOOLBAR,          STR_CHAT_BUTTON_ON_TOOLBAR_TIP               ), // Chat
+        Widgets::Checkbox({ 24, kToolbarGroupStart + 91}, {122, 12},                WindowColour::tertiary , STR_ZOOM_BUTTON_ON_TOOLBAR,          STR_ZOOM_BUTTON_ON_TOOLBAR_TIP               ), // Zoom
+        Widgets::Checkbox({155, kToolbarGroupStart + 91}, {145, 12},                WindowColour::tertiary , STR_ROTATE_ANTI_CLOCKWISE,           STR_ROTATE_VIEW_ANTI_CLOCKWISE_IN_TOOLBAR_TIP)  // Rotate anti-clockwise
     );
 
     constexpr int32_t kTitleSequenceStart = 53;
@@ -427,14 +428,14 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({ 10, kScenarioOptionsGroupStart + 16}, {165, 12}, WidgetType::label,        WindowColour::secondary, STR_SCENARIO_PREVIEWS_LABEL,    STR_SCENARIO_PREVIEWS_TIP ),
         makeWidget({175, kScenarioOptionsGroupStart + 15}, {125, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                            ), // Scenario previews
         makeWidget({288, kScenarioOptionsGroupStart + 16}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,             STR_SCENARIO_PREVIEWS_TIP ),
-        makeWidget({ 10, kScenarioOptionsGroupStart + 32}, {275, 16}, WidgetType::checkbox,     WindowColour::tertiary,  STR_OPTIONS_SCENARIO_UNLOCKING, STR_SCENARIO_UNLOCKING_TIP), // Unlocking of scenarios
-        makeWidget({ 10, kScenarioOptionsGroupStart + 47}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary,  STR_ALLOW_EARLY_COMPLETION,     STR_EARLY_COMPLETION_TIP  ), // Allow early scenario completion
+        Widgets::Checkbox({ 10, kScenarioOptionsGroupStart + 32}, {275, 16},                    WindowColour::tertiary,  STR_OPTIONS_SCENARIO_UNLOCKING, STR_SCENARIO_UNLOCKING_TIP), // Unlocking of scenarios
+        Widgets::Checkbox({ 10, kScenarioOptionsGroupStart + 47}, {290, 15},                    WindowColour::tertiary,  STR_ALLOW_EARLY_COMPLETION,     STR_EARLY_COMPLETION_TIP  ), // Allow early scenario completion
 
         makeWidget({  5,  kTweaksStart + 0}, {300, 96}, WidgetType::groupbox,     WindowColour::secondary, STR_OPTIONS_TWEAKS                                                  ),
-        makeWidget({ 10, kTweaksStart + 15}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_REAL_NAME_GUESTS,     STR_REAL_NAME_GUESTS_TIP                  ), // Show 'real' names of guests
-        makeWidget({ 10, kTweaksStart + 30}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_REAL_NAME_STAFF,      STR_REAL_NAME_STAFF_TIP                   ), // Show 'real' names of staff
-        makeWidget({ 10, kTweaksStart + 45}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_AUTO_STAFF_PLACEMENT, STR_AUTO_STAFF_PLACEMENT_TIP              ), // Auto staff placement
-        makeWidget({ 10, kTweaksStart + 60}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_AUTO_OPEN_SHOPS,      STR_AUTO_OPEN_SHOPS_TIP                   ), // Automatically open shops & stalls
+        Widgets::Checkbox({ 10, kTweaksStart + 15}, {290, 15},                    WindowColour::tertiary , STR_REAL_NAME_GUESTS,     STR_REAL_NAME_GUESTS_TIP                  ), // Show 'real' names of guests
+        Widgets::Checkbox({ 10, kTweaksStart + 30}, {290, 15},                    WindowColour::tertiary , STR_REAL_NAME_STAFF,      STR_REAL_NAME_STAFF_TIP                   ), // Show 'real' names of staff
+        Widgets::Checkbox({ 10, kTweaksStart + 45}, {290, 15},                    WindowColour::tertiary , STR_AUTO_STAFF_PLACEMENT, STR_AUTO_STAFF_PLACEMENT_TIP              ), // Auto staff placement
+        Widgets::Checkbox({ 10, kTweaksStart + 60}, {290, 15},                    WindowColour::tertiary , STR_AUTO_OPEN_SHOPS,      STR_AUTO_OPEN_SHOPS_TIP                   ), // Automatically open shops & stalls
         makeWidget({ 10, kTweaksStart + 77}, {165, 12}, WidgetType::label,        WindowColour::secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
         makeWidget({175, kTweaksStart + 76}, {125, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                      ), // Default inspection time dropdown
         makeWidget({288, kTweaksStart + 77}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       )  // Default inspection time dropdown button
@@ -453,8 +454,8 @@ namespace OpenRCT2::Ui::Windows
         makeWidget        ({249, kRCT1Start + 15}, { 50, 14}, WidgetType::button,       WindowColour::secondary, STR_CLEAR_BUTTON,                          STR_PATH_TO_RCT1_CLEAR_TIP                   ), // RCT 1 path clear
 
         makeWidget        ({  5, kSavingStart +  0}, {300, 82}, WidgetType::groupbox,     WindowColour::secondary, STR_GROUP_SAVING                                                                        ),
-        makeWidget        ({ 10, kSavingStart + 16}, {290, 12}, WidgetType::checkbox,     WindowColour::tertiary,  STR_SAVE_PLUGIN_DATA,                      STR_SAVE_PLUGIN_DATA_TIP                     ), // Export plug-in objects with saved games
-        makeWidget        ({ 10, kSavingStart + 30}, {290, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_ALWAYS_NATIVE_LOADSAVE,                STR_ALWAYS_NATIVE_LOADSAVE_TIP               ), // Use native load/save window
+        Widgets::Checkbox ({ 10, kSavingStart + 16}, {290, 12},                           WindowColour::tertiary,  STR_SAVE_PLUGIN_DATA,                      STR_SAVE_PLUGIN_DATA_TIP                     ), // Export plug-in objects with saved games
+        Widgets::Checkbox ({ 10, kSavingStart + 30}, {290, 12},                           WindowColour::secondary, STR_ALWAYS_NATIVE_LOADSAVE,                STR_ALWAYS_NATIVE_LOADSAVE_TIP               ), // Use native load/save window
         makeWidget        ({ 23, kSavingStart + 46}, {135, 12}, WidgetType::label,        WindowColour::secondary, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL,      STR_AUTOSAVE_FREQUENCY_TIP                   ),
         makeWidget        ({165, kSavingStart + 45}, {135, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                                          ), // Autosave dropdown
         makeWidget        ({288, kSavingStart + 46}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,                        STR_AUTOSAVE_FREQUENCY_TIP                   ), // Autosave dropdown button
@@ -462,8 +463,8 @@ namespace OpenRCT2::Ui::Windows
         makeSpinnerWidgets({165, kSavingStart + 62}, {135, 14}, WidgetType::spinner,      WindowColour::secondary, kStringIdNone,                             STR_AUTOSAVE_AMOUNT_TIP                      ), // Autosave amount spinner
 
         makeWidget        ({  5, kAdvancedStart +  0}, {300, 97}, WidgetType::groupbox,     WindowColour::secondary, STR_GROUP_ADVANCED                                                                      ),
-        makeWidget        ({ 10, kAdvancedStart + 16}, {295, 12}, WidgetType::checkbox,     WindowColour::tertiary,  STR_ENABLE_DEBUGGING_TOOLS,                STR_ENABLE_DEBUGGING_TOOLS_TIP               ), // Enable debugging tools
-        makeWidget        ({ 10, kAdvancedStart + 30}, {295, 12}, WidgetType::checkbox,     WindowColour::tertiary,  STR_STAY_CONNECTED_AFTER_DESYNC,           STR_STAY_CONNECTED_AFTER_DESYNC_TIP          ), // Do not disconnect after the client desynchronises with the server
+        Widgets::Checkbox ({ 10, kAdvancedStart + 16}, {295, 12},                           WindowColour::tertiary,  STR_ENABLE_DEBUGGING_TOOLS,                STR_ENABLE_DEBUGGING_TOOLS_TIP               ), // Enable debugging tools
+        Widgets::Checkbox ({ 10, kAdvancedStart + 30}, {295, 12},                           WindowColour::tertiary,  STR_STAY_CONNECTED_AFTER_DESYNC,           STR_STAY_CONNECTED_AFTER_DESYNC_TIP          ), // Do not disconnect after the client desynchronises with the server
 #ifdef __EMSCRIPTEN__
         makeWidget        ({ 10, kAdvancedStart + 46}, {135, 14}, WidgetType::button,       WindowColour::secondary, STR_EXPORT_EMSCRIPTEN,                     kStringIdNone                                ), // Emscripten data export
         makeWidget        ({150, kAdvancedStart + 46}, {150, 14}, WidgetType::button,       WindowColour::secondary, STR_IMPORT_EMSCRIPTEN,                     kStringIdNone                                ), // Emscripten data import

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/interface/Theme.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -98,13 +99,13 @@ namespace OpenRCT2::Ui::Windows
         return makeWidgets(
             makeWindowShim(kWindowTitle, { width, kWindowHeight }),
             makeWidget({   0, 43 }, { width, 131 }, WidgetType::resize, WindowColour::secondary),
-            makeTab   ({   3, 17 }, STR_PARK_ENTRANCE_TAB_TIP                                  ),
-            makeTab   ({  34, 17 }, STR_PARK_RATING_TAB_TIP                                    ),
-            makeTab   ({  65, 17 }, STR_PARK_GUESTS_TAB_TIP                                    ),
-            makeTab   ({  96, 17 }, STR_PARK_PRICE_TAB_TIP                                     ),
-            makeTab   ({ 127, 17 }, STR_PARK_STATS_TAB_TIP                                     ),
-            makeTab   ({ 158, 17 }, STR_PARK_OBJECTIVE_TAB_TIP                                 ),
-            makeTab   ({ 189, 17 }, STR_PARK_AWARDS_TAB_TIP                                    )
+            Widgets::Tab({   3, 17 }, STR_PARK_ENTRANCE_TAB_TIP ),
+            Widgets::Tab({  34, 17 }, STR_PARK_RATING_TAB_TIP   ),
+            Widgets::Tab({  65, 17 }, STR_PARK_GUESTS_TAB_TIP   ),
+            Widgets::Tab({  96, 17 }, STR_PARK_PRICE_TAB_TIP    ),
+            Widgets::Tab({ 127, 17 }, STR_PARK_STATS_TAB_TIP    ),
+            Widgets::Tab({ 158, 17 }, STR_PARK_OBJECTIVE_TAB_TIP),
+            Widgets::Tab({ 189, 17 }, STR_PARK_AWARDS_TAB_TIP   )
         );
     };
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -57,8 +58,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kCommonPlayerWidgets = makeWidgets(
         makeWindowShim(kStringIdNone, kWindowSize),
         makeWidget({ 0, 43}, {192, 114}, WidgetType::resize, WindowColour::secondary),
-        makeTab   ({ 3, 17}                                                         ),
-        makeTab   ({34, 17}                                                         )
+        Widgets::Tab({ 3, 17}),
+        Widgets::Tab({34, 17})
     );
 
     static constexpr auto window_player_overview_widgets = makeWidgets(

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -86,13 +87,13 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({  8,  59}, {                          160,  14}, WidgetType::dropdownMenu, WindowColour::tertiary, 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
         makeWidget({156,  60}, {                           11,  12}, WidgetType::button,       WindowColour::tertiary, STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
         makeWidget({  3,  96}, { kWindowSizeFunding.width - 6, 107}, WidgetType::groupbox,     WindowColour::tertiary, STR_RESEARCH_PRIORITIES                                                           ),
-        makeWidget({  8, 108}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
-        makeWidget({  8, 121}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
-        makeWidget({  8, 134}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
-        makeWidget({  8, 147}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
-        makeWidget({  8, 160}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
-        makeWidget({  8, 173}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
-        makeWidget({  8, 186}, {kWindowSizeFunding.width - 16,  12}, WidgetType::checkbox,     WindowColour::tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    )
+        Widgets::Checkbox({  8, 108}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_TRANSPORT_RIDES,     STR_RESEARCH_NEW_TRANSPORT_RIDES_TIP        ),
+        Widgets::Checkbox({  8, 121}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_GENTLE_RIDES,        STR_RESEARCH_NEW_GENTLE_RIDES_TIP           ),
+        Widgets::Checkbox({  8, 134}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_ROLLER_COASTERS,     STR_RESEARCH_NEW_ROLLER_COASTERS_TIP        ),
+        Widgets::Checkbox({  8, 147}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_THRILL_RIDES,        STR_RESEARCH_NEW_THRILL_RIDES_TIP           ),
+        Widgets::Checkbox({  8, 160}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_WATER_RIDES,         STR_RESEARCH_NEW_WATER_RIDES_TIP            ),
+        Widgets::Checkbox({  8, 173}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_SHOPS_AND_STALLS,    STR_RESEARCH_NEW_SHOPS_AND_STALLS_TIP       ),
+        Widgets::Checkbox({  8, 186}, {kWindowSizeFunding.width - 16,  12},                    WindowColour::tertiary, STR_RESEARCH_NEW_SCENERY_AND_THEMING, STR_RESEARCH_NEW_SCENERY_AND_THEMING_TIP    )
     );
 
     static constexpr std::span<const Widget> window_research_page_widgets[] = {

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -71,8 +72,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto window_research_development_widgets = makeWidgets(
         makeWindowShim(STR_RESEARCH_AND_DEVELOPMENT, kWindowSizeDevelopment),
         makeWidget({  0,  43}, {     kWindowSizeDevelopment.width, 153}, WidgetType::resize,   WindowColour::secondary                                                                 ),
-        makeTab   ({  3,  17},                                                                                          STR_RESEARCH_AND_DEVELOPMENT_TIP                               ),
-        makeTab   ({ 34,  17},                                                                                          STR_FINANCES_RESEARCH_TIP                                      ),
+        Widgets::Tab({ 3, 17}, STR_RESEARCH_AND_DEVELOPMENT_TIP),
+        Widgets::Tab({34, 17}, STR_FINANCES_RESEARCH_TIP       ),
         makeWidget({  3,  47}, {kWindowSizeDevelopment.width - 10,  70}, WidgetType::groupbox, WindowColour::tertiary,  STR_CURRENTLY_IN_DEVELOPMENT                                   ),
         makeWidget({  3, 124}, {kWindowSizeDevelopment.width - 10,  65}, WidgetType::groupbox, WindowColour::tertiary,  STR_LAST_DEVELOPMENT                                           ),
         makeWidget({265, 161}, {                               24,  24}, WidgetType::flatBtn,  WindowColour::tertiary,  0xFFFFFFFF,                       STR_RESEARCH_SHOW_DETAILS_TIP)
@@ -81,8 +82,8 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto window_research_funding_widgets = makeWidgets(
         makeWindowShim(STR_RESEARCH_FUNDING, kWindowSizeFunding),
         makeWidget({  0,  43}, {     kWindowSizeFunding.width, 164}, WidgetType::resize,       WindowColour::secondary                                                                                   ),
-        makeTab   ({  3,  17},                                                                                         STR_RESEARCH_AND_DEVELOPMENT_TIP                                                  ),
-        makeTab   ({ 34,  17},                                                                                         STR_FINANCES_RESEARCH_TIP                                                         ),
+        Widgets::Tab({  3,  17}, STR_RESEARCH_AND_DEVELOPMENT_TIP),
+        Widgets::Tab({ 34,  17}, STR_FINANCES_RESEARCH_TIP       ),
         makeWidget({  3,  47}, { kWindowSizeFunding.width - 6,  45}, WidgetType::groupbox,     WindowColour::tertiary, STR_RESEARCH_FUNDING_                                                             ),
         makeWidget({  8,  59}, {                          160,  14}, WidgetType::dropdownMenu, WindowColour::tertiary, 0xFFFFFFFF,                           STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),
         makeWidget({156,  60}, {                           11,  12}, WidgetType::button,       WindowColour::tertiary, STR_DROPDOWN_GLYPH,                   STR_SELECT_LEVEL_OF_RESEARCH_AND_DEVELOPMENT),

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -18,6 +18,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
@@ -260,16 +261,16 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kMainRideWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({  0, 43}, {kMinimumWindowWidth, 137}, WidgetType::resize, WindowColour::secondary),
-        makeTab({   3, 17 }, STR_VIEW_OF_RIDE_ATTRACTION_TIP),
-        makeTab({  34, 17 }, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP),
-        makeTab({  65, 17 }, STR_OPERATING_OPTIONS_TIP),
-        makeTab({  96, 17 }, STR_MAINTENANCE_OPTIONS_TIP),
-        makeTab({ 127, 17 }, STR_COLOUR_SCHEME_OPTIONS_TIP),
-        makeTab({ 158, 17 }, STR_SOUND_AND_MUSIC_OPTIONS_TIP),
-        makeTab({ 189, 17 }, STR_MEASUREMENTS_AND_TEST_DATA_TIP),
-        makeTab({ 220, 17 }, STR_GRAPHS_TIP),
-        makeTab({ 251, 17 }, STR_INCOME_AND_COSTS_TIP),
-        makeTab({ 282, 17 }, STR_CUSTOMER_INFORMATION_TIP)
+        Widgets::Tab({   3, 17 }, STR_VIEW_OF_RIDE_ATTRACTION_TIP),
+        Widgets::Tab({  34, 17 }, STR_VEHICLE_DETAILS_AND_OPTIONS_TIP),
+        Widgets::Tab({  65, 17 }, STR_OPERATING_OPTIONS_TIP),
+        Widgets::Tab({  96, 17 }, STR_MAINTENANCE_OPTIONS_TIP),
+        Widgets::Tab({ 127, 17 }, STR_COLOUR_SCHEME_OPTIONS_TIP),
+        Widgets::Tab({ 158, 17 }, STR_SOUND_AND_MUSIC_OPTIONS_TIP),
+        Widgets::Tab({ 189, 17 }, STR_MEASUREMENTS_AND_TEST_DATA_TIP),
+        Widgets::Tab({ 220, 17 }, STR_GRAPHS_TIP),
+        Widgets::Tab({ 251, 17 }, STR_INCOME_AND_COSTS_TIP),
+        Widgets::Tab({ 282, 17 }, STR_CUSTOMER_INFORMATION_TIP)
     );
 
     // 0x009ADC34

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -17,6 +17,7 @@
 #include <openrct2-ui/interface/Theme.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Cheats.h>
 #include <openrct2/Context.h>
@@ -294,7 +295,7 @@ namespace OpenRCT2::Ui::Windows
         kMainRideWidgets,
         makeWidget        ({  7,  50}, {302, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                          ),
         makeWidget        ({297,  51}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                      ),
-        makeWidget        ({  7, 137}, {302, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_OPTION_REVERSE_TRAINS, STR_OPTION_REVERSE_TRAINS_TIP),
+        Widgets::Checkbox        ({  7, 137}, {302, 12},                           WindowColour::secondary, STR_OPTION_REVERSE_TRAINS, STR_OPTION_REVERSE_TRAINS_TIP),
         makeWidget        ({  7, 154}, {302, 43}, WidgetType::scroll,       WindowColour::secondary, kStringIdEmpty                                          ),
         makeHoldableSpinnerWidgets({  7, 203}, {145, 14}, WidgetType::spinner,      WindowColour::secondary, STR_RIDE_VEHICLE_COUNT,    STR_MAX_VEHICLES_TIP         ),
         makeHoldableSpinnerWidgets({164, 203}, {145, 14}, WidgetType::spinner,      WindowColour::secondary, kStringIdEmpty,            STR_MAX_CARS_PER_TRAIN_TIP   )
@@ -316,20 +317,16 @@ namespace OpenRCT2::Ui::Windows
 
         // Load/wait/sync group
         makeWidget                ({  3,   0}, {310, 67}, WidgetType::groupbox,     WindowColour::secondary, STR_WAIT_AND_LOAD_GROUP                                                             ),
-        makeWidget                ({  7, 118}, { 80, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_WAIT_FOR,                           STR_WAIT_FOR_PASSENGERS_BEFORE_DEPARTING_TIP),
+        Widgets::Checkbox         ({  7, 118}, { 80, 12},                           WindowColour::secondary, STR_WAIT_FOR,                           STR_WAIT_FOR_PASSENGERS_BEFORE_DEPARTING_TIP),
         makeWidget                ({ 87, 117}, {222, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                                      ),
         makeWidget                ({297, 118}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                                                  ),
-        makeWidget                ({  7, 135}, {302, 12}, WidgetType::checkbox,     WindowColour::secondary                                                                                      ),
-        makeWidget                ({  7, 151}, {150, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_MINIMUM_WAITING_TIME,               STR_MINIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
+        Widgets::Checkbox         ({  7, 135}, {302, 12},                           WindowColour::secondary                                                                                      ),
+        Widgets::Checkbox         ({  7, 151}, {150, 12},                           WindowColour::secondary, STR_MINIMUM_WAITING_TIME,               STR_MINIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
         makeHoldableSpinnerWidgets({157, 150}, {152, 14}, WidgetType::spinner,      WindowColour::secondary, kStringIdEmpty                                                                      ), // NB: 3 widgets
-        makeWidget                ({  7, 168}, {150, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_MAXIMUM_WAITING_TIME,               STR_MAXIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
+        Widgets::Checkbox         ({  7, 168}, {150, 12},                           WindowColour::secondary, STR_MAXIMUM_WAITING_TIME,               STR_MAXIMUM_LENGTH_BEFORE_DEPARTING_TIP     ),
         makeHoldableSpinnerWidgets({157, 167}, {152, 14}, WidgetType::spinner,      WindowColour::secondary, kStringIdEmpty                                                                      ), // NB: 3 widgets
-        makeWidget                ({  7, 184}, {302, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS_TIP  ),
+        Widgets::Checkbox         ({  7, 184}, {302, 12},                           WindowColour::secondary, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS, STR_SYNCHRONISE_WITH_ADJACENT_STATIONS_TIP  )
 
-        // Ride type group (cheat)
-        makeWidget                ({  3,   0}, {310, 35}, WidgetType::groupbox,     WindowColour::secondary, STR_RIDE_TYPE_GROUP                                                                 ),
-        makeWidget                ({  7, 225}, {302, 14}, WidgetType::dropdownMenu, WindowColour::secondary, kStringIdEmpty                                                                      ),
-        makeWidget                ({297, 226}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH                                                                  )
     );
 
     // 0x009AE190
@@ -360,7 +357,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({289,  68}, { 24, 24}, WidgetType::flatBtn,      WindowColour::secondary, ImageId(SPR_PAINTBRUSH),       STR_PAINT_INDIVIDUAL_AREA_TIP                ),
 
         // Shops only
-        makeWidget({100,  74}, {239, 12}, WidgetType::checkbox,     WindowColour::secondary, STR_RANDOM_COLOUR                                                           ),
+        Widgets::Checkbox({100,  74}, {239, 12},                    WindowColour::secondary, STR_RANDOM_COLOUR                                                           ),
 
         // Mazes only
         makeWidget({ 74,  49}, {229, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                              ),
@@ -391,7 +388,7 @@ namespace OpenRCT2::Ui::Windows
     // 0x009AE4C8
     static constexpr auto _musicWidgets = makeWidgets(
         kMainRideWidgets,
-        makeWidget({  7, 47}, {302,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_PLAY_MUSIC,     STR_SELECT_MUSIC_TIP      ),
+        Widgets::Checkbox({  7, 47}, {302,  12},                    WindowColour::secondary, STR_PLAY_MUSIC,     STR_SELECT_MUSIC_TIP      ),
         makeWidget({  7, 62}, {302,  14}, WidgetType::dropdownMenu, WindowColour::secondary, kStringIdEmpty                                ),
         makeWidget({297, 63}, { 11,  12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH, STR_SELECT_MUSIC_STYLE_TIP),
         makeWidget({154, 90}, {114, 114}, WidgetType::flatBtn,      WindowColour::secondary                                                ),
@@ -421,12 +418,12 @@ namespace OpenRCT2::Ui::Windows
     // 0x009AE844
     static constexpr auto _incomeWidgets = makeWidgets(
         kMainRideWidgets,
-        makeWidget        ({ 19,  51}, {126, 14}, WidgetType::label,    WindowColour::secondary                                                                    ),
+        makeWidget                ({ 19,  51}, {126, 14}, WidgetType::label,    WindowColour::secondary                                                                    ),
         makeHoldableSpinnerWidgets({147,  50}, {162, 14}, WidgetType::spinner,  WindowColour::secondary, kStringIdEmpty                                            ), // NB: 3 widgets
-        makeWidget                ({  5,  62}, {306, 13}, WidgetType::checkbox, WindowColour::secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
+        Widgets::Checkbox         ({  5,  62}, {306, 13},                       WindowColour::secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP),
         makeWidget                ({ 19,  95}, {126, 14}, WidgetType::label,    WindowColour::secondary                                                            ),
         makeHoldableSpinnerWidgets({147,  94}, {162, 14}, WidgetType::spinner,  WindowColour::secondary, kStringIdEmpty                                            ), // NB: 3 widgets
-        makeWidget        ({  5, 106}, {306, 13}, WidgetType::checkbox, WindowColour::secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP)
+        Widgets::Checkbox         ({  5, 106}, {306, 13},                       WindowColour::secondary, STR_SAME_PRICE_THROUGHOUT_PARK, STR_SAME_PRICE_THROUGHOUT_PARK_TIP)
     );
 
     // 0x009AE9C8

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Theme.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -73,9 +74,9 @@ namespace OpenRCT2::Ui::Windows
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({  0, 43}, {340, 197}, WidgetType::resize,       WindowColour::secondary                                                                        ), // tab page background
         makeWidget({315, 60}, { 24,  24}, WidgetType::flatBtn,      WindowColour::secondary, ImageId(SPR_TOGGLE_OPEN_CLOSE),     STR_OPEN_OR_CLOSE_ALL_RIDES       ), // open / close all toggle
-        makeTab   ({  3, 17},                                                                STR_LIST_RIDES_TIP                                                    ), // tab 1
-        makeTab   ({ 34, 17},                                                                STR_LIST_SHOPS_AND_STALLS_TIP                                         ), // tab 2
-        makeTab   ({ 65, 17},                                                                STR_LIST_KIOSKS_AND_FACILITIES_TIP                                    ), // tab 3
+        Widgets::Tab({  3, 17}, STR_LIST_RIDES_TIP                ),
+        Widgets::Tab({ 34, 17}, STR_LIST_SHOPS_AND_STALLS_TIP     ),
+        Widgets::Tab({ 65, 17}, STR_LIST_KIOSKS_AND_FACILITIES_TIP),
         makeWidget({  3, 47}, {264,  14}, WidgetType::textBox,      WindowColour::secondary                                                                        ), // search text box
         makeWidget({264, 47}, { 70,  14}, WidgetType::button,       WindowColour::secondary, STR_OBJECT_SEARCH_CLEAR                                               ), // search clear button
         makeWidget({  3, 62}, {150,  14}, WidgetType::tableHeader,  WindowColour::secondary                                                                        ), // name header

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/interface/ViewportInteraction.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -1417,7 +1418,7 @@ namespace OpenRCT2::Ui::Windows
             ScreenCoordsXY pos = { kTabMargin, widgets[WIDX_SCENERY_TITLE].bottom + kTabMargin };
             for (const auto& tabInfo : _tabEntries)
             {
-                auto widget = makeTab(pos, STR_STRING_DEFINED_TOOLTIP);
+                auto widget = Widgets::Tab(pos, STR_STRING_DEFINED_TOOLTIP);
                 pos.x += kTabWidth;
 
                 if (tabInfo.IsMisc())

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -13,6 +13,7 @@
 
     #include <openrct2-ui/interface/Widget.h>
     #include <openrct2-ui/interface/Window.h>
+    #include <openrct2-ui/widget/CheckboxWidget.h>
     #include <openrct2-ui/windows/Windows.h>
     #include <openrct2/Context.h>
     #include <openrct2/Game.h>
@@ -55,7 +56,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({ 120, 68 }, { 173, 13 }, WidgetType::textBox, WindowColour::secondary), // greeting text box
         makeWidget({ 120, 84 }, { 173, 13 }, WidgetType::textBox, WindowColour::secondary), // password text box
         makeSpinnerWidgets({ 120, 100 }, { 173, 12 }, WidgetType::spinner, WindowColour::secondary,kStringIdEmpty), // max players (3 widgets)
-        makeWidget({ 6, 117 }, { 287, 14 }, WidgetType::checkbox, WindowColour::secondary, STR_ADVERTISE,STR_ADVERTISE_SERVER_TIP), // advertise checkbox
+        Widgets::Checkbox({ 6, 117 }, { 287, 14 }, WindowColour::secondary, STR_ADVERTISE, STR_ADVERTISE_SERVER_TIP), // advertise checkbox
         makeWidget({ 6, kWindowSize.height - 6 - 13 }, { 101, 14 }, WidgetType::button, WindowColour::secondary,STR_NEW_GAME), // start server button
         makeWidget({ 112, kWindowSize.height - 6 - 13 }, { 101, 14 }, WidgetType::button, WindowColour::secondary, STR_LOAD_GAME) // None
     );

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/input/ShortcutManager.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2/SpriteIds.h>
 #include <openrct2/drawing/ColourMap.h>
 #include <openrct2/drawing/Drawing.h>
@@ -457,7 +458,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t x = 3;
             for (size_t i = 0; i < _tabs.size(); i++)
             {
-                auto tab = makeTab({ x, 17 }, kStringIdNone);
+                auto tab = Widgets::Tab({ x, 17 });
                 widgets.push_back(tab);
                 x += 31;
             }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -88,9 +89,9 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kMainStaffWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({ 0, 43 }, { 190, 137 }, WidgetType::resize, WindowColour::secondary),
-        makeTab({ 3, 17 }, STR_STAFF_OVERVIEW_TIP),
-        makeTab({ 34, 17 }, STR_STAFF_OPTIONS_TIP),
-        makeTab({ 65, 17 }, STR_STAFF_STATS_TIP)
+        Widgets::Tab({ 3, 17 }, STR_STAFF_OVERVIEW_TIP),
+        Widgets::Tab({ 34, 17 }, STR_STAFF_OPTIONS_TIP),
+        Widgets::Tab({ 65, 17 }, STR_STAFF_STATS_TIP)
     );
 
     static constexpr auto _staffOverviewWidgets = makeWidgets(

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/ViewportQuery.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -106,12 +107,12 @@ namespace OpenRCT2::Ui::Windows
     //0x9AF910
     static constexpr auto _staffOptionsWidgets = makeWidgets(
         kMainStaffWidgets,
-        makeWidget     ({      5,  50},                {180,  12}, WidgetType::checkbox,     WindowColour::secondary                                            ), // Checkbox 1
-        makeWidget     ({      5,  67},                {180,  12}, WidgetType::checkbox,     WindowColour::secondary                                            ), // Checkbox 2
-        makeWidget     ({      5,  84},                {180,  12}, WidgetType::checkbox,     WindowColour::secondary                                            ), // Checkbox 3
-        makeWidget     ({      5, 101},                {180,  12}, WidgetType::checkbox,     WindowColour::secondary                                            ), // Checkbox 4
-        makeWidget     ({      5,  50},                {180,  12}, WidgetType::dropdownMenu, WindowColour::secondary                                            ), // Costume Dropdown
-        makeWidget     ({kWindowSize.width - 17,  51}, { 11,  10}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH, STR_SELECT_COSTUME_TIP) // Costume Dropdown Button
+        Widgets::Checkbox({      5,  50},                {180,  12},                           WindowColour::secondary                                            ), // Checkbox 1
+        Widgets::Checkbox({      5,  67},                {180,  12},                           WindowColour::secondary                                            ), // Checkbox 2
+        Widgets::Checkbox({      5,  84},                {180,  12},                           WindowColour::secondary                                            ), // Checkbox 3
+        Widgets::Checkbox({      5, 101},                {180,  12},                           WindowColour::secondary                                            ), // Checkbox 4
+        makeWidget       ({      5,  50},                {180,  12}, WidgetType::dropdownMenu, WindowColour::secondary                                            ), // Costume Dropdown
+        makeWidget       ({kWindowSize.width - 17,  51}, { 11,  10}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH, STR_SELECT_COSTUME_TIP) // Costume Dropdown Button
     );
 
     // 0x9AF9F4

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -14,6 +14,7 @@
 #include <openrct2-ui/interface/ViewportQuery.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
@@ -83,10 +84,10 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto _staffListWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({  0, 43}, { kWindowSize.width, kWindowSize.height - 43}, WidgetType::resize,    WindowColour::secondary                                                    ), // tab content panel
-        makeTab   ({  3, 17},                                                                                                STR_STAFF_HANDYMEN_TAB_TIP                        ), // handymen tab
-        makeTab   ({ 34, 17},                                                                                                STR_STAFF_MECHANICS_TAB_TIP                       ), // mechanics tab
-        makeTab   ({ 65, 17},                                                                                                STR_STAFF_SECURITY_TAB_TIP                        ), // security guards tab
-        makeTab   ({ 96, 17},                                                                                                STR_STAFF_ENTERTAINERS_TAB_TIP                    ), // entertainers tab
+        Widgets::Tab({  3, 17}, STR_STAFF_HANDYMEN_TAB_TIP    ), // handymen tab
+        Widgets::Tab({ 34, 17}, STR_STAFF_MECHANICS_TAB_TIP   ), // mechanics tab
+        Widgets::Tab({ 65, 17}, STR_STAFF_SECURITY_TAB_TIP    ), // security guards tab
+        Widgets::Tab({ 96, 17}, STR_STAFF_ENTERTAINERS_TAB_TIP), // entertainers tab
         makeWidget({  3, 72}, {kWindowSize.width - 6, 195},                  WidgetType::scroll,    WindowColour::secondary, SCROLL_VERTICAL                                   ), // staff list
         makeWidget({130, 58}, {    12,      12},                             WidgetType::colourBtn, WindowColour::secondary, kStringIdNone,           STR_UNIFORM_COLOUR_TIP   ), // uniform colour picker
         makeWidget({165, 17}, {   145,      13},                             WidgetType::button,    WindowColour::primary  , kStringIdNone,           STR_HIRE_STAFF_TIP       ), // hire button

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/widget/CheckboxWidget.h>
+#include <openrct2-ui/widget/TabWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/SpriteIds.h>
@@ -89,15 +90,15 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto _themesWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
         makeWidget({  0, 43}, {320,  64},               WidgetType::resize,       WindowColour::secondary                                                                                ), // tab content panel
-        makeTab   ({  3, 17},                                                                              STR_THEMES_TAB_SETTINGS_TIP                                                   ), // settings tab
-        makeTab   ({ 34, 17},                                                                              STR_THEMES_TAB_MAIN_TIP                                                       ), // main ui tab
-        makeTab   ({ 65, 17},                                                                              STR_THEMES_TAB_PARK_TIP                                                       ), // park tab
-        makeTab   ({ 96, 17},                                                                              STR_THEMES_TAB_TOOLS_TIP                                                      ), // tools tab
-        makeTab   ({127, 17},                                                                              STR_THEMES_TAB_RIDES_AND_GUESTS_TIP                                           ), // rides and peeps tab
-        makeTab   ({158, 17},                                                                              STR_THEMES_TAB_EDITORS_TIP                                                    ), // editors tab
-        makeTab   ({189, 17},                                                                              STR_THEMES_TAB_MISC_TIP                                                       ), // misc tab
-        makeTab   ({220, 17},                                                                              STR_THEMES_TAB_PROMPTS_TIP                                                    ), // prompts tab
-        makeTab   ({251, 17},                                                                              STR_THEMES_TAB_FEATURES_TIP                                                   ), // features tab
+        Widgets::Tab({  3, 17}, STR_THEMES_TAB_SETTINGS_TIP        ), // settings tab
+        Widgets::Tab({ 34, 17}, STR_THEMES_TAB_MAIN_TIP            ), // main ui tab
+        Widgets::Tab({ 65, 17}, STR_THEMES_TAB_PARK_TIP            ), // park tab
+        Widgets::Tab({ 96, 17}, STR_THEMES_TAB_TOOLS_TIP           ), // tools tab
+        Widgets::Tab({127, 17}, STR_THEMES_TAB_RIDES_AND_GUESTS_TIP), // rides and peeps tab
+        Widgets::Tab({158, 17}, STR_THEMES_TAB_EDITORS_TIP         ), // editors tab
+        Widgets::Tab({189, 17}, STR_THEMES_TAB_MISC_TIP            ), // misc tab
+        Widgets::Tab({220, 17}, STR_THEMES_TAB_PROMPTS_TIP         ), // prompts tab
+        Widgets::Tab({251, 17}, STR_THEMES_TAB_FEATURES_TIP        ), // features tab
         makeWidget({  5, 46}, {kWindowHeaderWidth, 15}, WidgetType::tableHeader,  WindowColour::secondary, STR_THEMES_HEADER_WINDOW                                                      ), // Window header
         makeWidget({157, 46}, { 79,                15}, WidgetType::tableHeader,  WindowColour::secondary, STR_THEMES_HEADER_PALETTE                                                     ), // Palette header
         makeWidget({236, 46}, { 80,                15}, WidgetType::tableHeader,  WindowColour::secondary, STR_THEMES_HEADER_TRANSPARENCY                                                ), // Transparency header

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -12,6 +12,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/SpriteIds.h>
@@ -107,11 +108,11 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({210, 82}, { 91,                12}, WidgetType::button,       WindowColour::secondary, STR_TRACK_MANAGE_RENAME,                       STR_THEMES_ACTION_RENAME_TIP   ), // Rename button
         makeWidget({  0,  0}, {  1,                 1}, WidgetType::colourBtn,    WindowColour::secondary                                                                                ), // colour button mask
         makeWidget({  3, 60}, {314,                44}, WidgetType::scroll,       WindowColour::secondary, SCROLL_VERTICAL                                                               ), // staff list
-        makeWidget({ 10, 54}, {290,                12}, WidgetType::checkbox,     WindowColour::secondary, STR_THEMES_OPTION_RCT1_RIDE_CONTROLS                                          ), // rct1 ride lights
-        makeWidget({ 10, 69}, {290,                12}, WidgetType::checkbox,     WindowColour::secondary, STR_THEMES_OPTION_RCT1_PARK_CONTROLS                                          ), // rct1 park lights
-        makeWidget({ 10, 84}, {290,                12}, WidgetType::checkbox,     WindowColour::secondary, STR_THEMES_OPTION_RCT1_SCENARIO_SELECTION_FONT                                ), // rct1 scenario font
-        makeWidget({ 10, 99}, {290,                12}, WidgetType::checkbox,     WindowColour::secondary, STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR                                         ), // rct1 bottom toolbar
-        makeWidget({ 10,114}, {290,                12}, WidgetType::checkbox,     WindowColour::secondary, STR_THEMES_OPTION_USE_3D_IMAGE_BUTTONS                                        )  // use 3D image buttons
+        Widgets::Checkbox({ 10, 54}, {290,         12},                           WindowColour::secondary, STR_THEMES_OPTION_RCT1_RIDE_CONTROLS                                          ), // rct1 ride lights
+        Widgets::Checkbox({ 10, 69}, {290,         12},                           WindowColour::secondary, STR_THEMES_OPTION_RCT1_PARK_CONTROLS                                          ), // rct1 park lights
+        Widgets::Checkbox({ 10, 84}, {290,         12},                           WindowColour::secondary, STR_THEMES_OPTION_RCT1_SCENARIO_SELECTION_FONT                                ), // rct1 scenario font
+        Widgets::Checkbox({ 10, 99}, {290,         12},                           WindowColour::secondary, STR_THEMES_OPTION_RCT1_BOTTOM_TOOLBAR                                         ), // rct1 bottom toolbar
+        Widgets::Checkbox({ 10,114}, {290,         12},                           WindowColour::secondary, STR_THEMES_OPTION_USE_3D_IMAGE_BUTTONS                                        )  // use 3D image buttons
     );
     // clang-format on
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -13,6 +13,7 @@
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/GameState.h>
 #include <openrct2/SpriteIds.h>
@@ -315,11 +316,11 @@ namespace OpenRCT2::Ui::Windows
         makeHoldableSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), kPropertySpinnerSize, WidgetType::spinner, WindowColour::secondary), // WIDX_SURFACE_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
         makeWidget(PropertyRowCol({ 12, 0 }, 1, 0),         kPropertyButtonSize, WidgetType::button,  WindowColour::secondary, STR_TILE_INSPECTOR_SURFACE_REMOVE_FENCES), // WIDX_SURFACE_BUTTON_REMOVE_FENCES
         makeWidget(PropertyRowCol({ 12, 0 }, 1, 1),         kPropertyButtonSize, WidgetType::button,  WindowColour::secondary, STR_TILE_INSPECTOR_SURFACE_RESTORE_FENCES), // WIDX_SURFACE_BUTTON_RESTORE_FENCES
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 0), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_N
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_E
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 2), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_S
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_W
-        makeWidget(PropertyRowCol({ 12, 0 }, 3, 0), kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_SURFACE_DIAGONAL) // WIDX_SURFACE_CHECK_DIAGONAL
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 0), { 12, 12 }, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_N
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1), { 12, 12 }, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_E
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 2), { 12, 12 }, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_S
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1), { 12, 12 }, WindowColour::secondary), // WIDX_SURFACE_CHECK_CORNER_W
+        Widgets::Checkbox(PropertyRowCol({ 12, 0 }, 3, 0), kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_SURFACE_DIAGONAL) // WIDX_SURFACE_CHECK_DIAGONAL
     );
 
     constexpr int32_t kNumPathProperties = 6;
@@ -329,17 +330,17 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kPathWidgets = makeWidgets(
         kMainTileInspectorWidgets,
         makeHoldableSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), kPropertySpinnerSize, WidgetType::spinner, WindowColour::secondary), // WIDX_PATH_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-        makeWidget(PropertyRowCol({ 12, 0 }, 1, 0), kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_PATH_BROKEN), // WIDX_PATH_CHECK_BROKEN
-        makeWidget(PropertyRowCol({ 12, 0 }, 2, 0), kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_PATH_SLOPED), // WIDX_PATH_CHECK_SLOPED
-        makeWidget(PropertyRowCol({ 12, 0 }, 3, 0), kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_PATH_JUNCTION_RAILINGS), // WIDX_PATH_CHECK_JUNCTION_RAILINGS
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_NE
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 4, 2), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_E
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 3), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_SE
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 4), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_S
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 3), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_SW
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 0, 2), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_W
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_NW
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 0), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary)  // WIDX_PATH_CHECK_EDGE_N
+        Widgets::Checkbox(PropertyRowCol({ 12, 0 }, 1, 0), kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_PATH_BROKEN), // WIDX_PATH_CHECK_BROKEN
+        Widgets::Checkbox(PropertyRowCol({ 12, 0 }, 2, 0), kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_PATH_SLOPED), // WIDX_PATH_CHECK_SLOPED
+        Widgets::Checkbox(PropertyRowCol({ 12, 0 }, 3, 0), kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_PATH_JUNCTION_RAILINGS), // WIDX_PATH_CHECK_JUNCTION_RAILINGS
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 1), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_NE
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 4, 2), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_E
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 3, 3), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_SE
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 4), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_S
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 3), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_SW
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 0, 2), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_W
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 1, 1), { 12, 12 }, WindowColour::secondary), // WIDX_PATH_CHECK_EDGE_NW
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 4, 1), 2, 0), { 12, 12 }, WindowColour::secondary)  // WIDX_PATH_CHECK_EDGE_N
     );
 
     constexpr int32_t kNumTrackProperties = 5;
@@ -348,11 +349,11 @@ namespace OpenRCT2::Ui::Windows
     constexpr int32_t kTrackDetailsHeight = 20 + kNumTrackDetails * 11;
     static constexpr auto kTrackWidgets = makeWidgets(
         kMainTileInspectorWidgets,
-        makeWidget(PropertyRowCol({ 12, 0}, 0, 0),          kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_ENTIRE_TRACK_PIECE), // WIDX_TRACK_CHECK_APPLY_TO_ALL
+        Widgets::Checkbox(PropertyRowCol({ 12, 0}, 0, 0),          kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_ENTIRE_TRACK_PIECE), // WIDX_TRACK_CHECK_APPLY_TO_ALL
         makeHoldableSpinnerWidgets(PropertyRowCol({ 12, 0 }, 1, 1), kPropertySpinnerSize, WidgetType::spinner, WindowColour::secondary), // WIDX_TRACK_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-        makeWidget(PropertyRowCol({ 12, 0}, 2, 0),          kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_CHAIN_LIFT), // WIDX_TRACK_CHECK_CHAIN_LIFT
-        makeWidget(PropertyRowCol({ 12, 0}, 3, 0),          kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_BRAKE_CLOSED), // WIDX_TRACK_CHECK_BRAKE_CLOSED
-        makeWidget(PropertyRowCol({ 12, 0}, 4, 0),          kPropertyFullWidth, WidgetType::checkbox, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_IS_INDESTRUCTIBLE) // WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE
+        Widgets::Checkbox(PropertyRowCol({ 12, 0}, 2, 0),          kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_CHAIN_LIFT), // WIDX_TRACK_CHECK_CHAIN_LIFT
+        Widgets::Checkbox(PropertyRowCol({ 12, 0}, 3, 0),          kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_BRAKE_CLOSED), // WIDX_TRACK_CHECK_BRAKE_CLOSED
+        Widgets::Checkbox(PropertyRowCol({ 12, 0}, 4, 0),          kPropertyFullWidth, WindowColour::secondary, STR_TILE_INSPECTOR_TRACK_IS_INDESTRUCTIBLE) // WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE
     );
 
     constexpr int32_t kNumSceneryProperties = 4; // The checkbox groups both count for 2 rows
@@ -362,14 +363,14 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kSceneryWidgets = makeWidgets(
         kMainTileInspectorWidgets,
         makeHoldableSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), kPropertySpinnerSize, WidgetType::spinner, WindowColour::secondary), // WIDX_SCENERY_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 0 + 0), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_N
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 2, 0 + 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_E
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 0 + 2), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_S
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 0, 0 + 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_W
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 1 + 0), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_COLLISION_N
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1 + 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_COLLISION_E
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 1 + 2), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_SCENERY_CHECK_COLLISION_S
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1 + 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary)  // WIDX_SCENERY_CHECK_COLLISION_W
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 0 + 0), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_N
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 2, 0 + 1), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_E
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 0 + 2), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_S
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 0, 0 + 1), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_QUARTER_W
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 1 + 0), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_COLLISION_N
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 2, 1 + 1), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_COLLISION_E
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 1, 1 + 2), { 12, 12 }, WindowColour::secondary), // WIDX_SCENERY_CHECK_COLLISION_S
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 2, 1), 0, 1 + 1), { 12, 12 }, WindowColour::secondary)  // WIDX_SCENERY_CHECK_COLLISION_W
     );
 
     constexpr int32_t kNumEntranceProperties = 2;
@@ -392,7 +393,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget(PropertyRowCol({ 12, 0 }, 1, 1),                                  kPropertyButtonSize, WidgetType::dropdownMenu, WindowColour::secondary), // WIDX_WALL_DROPDOWN_SLOPE
         makeWidget(PropertyRowCol({ 12 + kPropertyButtonSize.width - 12, 0 }, 1, 1), { 11,  12},          WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH), // WIDX_WALL_DROPDOWN_SLOPE_BUTTON
         makeHoldableSpinnerWidgets(PropertyRowCol({ 12, 0 }, 2, 1),                          kPropertySpinnerSize, WidgetType::spinner,      WindowColour::secondary), // WIDX_WALL_SPINNER_ANIMATION_FRAME{,_INCREASE,_DECREASE}
-        makeWidget(PropertyRowCol({ 12, 0 }, 3, 0),                                  kPropertyFullWidth,  WidgetType::checkbox,     WindowColour::secondary, STR_TILE_INSPECTOR_WALL_ANIMATION_IS_BACKWARDS) // WIDX_WALL_ANIMATION_IS_BACKWARDS
+        Widgets::Checkbox(PropertyRowCol({ 12, 0 }, 3, 0),                                  kPropertyFullWidth,      WindowColour::secondary, STR_TILE_INSPECTOR_WALL_ANIMATION_IS_BACKWARDS) // WIDX_WALL_ANIMATION_IS_BACKWARDS
     );
 
     constexpr int32_t kNumLargeSceneryProperties = 1;
@@ -411,10 +412,10 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kBannerWidgets = makeWidgets(
         kMainTileInspectorWidgets,
         makeHoldableSpinnerWidgets(PropertyRowCol({ 12, 0 }, 0, 1), kPropertySpinnerSize, WidgetType::spinner, WindowColour::secondary), // WIDX_BANNER_SPINNER_HEIGHT{,_INCREASE,_DECREASE}
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_BANNER_CHECK_BLOCK_NE
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 3), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_BANNER_CHECK_BLOCK_SE
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 3), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary), // WIDX_BANNER_CHECK_BLOCK_SW
-        makeWidget(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 1), { 12, 12 }, WidgetType::checkbox, WindowColour::secondary)  // WIDX_BANNER_CHECK_BLOCK_NW
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 1), { 12, 12 }, WindowColour::secondary), // WIDX_BANNER_CHECK_BLOCK_NE
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 3, 3), { 12, 12 }, WindowColour::secondary), // WIDX_BANNER_CHECK_BLOCK_SE
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 3), { 12, 12 }, WindowColour::secondary), // WIDX_BANNER_CHECK_BLOCK_SW
+        Widgets::Checkbox(CheckboxGroupOffset(PropertyRowCol({ 12, 0 }, 1, 1), 1, 1), { 12, 12 }, WindowColour::secondary)  // WIDX_BANNER_CHECK_BLOCK_NW
     );
 
     static constexpr std::span<const Widget> kWidgetsByPage[] = {

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
+#include <openrct2-ui/widget/CheckboxWidget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/config/Config.h>
 #include <openrct2/drawing/Drawing.Screen.h>
@@ -57,11 +58,11 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr auto _viewClippingWidgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
-        makeWidget                ({     11,  19}, {    159,  11},                WidgetType::checkbox, WindowColour::primary, STR_VIEW_CLIPPING_HEIGHT_ENABLE,                  STR_VIEW_CLIPPING_HEIGHT_ENABLE_TIP               ), // clip enable/disable check box
+        Widgets::Checkbox         ({     11,  19}, {    159,  11},                                      WindowColour::primary, STR_VIEW_CLIPPING_HEIGHT_ENABLE,                  STR_VIEW_CLIPPING_HEIGHT_ENABLE_TIP               ), // clip enable/disable check box
         makeWidget                ({      5,  36}, {kWindowSize.width - 10,  65}, WidgetType::groupbox, WindowColour::primary, STR_VIEW_CLIPPING_VERTICAL_CLIPPING                                                                 ),
         makeHoldableSpinnerWidgets({     90,  51}, {     79,  12},                WidgetType::spinner,  WindowColour::primary, kStringIdNone,                                    STR_VIEW_CLIPPING_HEIGHT_VALUE_TOGGLE             ), // clip height (3 widgets)
         makeWidget                ({     11,  66}, {    158,  13},                WidgetType::scroll,   WindowColour::primary, SCROLL_HORIZONTAL,                                STR_VIEW_CLIPPING_HEIGHT_SCROLL_TIP               ), // clip height scrollbar
-        makeWidget                ({     11,  83}, {    159,  11},                WidgetType::checkbox, WindowColour::primary, STR_VIEW_CLIPPING_VERTICAL_CLIPPING_SEE_THROUGH, STR_VIEW_CLIPPING_VERTICAL_CLIPPING_SEE_THROUGH_TIP), // clip height enable/disable see-through check box
+        Widgets::Checkbox         ({     11,  83}, {    159,  11},                                      WindowColour::primary, STR_VIEW_CLIPPING_VERTICAL_CLIPPING_SEE_THROUGH, STR_VIEW_CLIPPING_VERTICAL_CLIPPING_SEE_THROUGH_TIP), // clip height enable/disable see-through check box
         makeWidget                ({      5, 107}, {kWindowSize.width - 10,  60}, WidgetType::groupbox, WindowColour::primary, STR_VIEW_CLIPPING_HORIZONTAL_CLIPPING                                                               ),
         makeWidget                ({     11, 122}, {    158,  17},                WidgetType::button,   WindowColour::primary, STR_VIEW_CLIPPING_SELECT_AREA                                                                       ), // selector
         makeWidget                ({     11, 143}, {    158,  18},                WidgetType::button,   WindowColour::primary, STR_VIEW_CLIPPING_CLEAR_SELECTION                                                                   )  // clear

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -127,17 +127,17 @@ namespace OpenRCT2
         constexpr Widget() = default;
 
         constexpr Widget(
-            ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour, StringId content,
-            StringId tooltip)
+            ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour_, StringId content_,
+                StringId tooltip_)
         {
             this->left = origin.x;
             this->right = origin.x + size.width - 1;
             this->top = origin.y;
             this->bottom = origin.y + size.height - 1;
             this->type = widgetType;
-            this->colour = EnumValue(colour);
-            this->content = content;
-            this->tooltip = tooltip;
+            this->colour = EnumValue(colour_);
+            this->content = content_;
+            this->tooltip = tooltip_;
         }
 
         int16_t width() const

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -17,6 +17,11 @@
 
 #include <cstdint>
 
+namespace OpenRCT2::Drawing
+{
+    struct RenderTarget;
+}
+
 namespace OpenRCT2
 {
     using WidgetIndex = uint16_t;
@@ -74,10 +79,28 @@ namespace OpenRCT2
         SCROLL_BOTH = SCROLL_HORIZONTAL | SCROLL_VERTICAL
     };
 
+    enum class WindowColour : uint8_t
+    {
+        primary,
+        secondary,
+        tertiary,
+        quaternary,
+    };
+
     constexpr const char* kCloseBoxStringBlackNormal = u8"{BLACK}❌";
     constexpr const char* kCloseBoxStringBlackLarge = u8"{BLACK}X";
     constexpr const char* kCloseBoxStringWhiteNormal = u8"{WHITE}❌";
     constexpr const char* kCloseBoxStringWhiteLarge = u8"{WHITE}X";
+
+    struct Widget;
+    struct WindowBase;
+
+    struct WidgetEventList
+    {
+        void (*draw)(
+            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window)
+            = nullptr;
+    };
 
     struct Widget
     {
@@ -97,8 +120,25 @@ namespace OpenRCT2
         StringId tooltip{ kStringIdNone };
 
         // New properties
+        WidgetEventList events{};
         WidgetFlags flags{};
         const utf8* sztooltip{};
+
+        constexpr Widget() = default;
+
+        constexpr Widget(
+            ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour, StringId content,
+            StringId tooltip)
+        {
+            this->left = origin.x;
+            this->right = origin.x + size.width - 1;
+            this->top = origin.y;
+            this->bottom = origin.y + size.height - 1;
+            this->type = widgetType;
+            this->colour = EnumValue(colour);
+            this->content = content;
+            this->tooltip = tooltip;
+        }
 
         int16_t width() const
         {

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -128,7 +128,7 @@ namespace OpenRCT2
 
         constexpr Widget(
             ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour_, StringId content_,
-                StringId tooltip_)
+            StringId tooltip_)
         {
             this->left = origin.x;
             this->right = origin.x + size.width - 1;

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -98,7 +98,7 @@ namespace OpenRCT2
     struct WidgetEventList
     {
         void (*draw)(
-            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window)
+            Drawing::RenderTarget& RenderTarget, Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window)
             = nullptr;
     };
 
@@ -127,7 +127,7 @@ namespace OpenRCT2
         constexpr Widget() = default;
 
         constexpr Widget(
-            ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour_, StringId content_,
+            ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour_, uint32_t content_,
             StringId tooltip_)
         {
             this->left = origin.x;

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -17,6 +17,11 @@
 
 #include <cstdint>
 
+namespace OpenRCT2::Drawing
+{
+    struct RenderTarget;
+}
+
 namespace OpenRCT2
 {
     using WidgetIndex = uint16_t;
@@ -74,10 +79,28 @@ namespace OpenRCT2
         SCROLL_BOTH = SCROLL_HORIZONTAL | SCROLL_VERTICAL
     };
 
+    enum class WindowColour : uint8_t
+    {
+        primary,
+        secondary,
+        tertiary,
+        quaternary,
+    };
+
     constexpr const char* kCloseBoxStringBlackNormal = u8"{BLACK}✕";
     constexpr const char* kCloseBoxStringBlackLarge = u8"{BLACK}❌";
     constexpr const char* kCloseBoxStringWhiteNormal = u8"{WHITE}✕";
     constexpr const char* kCloseBoxStringWhiteLarge = u8"{WHITE}❌";
+
+    struct Widget;
+    struct WindowBase;
+
+    struct WidgetEventList
+    {
+        void (*draw)(
+            Drawing::RenderTarget& RenderTarget, const Widget& widget, const WidgetIndex widgetIndex, const WindowBase& window)
+            = nullptr;
+    };
 
     struct Widget
     {
@@ -97,8 +120,25 @@ namespace OpenRCT2
         StringId tooltip{ kStringIdNone };
 
         // New properties
+        WidgetEventList events{};
         WidgetFlags flags{};
         const utf8* sztooltip{};
+
+        constexpr Widget() = default;
+
+        constexpr Widget(
+            ScreenCoordsXY origin, ScreenSize size, WidgetType widgetType, WindowColour colour_, StringId content_,
+            StringId tooltip_)
+        {
+            this->left = origin.x;
+            this->right = origin.x + size.width - 1;
+            this->top = origin.y;
+            this->bottom = origin.y + size.height - 1;
+            this->type = widgetType;
+            this->colour = EnumValue(colour_);
+            this->content = content_;
+            this->tooltip = tooltip_;
+        }
 
         int16_t width() const
         {

--- a/test/tests/WidgetStateTests.cpp
+++ b/test/tests/WidgetStateTests.cpp
@@ -96,7 +96,6 @@ TEST(WidgetStateTest, WithFlagSetsFlagWithoutDisturbingOthers)
 TEST(WidgetStateTest, MakeHoldableWidgetHasHoldableFlag)
 {
     using Ui::makeHoldableWidget;
-    using Ui::WindowColour;
 
     constexpr auto w = makeHoldableWidget({ 0, 0 }, { 10, 10 }, WidgetType::button, WindowColour::primary);
     static_assert(w.flags.has(WidgetFlag::isHoldable));
@@ -108,7 +107,6 @@ TEST(WidgetStateTest, MakeHoldableWidgetHasHoldableFlag)
 TEST(WidgetStateTest, MakeWidgetDefaultHasNoFlags)
 {
     using Ui::makeWidget;
-    using Ui::WindowColour;
 
     constexpr auto w = makeWidget({ 0, 0 }, { 10, 10 }, WidgetType::button, WindowColour::primary);
     static_assert(w.flags.isEmpty());
@@ -118,7 +116,6 @@ TEST(WidgetStateTest, MakeWidgetDefaultHasNoFlags)
 TEST(WidgetStateTest, MakeSpinnerWidgetsHasNoHoldableFlag)
 {
     using Ui::makeSpinnerWidgets;
-    using Ui::WindowColour;
 
     constexpr auto widgets = makeSpinnerWidgets({ 0, 0 }, { 100, 14 }, WidgetType::spinner, WindowColour::primary);
     static_assert(!widgets[0].flags.has(WidgetFlag::isHoldable));
@@ -129,7 +126,6 @@ TEST(WidgetStateTest, MakeSpinnerWidgetsHasNoHoldableFlag)
 TEST(WidgetStateTest, MakeHoldableSpinnerWidgetsHasHoldableOnIncrementButtons)
 {
     using Ui::makeHoldableSpinnerWidgets;
-    using Ui::WindowColour;
 
     constexpr auto widgets = makeHoldableSpinnerWidgets({ 0, 0 }, { 100, 14 }, WidgetType::spinner, WindowColour::primary);
     // Element [0] is the spinner input field; increment/decrement buttons are


### PR DESCRIPTION
This PR starts the process of introducing distinct widget specialisation types, keeping the underlying `Widget` struct mostly unchanged for now. We start the process of moving the widget drawing routines into widget event functions. The goal here is to have one dedicated drawing event function per widget type.

Given C++23 does not yet have any type reflection functionality, we try to keep things simple by introducing and using event (function) lists for widgets, avoiding (slow) virtual functions and preventing us from having to rely on casting to get to member functions.

For now, this PR tackles three widget types as a proof of concept: captions, checkboxes, and tabs.

We can revisit the underlying data structure after the widget code has been properly separated. That should reveal what is common (or common enough) to be shared, hopefully allowing for a flexible yet fast compromise.