### PR TITLE
Fix #26304: Use common prototypes for JS entities

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -1204,6 +1204,7 @@
     <ClCompile Include="scripting\bindings\entity\ScLitter.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScMoneyEffect.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScParticle.cpp" />
+    <ClCompile Include="scripting\bindings\entity\ScPeep.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScStaff.cpp" />
     <ClCompile Include="scripting\bindings\entity\ScVehicle.cpp" />
     <ClCompile Include="scripting\bindings\network\ScNetwork.cpp" />

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -30,9 +30,14 @@
     #include "../platform/Platform.h"
     #include "../profiling/Profiling.h"
     #include "../ride/ted/PitchAndRoll.h"
+    #include "bindings/entity/ScBalloon.hpp"
     #include "bindings/entity/ScEntity.hpp"
     #include "bindings/entity/ScGuest.hpp"
+    #include "bindings/entity/ScLitter.hpp"
+    #include "bindings/entity/ScMoneyEffect.hpp"
+    #include "bindings/entity/ScParticle.hpp"
     #include "bindings/entity/ScStaff.hpp"
+    #include "bindings/entity/ScVehicle.hpp"
     #include "bindings/game/ScCheats.hpp"
     #include "bindings/game/ScConsole.hpp"
     #include "bindings/game/ScContext.hpp"
@@ -573,6 +578,17 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     gScTrackIterator.Register(ctx);
     gScTrackSegment.Register(ctx);
     gScEntity.Register(ctx);
+    gScPeep.Register(ctx);
+    gScGuest.Register(ctx);
+    gScStaff.Register(ctx);
+    gScHandyman.Register(ctx);
+    gScMechanic.Register(ctx);
+    gScSecurity.Register(ctx);
+    gScBalloon.Register(ctx);
+    gScLitter.Register(ctx);
+    gScMoneyEffect.Register(ctx);
+    gScCrashedVehicleParticle.Register(ctx);
+    gScVehicle.Register(ctx);
     gScThought.Register(ctx);
     #ifndef DISABLE_NETWORK
     gScSocket.Register(ctx);
@@ -615,6 +631,17 @@ void ScriptEngine::UnregisterClasses()
     gScTrackIterator.Unregister();
     gScTrackSegment.Unregister();
     gScEntity.Unregister();
+    gScPeep.Unregister();
+    gScGuest.Unregister();
+    gScStaff.Unregister();
+    gScHandyman.Unregister();
+    gScMechanic.Unregister();
+    gScSecurity.Unregister();
+    gScBalloon.Unregister();
+    gScLitter.Unregister();
+    gScMoneyEffect.Unregister();
+    gScCrashedVehicleParticle.Unregister();
+    gScVehicle.Unregister();
     gScThought.Unregister();
     #ifndef DISABLE_NETWORK
     gScSocket.Unregister();

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -323,7 +323,30 @@ namespace OpenRCT2::Scripting
                 JS_FreeValue(protoCtx, proto);
         }
 
+        [[nodiscard]] JSValue GetProto() const
+        {
+            return proto;
+        }
+
+        void RegisterDerived(JSContext* ctx, const ScBase& parent, std::span<const JSCFunctionListEntry> classFuncs)
+        {
+            proto = JS_NewObject(ctx);
+            protoCtx = ctx;
+            JS_SetPrototype(ctx, proto, parent.GetProto());
+            JS_SetPropertyFunctionList(ctx, proto, classFuncs.data(), static_cast<int>(classFuncs.size()));
+        }
+
     protected:
+        [[nodiscard]] JSValue MakeWithOpaqueAndProto(JSContext* ctx, void* opaque, JSValue customProto) const
+        {
+            assert(opaque == nullptr || hasFinalizer);
+            JSValue obj = JS_NewObjectProtoClass(ctx, customProto, classId);
+            if (JS_IsException(obj))
+                throw std::runtime_error("Failed to create new object for class.");
+            JS_SetOpaque(obj, opaque);
+            return obj;
+        }
+
         [[nodiscard]] JSValue MakeWithOpaque(JSContext* ctx, void* opaque) const
         {
             // If you fail this assert you probably need a finalizer to free the opaque ptr.

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.cpp
@@ -15,18 +15,18 @@
 
 namespace OpenRCT2::Scripting
 {
+    ScBalloon gScBalloon;
+
     JSValue ScBalloon::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = gScEntity.New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScBalloon.GetProto());
     }
 
