### PR TITLE
Drop old hack from processStringLiteral

### DIFF
--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -641,18 +641,8 @@ namespace OpenRCT2::Drawing
                     if (ttfRunIndex.has_value())
                     {
                         // Draw the TTF run
-                        // This error suppression abomination is here to suppress
-                        // https://github.com/OpenRCT2/OpenRCT2/issues/17371. Additionally, we have to suppress the error for
-                        // the error suppression... :'-( https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105937 is fixed in GCC13
-    #if defined(__GNUC__) && !defined(__clang__)
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-    #endif
                         auto len = it.GetIndex() - ttfRunIndex.value();
                         drawStringRawTTF(rt, text.substr(ttfRunIndex.value(), len), info);
-    #if defined(__GNUC__) && !defined(__clang__)
-        #pragma GCC diagnostic pop
-    #endif
                         ttfRunIndex = std::nullopt;
                     }
 


### PR DESCRIPTION
This hack was introduced four years ago to address a false-positive in gcc 12. This was before we even compiled the source code as C++20. With gcc 15 being the latest version, I believe it is time to drop this hack.