### PR TITLE
Fix #26306: Check Homebrew paths when FindApp fails on macOS

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -259,6 +259,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Marcel Vos (MarcelVos96)
 * Jonas Doggart
 * (pg805)
+* Sjoerd de Bruin (sjoerddebruin)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#26196] The sprites of one angle of the Steeplechase left large turn are misaligned (original bug).
 - Fix: [#26214] The wrong sprite is used for one angle of the gentle diagonal slope of Alpine, Hybrid and Single Rail tracks.
 - Fix: [#26243] Increase max dropdown size from 512 to 1024 to accommodate parks with more than 512 rides.
+- Fix: [#26306] Platform::FindApp fails to locate Homebrew-installed tools on macOS.
 
 0.4.32 (2026-03-01)
 ------------------------------------------------------------------------

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -115,14 +115,31 @@ namespace OpenRCT2::Platform
 
     bool FindApp(std::string_view app, std::string* output)
     {
+        auto tryPath = [&](const std::string& path) -> bool {
+            const char* args[] = { path.c_str(), "--version", nullptr };
+            if (Execute(args, nullptr) == 0)
+            {
+                if (output)
+                    *output = path;
+                return true;
+            }
+            return false;
+        };
+
         std::string appStr = std::string(app);
-        const char* args[] = { appStr.c_str(), "--version", nullptr };
-        int result = Execute(args, nullptr);
-        if (result == 0 && output)
+        if (tryPath(appStr))
+            return true;
+
+    #ifdef __APPLE__
+        // Apps on macOS don't inherit the shell PATH, so check common Homebrew install locations as a fallback.
+        for (const char* prefix : { "/opt/homebrew/bin/", "/usr/local/bin/" })
         {
-            *output = appStr;
+            if (tryPath(std::string(prefix) + appStr))
+                return true;
         }
-        return result == 0;
+    #endif
+
+        return false;
     }
 
     int32_t Execute(const char* args[], std::string* output)


### PR DESCRIPTION
Fixes #26306, this allowed the set-up process to continue on my system.