### PR TITLE
Fix tiles mistakenly culled when elements below water and none above

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
+- Fix: [#26410] Tiles with water can draw incorrectly when there is something underwater and nothing above water.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -188,19 +188,17 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
     if (screenMinY + 52 <= session.rt.WorldY())
         return;
 
-    const TileElement* element = tile_element; // push tile_element
-
     uint16_t maxHeight = 0;
-    do
     {
-        maxHeight = std::max(maxHeight, static_cast<uint16_t>(element->GetClearanceZ()));
-    } while (!(element++)->IsLastForTile());
-
-    element--;
-
-    if (element->GetType() == TileElementType::Surface && (element->AsSurface()->GetWaterHeight() > 0))
-    {
-        maxHeight = std::max(maxHeight, static_cast<uint16_t>(element->AsSurface()->GetWaterHeight()));
+        const TileElement* element = tile_element;
+        do
+        {
+            maxHeight = std::max(maxHeight, static_cast<uint16_t>(element->GetClearanceZ()));
+            if (element->GetType() == TileElementType::Surface)
+            {
+                maxHeight = std::max(maxHeight, static_cast<uint16_t>(element->AsSurface()->GetWaterHeight()));
+            }
+        } while (!(element++)->IsLastForTile());
     }
 
     if (partOfVirtualFloor)


### PR DESCRIPTION
This fixes tiles getting culled when there is something below water but nothing above it.

In order to get the correct height for a tile, the height of the water needs to be checked, but it was only checking the last tile element. That's true through normal gameplay, nothing can be placed underwater so either the surface element is last, or there's something after it that's higher than the water. But with zero clearances you can place an object above the surface but under the water so the height of the water is not taken into account.

Typically parks use workarounds like using the tile inspector to put the surface last, or putting invisible objects above the water.

This checks all tile elements for the water height instead of just the last.
I don't have any numbers but this is likely a tiny perf downgrade. In general I don't notice any difference in fps but I've tried a couple of parks that seem to dip a single frame more than usual. I guess I'll leave it with you guys. This is the problem and a solution, maybe it's worth it, maybe not. Maybe there's something smarter than can be done. This could lead to being able to place things underwater without cheats?

https://github.com/user-attachments/assets/a726e969-0201-4697-9878-0022f63109b6


https://github.com/user-attachments/assets/b04d27e2-1817-4ea2-b312-399430db59af

Test park:
[tilecullingglitch.zip](https://github.com/user-attachments/files/26853940/tilecullingglitch.zip)
