### PR TITLE
Add new screenshot to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,8 @@
 
 ---
 
-![OpenRCT2.org Group Park 5](https://i.imgur.com/e7CK5Sc.png)
+![Still from the v0.5.0 title sequence](https://github.com/user-attachments/assets/fa893cc8-1484-4751-94be-4ead00a6c8f9)
+
 
 ---
 


### PR DESCRIPTION
The old one was from 2014/2015 and didn’t really showcase anything OpenRCT2-specific.

Took this still from the new title sequence, which shows off the zero G roll.

Brought to my attention by Maji.