### PR TITLE
Add stats reset when lap count is forcibly changed & avoid unnecessary lap count resets

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Change: [#26689] A clear scenario editor can now be opened directly from the command line.
 - Change: [objects#439] Drop numbers from Wacky Worlds scenery descriptions.
 - Fix: [#24613] Incorrect sprites drawn for path elements without a valid object.
+- Fix: [#26323] Ride stats do not reset when changing the number of trains changes the number of laps.
 - Fix: [#26494] The limits for where walls on the path side of the first tile block the view of rides/scenery are wrong (original bug).
 - Fix: [#26504] The boosts/penalties to excitement and nausea that air time provides are calculated wrong.
 - Fix: [#26545] Game crashes when plugin API function generateGuest fails to generate a guest.
@@ -41,7 +42,7 @@
 - Fix: [#25581] Chart drawing issue on some platforms due to compiler optimisation.
 - Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don‘t draw in tunnels at some angles (original bug).
 - Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
-- Fix: [#26287] Game crashes upon connect/disconnect of physical keyboard. 
+- Fix: [#26287] Game crashes upon connect/disconnect of physical keyboard.
 - Fix: [#26299] Single Rail S-Bend sprites don’t fully connect to the next track piece at certain angles.
 - Fix: [#26352] Large scenery items are incorrectly labelled as ‘banners’ in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#26308] Add all new track pieces to the inverted roller coaster.
 - Feature: [#26442] Add cheat to disable grass growing.
+- Improved: [#26325] Changing the train type, length, or direction no longer resets the number of laps if there is just one train.
 - Improved: [objects#437] Re-order St. Basil’s Cathedral pieces to be more consistent.
 - Change: [#26689] A clear scenario editor can now be opened directly from the command line.
 - Change: [objects#439] Drop numbers from Wacky Worlds scenery descriptions.

--- a/src/openrct2/actions/ride/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.cpp
@@ -205,8 +205,11 @@ namespace OpenRCT2::GameActions
                 return Result(Status::invalidParameters, errTitle, kStringIdNone);
         }
 
-        ride->numCircuits = 1;
         ride->updateMaxVehicles();
+        if (ride->numTrains > 1)
+        {
+            ride->numCircuits = 1;
+        }
 
         auto res = Result();
         if (!ride->overallView.IsNull())

--- a/src/openrct2/actions/ride/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/ride/RideSetVehicleAction.cpp
@@ -139,6 +139,10 @@ namespace OpenRCT2::GameActions
                 ride->removePeeps();
                 ride->vehicleChangeTimeout = 100;
 
+                if (ride->numCircuits > 1)
+                {
+                    InvalidateTestResults(*ride);
+                }
                 ride->proposedNumTrains = _value;
                 break;
             case RideSetVehicleType::numCarsPerTrain:


### PR DESCRIPTION
Fixes #26323

The ride stats don't get reset when the number of laps is forcibly changed to one after increasing the number of trains from one to multiple. This PR changes that.

This PR also stops the lap count from being reset after changing the train type, the train length, or direction of the train. Now it only gets reset if the number of trains changes.