### PR TITLE
Reject truncated network packet reads

### DIFF
--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -14,6 +14,7 @@
     #include "NetworkTypes.h"
 
     #include <memory>
+    #include <stdexcept>
 
 namespace OpenRCT2::Network
 {
@@ -77,9 +78,9 @@ namespace OpenRCT2::Network
 
     const uint8_t* Packet::Read(size_t size)
     {
-        if (BytesRead + size > Data.size())
+        if (BytesRead > Data.size() || size > (Data.size() - BytesRead))
         {
-            return nullptr;
+            throw std::out_of_range("Failed to read packet data.");
         }
 
         const uint8_t* data = Data.data() + BytesRead;

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/LanguagePackTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/LocalisationTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/MultiLaunch.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/NetworkPacketTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Pathfinding.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"
@@ -47,4 +48,3 @@ set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_
 gtest_discover_tests(OpenRCT2Tests
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DISCOVERY_MODE PRE_TEST)
-

--- a/test/tests/NetworkPacketTests.cpp
+++ b/test/tests/NetworkPacketTests.cpp
@@ -1,0 +1,54 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <array>
+#include <gtest/gtest.h>
+#include <openrct2/network/NetworkPacket.h>
+#include <stdexcept>
+
+#ifndef DISABLE_NETWORK
+
+using namespace OpenRCT2::Network;
+
+TEST(NetworkPacket, read_returns_bytes_when_available)
+{
+    Packet packet(Command::ping);
+    constexpr std::array<uint8_t, 3> payload = { 0x01, 0x02, 0x03 };
+
+    packet.Write(payload.data(), payload.size());
+
+    const auto* data = packet.Read(payload.size());
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(data[0], payload[0]);
+    EXPECT_EQ(data[1], payload[1]);
+    EXPECT_EQ(data[2], payload[2]);
+    EXPECT_EQ(packet.BytesRead, payload.size());
+}
+
+TEST(NetworkPacket, read_throws_when_packet_is_truncated)
+{
+    Packet packet(Command::ping);
+    constexpr std::array<uint8_t, 2> payload = { 0x01, 0x02 };
+
+    packet.Write(payload.data(), payload.size());
+
+    EXPECT_THROW(packet.Read(payload.size() + 1), std::out_of_range);
+    EXPECT_EQ(packet.BytesRead, 0u);
+}
+
+TEST(NetworkPacket, read_throws_when_read_position_is_out_of_bounds)
+{
+    Packet packet(Command::ping);
+    packet.Data.push_back(0x01);
+    packet.BytesRead = packet.Data.size() + 1;
+
+    EXPECT_THROW(packet.Read(1), std::out_of_range);
+}
+
+#endif

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="IniWriterTest.cpp" />
     <ClCompile Include="LocalisationTest.cpp" />
     <ClCompile Include="MultiLaunch.cpp" />
+    <ClCompile Include="NetworkPacketTests.cpp" />
     <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
@@ -128,4 +129,3 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>
-


### PR DESCRIPTION
## Summary

  This change hardens `Network::Packet::Read()` against truncated and out-of-bounds reads.

  Instead of returning invalid data on short reads, it now throws immediately, which allows malformed packet handling to fail safely instead
  of propagating bad pointers into downstream packet handlers.

  ## What changed

  - make `Packet::Read()` reject out-of-bounds reads explicitly
  - add regression tests for:
    - successful reads with valid payloads
    - truncated reads
    - invalid read position state
  - add `NetworkPacketTests.cpp` to the Visual Studio test project so the test file is included there as well

  ## Why

  Some client packet handlers read variable-length payloads and assume the payload is complete.
  If a packet is shorter than declared, this could propagate invalid read results into handler logic and crash the client.

  This patch centralises the failure at the packet read boundary and adds regression coverage for that behaviour.

  ## Tests

  Added:
  - `NetworkPacket.read_returns_bytes_when_available`
  - `NetworkPacket.read_throws_when_packet_is_truncated`
  - `NetworkPacket.read_throws_when_read_position_is_out_of_bounds`

  ## Notes

  This is a minimal hardening change and does not refactor packet handler logic beyond enforcing safe failure on invalid reads.