### PR TITLE
Fix: sanitise packed object filenames

### DIFF
--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -609,7 +609,12 @@ namespace OpenRCT2
             auto userObjPath = _env.GetDirectoryPath(DirBase::user, DirId::objects);
             Path::CreateDirectory(userObjPath);
 
-            auto fileName = u8string(jsonIdentifier);
+            // The identifier comes from park data; sanitise the storage path so it stays within the objects directory.
+            auto fileName = Platform::SanitiseFilename(jsonIdentifier);
+            if (fileName.empty())
+            {
+                fileName = "object";
+            }
             auto extension = u8string(u8".parkobj");
             return updateFileName(fileName, extension);
         }

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/LanguagePackTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/LocalisationTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/MultiLaunch.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/ObjectRepositoryTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Pathfinding.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"
@@ -47,4 +48,3 @@ set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_
 gtest_discover_tests(OpenRCT2Tests
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DISCOVERY_MODE PRE_TEST)
-

--- a/test/tests/ObjectRepositoryTests.cpp
+++ b/test/tests/ObjectRepositoryTests.cpp
@@ -1,0 +1,124 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/PlatformEnvironment.h>
+#include <openrct2/audio/AudioContext.h>
+#include <openrct2/core/EnumUtils.hpp>
+#include <openrct2/core/File.h>
+#include <openrct2/core/FileSystem.hpp>
+#include <openrct2/core/Path.hpp>
+#include <openrct2/core/Zip.h>
+#include <openrct2/object/ObjectRepository.h>
+#include <openrct2/platform/Platform.h>
+#include <openrct2/ui/UiContext.h>
+#include <string>
+#include <system_error>
+#include <vector>
+
+using namespace OpenRCT2;
+
+namespace
+{
+    std::vector<uint8_t> CreateMinimalParkObjData(const fs::path& basePath)
+    {
+        const auto archivePath = (basePath / "source.parkobj").u8string();
+        auto archive = Zip::Open(archivePath, ZipAccess::write);
+        if (archive == nullptr)
+        {
+            return {};
+        }
+
+        static constexpr std::string_view ObjectJson = R"({
+  "id": "openrct2.test.object_repository",
+  "objectType": "scenario_meta",
+  "version": "1.0",
+  "authors": ["OpenRCT2"],
+  "strings": {
+    "name": {
+      "en-GB": "Object Repository Test"
+    }
+  }
+})";
+
+        archive->SetFileData("object.json", std::vector<uint8_t>(ObjectJson.begin(), ObjectJson.end()));
+        archive.reset();
+
+        return File::ReadAllBytes(archivePath);
+    }
+
+    class ScopedTempDirectory
+    {
+    public:
+        ScopedTempDirectory()
+        {
+            auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+            _path = fs::temp_directory_path() / fs::path("openrct2-object-repository-test-" + std::to_string(now));
+            fs::create_directories(_path);
+        }
+
+        ~ScopedTempDirectory()
+        {
+            std::error_code ec;
+            fs::remove_all(_path, ec);
+        }
+
+        const fs::path& Path() const
+        {
+            return _path;
+        }
+
+    private:
+        fs::path _path;
+    };
+} // namespace
+
+TEST(ObjectRepository, add_json_object_from_file_sanitises_filename)
+{
+    ScopedTempDirectory tempDirectory;
+    const auto repoRoot = fs::u8path(__FILE__).parent_path().parent_path().parent_path();
+
+    DirBaseValues basePaths{};
+    basePaths[EnumValue(DirBase::openrct2)] = (repoRoot / "data").u8string();
+    basePaths[EnumValue(DirBase::user)] = (tempDirectory.Path() / "user").u8string();
+    basePaths[EnumValue(DirBase::cache)] = (tempDirectory.Path() / "cache").u8string();
+    basePaths[EnumValue(DirBase::config)] = (tempDirectory.Path() / "config").u8string();
+    basePaths[EnumValue(DirBase::documentation)] = (tempDirectory.Path() / "docs").u8string();
+
+    for (const auto& basePath : basePaths)
+    {
+        if (!basePath.empty())
+        {
+            fs::create_directories(fs::u8path(basePath));
+        }
+    }
+
+    gOpenRCT2Headless = true;
+    gOpenRCT2NoGraphics = true;
+
+    auto env = CreatePlatformEnvironment(basePaths);
+    auto context = CreateContext(std::move(env), Audio::CreateDummyAudioContext(), Ui::CreateDummyUiContext());
+    ASSERT_TRUE(context->Initialise());
+
+    const auto objectData = CreateMinimalParkObjData(tempDirectory.Path());
+    ASSERT_FALSE(objectData.empty());
+    const std::string identifier = "../../escape/payload";
+    context->GetObjectRepository().AddObjectFromFile(ObjectGeneration::JSON, identifier, objectData.data(), objectData.size());
+
+    const auto objectsPath = fs::u8path(context->GetPlatformEnvironment().GetDirectoryPath(DirBase::user, DirId::objects));
+    const auto expectedPath = fs::u8path(
+        Path::Combine(objectsPath.u8string(), Platform::SanitiseFilename(identifier) + ".parkobj"));
+    const auto escapedPath = (objectsPath / ".." / ".." / "escape" / "payload.parkobj").lexically_normal();
+
+    EXPECT_TRUE(fs::exists(expectedPath));
+    EXPECT_FALSE(fs::exists(escapedPath));
+}

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="IniWriterTest.cpp" />
     <ClCompile Include="LocalisationTest.cpp" />
     <ClCompile Include="MultiLaunch.cpp" />
+    <ClCompile Include="ObjectRepositoryTests.cpp" />
     <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
@@ -128,4 +129,3 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>
-


### PR DESCRIPTION
  ## Summary

  Sanitise packed JSON object filenames before storing imported `.parkobj` files.

  ## What changed

  - sanitise the filename derived from packed JSON object identifiers
  - keep imported files inside the user objects directory
  - add a regression test covering a traversal-style identifier

  ## Why

  Packed object identifiers come from park data and should not be able to influence filesystem paths outside the intended storage directory.

  ## Tests

  Added:
  - `ObjectRepository.add_json_object_from_file_sanitises_filename`
