### PR TITLE
Fix: reject truncated network packet reads

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -111,6 +111,16 @@ namespace OpenRCT2::Network
     static u8string GetPrivateKeyPath(u8string_view playerName);
     static u8string GetPublicKeyPath(u8string_view playerName, u8string_view hash);
 
+    static const uint8_t* ReadRequired(Packet& packet, size_t size)
+    {
+        const auto* data = packet.Read(size);
+        if (data == nullptr)
+        {
+            throw std::runtime_error("Failed to read packet.");
+        }
+        return data;
+    }
+
     NetworkBase::NetworkBase(IContext& context)
         : System(context)
     {
@@ -2299,7 +2309,7 @@ namespace OpenRCT2::Network
 
         uint32_t challenge_size;
         packet >> challenge_size;
-        const char* challenge = reinterpret_cast<const char*>(packet.Read(challenge_size));
+        const char* challenge = reinterpret_cast<const char*>(ReadRequired(packet, challenge_size));
 
         std::vector<uint8_t> signature;
         const std::string pubkey = _key.PublicKeyString();
@@ -2523,7 +2533,7 @@ namespace OpenRCT2::Network
             uint32_t codeSize{};
             packet >> codeSize;
 
-            const uint8_t* scriptData = packet.Read(codeSize);
+            const uint8_t* scriptData = ReadRequired(packet, codeSize);
 
             auto code = std::string_view(reinterpret_cast<const char*>(scriptData), codeSize);
             scriptEngine.AddNetworkPlugin(code);
@@ -2553,7 +2563,7 @@ namespace OpenRCT2::Network
 
         _serverGameState.SetPosition(offset);
 
-        const uint8_t* data = packet.Read(dataSize);
+        const uint8_t* data = ReadRequired(packet, dataSize);
         _serverGameState.Write(data, dataSize);
 
         LOG_VERBOSE(
@@ -2620,7 +2630,7 @@ namespace OpenRCT2::Network
             const ObjectRepositoryItem* item{};
             if (generation == static_cast<uint8_t>(ObjectGeneration::DAT))
             {
-                const auto* entry = reinterpret_cast<const RCTObjectEntry*>(packet.Read(sizeof(RCTObjectEntry)));
+                const auto* entry = reinterpret_cast<const RCTObjectEntry*>(ReadRequired(packet, sizeof(RCTObjectEntry)));
                 objectName = std::string(entry->GetName());
                 LOG_VERBOSE("Client requested object %s", objectName.c_str());
                 item = repo.FindObject(entry);
@@ -2967,7 +2977,7 @@ namespace OpenRCT2::Network
 
         MemoryStream stream;
         const size_t size = packet.Header.size - packet.BytesRead;
-        stream.WriteArray(packet.Read(size), size);
+        stream.WriteArray(ReadRequired(packet, size), size);
         stream.SetPosition(0);
 
         DataSerialiser ds(false, stream);
@@ -3057,7 +3067,7 @@ namespace OpenRCT2::Network
 
         DataSerialiser stream(false);
         const size_t size = packet.Header.size - packet.BytesRead;
-        stream.GetStream().WriteArray(packet.Read(size), size);
+        stream.GetStream().WriteArray(ReadRequired(packet, size), size);
         stream.GetStream().SetPosition(0);
 
         ga->Serialise(stream);

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -77,7 +77,7 @@ namespace OpenRCT2::Network
 
     const uint8_t* Packet::Read(size_t size)
     {
-        if (BytesRead + size > Data.size())
+        if (BytesRead > Data.size() || size > (Data.size() - BytesRead))
         {
             return nullptr;
         }

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/LanguagePackTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/LocalisationTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/MultiLaunch.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/NetworkPacketTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Pathfinding.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"
@@ -47,4 +48,3 @@ set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_
 gtest_discover_tests(OpenRCT2Tests
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DISCOVERY_MODE PRE_TEST)
-

--- a/test/tests/NetworkPacketTests.cpp
+++ b/test/tests/NetworkPacketTests.cpp
@@ -1,0 +1,52 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <array>
+#include <gtest/gtest.h>
+#include <openrct2/network/NetworkPacket.h>
+#ifndef DISABLE_NETWORK
+
+using namespace OpenRCT2::Network;
+
+TEST(NetworkPacket, read_returns_bytes_when_available)
+{
+    Packet packet(Command::ping);
+    constexpr std::array<uint8_t, 3> payload = { 0x01, 0x02, 0x03 };
+
+    packet.Write(payload.data(), payload.size());
+
+    const auto* data = packet.Read(payload.size());
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(data[0], payload[0]);
+    EXPECT_EQ(data[1], payload[1]);
+    EXPECT_EQ(data[2], payload[2]);
+    EXPECT_EQ(packet.BytesRead, payload.size());
+}
+
+TEST(NetworkPacket, read_returns_nullptr_when_packet_is_truncated)
+{
+    Packet packet(Command::ping);
+    constexpr std::array<uint8_t, 2> payload = { 0x01, 0x02 };
+
+    packet.Write(payload.data(), payload.size());
+
+    EXPECT_EQ(packet.Read(payload.size() + 1), nullptr);
+    EXPECT_EQ(packet.BytesRead, 0u);
+}
+
+TEST(NetworkPacket, read_returns_nullptr_when_read_position_is_out_of_bounds)
+{
+    Packet packet(Command::ping);
+    packet.Data.push_back(0x01);
+    packet.BytesRead = packet.Data.size() + 1;
+
+    EXPECT_EQ(packet.Read(1), nullptr);
+}
+
+#endif

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="IniWriterTest.cpp" />
     <ClCompile Include="LocalisationTest.cpp" />
     <ClCompile Include="MultiLaunch.cpp" />
+    <ClCompile Include="NetworkPacketTests.cpp" />
     <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
@@ -128,4 +129,3 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>
-


### PR DESCRIPTION
  ## Summary

  Harden `Network::Packet::Read()` so truncated or out-of-bounds reads fail immediately.

  ## What changed

  - throw on invalid packet reads
  - add regression tests for valid, truncated, and out-of-bounds reads
  - add `NetworkPacketTests.cpp` to the Visual Studio test project

  ## Why

  Malformed packets should fail safely at the packet boundary instead of propagating invalid data into packet handlers.

  ## Tests

  Added:
  - `NetworkPacket.read_returns_bytes_when_available`
  - `NetworkPacket.read_throws_when_packet_is_truncated`
  - `NetworkPacket.read_throws_when_read_position_is_out_of_bounds`
