### PR TITLE
Fix #26419: Having an inversion on the Flying Coaster doesn't prevent stat penalty for drops or negative g's

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
-- Fix: [#26419] Drop count stat requirement for Flying Roller Coaster doesn't get nullified by having an inversion.
+- Fix: [#26419] Drop count & height and negative g's stat requirements for Flying Roller Coaster don't get nullified by having an inversion.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
-- Fix: [#26419] Drop count & height and negative g's stat requirements for Flying Roller Coaster don't get nullified by having an inversion.
+- Fix: [#26419] Drop count & negative g's stat requirements for Flying Roller Coaster don't get nullified by having an inversion.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
+- Fix: [#26419] Drop count stat requirement for Flying Roller Coaster doesn't get nullified by having an inversion.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/rtd/coaster/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/FlyingRollerCoaster.h
@@ -72,7 +72,7 @@ constexpr RideTypeDescriptor FlyingRollerCoasterRTD =
         { RideRating::make(4, 35), RideRating::make(1, 85), RideRating::make(4, 33) },
         17,
         kDynamicRideShelterRating,
-        false,
+        true,
         {
             { RatingsModifierType::BonusLength,           6000,             764, 0, 0 },
             { RatingsModifierType::BonusSynchronisation,  0,                RideRating::make(0, 40), RideRating::make(0, 05), 0 },
@@ -143,7 +143,7 @@ constexpr RideTypeDescriptor FlyingRollerCoasterAltRTD =
         { RideRating::make(4, 35), RideRating::make(1, 85), RideRating::make(4, 33) },
         17,
         kDynamicRideShelterRating,
-        false,
+        true,
         {
             { RatingsModifierType::BonusLength,           6000,             764, 0, 0 },
             { RatingsModifierType::BonusSynchronisation,  0,                RideRating::make(0, 40), RideRating::make(0, 05), 0 },


### PR DESCRIPTION
Fixes #26419