### PR TITLE
Add tunnels to TED and use in trackPaintGeneric

### DIFF
--- a/src/openrct2/paint/track/TrackPaintGeneric.cpp
+++ b/src/openrct2/paint/track/TrackPaintGeneric.cpp
@@ -34,4 +34,20 @@ namespace OpenRCT2
                 session, imageId.WithIndexOffset(imageIndexOffset), height, { 0, 0, 0 }, boundingBoxes[sequenceIndex]);
         }
     }
+
+    void paintTrackTunnel(
+        PaintSession& session, const Direction direction, const int32_t height, const TrackMetadata::SequenceTunnel& tunnel,
+        const TrackMetadata::SequenceTunnelType tunnelType, const TunnelGroup tunnelGroup)
+    {
+        if (tunnel.direction == direction)
+        {
+            const auto& tunnelInfo = tunnel.tunnelInfo[EnumValue(tunnelType)];
+            PaintUtilPushTunnelLeft(session, height + tunnelInfo.height, tunnelGroup, tunnelInfo.type);
+        }
+        else if (tunnel.direction == DirectionNext(direction))
+        {
+            const auto& tunnelInfo = tunnel.tunnelInfo[EnumValue(tunnelType)];
+            PaintUtilPushTunnelRight(session, height + tunnelInfo.height, tunnelGroup, tunnelInfo.type);
+        }
+    }
 } // namespace OpenRCT2

--- a/src/openrct2/paint/track/TrackPaintGeneric.h
+++ b/src/openrct2/paint/track/TrackPaintGeneric.h
@@ -51,6 +51,10 @@ namespace OpenRCT2
         const uint8_t spriteCount, const uint8_t spriteIndex, const uint64_t spriteMap, const ImageId imageId,
         const int32_t height, const BoundBoxXYZ* const boundingBoxes);
 
+    void paintTrackTunnel(
+        PaintSession& session, const Direction direction, const int32_t height, const TrackMetadata::SequenceTunnel& tunnel,
+        const TrackMetadata::SequenceTunnelType tunnelType, const TunnelGroup tunnelGroup);
+
     template<
         const size_t sequenceCount, const size_t mapSpriteCount, const size_t sequenceSpriteCount, const ImageIndex imageIndex,
         const uint64_t spriteMap,
@@ -59,11 +63,14 @@ namespace OpenRCT2
         const bool woodenSupports,
         const std::array<std::array<int8_t, kNumOrthogonalDirections>, sequenceCount>& supportHeightExtras,
         const OpenRCT2::BlockedSegmentsType blockedSegmentsType, const TunnelGroup tunnelGroup,
-        const int16_t trackClearanceHeight, const auto tunnelPaintFunction, const bool down, const bool trackSupportColours>
+        const TrackMetadata::SequenceTunnelType tunnelType, const uint8_t tunnelCount, const int16_t trackClearanceHeight,
+        const bool down, const bool trackSupportColours>
     void trackPaintGeneric(
         PaintSession& session, const Ride& ride, const uint8_t trackSequence, const Direction direction, const int32_t height,
         const OpenRCT2::TrackElement& trackElement, const SupportType supportType)
     {
+        static_assert(tunnelCount <= TrackMetadata::kSequenceTunnelMaxPerSequence);
+
         const auto& ted = OpenRCT2::TrackMetadata::GetTrackElementDescriptor(trackElement.GetTrackType());
         const auto& sequenceDescriptor = ted.sequenceData.sequences[trackSequence];
 
@@ -122,6 +129,13 @@ namespace OpenRCT2
             != TrackMetadata::kDoNotSetGeneralSupportHeight;
         PaintUtilSetGeneralSupportHeight(session, generalSupportHeight * setGeneralSupportHeight);
 
-        tunnelPaintFunction(session, modifiedTrackSequence, modifiedDirection, height, tunnelGroup);
+        if constexpr (tunnelCount >= 1)
+        {
+            paintTrackTunnel(session, direction, height, sequenceDescriptor.tunnels[0], tunnelType, tunnelGroup);
+        }
+        if constexpr (tunnelCount >= 2)
+        {
+            paintTrackTunnel(session, direction, height, sequenceDescriptor.tunnels[1], tunnelType, tunnelGroup);
+        }
     }
 } // namespace OpenRCT2

