### PR TITLE
Make changing the number of trains reset ride stats

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#26196] The sprites of one angle of the Steeplechase left large turn are misaligned (original bug).
 - Fix: [#26214] The wrong sprite is used for one angle of the gentle diagonal slope of Alpine, Hybrid and Single Rail tracks.
 - Fix: [#26243] Increase max dropdown size from 512 to 1024 to accommodate parks with more than 512 rides.
+- Fix: [#26303] Make changing the number of trains reset ride stats.
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/ride/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.cpp
@@ -141,6 +141,7 @@ namespace OpenRCT2::GameActions
                 ride->removePeeps();
                 ride->vehicleChangeTimeout = 100;
 
+                InvalidateTestResults(*ride);
                 ride->proposedNumTrains = _value;
                 break;
             case RideSetVehicleType::NumCarsPerTrain:


### PR DESCRIPTION
Currently changing the number of trains does not reset the ride stats, which allows for all kinds of exploits. This is also a bug anyway since in vanilla it does reset them.