### PR TITLE
Fix #26310: crash when multiple subscribers register for the same event

### DIFF
--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -122,7 +122,16 @@ void HookEngine::Call(HookType type, const JSValue arg, bool isGameStateMutable,
     auto& hookList = GetHookList(type);
     for (auto& hook : hookList.Hooks)
     {
-        _scriptEngine.ExecutePluginCall(hook.Owner, hook.Function.callback, { arg }, isGameStateMutable, keepArgsAlive);
+        JSContext* ctx = hook.Owner ? hook.Owner->GetContext() : _scriptEngine.GetContext();
+        _scriptEngine.ExecutePluginCall(
+            hook.Owner, hook.Function.callback, { JS_DupValue(ctx, arg) }, isGameStateMutable, false);
+    }
+
+    if (!keepArgsAlive)
+    {
+        // One final free as we are the "owner" of the passed arg
+        JSContext* ctx = _scriptEngine.GetContext();
+        JS_FreeValue(ctx, arg);
     }
 }
 

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/S6ImportExportTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/SawyerCodingTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/ScenarioPatcherTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/ScriptingTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/StringTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/TestData.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/TestData.h"

--- a/test/tests/ScriptingTests.cpp
+++ b/test/tests/ScriptingTests.cpp
@@ -1,0 +1,76 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/GameState.h>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/scripting/ScriptEngine.h>
+#include <quickjs.h>
+
+using namespace OpenRCT2;
+using namespace OpenRCT2::Scripting;
+
+class ScriptingTests : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        gOpenRCT2Headless = true;
+        gOpenRCT2NoGraphics = true;
+        _context = CreateContext();
+        _context->Initialise();
+    }
+
+    std::unique_ptr<IContext> _context;
+};
+
+#ifdef ENABLE_SCRIPTING
+
+TEST_F(ScriptingTests, MultipleSubscribersToSameEventShouldNotCrash)
+{
+    auto& scriptEngine = static_cast<ScriptEngine&>(_context->GetScriptEngine());
+
+    // Register a plugin that subscribes twice to the same event
+    const char* pluginCode = R"(
+        registerPlugin({
+            name: 'test-plugin-multiple-subscribers',
+            version: '1.0.0',
+            authors: ['openrct2-test'],
+            type: 'remote',
+            licence: 'MIT',
+            minApiVersion: 110, // deliberately the version before quickjs
+            targetApiVersion: 110,
+            main: function () {
+                context.subscribe('interval.tick', function (e) {
+                    // first subscriber
+                });
+                context.subscribe('interval.tick', function (e) {
+                    // second subscriber
+                });
+            }
+        });
+    )";
+
+    scriptEngine.AddNetworkPlugin(pluginCode);
+    scriptEngine.LoadTransientPlugins();
+    scriptEngine.Tick();
+
+    auto& hookEngine = scriptEngine.GetHookEngine();
+
+    // We need a JSValue to pass to Call.
+    JSContext* ctx = scriptEngine.GetContext();
+    JSValue arg = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, arg, "test", JS_NewInt32(ctx, 1));
+
+    // This should NOT crash.
+    hookEngine.Call(HookType::intervalTick, arg, false);
+}
+
+#endif

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -103,6 +103,7 @@
     <ClCompile Include="S6ImportExportTests.cpp" />
     <ClCompile Include="SawyerCodingTest.cpp" />
     <ClCompile Include="ScenarioPatcherTests.cpp" />
+    <ClCompile Include="ScriptingTests.cpp" />
     <ClCompile Include="TestData.cpp" />
     <ClCompile Include="tests.cpp" />
     <ClCompile Include="StringTest.cpp" />


### PR DESCRIPTION
The scripting engine's `ExecutePluginCall` by default frees its `JSValue` arguments. When `HookEngine::Call` iterates over multiple subscribers, the first call would free the argument, leaving subsequent subscribers with an invalid pointer.

This commit fixes the issue by duplicating the `JSValue` for each subscriber and ensuring the original value is correctly managed based on the `keepArgsAlive` flag.

A new C++ headless test `ScriptingTests.cpp` is added to verify the fix and prevent future regressions.

I don't think this warrants the plugin API version bump.