--- a/src/openrct2/paint/track_pieces/QuarterHelix.cpp
+++ b/src/openrct2/paint/track_pieces/QuarterHelix.cpp
@@ -51,48 +51,4 @@ namespace OpenRCT2
     } };
     const QuarterHelixBoundingBoxes kRightQuarterHelixLargeUpBoundingBoxes = flipTrackSequenceBoundBoxesXAxis(
         kLeftQuarterHelixLargeUpBoundingBoxes);
-
-    void trackPaintLeftQuarterHelixTunnels(
-        PaintSession& session, const uint8_t trackSequence, const Direction direction, const int32_t height,
-        const TunnelGroup tunnelGroup)
-    {
-        if (trackSequence == 0 && direction == 0)
-        {
-            PaintUtilPushTunnelLeft(session, height, tunnelGroup, TunnelSubType::Flat);
-        }
-        else if (trackSequence == 0 && direction == 3)
-        {
-            PaintUtilPushTunnelRight(session, height, tunnelGroup, TunnelSubType::Flat);
-        }
-        else if (trackSequence == 6 && direction == 2)
-        {
-            PaintUtilPushTunnelRight(session, height + kLandHeightStep, tunnelGroup, TunnelSubType::FlatTo25Deg);
-        }
-        else if (trackSequence == 6 && direction == 3)
-        {
-            PaintUtilPushTunnelLeft(session, height + kLandHeightStep, tunnelGroup, TunnelSubType::FlatTo25Deg);
-        }
-    }
-
-    void trackPaintRightQuarterHelixTunnels(
-        PaintSession& session, const uint8_t trackSequence, const Direction direction, const int32_t height,
-        const TunnelGroup tunnelGroup)
-    {
-        if (trackSequence == 0 && direction == 0)
-        {
-            PaintUtilPushTunnelLeft(session, height, tunnelGroup, TunnelSubType::Flat);
-        }
-        else if (trackSequence == 0 && direction == 3)
-        {
-            PaintUtilPushTunnelRight(session, height, tunnelGroup, TunnelSubType::Flat);
-        }
-        else if (trackSequence == 6 && direction == 0)
-        {
-            PaintUtilPushTunnelRight(session, height + kLandHeightStep, tunnelGroup, TunnelSubType::FlatTo25Deg);
-        }
-        else if (trackSequence == 6 && direction == 1)
-        {
-            PaintUtilPushTunnelLeft(session, height + kLandHeightStep, tunnelGroup, TunnelSubType::FlatTo25Deg);
-        }
-    }
 } // namespace OpenRCT2

--- a/src/openrct2/paint/track_pieces/QuarterHelix.h
+++ b/src/openrct2/paint/track_pieces/QuarterHelix.h
@@ -94,13 +94,6 @@ namespace OpenRCT2
     extern const QuarterHelixBoundingBoxes kLeftQuarterHelixLargeUpBoundingBoxes;
     extern const QuarterHelixBoundingBoxes kRightQuarterHelixLargeUpBoundingBoxes;
 
-    void trackPaintLeftQuarterHelixTunnels(
-        PaintSession& session, const uint8_t trackSequence, const Direction direction, const int32_t height,
-        const TunnelGroup tunnelGroup);
-    void trackPaintRightQuarterHelixTunnels(
-        PaintSession& session, const uint8_t trackSequence, const Direction direction, const int32_t height,
-        const TunnelGroup tunnelGroup);
-
     template<
         const ImageIndex imageIndex, const uint64_t spriteMap, const bool woodenSupports,
         const std::array<std::array<int8_t, kNumOrthogonalDirections>, kQuarterHelixSequenceCount>& supportHeightExtras,
