### PR TITLE
Fix: Plugin-driven list view not invalidated on setting changes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.2 (in development)
 ------------------------------------------------------------------------
 - Improved: [#26566] Improve the performance of sorting sprites.
+- Fix: [#26350] ListViews altered by plugins post their creation are not invalidated.
 - Fix: [#26565] Game crashes when switching to another tab in the guest window.
 - Fix: [#26583] The default tab is not highlighted when opening a ride window.
 - Fix: [#26602] Crash when locating the nearest mechanic for a ride that has not previously been inspected.

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -873,6 +873,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->CanSelect = valueBool;
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -895,6 +896,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->IsStriped = valueBool;
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -916,6 +918,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SetScrollbars(ScrollbarTypeFromJS(ctx, value));
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -938,6 +941,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->ShowColumnHeaders = valueBool;
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -968,6 +972,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SelectedCell = RowColumnFromJS(ctx, value);
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -999,6 +1004,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SetItems(ListViewItemVecFromJS(ctx, value));
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -1024,6 +1030,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SetColumns(ListViewColumnVecFromJS(ctx, value));
+                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -940,7 +940,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->ShowColumnHeaders = valueBool;
-                WindowUpdateScrollWidgets(GetWindow(thisVal));
+                WindowUpdateScrollWidgets(*GetWindow(thisVal));
                 Invalidate(thisVal);
             }
             return JS_UNDEFINED;

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -918,7 +918,6 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SetScrollbars(ScrollbarTypeFromJS(ctx, value));
-                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -941,6 +940,7 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->ShowColumnHeaders = valueBool;
+                WindowUpdateScrollWidgets(GetWindow(thisVal));
                 Invalidate(thisVal);
             }
             return JS_UNDEFINED;
@@ -1004,7 +1004,6 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SetItems(ListViewItemVecFromJS(ctx, value));
-                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }
@@ -1030,7 +1029,6 @@ namespace OpenRCT2::Scripting
             if (listView != nullptr)
             {
                 listView->SetColumns(ListViewColumnVecFromJS(ctx, value));
-                Invalidate(thisVal);
             }
             return JS_UNDEFINED;
         }


### PR DESCRIPTION
ListViews driven by plugins are not properly invalidated when the plugin changes their properties after creation.

I'm not sure if some of these were intentional, but in particular, this makes changing selectedCell in response to UI events buggy.

For testing, I have a fork of [Peep Editor](https://github.com/SunsetFi/OpenRCT2-PeepEditor/tree/peep-list) where I am trying to use this behavior.  

Pre-fix: Changing selectedCell in the plugin either does not re-render the window, or renders it partially in a broken state
Post-fix: Changing selectedCell in the plugin results in the visibly selected cell updating.