-    void ScBalloon::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScBalloon::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = { JS_CGETSET_DEF(
             "colour", &ScBalloon::colour_get, &ScBalloon::colour_set) };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScBalloon.RegisterDerived(ctx, gScEntity, funcs);
     }
 
     Balloon* ScBalloon::GetBalloon(JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScBalloon.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScBalloon.hpp
@@ -20,13 +20,16 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
+    class ScBalloon;
+    extern ScBalloon gScBalloon;
+
     class ScBalloon final : public ScEntity
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
         static Balloon* GetBalloon(JSValue thisVal);
 
         static JSValue colour_get(JSContext* ctx, JSValue thisVal);

--- a/src/openrct2/scripting/bindings/entity/ScEntity.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.cpp
@@ -207,6 +207,11 @@ namespace OpenRCT2::Scripting
         return MakeWithOpaque(ctx, new OpaqueEntityData{ entityId });
     }
 
+    JSValue ScEntity::NewDerivedInstance(JSContext* ctx, EntityId entityId, JSValue derivedProto)
+    {
+        return MakeWithOpaqueAndProto(ctx, new OpaqueEntityData{ entityId }, derivedProto);
+    }
+
     // this one exists as a hack to make a template work in ScMap
     JSValue ScEntity::New(JSContext* ctx, EntityId entityId)
     {

--- a/src/openrct2/scripting/bindings/entity/ScEntity.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScEntity.hpp
@@ -51,6 +51,7 @@ namespace OpenRCT2::Scripting
 
     public:
         JSValue NewInstance(JSContext* ctx, EntityId entityId);
+        JSValue NewDerivedInstance(JSContext* ctx, EntityId entityId, JSValue derivedProto);
         static JSValue New(JSContext* ctx, EntityId entityId);
 
         void Register(JSContext* ctx);

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -151,14 +151,14 @@ namespace OpenRCT2::Scripting
             { "here_we_are", PeepThoughtType::HereWeAre },
         });
 
+    ScGuest gScGuest;
+
     JSValue ScGuest::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = ScPeep::New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScGuest.GetProto());
     }
 
-    void ScGuest::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScGuest::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("tshirtColour", &ScGuest::tshirtColour_get, &ScGuest::tshirtColour_set),
@@ -194,7 +194,7 @@ namespace OpenRCT2::Scripting
             JS_CFUNC_DEF("removeItem", 1, &ScGuest::remove_item),
             JS_CFUNC_DEF("removeAllItems", 0, &ScGuest::remove_all_items),
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScGuest.RegisterDerived(ctx, gScPeep, funcs);
     }
 
     Guest* ScGuest::GetGuest(JSValue thisVal)
@@ -923,7 +923,7 @@ namespace OpenRCT2::Scripting
             return spriteIds;
         }
 
-        auto peep = GetPeep(thisVal);
+        auto peep = GetGuest(thisVal);
         if (peep != nullptr)
         {
             auto& objManager = GetContext()->GetObjectManager();

--- a/src/openrct2/scripting/bindings/entity/ScGuest.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.hpp
@@ -107,13 +107,16 @@ namespace OpenRCT2::Scripting
         static JSValue toString(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv);
     };
 
-    class ScGuest final : public ScPeep
+    class ScGuest;
+    extern ScGuest gScGuest;
+
+    class ScGuest final : public ScEntity
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
         static Guest* GetGuest(JSValue thisVal);
 
         static JSValue tshirtColour_get(JSContext* ctx, JSValue thisVal);

--- a/src/openrct2/scripting/bindings/entity/ScLitter.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.cpp
@@ -32,20 +32,20 @@ namespace OpenRCT2::Scripting
             { "empty_bowl_blue", Litter::Type::emptyBowlBlue },
         });
 
+    ScLitter gScLitter;
+
     JSValue ScLitter::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = gScEntity.New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScLitter.GetProto());
     }
 