@@ -111,8 +104,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintLeftQuarterHelixTunnels, false, trackSupportColours>(
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, false, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -126,8 +119,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintRightQuarterHelixTunnels, false, trackSupportColours>(
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, false, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -141,8 +134,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintRightQuarterHelixTunnels, true, trackSupportColours>(
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, true, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -156,8 +149,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 1, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintLeftQuarterHelixTunnels, true, trackSupportColours>(
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, true, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -171,8 +164,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintLeftQuarterHelixTunnels, false, trackSupportColours>(
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, false, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -186,8 +179,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintRightQuarterHelixTunnels, false, trackSupportColours>(
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, false, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -201,8 +194,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintRightQuarterHelixTunnels, true, trackSupportColours>(
+            kRightQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, true, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 
@@ -216,8 +209,8 @@ namespace OpenRCT2
     {
         trackPaintGeneric<
             kQuarterHelixSequenceCount, kQuarterHelixSequenceSpriteCount, 2, imageIndex, spriteMap,
-            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup, 24,
-            trackPaintLeftQuarterHelixTunnels, true, trackSupportColours>(
+            kLeftQuarterHelixLargeUpBoundingBoxes, woodenSupports, supportHeightExtras, blockedSegmentsType, tunnelGroup,
+            TrackMetadata::SequenceTunnelType::upright, 1, 24, true, trackSupportColours>(
             session, ride, trackSequence, direction, height, trackElement, supportType);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/ride/TrackData.cpp
+++ b/src/openrct2/ride/TrackData.cpp
@@ -1611,6 +1611,16 @@ namespace OpenRCT2::TrackMetadata
             kSegmentsAll,                                                                           // wide
         } },
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterBankedHelixLargeUpSeq0.clearance, 0, false),
+        .tunnels = {
+            SequenceTunnel{
+                .direction = 0,
+                .tunnelInfo = {
+                    SequenceTunnelInfo{ 0, TunnelSubType::Flat }, // upright
+                    SequenceTunnelInfo{ 0, TunnelSubType::Flat }, // inverted
+                    SequenceTunnelInfo{ 0, TunnelSubType::Tall }, // invertedFlying
+                },
+            },
+        },
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeUpSeq1 = {
@@ -1681,6 +1691,16 @@ namespace OpenRCT2::TrackMetadata
             kSegmentsAll,                                                                                 // wide
         } },
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterBankedHelixLargeUpSeq6.clearance, 0, false),
+        .tunnels = {
+            SequenceTunnel{
+                .direction = 3,
+                .tunnelInfo = {
+                    SequenceTunnelInfo{ kLandHeightStep, TunnelSubType::FlatTo25Deg }, // upright
+                    SequenceTunnelInfo{ kLandHeightStep, TunnelSubType::Flat },        // inverted
+                    SequenceTunnelInfo{ kLandHeightStep, TunnelSubType::Tall },        // invertedFlying
+                },
+            },
+        },
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeUpSeq0 = {
@@ -1691,6 +1711,7 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .blockedSegments = blockedSegmentsFlipXAxis(kLeftQuarterBankedHelixLargeUpSeq0.blockedSegments),
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterBankedHelixLargeUpSeq0.clearance, 0, false),
+        .tunnels = sequenceTunnelsModify<DirectionFlipXAxis>(kLeftQuarterBankedHelixLargeUpSeq0.tunnels),
     };
 
     static constexpr SequenceDescriptor kRightQuarterBankedHelixLargeUpSeq1 = {
@@ -1741,6 +1762,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 1,
         .blockedSegments = blockedSegmentsFlipXAxis(kLeftQuarterBankedHelixLargeUpSeq6.blockedSegments),
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterBankedHelixLargeUpSeq6.clearance, 0, false),
+        .tunnels = sequenceTunnelsModify<DirectionFlipXAxis>(kLeftQuarterBankedHelixLargeUpSeq6.tunnels),
     };
 
     static constexpr SequenceDescriptor kLeftQuarterBankedHelixLargeDownSeq0 = {
@@ -1752,6 +1774,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 2,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq0.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterBankedHelixLargeDownSeq0.clearance, 0, false),
+        .tunnels = sequenceTunnelsModify<DirectionPrev>(kRightQuarterBankedHelixLargeUpSeq6.tunnels),
         .reversedTrackSequence = 6,
     };
 
@@ -1807,6 +1830,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = -1,
         .blockedSegments = kLeftQuarterBankedHelixLargeUpSeq6.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterBankedHelixLargeDownSeq6.clearance, 0, false),
