### PR TITLE
Minor clean ups for macOS Platform and UiContext units

### DIFF
--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -11,19 +11,13 @@
 
     #include "UiContext.h"
 
-    #include <openrct2/Diagnostic.h>
-    #include <openrct2/core/String.hpp>
-    #include <openrct2/ui/UiContext.h>
-
-    // undefine `interface` and `abstract`, because it's causing conflicts with Objective-C's keywords
-    #undef interface
-    #undef abstract
-
     #include <ApplicationServices/ApplicationServices.h>
-    #import <Cocoa/Cocoa.h>
+    #include <Cocoa/Cocoa.h>
     #include <CoreFoundation/CFBundle.h>
     #include <SDL.h>
     #include <mach-o/dyld.h>
+    #include <openrct2/Diagnostic.h>
+    #include <openrct2/ui/UiContext.h>
     #include <string>
 
 namespace OpenRCT2::Ui

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -11,21 +11,14 @@
 
     #include "Platform.h"
 
-    #include "../Date.h"
     #include "../OpenRCT2.h"
     #include "../core/Path.hpp"
     #include "../core/String.hpp"
     #include "../localisation/Language.h"
 
-    // undefine `interface` and `abstract`, because it's causing conflicts with Objective-C's keywords
-    #undef interface
-    #undef abstract
-
-    #include <AvailabilityMacros.h>
     #include <CoreText/CoreText.h>
     #include <Foundation/Foundation.h>
     #include <mach-o/dyld.h>
-    #include <mach/mach_time.h>
     #include <pwd.h>
 
 namespace OpenRCT2::Platform


### PR DESCRIPTION
This removes a few unnecessary includes from the macOS Platform and UiContext units. We also remove the `interface` and `abstract` 'undefines'. Neither has been defined for years, ever since `Common.h` has been reworked.