-    void ScLitter::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScLitter::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("litterType", &ScLitter::litterType_get, &ScLitter::litterType_set),
             JS_CGETSET_DEF("creationTick", &ScLitter::creationTick_get, nullptr)
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScLitter.RegisterDerived(ctx, gScEntity, funcs);
     }
 
     Litter* ScLitter::GetLitter(JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScLitter.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScLitter.hpp
@@ -20,13 +20,16 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
+    class ScLitter;
+    extern ScLitter gScLitter;
+
     class ScLitter final : public ScEntity
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
         static Litter* GetLitter(JSValue thisVal);
 
         static JSValue litterType_get(JSContext* ctx, JSValue thisVal);

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -16,18 +16,18 @@
 
 namespace OpenRCT2::Scripting
 {
+    ScMoneyEffect gScMoneyEffect;
+
     JSValue ScMoneyEffect::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = gScEntity.New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScMoneyEffect.GetProto());
     }
 
-    void ScMoneyEffect::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScMoneyEffect::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = { JS_CGETSET_DEF(
             "value", &ScMoneyEffect::value_get, &ScMoneyEffect::value_set) };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScMoneyEffect.RegisterDerived(ctx, gScEntity, funcs);
     }
 
     MoneyEffect* ScMoneyEffect::GetMoneyEffect(JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.hpp
@@ -20,13 +20,16 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
+    class ScMoneyEffect;
+    extern ScMoneyEffect gScMoneyEffect;
+
     class ScMoneyEffect final : public ScEntity
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
         static MoneyEffect* GetMoneyEffect(JSValue thisVal);
 
         static JSValue value_get(JSContext* ctx, JSValue thisVal);

--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -25,14 +25,14 @@ namespace OpenRCT2::Scripting
             { "seat", 4 },
         });
 
+    ScCrashedVehicleParticle gScCrashedVehicleParticle;
+
     JSValue ScCrashedVehicleParticle::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = gScEntity.New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScCrashedVehicleParticle.GetProto());
     }
 
-    void ScCrashedVehicleParticle::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScCrashedVehicleParticle::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF(
@@ -46,7 +46,7 @@ namespace OpenRCT2::Scripting
             JS_CGETSET_DEF("frame", &ScCrashedVehicleParticle::frame_get, &ScCrashedVehicleParticle::frame_set),
             JS_CFUNC_DEF("launch", 1, &ScCrashedVehicleParticle::Launch),
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScCrashedVehicleParticle.RegisterDerived(ctx, gScEntity, funcs);
     }
 
     VehicleCrashParticle* ScCrashedVehicleParticle::GetCrashedVehicleParticle(JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScParticle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.hpp
@@ -19,13 +19,16 @@
 
 namespace OpenRCT2::Scripting
 {
+    class ScCrashedVehicleParticle;
+    extern ScCrashedVehicleParticle gScCrashedVehicleParticle;
+
     class ScCrashedVehicleParticle final : public ScEntity
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
         static VehicleCrashParticle* GetCrashedVehicleParticle(JSValue thisVal);
 
         static JSValue colours_get(JSContext* ctx, JSValue thisVal);

--- a/src/openrct2/scripting/bindings/entity/ScPeep.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.cpp
@@ -1,0 +1,40 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "ScPeep.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    ScPeep gScPeep;
+
+    JSValue ScPeep::New(JSContext* ctx, EntityId entityId)
+    {
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScPeep.GetProto());
+    }
+
+    void ScPeep::Register(JSContext* ctx)
+    {
+        static constexpr JSCFunctionListEntry funcs[] = {
+            JS_CGETSET_DEF("peepType", &ScPeep::peepType_get, nullptr),
+            JS_CGETSET_DEF("name", &ScPeep::name_get, &ScPeep::name_set),
+            JS_CGETSET_DEF("destination", &ScPeep::destination_get, &ScPeep::destination_set),
+            JS_CGETSET_DEF("direction", &ScPeep::direction_get, &ScPeep::direction_set),
+            JS_CGETSET_DEF("energy", &ScPeep::energy_get, &ScPeep::energy_set),
+            JS_CGETSET_DEF("energyTarget", &ScPeep::energyTarget_get, &ScPeep::energyTarget_set),
+            JS_CFUNC_DEF("getFlag", 1, &ScPeep::getFlag),
+            JS_CFUNC_DEF("setFlag", 2, &ScPeep::setFlag),
+        };
+        gScPeep.RegisterDerived(ctx, gScEntity, funcs);
+    }
+
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/entity/ScPeep.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScPeep.hpp
@@ -47,32 +47,16 @@ namespace OpenRCT2::Scripting
             { "animationFrozen", PEEP_FLAGS_ANIMATION_FROZEN },
         });
 
