### PR TITLE
fix scenery group selection overflow

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
+- Fix: [#26421] Active scenery selection overflows when 64 or more scenery groups are selected.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -923,19 +923,13 @@ namespace OpenRCT2::Ui
 
     bool widgetIsPressed(const WindowBase& w, WidgetIndex widgetIndex)
     {
-        if (w.classification == WindowClass::custom)
+        if (w.widgets[widgetIndex].flags.has(WidgetFlag::isPressed))
         {
-            if (w.widgets[widgetIndex].flags.has(WidgetFlag::isPressed))
-            {
-                return true;
-            }
+            return true;
         }
-        else
+        if (widgetIndex < 64 && (w.pressedWidgets & (1uLL << widgetIndex)))
         {
-            if (w.pressedWidgets & (1LL << widgetIndex))
-            {
-                return true;
-            }
+            return true;
         }
 
         if (InputGetState() == InputState::WidgetPressed || InputGetState() == InputState::DropdownActive)
@@ -1144,6 +1138,8 @@ namespace OpenRCT2::Ui
     void widgetSetPressed(WindowBase& w, WidgetIndex widgetIndex, bool value)
     {
         SafeSetWidgetFlag(w, widgetIndex, WidgetFlag::isPressed, value);
+        if (widgetIndex >= 64)
+            return;
         if (value)
             w.pressedWidgets |= (1uLL << widgetIndex);
         else

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -712,7 +712,10 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_FILTER_TEXT_BOX].string = _filteredSceneryTab.Filter.data();
 
             pressedWidgets = 0;
-            pressedWidgets |= 1uLL << (tabIndex + WIDX_SCENERY_TAB_1);
+            for (size_t i = 0; i < _tabEntries.size(); i++)
+            {
+                widgets[WIDX_SCENERY_TAB_1 + i].flags.set(WidgetFlag::isPressed, i == tabIndex);
+            }
             if (_sceneryPaintEnabled)
                 pressedWidgets |= (1uLL << WIDX_SCENERY_REPAINT_SCENERY_BUTTON);
             if (gWindowSceneryEyedropperEnabled)


### PR DESCRIPTION
Fixes https://github.com/OpenRCT2/OpenRCT2/issues/26421.

Just wondering: is there a plan to fully migrate built-in windows away from the `WindowBase` pressed/disabled/holdable bitmasks and onto per-widget `WidgetFlag`, so custom and built-in windows share a single storage model?