### PR TITLE
Fix outline when hovering over banner with RCT1 theme

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3306,7 +3306,7 @@ STR_6304    :Open scenery picker
 STR_6305    :Multithreading
 STR_6306    :Experimental option to use multiple threads to render, may cause instability.
 STR_6307    :Colour scheme: {BLACK}{STRINGID}
-STR_6308    :{TOPAZ}“{STRINGID}{OUTLINE}{TOPAZ}”{NEWLINE}{STRINGID}
+STR_6308    :{TOPAZ}“{STRINGID}{TOPAZ}”{NEWLINE}{STRINGID}
 STR_6309    :Reconnect
 STR_6310    :{WINDOW_COLOUR_2}Position: {BLACK}{INT32} {INT32} {INT32}
 STR_6311    :{WINDOW_COLOUR_2}Next: {BLACK}{INT32} {INT32} {INT32}


### PR DESCRIPTION
A map tooltip (RCT2 style) has an outline, while text in the status bar (RCT1 style) does not. This fixes the tooltip for both situations.

Before:
<img width="276" height="99" alt="Schermafdruk van 2026-04-05 14-55-00" src="https://github.com/user-attachments/assets/760d6db1-d2f5-48f0-9f40-bb2682429273" />