+        .tunnels = sequenceTunnelsModify<DirectionPrev>(kRightQuarterBankedHelixLargeUpSeq0.tunnels),
         .reversedTrackSequence = 0,
     };
 
@@ -1819,6 +1843,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 2,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq0.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterBankedHelixLargeDownSeq0.clearance, 0, false),
+        .tunnels = sequenceTunnelsModify<DirectionFlipXAxis>(kLeftQuarterBankedHelixLargeDownSeq0.tunnels),
         .reversedTrackSequence = 6,
     };
 
@@ -1874,6 +1899,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 1,
         .blockedSegments = kRightQuarterBankedHelixLargeUpSeq6.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterBankedHelixLargeDownSeq6.clearance, 0, false),
+        .tunnels = sequenceTunnelsModify<DirectionFlipXAxis>(kLeftQuarterBankedHelixLargeDownSeq6.tunnels),
         .reversedTrackSequence = 0,
     };
 
@@ -1889,6 +1915,7 @@ namespace OpenRCT2::TrackMetadata
             kSegmentsAll,                                                                     // wide
         } },
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterHelixLargeUpSeq0.clearance, 0, false),
+        .tunnels = kLeftQuarterBankedHelixLargeUpSeq0.tunnels,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeUpSeq1 = {
@@ -1943,6 +1970,7 @@ namespace OpenRCT2::TrackMetadata
             kSegmentsAll,                                                                       // wide
         } },
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterHelixLargeUpSeq6.clearance, 0, false),
+        .tunnels = kLeftQuarterBankedHelixLargeUpSeq6.tunnels,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeUpSeq0 = {
@@ -1953,6 +1981,7 @@ namespace OpenRCT2::TrackMetadata
         .metalSupports = { MetalSupportPlace::centre },
         .blockedSegments = blockedSegmentsFlipXAxis(kLeftQuarterHelixLargeUpSeq0.blockedSegments),
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterHelixLargeUpSeq0.clearance, 0, false),
+        .tunnels = kRightQuarterBankedHelixLargeUpSeq0.tunnels,
     };
 
     static constexpr SequenceDescriptor kRightQuarterHelixLargeUpSeq1 = {
@@ -2003,6 +2032,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 1,
         .blockedSegments = blockedSegmentsFlipXAxis(kLeftQuarterHelixLargeUpSeq6.blockedSegments),
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterHelixLargeUpSeq6.clearance, 0, false),
+        .tunnels = kRightQuarterBankedHelixLargeUpSeq6.tunnels,
     };
 
     static constexpr SequenceDescriptor kLeftQuarterHelixLargeDownSeq0 = {
@@ -2014,6 +2044,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 2,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq0.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterHelixLargeDownSeq0.clearance, 0, false),
+        .tunnels = kLeftQuarterBankedHelixLargeDownSeq0.tunnels,
         .reversedTrackSequence = 6,
     };
 
@@ -2069,6 +2100,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = -1,
         .blockedSegments = kLeftQuarterHelixLargeUpSeq6.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kLeftQuarterHelixLargeDownSeq6.clearance, 0, false),
+        .tunnels = kLeftQuarterBankedHelixLargeDownSeq6.tunnels,
         .reversedTrackSequence = 0,
     };
 
