### PR TITLE
Fix #26019: Inverted large half loops tunnel, support and train drawing glitches

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#24242] [Plugin] Add ride-breakdown hooktype.
 - Feature: [#24879] [Plugin] Add methods for showing and hiding gridlines.
+- Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don't draw in tunnels at some angles (original bug).
 - Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
 - Fix: [#26299] Single Rail S-Bend sprites don't fully connect to the next track piece at certain angles.
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.

--- a/src/openrct2/paint/track/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/FlyingRollerCoaster.cpp
@@ -503,7 +503,7 @@ static void FlyingRCTrackLeftFlyingLargeHalfLoopInvertedUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27644), { 0, 0, height - 4 },
-                        { { 30, 16, height }, { 2, 16, 3 } });
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -518,7 +518,7 @@ static void FlyingRCTrackLeftFlyingLargeHalfLoopInvertedUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27665), { 0, 0, height - 4 },
-                        { { 30, 0, height + 140 }, { 2, 16, 3 } });
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -537,32 +537,26 @@ static void FlyingRCTrackLeftFlyingLargeHalfLoopInvertedUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27645), { 0, 0, height - 4 },
-                        { { 0, 16, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27652), { 0, 0, height - 4 },
-                        { { 0, 16, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27659), { 0, 0, height - 4 },
-                        { { 0, 0, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27666), { 0, 0, height - 4 },
-                        { { 0, 0, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
             }
+
+            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
@@ -752,7 +746,7 @@ static void FlyingRCTrackRightFlyingLargeHalfLoopInvertedUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27693), { 0, 0, height - 4 },
-                        { { 30, 7, height + 140 }, { 2, 16, 3 } });
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -767,7 +761,7 @@ static void FlyingRCTrackRightFlyingLargeHalfLoopInvertedUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27672), { 0, 0, height - 4 },
-                        { { 30, 16, height + 140 }, { 2, 16, 3 } });
+                        { { 0, 6, height + 211 }, { 32, 20, 3 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -786,32 +780,25 @@ static void FlyingRCTrackRightFlyingLargeHalfLoopInvertedUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27694), { 0, 0, height - 4 },
-                        { { 0, 0, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27687), { 0, 0, height - 4 },
-                        { { 0, 0, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27680), { 0, 0, height - 4 },
-                        { { 0, 16, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27673), { 0, 0, height - 4 },
-                        { { 0, 16, height + 32 }, { 32, 24, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 0, height + 24, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
             }
+            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);

--- a/src/openrct2/paint/track/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/paint/track/coaster/InvertedRollerCoaster.cpp
@@ -9451,7 +9451,7 @@ static void InvertedRCTrackLeftLargeHalfLoopUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27644), { 0, 0, height },
-                        { { 30, 16, height }, { 2, 16, 3 } });
+                        { { 0, 6, height + 227 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -9466,7 +9466,7 @@ static void InvertedRCTrackLeftLargeHalfLoopUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27665), { 0, 0, height },
-                        { { 30, 0, height + 140 }, { 2, 16, 3 } });
+                        { { 0, 6, height + 227 }, { 32, 20, 3 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -9485,32 +9485,25 @@ static void InvertedRCTrackLeftLargeHalfLoopUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27645), { 0, 0, height },
-                        { { 0, 16, height + 32 }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 27, height, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27652), { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 27, height, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27659), { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27666), { 0, 0, height },
-                        { { 0, 0, height + 32 }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 27, height, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
             }
+            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 30, height, session.SupportColours);
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);
@@ -9701,7 +9694,7 @@ static void InvertedRCTrackRightLargeHalfLoopUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27693), { 0, 0, height },
-                        { { 30, 0, height + 140 }, { 2, 16, 3 } });
+                        { { 0, 6, height + 227 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -9716,7 +9709,7 @@ static void InvertedRCTrackRightLargeHalfLoopUp(
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27672), { 0, 0, height },
-                        { { 30, 16, height + 140 }, { 2, 16, 3 } });
+                        { { 0, 6, height + 227 }, { 32, 20, 3 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -9735,32 +9728,25 @@ static void InvertedRCTrackRightLargeHalfLoopUp(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27694), { 0, 0, height },
-                        { { 0, 0, height + 32 }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 27, height, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27687), { 0, 0, height },
-                        { { 0, 0, height }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 25, height, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27680), { 0, 0, height },
-                        { { 0, 16, height }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 27, height, session.SupportColours);
+                        { { 0, 6, height }, { 32, 20, 3 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours.WithIndex(27673), { 0, 0, height },
-                        { { 0, 16, height + 32 }, { 32, 16, 0 } });
-                    MetalASupportsPaintSetup(
-                        session, supportType.metal, MetalSupportPlace::centre, 27, height, session.SupportColours);
+                        { { 0, 6, height + 32 }, { 32, 20, 3 } });
                     break;
             }
+            MetalASupportsPaintSetup(session, supportType.metal, MetalSupportPlace::centre, 30, height, session.SupportColours);
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height + 32, kTunnelGroup, TunnelSubType::Flat);


### PR DESCRIPTION
Fix #26019
This fixes a few issues with the inverted (and inverted flying) large half loops:

Tunnels:
<img width="262" height="257" alt="tunnelbug" src="https://github.com/user-attachments/assets/73a4ade8-dc4c-4318-9872-069935e812b9" /><img width="262" height="257" alt="tunnelfix" src="https://github.com/user-attachments/assets/7d90e0c3-b403-4a3a-aa2c-212f906e3652" />

Some train glitching:
<img width="323" height="317" alt="trainbug" src="https://github.com/user-attachments/assets/a7bec3b6-c609-485a-af58-7584bb28fa92" /><img width="323" height="317" alt="trainfix" src="https://github.com/user-attachments/assets/ee89216c-68e3-4322-983f-50b58793b799" />

Supports don't connect:
<img width="392" height="244" alt="supportbug" src="https://github.com/user-attachments/assets/0126f6a6-d479-435d-a914-29ee948d0b04" /><img width="392" height="244" alt="supportfix" src="https://github.com/user-attachments/assets/880bb792-e41e-4281-b36b-0ce4ec03235c" />

There is still a bit of glitching with the train at some angles on other parts of the loop. I think the best solution for that is to cut the sprites differently, but recutting vanilla sprites isn't really something I want to get in to right now.

Test save file and files with all pieces underground:
[invertlargehalfloop.zip](https://github.com/user-attachments/files/26714966/invertlargehalfloop.zip)
