### PR TITLE
Fix: [#25557] Invalidate adjacent tunnel tiles on ground height change

### DIFF
--- a/src/openrct2/actions/terraform/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/LandSetHeightAction.cpp
@@ -346,6 +346,25 @@ namespace OpenRCT2::GameActions
         }
 
         MapInvalidateTileFull(_coords);
+
+        // Invalidate adjacent tiles containing track elements, as tunnel portals
+        // on neighbouring tiles may be visually affected by the ground height change.
+        // Fixes: https://github.com/OpenRCT2/OpenRCT2/issues/25557
+        constexpr CoordsXY adjacentOffsets[] = {
+            { -kCoordsXYStep, 0 },
+            { kCoordsXYStep, 0 },
+            { 0, -kCoordsXYStep },
+            { 0, kCoordsXYStep },
+        };
+        for (const auto& offset : adjacentOffsets)
+        {
+            CoordsXY adjacentCoords = _coords + offset;
+            for ([[maybe_unused]] auto* trackElement : TileElementsView<TrackElement>(adjacentCoords))
+            {
+                MapInvalidateTileFull(adjacentCoords);
+                break;
+            }
+        }
     }
 
     bool LandSetHeightAction::MapSetLandHeightClearFunc(


### PR DESCRIPTION
## Summary
Fixes #25557.

When a tile's ground height changed, only that tile was invalidated. Track elements on adjacent tiles with tunnel portals rely on the neighbouring surface to compute their paint output, so they could render stale sprites (a missing portal or missing interior track) until the viewport was otherwise refreshed. The reporter's save demonstrates this on a Mine Train Coaster.

## Root cause
`LandSetHeightAction::SetSurfaceHeight` calls `MapInvalidateTileFull(_coords)` only for the tile whose height changed. Tunnel rendering, however, depends on the surface of neighbouring tiles — so an adjacent track tile's cached paint output goes stale after the height change, causing the visible glitch.

## Fix
After invalidating the modified tile, also invalidate each of the four orthogonally adjacent tiles if they contain any track element. This forces the paint system to recompute tunnel portals and interior track sprites on the next frame. The check uses the existing `TileElementsView<TrackElement>` idiom already used elsewhere in the file (e.g. `CheckRideSupports`), so it adds no new dependencies.

## Testing
- Reproduced the glitch locally with the save attached to #25557 (Mine Train Coaster).
- Before fix: raising/lowering the tile adjacent to the tunnel portal causes the portal or interior track to disappear.
- After fix: the tunnel renders correctly after every raise/lower operation.
- Verified no visible regressions on other tunnel-capable coaster types and on raise/lower operations far from any track.
- `clang-format` applied, CI expected to pass the Linux/Windows/macOS build matrix.

## Screenshots
- Before: [attach ClosedTunnel.png]
- After: [attach OpenTunnel.png]
<img width="442" height="480" alt="ClosedTunnel" src="https://github.com/user-attachments/assets/67d32020-fb7b-4adf-bfa9-2bbf841a5bef" />
<img width="467" height="550" alt="OpenTunnel" src="https://github.com/user-attachments/assets/2531e734-44f6-4191-ad68-60121968d283" />
