### PR TITLE
Fix #26287: Game crashes upon connect/disconnect of physical keyboard

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#26386] Initial window scale and toolbar options on fresh Android installations.
 - Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don't draw in tunnels at some angles (original bug).
 - Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
+- Fix: [#26287] Game crashes upon connect/disconnect of physical keyboard. 
 - Fix: [#26299] Single Rail S-Bend sprites don't fully connect to the next track piece at certain angles.
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.

--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         </activity>
         <activity
             android:name=".GameActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
             android:screenOrientation="landscape"
             android:preferMinimalPostProcessing="true"
             >


### PR DESCRIPTION
## Description
This PR fixes the crash occurring during hardware keyboard hotplugging (connect/disconnect) on Android devices. 

By adding `orientation|screenSize|keyboard|keyboardHidden` to the `android:configChanges` attribute in the Manifest, the system now handles these configuration changes through the activity's callback instead of destroying and recreating the activity, which was the root cause of the crash reported in the related issue.

## Related Issue
Fixes #26287

## Testing
- Verified on Android Emulator (API 35).
- Toggling "Enable hardware keyboard" in the emulator's extended controls no longer crashes the app.
- Logcat confirmed successful handling via `onConfigurationChanged`.