@@ -2081,6 +2113,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 2,
         .blockedSegments = kRightQuarterHelixLargeUpSeq0.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterHelixLargeDownSeq0.clearance, 0, false),
+        .tunnels = kRightQuarterBankedHelixLargeDownSeq0.tunnels,
         .reversedTrackSequence = 6,
     };
 
@@ -2136,6 +2169,7 @@ namespace OpenRCT2::TrackMetadata
         .extraSupportRotation = 1,
         .blockedSegments = kRightQuarterHelixLargeUpSeq6.blockedSegments,
         .generalSupportHeight = calculateGeneralSupportHeight(kRightQuarterHelixLargeDownSeq6.clearance, 0, false),
+        .tunnels = kRightQuarterBankedHelixLargeDownSeq6.tunnels,
         .reversedTrackSequence = 0,
     };
 

--- a/src/openrct2/ride/ted/TrackElementDescriptor.h
+++ b/src/openrct2/ride/ted/TrackElementDescriptor.h
@@ -13,6 +13,7 @@
 #include "../../localisation/StringIdType.h"
 #include "../../paint/support/MetalSupports.h"
 #include "../../paint/support/WoodenSupports.h"
+#include "../../paint/tile_element/Paint.Tunnel.h"
 #include "../../paint/tile_element/Segment.h"
 #include "../../world/QuarterTile.h"
 #include "PitchAndRoll.h"
@@ -245,6 +246,46 @@ namespace OpenRCT2::TrackMetadata
         return trackClearance + (clearanceOffset * kLandHeightStep);
     };
 
+    enum class SequenceTunnelType : uint8_t
+    {
+        upright,
+        inverted,
+        invertedFlying,
+    };
+    constexpr size_t kSequenceTunnelTypeCount = 3;
+
+    struct SequenceTunnelInfo
+    {
+        int8_t height = 0;
+        TunnelSubType type = TunnelSubType::Flat;
+    };
+
+    struct SequenceTunnel
+    {
+        Direction direction = kInvalidDirection;
+        std::array<SequenceTunnelInfo, kSequenceTunnelTypeCount> tunnelInfo{};
+    };
+
+    constexpr uint8_t kSequenceTunnelMaxPerSequence = 2;
+
+    constexpr SequenceTunnel sequenceTunnelAllTypes(const Direction direction, const int8_t height, const TunnelSubType type)
+    {
+        const SequenceTunnelInfo tunnelInfo{ height, type };
+        return SequenceTunnel{ direction, { tunnelInfo, tunnelInfo, tunnelInfo } };
+    }
+
+    using SequenceTunnels = std::array<SequenceTunnel, kSequenceTunnelMaxPerSequence>;
+
+    template<Direction (&directionFunction)(Direction)>
+    constexpr SequenceTunnels sequenceTunnelsModify(SequenceTunnels sequenceTunnels)
+    {
+        for (auto& tunnel : sequenceTunnels)
+        {
+            tunnel.direction = directionFunction(tunnel.direction);
+        }
+        return sequenceTunnels;
+    }
+
     struct SequenceDescriptor
     {
         SequenceClearance clearance{};
@@ -258,6 +299,7 @@ namespace OpenRCT2::TrackMetadata
         bool invertSegmentBlocking = false;
         BlockedSegmentsPerType blockedSegments{ kSegmentsNone, kSegmentsNone, kSegmentsNone };
         int16_t generalSupportHeight = kDoNotSetGeneralSupportHeight;
+        SequenceTunnels tunnels{};
         uint8_t reversedTrackSequence = 0;
 
         constexpr uint8_t getEntranceConnectionSides() const


### PR DESCRIPTION
This adds tunnels to the track sequence descriptor and then uses them in `trackPaintGeneric`.
Only data for the quarter helix. You get the idea ;)

There's 2 tunnels per sequence, and heights + tunnel types for 3 different coaster types.