### PR TITLE
Fix #26425: Benches don't reduce watching spots from 4 to 2 while other path additions do

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -16,7 +16,7 @@
     "sha256": "dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858"
   },
   "replays": {
-    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.92/replays.zip",
-    "sha256": "455a19172a8df81b935a942bbbda20167b4740b34653fdb74127740686bf4cbe"
+    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.93/replays.zip",
+    "sha256": "5295f115045eb6945b36b48ca2105c7059e7f6cf8a88832997d6cf878817e1b5"
   }
 }

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
+- Fix: [#26425] Benches don't reduce watching spots from 4 to 2 while other path additions do (should be reversed).
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5652,7 +5652,7 @@ namespace OpenRCT2
                     return;
                 }
 
-                if (!(pathAddEntry->flags & PATH_ADDITION_FLAG_IS_BENCH))
+                if ((pathAddEntry->flags & PATH_ADDITION_FLAG_IS_BENCH))
                     positions_free = 9;
             }
         }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -48,7 +48,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 5;
+constexpr uint8_t kStreamVersion = 6;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Fixes #26425