### PR TITLE
Replace old constant notation, convert ParkFileChunkType to enum

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -261,6 +261,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Jonas Doggart
 * (pg805)
 * Sjoerd de Bruin (sjoerddebruin)
+* Alex Harvey (loonyduck1)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/core/OrcaStream.hpp
+++ b/src/openrct2/core/OrcaStream.hpp
@@ -223,12 +223,12 @@ namespace OpenRCT2
             _compressionLevel = compressionLevel;
         }
 
-        template<typename TFunc>
-        bool readWriteChunk(const uint32_t chunkId, TFunc f)
+        template<typename TChunk, typename TFunc>
+        bool readWriteChunk(TChunk chunkId, TFunc f)
         {
             if (_mode == Mode::reading)
             {
-                if (seekChunk(chunkId))
+                if (seekChunk(EnumValue(chunkId)))
                 {
                     ChunkStream stream(_buffer, _mode);
                     f(stream);
@@ -238,7 +238,7 @@ namespace OpenRCT2
                 return false;
             }
 
-            _currentChunk.id = chunkId;
+            _currentChunk.id = EnumValue(chunkId);
             _currentChunk.offset = _buffer.GetPosition();
             _currentChunk.length = 0;
             ChunkStream stream(_buffer, _mode);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -81,29 +81,29 @@ namespace OpenRCT2
     namespace ParkFileChunkType
     {
         // clang-format off
-//      constexpr uint32_t kReserved0            = 0x00;
-        constexpr uint32_t kAuthoring            = 0x01;
-        constexpr uint32_t kObjects              = 0x02;
-        constexpr uint32_t kScenario             = 0x03;
-        constexpr uint32_t kGeneral              = 0x04;
-        constexpr uint32_t kClimate              = 0x05;
-        constexpr uint32_t kPark                 = 0x06;
-//      constexpr uint32_t kHistory              = 0x07;
-        constexpr uint32_t kResearch             = 0x08;
-        constexpr uint32_t kNotifications        = 0x09;
-        constexpr uint32_t kInterface            = 0x20;
-        constexpr uint32_t kTiles                = 0x30;
-        constexpr uint32_t kEntities             = 0x31;
-        constexpr uint32_t kRides                = 0x32;
-        constexpr uint32_t kBanners              = 0x33;
-//      constexpr uint32_t kStaff                = 0x35;
-        constexpr uint32_t kCheats               = 0x36;
-        constexpr uint32_t kRestrictedObjects   = 0x37;
-        constexpr uint32_t kPluginStorage       = 0x38;
-        constexpr uint32_t kPreview              = 0x39;
-        constexpr uint32_t kPackedObjects       = 0x80;
+//      constexpr uint32_t kReserved0               = 0x00;
+        constexpr uint32_t kAuthoring               = 0x01;
+        constexpr uint32_t kObjects                 = 0x02;
+        constexpr uint32_t kScenario                = 0x03;
+        constexpr uint32_t kGeneral                 = 0x04;
+        constexpr uint32_t kClimate                 = 0x05;
+        constexpr uint32_t kPark                    = 0x06;
+//      constexpr uint32_t kHistory                 = 0x07;
+        constexpr uint32_t kResearch                = 0x08;
+        constexpr uint32_t kNotifications           = 0x09;
+        constexpr uint32_t kInterface               = 0x20;
+        constexpr uint32_t kTitles                  = 0x30;
+        constexpr uint32_t kEntities                = 0x31;
+        constexpr uint32_t kRides                   = 0x32;
+        constexpr uint32_t kBanners                 = 0x33;
+//      constexpr uint32_t kStaff                   = 0x35;
+        constexpr uint32_t kCheats                  = 0x36;
+        constexpr uint32_t kRestrictedObjects       = 0x37;
+        constexpr uint32_t kPluginStorage           = 0x38;
+        constexpr uint32_t kPreview                 = 0x39;
+        constexpr uint32_t kPackedObjects           = 0x80;
         // clang-format on
-    } // namespace ParkFileChunkType
+    }; // namespace ParkFileChunkType
 
     class ParkFile
     {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -78,7 +78,7 @@ using namespace OpenRCT2;
 
 namespace OpenRCT2
 {
-    enum ParkFileChunkType : uint32_t
+    enum class ParkFileChunkType : uint32_t
     {
         // clang-format off
 //      kReserved0               = 0x00,
@@ -103,7 +103,7 @@ namespace OpenRCT2
         kPreview                 = 0x39,
         kPackedObjects           = 0x80
         // clang-format on
-    }; // enum ParkFileChunkType : uint32_t
+    }; // enum class ParkFileChunkType : uint32_t
 
     class ParkFile
     {
@@ -220,7 +220,7 @@ namespace OpenRCT2
         {
             ScenarioIndexEntry entry{};
             auto& os = *_os;
-            os.readWriteChunk(ParkFileChunkType::kScenario, [&entry](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kScenario), [&entry](OrcaStream::ChunkStream& cs) {
                 entry.Category = cs.read<Scenario::Category>();
 
                 std::string name;
@@ -250,7 +250,7 @@ namespace OpenRCT2
         {
             ParkPreview preview{};
             auto& os = *_os;
-            os.readWriteChunk(ParkFileChunkType::kPreview, [&preview](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kPreview), [&preview](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(preview.parkName);
                 cs.readWrite(preview.parkRating);
                 cs.readWrite(preview.year);
@@ -290,7 +290,7 @@ namespace OpenRCT2
             // Write-only for now
             if (os.getMode() == OrcaStream::Mode::writing)
             {
-                os.readWriteChunk(ParkFileChunkType::kAuthoring, [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(EnumValue(ParkFileChunkType::kAuthoring), [](OrcaStream::ChunkStream& cs) {
                     cs.write(std::string_view(gVersionInfoFull));
                     std::vector<std::string> authors;
                     cs.readWriteVector(authors, [](std::string& s) {});
@@ -325,7 +325,7 @@ namespace OpenRCT2
                 };
                 std::vector<LegacyFootpathMapping> legacyPathMappings;
                 os.readWriteChunk(
-                    ParkFileChunkType::kObjects, [&requiredObjects, version, &legacyPathMappings](OrcaStream::ChunkStream& cs) {
+                    EnumValue(ParkFileChunkType::kObjects), [&requiredObjects, version, &legacyPathMappings](OrcaStream::ChunkStream& cs) {
                         auto numSubLists = cs.read<uint16_t>();
                         for (size_t i = 0; i < numSubLists; i++)
                         {
@@ -434,7 +434,7 @@ namespace OpenRCT2
                 if (version < kClimateObjectsVersion)
                 {
                     RCT12::ClimateType legacyClimate{};
-                    os.readWriteChunk(ParkFileChunkType::kClimate, [&legacyClimate](OrcaStream::ChunkStream& cs) {
+                    os.readWriteChunk(EnumValue(ParkFileChunkType::kClimate), [&legacyClimate](OrcaStream::ChunkStream& cs) {
                         cs.readWrite(legacyClimate);
                     });
 
@@ -446,7 +446,7 @@ namespace OpenRCT2
             }
             else
             {
-                os.readWriteChunk(ParkFileChunkType::kObjects, [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(EnumValue(ParkFileChunkType::kObjects), [](OrcaStream::ChunkStream& cs) {
                     auto& objManager = GetContext()->GetObjectManager();
                     auto objectList = objManager.GetLoadedObjects();
 
@@ -486,7 +486,7 @@ namespace OpenRCT2
 
         void ReadWriteScenarioChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kScenario, [&gameState, &os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kScenario), [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.scenarioOptions.category);
                 ReadWriteStringTable(cs, gameState.scenarioOptions.name, "en-GB");
                 ReadWriteStringTable(cs, gameState.park.name, "en-GB");
@@ -532,7 +532,7 @@ namespace OpenRCT2
 
         void ReadWritePreviewChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kPreview, [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kPreview), [&gameState](OrcaStream::ChunkStream& cs) {
                 auto preview = generatePreviewFromGameState(gameState);
 
                 cs.readWrite(preview.parkName);
@@ -560,7 +560,7 @@ namespace OpenRCT2
         void ReadWriteGeneralChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            auto found = os.readWriteChunk(ParkFileChunkType::kGeneral, [&](OrcaStream::ChunkStream& cs) {
+            auto found = os.readWriteChunk(EnumValue(ParkFileChunkType::kGeneral), [&](OrcaStream::ChunkStream& cs) {
                 // Only GAME_PAUSED_NORMAL from gGamePaused is relevant.
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -695,7 +695,7 @@ namespace OpenRCT2
 
         void ReadWriteInterfaceChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kInterface, [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kInterface), [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.savedView.x);
                 cs.readWrite(gameState.savedView.y);
                 if (cs.getMode() == OrcaStream::Mode::reading)
@@ -715,7 +715,7 @@ namespace OpenRCT2
 
         void ReadWriteCheatsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kCheats, [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kCheats), [](OrcaStream::ChunkStream& cs) {
                 DataSerialiser ds(cs.getMode() == OrcaStream::Mode::writing, cs.getStream());
                 CheatsSerialise(ds);
             });
@@ -723,7 +723,7 @@ namespace OpenRCT2
 
         void ReadWriteRestrictedObjectsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kRestrictedObjects, [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kRestrictedObjects), [](OrcaStream::ChunkStream& cs) {
                 auto& restrictedScenery = GetRestrictedScenery();
 
                 // We are want to support all object types in the future, so convert scenery type
@@ -759,7 +759,7 @@ namespace OpenRCT2
                 }
             }
 
-            os.readWriteChunk(ParkFileChunkType::kPluginStorage, [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kPluginStorage), [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.pluginStorage);
             });
 
@@ -783,7 +783,7 @@ namespace OpenRCT2
                 return;
             }
 
-            os.readWriteChunk(ParkFileChunkType::kPackedObjects, [this](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kPackedObjects), [this](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     auto& objRepository = GetContext()->GetObjectRepository();
@@ -870,7 +870,7 @@ namespace OpenRCT2
 
         void ReadWriteClimateChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kClimate, [&os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kClimate), [&os, &gameState](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (version < kClimateObjectsVersion)
                 {
@@ -897,7 +897,7 @@ namespace OpenRCT2
             auto& park = gameState.park;
 
             os.readWriteChunk(
-                ParkFileChunkType::kPark, [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {
+                EnumValue(ParkFileChunkType::kPark), [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(park.name);
                     cs.readWrite(park.cash);
                     cs.readWrite(park.bankLoan);
@@ -1084,7 +1084,7 @@ namespace OpenRCT2
 
         void ReadWriteResearchChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kResearch, [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kResearch), [&gameState](OrcaStream::ChunkStream& cs) {
                 // Research status
                 cs.readWrite(gameState.researchFundingLevel);
                 cs.readWrite(gameState.researchPriorities);
@@ -1140,7 +1140,7 @@ namespace OpenRCT2
 
         void ReadWriteNotificationsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kNotifications, [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kNotifications), [&gameState](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     std::vector<News::Item> recent;
@@ -1190,7 +1190,7 @@ namespace OpenRCT2
             auto* pathToRailingsMap = _pathToRailingsMap;
 
             auto found = os.readWriteChunk(
-                ParkFileChunkType::kTiles,
+                EnumValue(ParkFileChunkType::kTiles),
                 [pathToSurfaceMap, pathToQueueSurfaceMap, pathToRailingsMap, &os, &gameState](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(gameState.mapSize.x);
                     cs.readWrite(gameState.mapSize.y);
@@ -1302,7 +1302,7 @@ namespace OpenRCT2
 
         void ReadWriteBannersChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(ParkFileChunkType::kBanners, [&os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kBanners), [&os](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (cs.getMode() == OrcaStream::Mode::writing)
                 {
@@ -1381,7 +1381,7 @@ namespace OpenRCT2
         void ReadWriteRidesChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            os.readWriteChunk(ParkFileChunkType::kRides, [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::kRides), [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
                 std::vector<RideId> rideIds;
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -2692,7 +2692,7 @@ namespace OpenRCT2
 
     void ParkFile::ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os)
     {
-        os.readWriteChunk(ParkFileChunkType::kEntities, [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
+        os.readWriteChunk(EnumValue(ParkFileChunkType::kEntities), [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
             if (cs.getMode() == OrcaStream::Mode::reading)
             {
                 getGameState().entities.ResetAllEntities();

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -81,27 +81,27 @@ namespace OpenRCT2
     enum class ParkFileChunkType : uint32_t
     {
         // clang-format off
-//      kReserved0               = 0x00,
-        kAuthoring               = 0x01,
-        kObjects                 = 0x02,
-        kScenario                = 0x03,
-        kGeneral                 = 0x04,
-        kClimate                 = 0x05,
-        kPark                    = 0x06,
-//      kHistory                 = 0x07,
-        kResearch                = 0x08,
-        kNotifications           = 0x09,
-        kInterface               = 0x20,
-        kTitles                  = 0x30,
-        kEntities                = 0x31,
-        kRides                   = 0x32,
-        kBanners                 = 0x33,
-//      kStaff                   = 0x35,
-        kCheats                  = 0x36,
-        kRestrictedObjects       = 0x37,
-        kPluginStorage           = 0x38,
-        kPreview                 = 0x39,
-        kPackedObjects           = 0x80
+//      Reserved0               = 0x00,
+        Authoring               = 0x01,
+        Objects                 = 0x02,
+        Scenario                = 0x03,
+        General                 = 0x04,
+        Climate                 = 0x05,
+        Park                    = 0x06,
+//      History                 = 0x07,
+        Research                = 0x08,
+        Notifications           = 0x09,
+        Interface               = 0x20,
+        Titles                  = 0x30,
+        Entities                = 0x31,
+        Rides                   = 0x32,
+        Banners                 = 0x33,
+//      Staff                   = 0x35,
+        Cheats                  = 0x36,
+        RestrictedObjects       = 0x37,
+        PluginStorage           = 0x38,
+        Preview                 = 0x39,
+        PackedObjects           = 0x80
         // clang-format on
     }; // enum class ParkFileChunkType : uint32_t
 
@@ -220,7 +220,7 @@ namespace OpenRCT2
         {
             ScenarioIndexEntry entry{};
             auto& os = *_os;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kScenario), [&entry](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Scenario), [&entry](OrcaStream::ChunkStream& cs) {
                 entry.Category = cs.read<Scenario::Category>();
 
                 std::string name;
@@ -250,7 +250,7 @@ namespace OpenRCT2
         {
             ParkPreview preview{};
             auto& os = *_os;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kPreview), [&preview](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Preview), [&preview](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(preview.parkName);
                 cs.readWrite(preview.parkRating);
                 cs.readWrite(preview.year);
@@ -290,7 +290,7 @@ namespace OpenRCT2
             // Write-only for now
             if (os.getMode() == OrcaStream::Mode::writing)
             {
-                os.readWriteChunk(EnumValue(ParkFileChunkType::kAuthoring), [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(EnumValue(ParkFileChunkType::Authoring), [](OrcaStream::ChunkStream& cs) {
                     cs.write(std::string_view(gVersionInfoFull));
                     std::vector<std::string> authors;
                     cs.readWriteVector(authors, [](std::string& s) {});
@@ -434,7 +434,7 @@ namespace OpenRCT2
                 if (version < kClimateObjectsVersion)
                 {
                     RCT12::ClimateType legacyClimate{};
-                    os.readWriteChunk(EnumValue(ParkFileChunkType::kClimate), [&legacyClimate](OrcaStream::ChunkStream& cs) {
+                    os.readWriteChunk(EnumValue(ParkFileChunkType::Climate), [&legacyClimate](OrcaStream::ChunkStream& cs) {
                         cs.readWrite(legacyClimate);
                     });
 
@@ -446,7 +446,7 @@ namespace OpenRCT2
             }
             else
             {
-                os.readWriteChunk(EnumValue(ParkFileChunkType::kObjects), [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(EnumValue(ParkFileChunkType::Objects), [](OrcaStream::ChunkStream& cs) {
                     auto& objManager = GetContext()->GetObjectManager();
                     auto objectList = objManager.GetLoadedObjects();
 
@@ -486,7 +486,7 @@ namespace OpenRCT2
 
         void ReadWriteScenarioChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kScenario), [&gameState, &os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Scenario), [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.scenarioOptions.category);
                 ReadWriteStringTable(cs, gameState.scenarioOptions.name, "en-GB");
                 ReadWriteStringTable(cs, gameState.park.name, "en-GB");
@@ -532,7 +532,7 @@ namespace OpenRCT2
 
         void ReadWritePreviewChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kPreview), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Preview), [&gameState](OrcaStream::ChunkStream& cs) {
                 auto preview = generatePreviewFromGameState(gameState);
 
                 cs.readWrite(preview.parkName);
@@ -560,7 +560,7 @@ namespace OpenRCT2
         void ReadWriteGeneralChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            auto found = os.readWriteChunk(EnumValue(ParkFileChunkType::kGeneral), [&](OrcaStream::ChunkStream& cs) {
+            auto found = os.readWriteChunk(EnumValue(ParkFileChunkType::General), [&](OrcaStream::ChunkStream& cs) {
                 // Only GAME_PAUSED_NORMAL from gGamePaused is relevant.
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -695,7 +695,7 @@ namespace OpenRCT2
 
         void ReadWriteInterfaceChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kInterface), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Interface), [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.savedView.x);
                 cs.readWrite(gameState.savedView.y);
                 if (cs.getMode() == OrcaStream::Mode::reading)
@@ -715,7 +715,7 @@ namespace OpenRCT2
 
         void ReadWriteCheatsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kCheats), [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Cheats), [](OrcaStream::ChunkStream& cs) {
                 DataSerialiser ds(cs.getMode() == OrcaStream::Mode::writing, cs.getStream());
                 CheatsSerialise(ds);
             });
@@ -723,7 +723,7 @@ namespace OpenRCT2
 
         void ReadWriteRestrictedObjectsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kRestrictedObjects), [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::RestrictedObjects), [](OrcaStream::ChunkStream& cs) {
                 auto& restrictedScenery = GetRestrictedScenery();
 
                 // We are want to support all object types in the future, so convert scenery type
@@ -759,7 +759,7 @@ namespace OpenRCT2
                 }
             }
 
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kPluginStorage), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::PluginStorage), [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.pluginStorage);
             });
 
@@ -783,7 +783,7 @@ namespace OpenRCT2
                 return;
             }
 
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kPackedObjects), [this](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::PackedObjects), [this](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     auto& objRepository = GetContext()->GetObjectRepository();
@@ -870,7 +870,7 @@ namespace OpenRCT2
 
         void ReadWriteClimateChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kClimate), [&os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Climate), [&os, &gameState](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (version < kClimateObjectsVersion)
                 {
@@ -1084,7 +1084,7 @@ namespace OpenRCT2
 
         void ReadWriteResearchChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kResearch), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Research), [&gameState](OrcaStream::ChunkStream& cs) {
                 // Research status
                 cs.readWrite(gameState.researchFundingLevel);
                 cs.readWrite(gameState.researchPriorities);
@@ -1140,7 +1140,7 @@ namespace OpenRCT2
 
         void ReadWriteNotificationsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kNotifications), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Notifications), [&gameState](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     std::vector<News::Item> recent;
@@ -1190,7 +1190,7 @@ namespace OpenRCT2
             auto* pathToRailingsMap = _pathToRailingsMap;
 
             auto found = os.readWriteChunk(
-                EnumValue(ParkFileChunkType::kTiles),
+                EnumValue(ParkFileChunkType::Titles),
                 [pathToSurfaceMap, pathToQueueSurfaceMap, pathToRailingsMap, &os, &gameState](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(gameState.mapSize.x);
                     cs.readWrite(gameState.mapSize.y);
@@ -1302,7 +1302,7 @@ namespace OpenRCT2
 
         void ReadWriteBannersChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kBanners), [&os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::Banners), [&os](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (cs.getMode() == OrcaStream::Mode::writing)
                 {
@@ -2692,7 +2692,7 @@ namespace OpenRCT2
 
     void ParkFile::ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os)
     {
-        os.readWriteChunk(EnumValue(ParkFileChunkType::kEntities), [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
+        os.readWriteChunk(EnumValue(ParkFileChunkType::Entities), [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
             if (cs.getMode() == OrcaStream::Mode::reading)
             {
                 getGameState().entities.ResetAllEntities();

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -103,7 +103,7 @@ namespace OpenRCT2
         kPreview                 = 0x39,
         kPackedObjects           = 0x80
         // clang-format on
-    }; // namespace ParkFileChunkType
+    }; // enum ParkFileChunkType : uint32_t
 
     class ParkFile
     {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -220,7 +220,7 @@ namespace OpenRCT2
         {
             ScenarioIndexEntry entry{};
             auto& os = *_os;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::scenario), [&entry](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::scenario, [&entry](OrcaStream::ChunkStream& cs) {
                 entry.Category = cs.read<Scenario::Category>();
 
                 std::string name;
@@ -250,7 +250,7 @@ namespace OpenRCT2
         {
             ParkPreview preview{};
             auto& os = *_os;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::preview), [&preview](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::preview, [&preview](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(preview.parkName);
                 cs.readWrite(preview.parkRating);
                 cs.readWrite(preview.year);
@@ -290,7 +290,7 @@ namespace OpenRCT2
             // Write-only for now
             if (os.getMode() == OrcaStream::Mode::writing)
             {
-                os.readWriteChunk(EnumValue(ParkFileChunkType::authoring), [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(ParkFileChunkType::authoring, [](OrcaStream::ChunkStream& cs) {
                     cs.write(std::string_view(gVersionInfoFull));
                     std::vector<std::string> authors;
                     cs.readWriteVector(authors, [](std::string& s) {});
@@ -325,7 +325,7 @@ namespace OpenRCT2
                 };
                 std::vector<LegacyFootpathMapping> legacyPathMappings;
                 os.readWriteChunk(
-                    EnumValue(ParkFileChunkType::objects), [&requiredObjects, version, &legacyPathMappings](OrcaStream::ChunkStream& cs) {
+                    ParkFileChunkType::objects, [&requiredObjects, version, &legacyPathMappings](OrcaStream::ChunkStream& cs) {
                         auto numSubLists = cs.read<uint16_t>();
                         for (size_t i = 0; i < numSubLists; i++)
                         {
@@ -434,7 +434,7 @@ namespace OpenRCT2
                 if (version < kClimateObjectsVersion)
                 {
                     RCT12::ClimateType legacyClimate{};
-                    os.readWriteChunk(EnumValue(ParkFileChunkType::climate), [&legacyClimate](OrcaStream::ChunkStream& cs) {
+                    os.readWriteChunk(ParkFileChunkType::climate, [&legacyClimate](OrcaStream::ChunkStream& cs) {
                         cs.readWrite(legacyClimate);
                     });
 
@@ -446,7 +446,7 @@ namespace OpenRCT2
             }
             else
             {
-                os.readWriteChunk(EnumValue(ParkFileChunkType::objects), [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(ParkFileChunkType::objects, [](OrcaStream::ChunkStream& cs) {
                     auto& objManager = GetContext()->GetObjectManager();
                     auto objectList = objManager.GetLoadedObjects();
 
@@ -486,7 +486,7 @@ namespace OpenRCT2
 
         void ReadWriteScenarioChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::scenario), [&gameState, &os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::scenario, [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.scenarioOptions.category);
                 ReadWriteStringTable(cs, gameState.scenarioOptions.name, "en-GB");
                 ReadWriteStringTable(cs, gameState.park.name, "en-GB");
@@ -532,7 +532,7 @@ namespace OpenRCT2
 
         void ReadWritePreviewChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::preview), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::preview, [&gameState](OrcaStream::ChunkStream& cs) {
                 auto preview = generatePreviewFromGameState(gameState);
 
                 cs.readWrite(preview.parkName);
@@ -560,7 +560,7 @@ namespace OpenRCT2
         void ReadWriteGeneralChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            auto found = os.readWriteChunk(EnumValue(ParkFileChunkType::general), [&](OrcaStream::ChunkStream& cs) {
+            auto found = os.readWriteChunk(ParkFileChunkType::general, [&](OrcaStream::ChunkStream& cs) {
                 // Only GAME_PAUSED_NORMAL from gGamePaused is relevant.
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -695,7 +695,7 @@ namespace OpenRCT2
 
         void ReadWriteInterfaceChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::interface), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::interface, [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.savedView.x);
                 cs.readWrite(gameState.savedView.y);
                 if (cs.getMode() == OrcaStream::Mode::reading)
@@ -715,7 +715,7 @@ namespace OpenRCT2
 
         void ReadWriteCheatsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::cheats), [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::cheats, [](OrcaStream::ChunkStream& cs) {
                 DataSerialiser ds(cs.getMode() == OrcaStream::Mode::writing, cs.getStream());
                 CheatsSerialise(ds);
             });
@@ -723,7 +723,7 @@ namespace OpenRCT2
 
         void ReadWriteRestrictedObjectsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::restrictedObjects), [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::restrictedObjects, [](OrcaStream::ChunkStream& cs) {
                 auto& restrictedScenery = GetRestrictedScenery();
 
                 // We are want to support all object types in the future, so convert scenery type
@@ -759,7 +759,7 @@ namespace OpenRCT2
                 }
             }
 
-            os.readWriteChunk(EnumValue(ParkFileChunkType::pluginStorage), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::pluginStorage, [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.pluginStorage);
             });
 
@@ -783,7 +783,7 @@ namespace OpenRCT2
                 return;
             }
 
-            os.readWriteChunk(EnumValue(ParkFileChunkType::packedObjects), [this](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::packedObjects, [this](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     auto& objRepository = GetContext()->GetObjectRepository();
@@ -870,7 +870,7 @@ namespace OpenRCT2
 
         void ReadWriteClimateChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::climate), [&os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::climate, [&os, &gameState](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (version < kClimateObjectsVersion)
                 {
@@ -897,7 +897,7 @@ namespace OpenRCT2
             auto& park = gameState.park;
 
             os.readWriteChunk(
-                EnumValue(ParkFileChunkType::park), [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {
+                ParkFileChunkType::park, [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(park.name);
                     cs.readWrite(park.cash);
                     cs.readWrite(park.bankLoan);
@@ -1084,7 +1084,7 @@ namespace OpenRCT2
 
         void ReadWriteResearchChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::research), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::research, [&gameState](OrcaStream::ChunkStream& cs) {
                 // Research status
                 cs.readWrite(gameState.researchFundingLevel);
                 cs.readWrite(gameState.researchPriorities);
@@ -1140,7 +1140,7 @@ namespace OpenRCT2
 
         void ReadWriteNotificationsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::notifications), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::notifications, [&gameState](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     std::vector<News::Item> recent;
@@ -1190,7 +1190,7 @@ namespace OpenRCT2
             auto* pathToRailingsMap = _pathToRailingsMap;
 
             auto found = os.readWriteChunk(
-                EnumValue(ParkFileChunkType::titles),
+                ParkFileChunkType::titles,
                 [pathToSurfaceMap, pathToQueueSurfaceMap, pathToRailingsMap, &os, &gameState](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(gameState.mapSize.x);
                     cs.readWrite(gameState.mapSize.y);
@@ -1302,7 +1302,7 @@ namespace OpenRCT2
 
         void ReadWriteBannersChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::banners), [&os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::banners, [&os](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (cs.getMode() == OrcaStream::Mode::writing)
                 {
@@ -1381,7 +1381,7 @@ namespace OpenRCT2
         void ReadWriteRidesChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::rides), [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(ParkFileChunkType::rides, [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
                 std::vector<RideId> rideIds;
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -2692,7 +2692,7 @@ namespace OpenRCT2
 
     void ParkFile::ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os)
     {
-        os.readWriteChunk(EnumValue(ParkFileChunkType::entities), [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
+        os.readWriteChunk(ParkFileChunkType::entities, [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
             if (cs.getMode() == OrcaStream::Mode::reading)
             {
                 getGameState().entities.ResetAllEntities();

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -78,30 +78,30 @@ using namespace OpenRCT2;
 
 namespace OpenRCT2
 {
-    namespace ParkFileChunkType
+    enum ParkFileChunkType : uint32_t
     {
         // clang-format off
-//      constexpr uint32_t kReserved0               = 0x00;
-        constexpr uint32_t kAuthoring               = 0x01;
-        constexpr uint32_t kObjects                 = 0x02;
-        constexpr uint32_t kScenario                = 0x03;
-        constexpr uint32_t kGeneral                 = 0x04;
-        constexpr uint32_t kClimate                 = 0x05;
-        constexpr uint32_t kPark                    = 0x06;
-//      constexpr uint32_t kHistory                 = 0x07;
-        constexpr uint32_t kResearch                = 0x08;
-        constexpr uint32_t kNotifications           = 0x09;
-        constexpr uint32_t kInterface               = 0x20;
-        constexpr uint32_t kTitles                  = 0x30;
-        constexpr uint32_t kEntities                = 0x31;
-        constexpr uint32_t kRides                   = 0x32;
-        constexpr uint32_t kBanners                 = 0x33;
-//      constexpr uint32_t kStaff                   = 0x35;
-        constexpr uint32_t kCheats                  = 0x36;
-        constexpr uint32_t kRestrictedObjects       = 0x37;
-        constexpr uint32_t kPluginStorage           = 0x38;
-        constexpr uint32_t kPreview                 = 0x39;
-        constexpr uint32_t kPackedObjects           = 0x80;
+//      kReserved0               = 0x00,
+        kAuthoring               = 0x01,
+        kObjects                 = 0x02,
+        kScenario                = 0x03,
+        kGeneral                 = 0x04,
+        kClimate                 = 0x05,
+        kPark                    = 0x06,
+//      kHistory                 = 0x07,
+        kResearch                = 0x08,
+        kNotifications           = 0x09,
+        kInterface               = 0x20,
+        kTitles                  = 0x30,
+        kEntities                = 0x31,
+        kRides                   = 0x32,
+        kBanners                 = 0x33,
+//      kStaff                   = 0x35,
+        kCheats                  = 0x36,
+        kRestrictedObjects       = 0x37,
+        kPluginStorage           = 0x38,
+        kPreview                 = 0x39,
+        kPackedObjects           = 0x80
         // clang-format on
     }; // namespace ParkFileChunkType
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -81,29 +81,29 @@ namespace OpenRCT2
     enum class ParkFileChunkType : uint32_t
     {
         // clang-format off
-//      Reserved0               = 0x00,
-        Authoring               = 0x01,
-        Objects                 = 0x02,
-        Scenario                = 0x03,
-        General                 = 0x04,
-        Climate                 = 0x05,
-        Park                    = 0x06,
-//      History                 = 0x07,
-        Research                = 0x08,
-        Notifications           = 0x09,
-        Interface               = 0x20,
-        Titles                  = 0x30,
-        Entities                = 0x31,
-        Rides                   = 0x32,
-        Banners                 = 0x33,
-//      Staff                   = 0x35,
-        Cheats                  = 0x36,
-        RestrictedObjects       = 0x37,
-        PluginStorage           = 0x38,
-        Preview                 = 0x39,
-        PackedObjects           = 0x80
+//      reserved0               = 0x00,
+        authoring               = 0x01,
+        objects                 = 0x02,
+        scenario                = 0x03,
+        general                 = 0x04,
+        climate                 = 0x05,
+        park                    = 0x06,
+//      history                 = 0x07,
+        research                = 0x08,
+        notifications           = 0x09,
+        interface               = 0x20,
+        titles                  = 0x30,
+        entities                = 0x31,
+        rides                   = 0x32,
+        banners                 = 0x33,
+//      staff                   = 0x35,
+        cheats                  = 0x36,
+        restrictedObjects       = 0x37,
+        pluginStorage           = 0x38,
+        preview                 = 0x39,
+        packedObjects           = 0x80
         // clang-format on
-    }; // enum class ParkFileChunkType : uint32_t
+    };
 
     class ParkFile
     {
@@ -220,7 +220,7 @@ namespace OpenRCT2
         {
             ScenarioIndexEntry entry{};
             auto& os = *_os;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Scenario), [&entry](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::scenario), [&entry](OrcaStream::ChunkStream& cs) {
                 entry.Category = cs.read<Scenario::Category>();
 
                 std::string name;
@@ -250,7 +250,7 @@ namespace OpenRCT2
         {
             ParkPreview preview{};
             auto& os = *_os;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Preview), [&preview](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::preview), [&preview](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(preview.parkName);
                 cs.readWrite(preview.parkRating);
                 cs.readWrite(preview.year);
@@ -290,7 +290,7 @@ namespace OpenRCT2
             // Write-only for now
             if (os.getMode() == OrcaStream::Mode::writing)
             {
-                os.readWriteChunk(EnumValue(ParkFileChunkType::Authoring), [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(EnumValue(ParkFileChunkType::authoring), [](OrcaStream::ChunkStream& cs) {
                     cs.write(std::string_view(gVersionInfoFull));
                     std::vector<std::string> authors;
                     cs.readWriteVector(authors, [](std::string& s) {});
@@ -325,7 +325,7 @@ namespace OpenRCT2
                 };
                 std::vector<LegacyFootpathMapping> legacyPathMappings;
                 os.readWriteChunk(
-                    EnumValue(ParkFileChunkType::kObjects), [&requiredObjects, version, &legacyPathMappings](OrcaStream::ChunkStream& cs) {
+                    EnumValue(ParkFileChunkType::objects), [&requiredObjects, version, &legacyPathMappings](OrcaStream::ChunkStream& cs) {
                         auto numSubLists = cs.read<uint16_t>();
                         for (size_t i = 0; i < numSubLists; i++)
                         {
@@ -434,7 +434,7 @@ namespace OpenRCT2
                 if (version < kClimateObjectsVersion)
                 {
                     RCT12::ClimateType legacyClimate{};
-                    os.readWriteChunk(EnumValue(ParkFileChunkType::Climate), [&legacyClimate](OrcaStream::ChunkStream& cs) {
+                    os.readWriteChunk(EnumValue(ParkFileChunkType::climate), [&legacyClimate](OrcaStream::ChunkStream& cs) {
                         cs.readWrite(legacyClimate);
                     });
 
@@ -446,7 +446,7 @@ namespace OpenRCT2
             }
             else
             {
-                os.readWriteChunk(EnumValue(ParkFileChunkType::Objects), [](OrcaStream::ChunkStream& cs) {
+                os.readWriteChunk(EnumValue(ParkFileChunkType::objects), [](OrcaStream::ChunkStream& cs) {
                     auto& objManager = GetContext()->GetObjectManager();
                     auto objectList = objManager.GetLoadedObjects();
 
@@ -486,7 +486,7 @@ namespace OpenRCT2
 
         void ReadWriteScenarioChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Scenario), [&gameState, &os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::scenario), [&gameState, &os](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.scenarioOptions.category);
                 ReadWriteStringTable(cs, gameState.scenarioOptions.name, "en-GB");
                 ReadWriteStringTable(cs, gameState.park.name, "en-GB");
@@ -532,7 +532,7 @@ namespace OpenRCT2
 
         void ReadWritePreviewChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Preview), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::preview), [&gameState](OrcaStream::ChunkStream& cs) {
                 auto preview = generatePreviewFromGameState(gameState);
 
                 cs.readWrite(preview.parkName);
@@ -560,7 +560,7 @@ namespace OpenRCT2
         void ReadWriteGeneralChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            auto found = os.readWriteChunk(EnumValue(ParkFileChunkType::General), [&](OrcaStream::ChunkStream& cs) {
+            auto found = os.readWriteChunk(EnumValue(ParkFileChunkType::general), [&](OrcaStream::ChunkStream& cs) {
                 // Only GAME_PAUSED_NORMAL from gGamePaused is relevant.
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -695,7 +695,7 @@ namespace OpenRCT2
 
         void ReadWriteInterfaceChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Interface), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::interface), [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.savedView.x);
                 cs.readWrite(gameState.savedView.y);
                 if (cs.getMode() == OrcaStream::Mode::reading)
@@ -715,7 +715,7 @@ namespace OpenRCT2
 
         void ReadWriteCheatsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Cheats), [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::cheats), [](OrcaStream::ChunkStream& cs) {
                 DataSerialiser ds(cs.getMode() == OrcaStream::Mode::writing, cs.getStream());
                 CheatsSerialise(ds);
             });
@@ -723,7 +723,7 @@ namespace OpenRCT2
 
         void ReadWriteRestrictedObjectsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::RestrictedObjects), [](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::restrictedObjects), [](OrcaStream::ChunkStream& cs) {
                 auto& restrictedScenery = GetRestrictedScenery();
 
                 // We are want to support all object types in the future, so convert scenery type
@@ -759,7 +759,7 @@ namespace OpenRCT2
                 }
             }
 
-            os.readWriteChunk(EnumValue(ParkFileChunkType::PluginStorage), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::pluginStorage), [&gameState](OrcaStream::ChunkStream& cs) {
                 cs.readWrite(gameState.pluginStorage);
             });
 
@@ -783,7 +783,7 @@ namespace OpenRCT2
                 return;
             }
 
-            os.readWriteChunk(EnumValue(ParkFileChunkType::PackedObjects), [this](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::packedObjects), [this](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     auto& objRepository = GetContext()->GetObjectRepository();
@@ -870,7 +870,7 @@ namespace OpenRCT2
 
         void ReadWriteClimateChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Climate), [&os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::climate), [&os, &gameState](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (version < kClimateObjectsVersion)
                 {
@@ -897,7 +897,7 @@ namespace OpenRCT2
             auto& park = gameState.park;
 
             os.readWriteChunk(
-                EnumValue(ParkFileChunkType::kPark), [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {
+                EnumValue(ParkFileChunkType::park), [version = os.getHeader().targetVersion, &park](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(park.name);
                     cs.readWrite(park.cash);
                     cs.readWrite(park.bankLoan);
@@ -1084,7 +1084,7 @@ namespace OpenRCT2
 
         void ReadWriteResearchChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Research), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::research), [&gameState](OrcaStream::ChunkStream& cs) {
                 // Research status
                 cs.readWrite(gameState.researchFundingLevel);
                 cs.readWrite(gameState.researchPriorities);
@@ -1140,7 +1140,7 @@ namespace OpenRCT2
 
         void ReadWriteNotificationsChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Notifications), [&gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::notifications), [&gameState](OrcaStream::ChunkStream& cs) {
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
                     std::vector<News::Item> recent;
@@ -1190,7 +1190,7 @@ namespace OpenRCT2
             auto* pathToRailingsMap = _pathToRailingsMap;
 
             auto found = os.readWriteChunk(
-                EnumValue(ParkFileChunkType::Titles),
+                EnumValue(ParkFileChunkType::titles),
                 [pathToSurfaceMap, pathToQueueSurfaceMap, pathToRailingsMap, &os, &gameState](OrcaStream::ChunkStream& cs) {
                     cs.readWrite(gameState.mapSize.x);
                     cs.readWrite(gameState.mapSize.y);
@@ -1302,7 +1302,7 @@ namespace OpenRCT2
 
         void ReadWriteBannersChunk(GameState_t& gameState, OrcaStream& os)
         {
-            os.readWriteChunk(EnumValue(ParkFileChunkType::Banners), [&os](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::banners), [&os](OrcaStream::ChunkStream& cs) {
                 auto version = os.getHeader().targetVersion;
                 if (cs.getMode() == OrcaStream::Mode::writing)
                 {
@@ -1381,7 +1381,7 @@ namespace OpenRCT2
         void ReadWriteRidesChunk(GameState_t& gameState, OrcaStream& os)
         {
             const auto version = os.getHeader().targetVersion;
-            os.readWriteChunk(EnumValue(ParkFileChunkType::kRides), [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
+            os.readWriteChunk(EnumValue(ParkFileChunkType::rides), [this, &version, &os, &gameState](OrcaStream::ChunkStream& cs) {
                 std::vector<RideId> rideIds;
                 if (cs.getMode() == OrcaStream::Mode::reading)
                 {
@@ -2692,7 +2692,7 @@ namespace OpenRCT2
 
     void ParkFile::ReadWriteEntitiesChunk(GameState_t& gameState, OrcaStream& os)
     {
-        os.readWriteChunk(EnumValue(ParkFileChunkType::Entities), [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
+        os.readWriteChunk(EnumValue(ParkFileChunkType::entities), [this, &gameState, &os](OrcaStream::ChunkStream& cs) {
             if (cs.getMode() == OrcaStream::Mode::reading)
             {
                 getGameState().entities.ResetAllEntities();

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -31,7 +31,7 @@ using namespace OpenRCT2::Audio;
 
 namespace OpenRCT2::RideAudio
 {
-    constexpr size_t MAX_RIDE_MUSIC_CHANNELS = 32;
+    constexpr size_t kMaxRideMusicChannels = 32;
 
     /**
      * Represents an audio channel to play a particular ride's music track.
@@ -243,7 +243,7 @@ namespace OpenRCT2::RideAudio
         {
             foundChannel->Update(instance);
         }
-        else if (_musicChannels.size() < MAX_RIDE_MUSIC_CHANNELS)
+        else if (_musicChannels.size() < kMaxRideMusicChannels)
         {
             StartRideMusicChannel(instance);
         }
@@ -315,7 +315,7 @@ namespace OpenRCT2::RideAudio
     {
         if (offset < length)
         {
-            if (_musicInstances.size() < MAX_RIDE_MUSIC_CHANNELS)
+            if (_musicInstances.size() < kMaxRideMusicChannels)
             {
                 auto& instance = _musicInstances.emplace_back();
                 instance.RideId = ride.id;

--- a/src/openrct2/scenes/title/TitleSequence.cpp
+++ b/src/openrct2/scenes/title/TitleSequence.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2::Title
         LOG_VERBOSE("Loading title sequence: %s", path.c_str());
 
         auto ext = Path::GetExtension(path);
-        if (String::equals(ext, TITLE_SEQUENCE_EXTENSION))
+        if (String::equals(ext, kTitleSequenceExtension))
         {
             auto zip = Zip::TryOpen(path, ZipAccess::read);
             if (zip == nullptr)
@@ -282,7 +282,7 @@ namespace OpenRCT2::Title
                         if (command.SaveIndex == index)
                         {
                             // Park no longer exists, so reset load command to invalid
-                            command.SaveIndex = SAVE_INDEX_INVALID;
+                            command.SaveIndex = kSaveIndexInvalid;
                         }
                         else if (command.SaveIndex > index)
                         {
@@ -342,7 +342,7 @@ namespace OpenRCT2::Title
             {
                 if (String::iequals(token, "LOAD"))
                 {
-                    auto saveIndex = SAVE_INDEX_INVALID;
+                    auto saveIndex = kSaveIndexInvalid;
                     const std::string relativePath = parts[1].data();
                     for (size_t i = 0; i < saves.size(); i++)
                     {

--- a/src/openrct2/scenes/title/TitleSequence.h
+++ b/src/openrct2/scenes/title/TitleSequence.h
@@ -48,8 +48,8 @@ namespace OpenRCT2::Title
         std::unique_ptr<IStream> Stream;
     };
 
-    constexpr const utf8* TITLE_SEQUENCE_EXTENSION = ".parkseq";
-    constexpr uint8_t SAVE_INDEX_INVALID = UINT8_MAX;
+    constexpr const utf8* kTitleSequenceExtension = ".parkseq";
+    constexpr uint8_t kSaveIndexInvalid = UINT8_MAX;
 
     [[nodiscard]] std::unique_ptr<TitleSequence> CreateTitleSequence();
     [[nodiscard]] std::unique_ptr<TitleSequence> LoadTitleSequence(const std::string& path);

--- a/src/openrct2/scenes/title/TitleSequenceManager.cpp
+++ b/src/openrct2/scenes/title/TitleSequenceManager.cpp
@@ -101,7 +101,7 @@ namespace OpenRCT2::TitleSequenceManager
         auto newPath = Path::Combine(Path::GetDirectory(oldPath), newName);
         if (item->IsZip)
         {
-            newPath += Title::TITLE_SEQUENCE_EXTENSION;
+            newPath += Title::kTitleSequenceExtension;
             File::Move(oldPath, newPath);
         }
         else
@@ -157,7 +157,7 @@ namespace OpenRCT2::TitleSequenceManager
         auto path = Path::Combine(GetUserSequencesPath(), name);
         if (isZip)
         {
-            path += Title::TITLE_SEQUENCE_EXTENSION;
+            path += Title::kTitleSequenceExtension;
         }
         return path;
     }


### PR DESCRIPTION
Building on the work that's been done for https://github.com/OpenRCT2/OpenRCT2/issues/21432, I've updated a few more files to use the new const notation.

Tested everything I think I've touched and it's all been fine.

Tried to keep commits to only touch files related to what consts have been changed. I think I saw some more fairly hefty changes to be made but I'll leave those for another MR or someone else to pick up.