### PR TITLE
Fix #26183: Ride stat graphs tab text is partially off screen.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#24242] [Plugin] Add ride-breakdown hooktype.
 - Feature: [#24879] [Plugin] Add methods for showing and hiding gridlines.
+- Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -6278,7 +6278,7 @@ namespace OpenRCT2::Ui::Windows
             if (measurement == nullptr)
             {
                 // No measurement message
-                ScreenCoordsXY stringCoords(widget->width() / 2, widget->height() - 1 / 2 - 5);
+                ScreenCoordsXY stringCoords(widget->width() / 2, widget->height() / 2 - 5);
                 int32_t txtWidth = widget->width() - 3;
                 drawTextWrapped(rt, stringCoords, txtWidth, message.str, message.args, { TextAlignment::centre });
                 return;


### PR DESCRIPTION
Did some digging, found there was a one line change that was causing the ride stat graph text to move off screen, this MR fixes that so it's now on screen again.

Closes: https://github.com/OpenRCT2/OpenRCT2/issues/26183

Photo from my build showing the new screen:

<img width="1356" height="817" alt="image" src="https://github.com/user-attachments/assets/8e704bc6-2ab1-4721-b6f5-bb8055542e46" />