+    class ScPeep;
+    extern ScPeep gScPeep;
+
     class ScPeep : public ScEntity
     {
     public:
-        static JSValue New(JSContext* ctx, EntityId entityId)
-        {
-            JSValue obj = gScEntity.New(ctx, entityId);
-            AddFuncs(ctx, obj);
-            return obj;
-        }
+        static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
-        {
-            static constexpr JSCFunctionListEntry funcs[] = {
-                JS_CGETSET_DEF("peepType", &ScPeep::peepType_get, nullptr),
-                JS_CGETSET_DEF("name", &ScPeep::name_get, &ScPeep::name_set),
-                JS_CGETSET_DEF("destination", &ScPeep::destination_get, &ScPeep::destination_set),
-                JS_CGETSET_DEF("direction", &ScPeep::direction_get, &ScPeep::direction_set),
-                JS_CGETSET_DEF("energy", &ScPeep::energy_get, &ScPeep::energy_set),
-                JS_CGETSET_DEF("energyTarget", &ScPeep::energyTarget_get, &ScPeep::energyTarget_set),
-                JS_CFUNC_DEF("getFlag", 1, &ScPeep::getFlag),
-                JS_CFUNC_DEF("setFlag", 2, &ScPeep::setFlag),
-            };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
-        }
-
         static JSValue peepType_get(JSContext* ctx, JSValue thisVal)
         {
             auto peep = GetPeep(thisVal);

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -21,14 +21,14 @@
 
 namespace OpenRCT2::Scripting
 {
+    ScStaff gScStaff;
+
     JSValue ScStaff::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = ScPeep::New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScStaff.GetProto());
     }
 
-    void ScStaff::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScStaff::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("staffType", &ScStaff::staffType_get, &ScStaff::staffType_set),
@@ -44,7 +44,7 @@ namespace OpenRCT2::Scripting
             JS_CFUNC_DEF("getAnimationSpriteIds", 2, &ScStaff::getAnimationSpriteIds),
             JS_CFUNC_DEF("getCostumeStrings", 0, &ScStaff::getCostumeStrings)
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScStaff.RegisterDerived(ctx, gScPeep, funcs);
     }
 
     Staff* ScStaff::GetStaff(JSValue thisVal)
@@ -433,14 +433,14 @@ namespace OpenRCT2::Scripting
         return JS_NewUint32(ctx, length);
     }
 
+    ScHandyman gScHandyman;
+
     JSValue ScHandyman::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = ScStaff::New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScHandyman.GetProto());
     }
 
-    void ScHandyman::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScHandyman::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("lawnsMown", &ScHandyman::lawnsMown_get, nullptr),
@@ -448,7 +448,7 @@ namespace OpenRCT2::Scripting
             JS_CGETSET_DEF("litterSwept", &ScHandyman::litterSwept_get, nullptr),
             JS_CGETSET_DEF("binsEmptied", &ScHandyman::binsEmptied_get, nullptr),
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScHandyman.RegisterDerived(ctx, gScStaff, funcs);
     }
 
     JSValue ScHandyman::lawnsMown_get(JSContext* ctx, JSValue thisVal)
@@ -503,20 +503,20 @@ namespace OpenRCT2::Scripting
         }
     }
 
+    ScMechanic gScMechanic;
+
     JSValue ScMechanic::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = ScStaff::New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScMechanic.GetProto());
     }
 
-    void ScMechanic::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScMechanic::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("ridesFixed", &ScMechanic::ridesFixed_get, nullptr),
             JS_CGETSET_DEF("ridesInspected", &ScMechanic::ridesInspected_get, nullptr),
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScMechanic.RegisterDerived(ctx, gScStaff, funcs);
     }
 
     JSValue ScMechanic::ridesFixed_get(JSContext* ctx, JSValue thisVal)
@@ -545,19 +545,19 @@ namespace OpenRCT2::Scripting
         }
     }
 
+    ScSecurity gScSecurity;
+
     JSValue ScSecurity::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = ScStaff::New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScSecurity.GetProto());
     }
 
