### PR TITLE
format-changelog.js: print error when typewriter quotes are used

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,19 +3,19 @@
 - Feature: [#24242] [Plugin] Add ride-breakdown hooktype.
 - Feature: [#24879] [Plugin] Add methods for showing and hiding gridlines.
 - Improved: [#26386] Initial window scale and toolbar options on fresh Android installations.
-- Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don't draw in tunnels at some angles (original bug).
+- Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don‘t draw in tunnels at some angles (original bug).
 - Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
 - Fix: [#26287] Game crashes upon connect/disconnect of physical keyboard. 
-- Fix: [#26299] Single Rail S-Bend sprites don't fully connect to the next track piece at certain angles.
-- Fix: [#26352] Large scenery items are incorrectly labelled as 'banners' in the tile inspector.
+- Fix: [#26299] Single Rail S-Bend sprites don’t fully connect to the next track piece at certain angles.
+- Fix: [#26352] Large scenery items are incorrectly labelled as ‘banners’ in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
 - Fix: [#26374] Add higher resolution app icons for Android.
 - Fix: [#26410] Tiles with water can draw incorrectly when there is something underwater and nothing above water.
 - Fix: [#26419] Drop count & negative g’s stat requirements for Flying Roller Coaster don’t get nullified by having an inversion.
 - Fix: [#26421] Wrong scenery tab highlighted when more than 64 scenery groups are selected.
-- Fix: [#26425] Benches don't reduce watching spots from 4 to 2 while other path additions do (should be reversed).
-- Fix: [#26432] Guests choose to head for rides they have already ridden if they don't have a map.
+- Fix: [#26425] Benches don’t reduce watching spots from 4 to 2 while other path additions do (should be reversed).
+- Fix: [#26432] Guests choose to head for rides they have already ridden if they don’t have a map.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -419,7 +419,7 @@
 - Fix: [#19782] Game stops counting inversions and golf holes after 31 (original bug).
 - Fix: [#21207] Track List window gets positioned incorrectly.
 - Fix: [#21919] Non-recolourable cars still show colour picker (original bug).
-- Fix: [#22182] [Plugin] Crash when using map.getAllEntities("car").
+- Fix: [#22182] [Plugin] Crash when using `map.getAllEntities("car")`.
 - Fix: [#22634] Asset packs with sound effect overrides are not loaded correctly at startup.
 - Fix: [#23108] Missing pieces on Hypercoaster and Hyper-Twister, even with the ‘all drawable track pieces’ cheat enabled.
 - Fix: [#24013] Failure to load a scenario preview image (minimap) could lead to an uncaught exception error message.

--- a/scripts/format-changelog.js
+++ b/scripts/format-changelog.js
@@ -126,6 +126,10 @@ function readVersionEntry(ctx, rawEntry, versionInfo) {
             reportLineError(rawEntry, `Invalid reference '${ref}', must be '#123' or 'project#123'`);
         }
     }
+    
+    if (text.includes('"') || text.includes('\'')) {
+        reportLineError(rawEntry, `Use of typewriter quotes (' or "), please use typographical quotes (‘ ’ and “ ”)`);
+    }
 
     const result = {
         changeType: changeType,

--- a/scripts/format-changelog.js
+++ b/scripts/format-changelog.js
@@ -127,7 +127,8 @@ function readVersionEntry(ctx, rawEntry, versionInfo) {
         }
     }
     
-    if (text.includes('"') || text.includes('\'')) {
+    const textWithoutCode = text.replaceAll(/`.*`/g, '');
+    if (textWithoutCode.includes('"') || textWithoutCode.includes('\'')) {
         reportLineError(rawEntry, `Use of typewriter quotes (' or "), please use typographical quotes (‘ ’ and “ ”)`);
     }
 


### PR DESCRIPTION
The CI will now print an error if a changelog line uses typewriter quotes.

For situations where they _have_ to be used, e.g. when quoting code (which happens on line 418), you can surround that code with backticks.

The four commits should illustrate the story very well. I can merge them into 1 or 2 commits if desired.