### PR TITLE
Update Changelog entry #23645

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,9 +1,9 @@
 0.5.0 (in development)
 ------------------------------------------------------------------------
+- Feature: [#23465] Change plugin JavaScript engine from Duktape to QuickJS-NG, allowing ES6+ features to be used in plugins.
 - Feature: [#26178] Port of the Spinning Cars from RollerCoaster Tycoon 1.
 - Improved: [#25314] Add unbanked and banked quarter helices to the Alpine, Corkscrew, Giga, Hybrid, Looping, Mine Ride, Mini, Multi-Dimension, Single Rail, Stand Up and Twister tracks.
 - Improved: [#26044] Simplify Android installation by bundling OpenRCT2 assets in APK.
-- Headline Change: [#23465] Change plugin JavaScript engine from Duktape to QuickJS-NG, allowing ES6+ features to be used in plugins.
 - Change: [#25962] The station style dropdown now shows entrance icons next to the labels for easier selection.
 - Change: [#26175] The ride colour tab is made more compact by collapsing unavailable sections instead of only hiding them.
 - Change: [#26178] Symmetric spinning trains and legacy ‘pre-reversed’ trains can no longer be reversed.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,7 +3,7 @@
 - Feature: [#26178] Port of the Spinning Cars from RollerCoaster Tycoon 1.
 - Improved: [#25314] Add unbanked and banked quarter helices to the Alpine, Corkscrew, Giga, Hybrid, Looping, Mine Ride, Mini, Multi-Dimension, Single Rail, Stand Up and Twister tracks.
 - Improved: [#26044] Simplify Android installation by bundling OpenRCT2 assets in APK.
-- Change: [#23465] Change plugin JavaScript engine from Duktape to QuickJS-NG.
+- Headline Change: [#23465] Change plugin JavaScript engine from Duktape to QuickJS-NG, allowing ES6+ features to be used in plugins.
 - Change: [#25962] The station style dropdown now shows entrance icons next to the labels for easier selection.
 - Change: [#26175] The ride colour tab is made more compact by collapsing unavailable sections instead of only hiding them.
 - Change: [#26178] Symmetric spinning trains and legacy ‘pre-reversed’ trains can no longer be reversed.


### PR DESCRIPTION
Taken from conversation with @Basssiiie, as it is a significant change:
<img width="651" height="459" alt="Screenshot 2026-04-01 at 16-03-09 • Discord #openrct2-talk OpenRCT2" src="https://github.com/user-attachments/assets/709e439c-9d64-44d8-acac-296f83519399" />
