### PR TITLE
Guests dying by voiding out applies a casualty penalty 

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3826,3 +3826,4 @@ STR_7026    :Makes the whole ride visible
 STR_7027    :{MOVE_X}{29}{STRINGID}
 STR_7028    :Quarter Helix up
 STR_7029    :Quarter Helix down
+STR_7030    :{RED}{STRINGID} has fallen into hell!

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -868,6 +868,15 @@ namespace OpenRCT2
             if (z <= 1)
             {
                 // Remove peep if it has gone to the void
+                if (Config::Get().notifications.guestDied)
+                {
+                    auto ft = Formatter();
+                    FormatNameTo(ft);
+                    News::AddItemToQueue(News::ItemType::blank, STR_NEWS_ITEM_GUEST_VOIDED_OUT, x | (y << 16), ft);
+                }
+
+                auto& gameState = getGameState();
+                gameState.park.ratingCasualtyPenalty = std::min(gameState.park.ratingCasualtyPenalty + 25, 1000);
                 Remove();
                 return;
             }

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1765,6 +1765,8 @@ enum : StringId
     STR_QUARTER_HELIX_UP = 7028,
     STR_QUARTER_HELIX_DOWN = 7029,
 
+    STR_NEWS_ITEM_GUEST_VOIDED_OUT = 7030
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
<img width="722" height="512" alt="Screenshot 2026-04-15 003234" src="https://github.com/user-attachments/assets/fae062e9-c259-4c27-98c9-de9bb066a897" />

A guest falling to their doom in the void previously didn't harm your park rating. Now it applies a penalty equal to if they had drowned.

The message I supplied is ridiculous and *will* need to change, but I can't decide how best to convey it. There are some suggestions in #18135. I used "STR_NEWS_ITEM_GUEST_VOIDED_OUT" internally, but "voiding out" is a very video gamey idea so might not fit for what the player sees.

uses stringid 7030, which will probably have to be changed by someone who actually knows what the allocation policy is. Also probably a network version bump? I don't actually know how the networking stuff works, though this doesn't do anything a drowning guest doesn't so it should be fine.