### PR TITLE
Fix unguarded access to shop items

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,7 +27,7 @@
 - Fix: [#26214] The wrong sprite is used for one angle of the gentle diagonal slope of Alpine, Hybrid and Single Rail tracks.
 - Fix: [#26243] Increase max dropdown size from 512 to 1024 to accommodate parks with more than 512 rides.
 - Fix: [#26306] Platform::FindApp fails to locate Homebrew-installed tools on macOS.
-- Fix: [#26339] Access to invalid shop items in marketing window.
+- Fix: [#26339] Crash when setting up a marketing campaign.
 - Fix: [objects#430] The RCT1 Reverse Freefall car can be reversed and show broken sprites when doing so.
 
 0.4.32 (2026-03-01)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#26214] The wrong sprite is used for one angle of the gentle diagonal slope of Alpine, Hybrid and Single Rail tracks.
 - Fix: [#26243] Increase max dropdown size from 512 to 1024 to accommodate parks with more than 512 rides.
 - Fix: [#26306] Platform::FindApp fails to locate Homebrew-installed tools on macOS.
+- Fix: [#26339] Access to invalid shop items in marketing window.
 - Fix: [objects#430] The RCT1 Reverse Freefall car can be reversed and show broken sprites when doing so.
 
 0.4.32 (2026-03-01)

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -223,6 +223,8 @@ bool MarketingIsCampaignTypeApplicable(int32_t campaignType)
                 {
                     for (auto& item : rideEntry->shop_item)
                     {
+                        if (item == ShopItem::none)
+                            continue;
                         if (GetShopItemDescriptor(item).IsFoodOrDrink())
                         {
                             return true;


### PR DESCRIPTION
[park_24696.park.txt](https://github.com/user-attachments/files/26540280/park_24696.park.txt)

In this park open the marketing tab in financials window

<img width="533" height="260" alt="image" src="https://github.com/user-attachments/assets/b0064483-31e0-4d2f-95c0-5e01506a9ebb" />

Access to this field is usually guarded with such check in other places