### PR TITLE
Fix #26432: Guests choose to head for rides they have already ridden if they don't have a map

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
 - Fix: [#26410] Tiles with water can draw incorrectly when there is something underwater and nothing above water.
 - Fix: [#26425] Benches don't reduce watching spots from 4 to 2 while other path additions do (should be reversed).
+- Fix: [#26432] Guests choose to head for rides they have already ridden if they don't have a map.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1898,10 +1898,7 @@ namespace OpenRCT2
             auto& gameState = getGameState();
             for (auto& ride : RideManager(gameState))
             {
-                if (!guest.HasRidden(ride))
-                {
-                    rideConsideration[ride.id.ToUnderlying()] = true;
-                }
+                rideConsideration[ride.id.ToUnderlying()] = true;
             }
         }
         else
@@ -1952,6 +1949,10 @@ namespace OpenRCT2
         auto& gameState = getGameState();
         for (auto& ride : RideManager(gameState))
         {
+            if (guest.HasRidden(ride))
+            {
+                continue;
+            }
             const auto rideIndex = ride.id.ToUnderlying();
             if (rideConsideration.size() > rideIndex && rideConsideration[rideIndex])
             {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -48,7 +48,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 6;
+constexpr uint8_t kStreamVersion = 7;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Fixes #26432