### PR TITLE
Changed default FoothpathSlope

### DIFF
--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -655,7 +655,7 @@ static void ApplyPathFixes(const json_t& scenarioPatch)
 
         for (auto coordinate : coordinates)
         {
-            auto slope = FootpathSlope{FootpathSlopeType::flat, Direction{}};
+            auto slope = FootpathSlope{ FootpathSlopeType::flat, Direction{} };
             if (direction != kInvalidDirection)
                 slope = { FootpathSlopeType::sloped, direction };
             auto footpathPlaceAction = GameActions::FootpathPlaceAction(

--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -655,7 +655,7 @@ static void ApplyPathFixes(const json_t& scenarioPatch)
 
         for (auto coordinate : coordinates)
         {
-            auto slope = FootpathSlope(FootpathSlopeType::flat, 0);
+            auto slope = FootpathSlope{FootpathSlopeType::flat, Direction{}};
             if (direction != kInvalidDirection)
                 slope = { FootpathSlopeType::sloped, direction };
             auto footpathPlaceAction = GameActions::FootpathPlaceAction(


### PR DESCRIPTION
Changed default FoothpathSlope in ScenarioPatcher so that builds work on XCode 15.

When building on XCode 15, I could not build with the error "/OpenRCT2/src/openrct2/rct12/ScenarioPatcher.cpp:658:26: error: no matching constructor for initialization of 'FootpathSlope'
            auto slope = FootpathSlope(FootpathSlopeType::flat, 0);
                         ^             ~~~~~~
/OpenRCT2/src/openrct2/rct12/../actions/footpath/../../world/Footpath.h:103:12: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
    struct FootpathSlope".

This change allowed me to create the build and run the program.