### PR TITLE
Fix #26270: Building a ride crashes the game

### DIFF
--- a/src/openrct2/localisation/LocalisationService.cpp
+++ b/src/openrct2/localisation/LocalisationService.cpp
@@ -63,7 +63,7 @@ namespace OpenRCT2::Localisation
             return "(undefined string)";
         }
 
-        return nullptr;
+        return "";
     }
 
     std::string LocalisationService::GetLanguagePath(uint32_t languageId) const


### PR DESCRIPTION
`LocalisationService::GetString()` can return nullptr, which goes tits up when trying to assign that to a string. Instead, make it always return a string and avoid a crash.