-    void ScSecurity::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScSecurity::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("vandalsStopped", &ScSecurity::vandalsStopped_get, nullptr),
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScSecurity.RegisterDerived(ctx, gScStaff, funcs);
     }
 
     JSValue ScSecurity::vandalsStopped_get(JSContext* ctx, JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -50,13 +50,12 @@ namespace OpenRCT2::Scripting
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     protected:
         static Staff* GetStaff(JSValue thisVal);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
-
         static JSValue staffType_get(JSContext* ctx, JSValue thisVal);
         static JSValue staffType_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
@@ -83,14 +82,15 @@ namespace OpenRCT2::Scripting
         static JSValue animationLength_get(JSContext* ctx, JSValue thisVal);
     };
 
+    extern ScStaff gScStaff;
+
     class ScHandyman final : public ScStaff
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
-
         static JSValue lawnsMown_get(JSContext* ctx, JSValue thisVal);
 
         static JSValue gardensWatered_get(JSContext* ctx, JSValue thisVal);
@@ -100,29 +100,36 @@ namespace OpenRCT2::Scripting
         static JSValue binsEmptied_get(JSContext* ctx, JSValue thisVal);
     };
 
+    class ScHandyman;
+    extern ScHandyman gScHandyman;
+
     class ScMechanic final : public ScStaff
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
-
         static JSValue ridesFixed_get(JSContext* ctx, JSValue thisVal);
 
         static JSValue ridesInspected_get(JSContext* ctx, JSValue thisVal);
     };
 
+    class ScMechanic;
+    extern ScMechanic gScMechanic;
+
     class ScSecurity final : public ScStaff
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
-
         static JSValue vandalsStopped_get(JSContext* ctx, JSValue thisVal);
     };
+
+    class ScSecurity;
+    extern ScSecurity gScSecurity;
 
 } // namespace OpenRCT2::Scripting
 

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -59,14 +59,14 @@ namespace OpenRCT2::Scripting
             { "stopped_by_block_brake", Vehicle::Status::stoppedByBlockBrakes },
         });
 
+    ScVehicle gScVehicle;
+
     JSValue ScVehicle::New(JSContext* ctx, EntityId entityId)
     {
-        JSValue obj = gScEntity.New(ctx, entityId);
-        AddFuncs(ctx, obj);
-        return obj;
+        return gScEntity.NewDerivedInstance(ctx, entityId, gScVehicle.GetProto());
     }
 
-    void ScVehicle::AddFuncs(JSContext* ctx, JSValue obj)
+    void ScVehicle::Register(JSContext* ctx)
     {
         static constexpr JSCFunctionListEntry funcs[] = {
             JS_CGETSET_DEF("ride", &ScVehicle::ride_get, &ScVehicle::ride_set),
@@ -101,7 +101,7 @@ namespace OpenRCT2::Scripting
             JS_CFUNC_DEF("travelBy", 1, &ScVehicle::travelBy),
             JS_CFUNC_DEF("moveToTrack", 3, &ScVehicle::moveToTrack),
         };
-        JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+        gScVehicle.RegisterDerived(ctx, gScEntity, funcs);
     }
 
     Vehicle* ScVehicle::GetVehicle(JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
@@ -20,13 +20,16 @@
 
 namespace OpenRCT2::Scripting
 {
+    class ScVehicle;
+    extern ScVehicle gScVehicle;
+
     class ScVehicle final : public ScEntity
     {
     public:
         static JSValue New(JSContext* ctx, EntityId entityId);
+        void Register(JSContext* ctx);
 
     private:
-        static void AddFuncs(JSContext* ctx, JSValue obj);
         static Vehicle* GetVehicle(JSValue thisVal);
 
         static JSValue rideObject_get(JSContext* ctx, JSValue thisVal);


### PR DESCRIPTION
Previously JS entities would create prototypes on each allocation in `Sc*::New`. This change creates a single global protype for each entity class which then gets copied upon entity allocation in JS realm.

Running test with "Live Ride Measurements" plugin on a park shared for performance testing I get following results:

|                 | OpenRCT2::Scripting::HookEngine::Call | OpenRCT2::Scripting::ScMap::getAllEntities |
|-----------------|---------------------------------------|--------------------------------------------|
| duktape         | 68ms                                  | 10ms                                       |
| quickjs current | 318ms                                 | 126ms                                      |
| quickjs + fix   | 22ms                                  | 942µs                                      |

Previously each call to `getAllEntities` would result in 1382 calls to `JS_SetPropertyFunctionList`, each costing 90.5µs.

Park used: https://files.catbox.moe/z6j2g4.park