### PR TITLE
Use ParkData& in Park and Finances windows

### DIFF
--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -29,10 +29,12 @@
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/world/Park.h>
 
-using namespace OpenRCT2::Drawing;
-
 namespace OpenRCT2::Ui::Windows
 {
+    using namespace OpenRCT2::Drawing;
+
+    using Park::ParkData;
+
     enum
     {
         WINDOW_FINANCES_PAGE_SUMMARY,
@@ -220,13 +222,17 @@ namespace OpenRCT2::Ui::Windows
         ScreenRect _graphBounds;
         Graph::GraphProperties<money64> _graphProps{};
         u8string _loanSpinnerText{};
+        ParkData& _parkData;
 
         void SetDisabledTabs()
         {
-            setWidgetDisabled(WIDX_TAB_5, (getGameState().park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
+            setWidgetDisabled(WIDX_TAB_5, (_parkData.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) != 0);
         }
 
     public:
+        FinancesWindow(ParkData& parkData)
+            : _parkData(parkData) {};
+
         void onOpen() override
         {
             setPage(WINDOW_FINANCES_PAGE_SUMMARY);
@@ -323,17 +329,17 @@ namespace OpenRCT2::Ui::Windows
                 case WINDOW_FINANCES_PAGE_VALUE_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = false;
-                    _graphProps.series = getGameState().park.valueHistory;
+                    _graphProps.series = _parkData.valueHistory;
                     break;
                 case WINDOW_FINANCES_PAGE_PROFIT_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = true;
-                    _graphProps.series = getGameState().park.weeklyProfitHistory;
+                    _graphProps.series = _parkData.weeklyProfitHistory;
                     break;
                 case WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH:
                     graphPageWidget = &widgets[WIDX_PAGE_BACKGROUND];
                     centredGraph = true;
-                    _graphProps.series = getGameState().park.cashHistory;
+                    _graphProps.series = _parkData.cashHistory;
                     break;
                 default:
                     return;
@@ -353,8 +359,7 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH:
                 {
-                    auto& gameState = getGameState();
-                    const auto cashLessLoan = gameState.park.cash - gameState.park.bankLoan;
+                    const auto cashLessLoan = _parkData.cash - _parkData.bankLoan;
                     const auto fmt = cashLessLoan >= 0 ? STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_POSITIVE
                                                        : STR_FINANCES_FINANCIAL_GRAPH_CASH_LESS_LOAN_NEGATIVE;
                     onDrawGraph(rt, cashLessLoan, fmt);
@@ -365,10 +370,9 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 case WINDOW_FINANCES_PAGE_PROFIT_GRAPH:
                 {
-                    auto& gameState = getGameState();
-                    const auto fmt = gameState.park.currentProfit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE
-                                                                       : STR_FINANCES_WEEKLY_PROFIT_LOSS;
-                    onDrawGraph(rt, gameState.park.currentProfit, fmt);
+                    const auto fmt = _parkData.currentProfit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE
+                                                                  : STR_FINANCES_WEEKLY_PROFIT_LOSS;
+                    onDrawGraph(rt, _parkData.currentProfit, fmt);
                     break;
                 }
                 case WINDOW_FINANCES_PAGE_MARKETING:
@@ -414,7 +418,6 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += kTableCellHeight;
             }
 
-            auto& gameState = getGameState();
             // Expenditure / Income values for each month
             auto currentMonthYear = GetDate().GetMonthsElapsed();
             for (int32_t i = SummaryMaxAvailableMonth(); i >= 0; i--)
@@ -437,7 +440,7 @@ namespace OpenRCT2::Ui::Windows
                 money64 profit = 0;
                 for (int32_t j = 0; j < static_cast<int32_t>(ExpenditureType::count); j++)
                 {
-                    auto expenditure = gameState.park.expenditureTable[i][j];
+                    auto expenditure = _parkData.expenditureTable[i][j];
                     if (expenditure != 0)
                     {
                         profit += expenditure;
@@ -535,20 +538,19 @@ namespace OpenRCT2::Ui::Windows
 
         void onMouseDownSummary(WidgetIndex widgetIndex)
         {
-            auto& gameState = getGameState();
             switch (widgetIndex)
             {
                 case WIDX_LOAN_INCREASE:
                 {
                     // If loan can be increased, do so.
                     // If not, action shows error message.
-                    auto newLoan = gameState.park.bankLoan + 1000.00_GBP;
-                    if (gameState.park.bankLoan < gameState.park.maxBankLoan)
+                    auto newLoan = _parkData.bankLoan + 1000.00_GBP;
+                    if (_parkData.bankLoan < _parkData.maxBankLoan)
                     {
-                        newLoan = std::min(gameState.park.maxBankLoan, newLoan);
+                        newLoan = std::min(_parkData.maxBankLoan, newLoan);
                     }
                     auto gameAction = GameActions::ParkSetLoanAction(newLoan);
-                    GameActions::Execute(&gameAction, gameState);
+                    GameActions::Execute(&gameAction, getGameState());
                     break;
                 }
                 case WIDX_LOAN_DECREASE:
@@ -556,15 +558,15 @@ namespace OpenRCT2::Ui::Windows
                     // If loan is positive, decrease it.
                     // If loan is negative, action shows error message.
                     // If loan is exactly 0, prevent error message.
-                    if (gameState.park.bankLoan != 0)
+                    if (_parkData.bankLoan != 0)
                     {
-                        auto newLoan = gameState.park.bankLoan - 1000.00_GBP;
-                        if (gameState.park.bankLoan > 0)
+                        auto newLoan = _parkData.bankLoan - 1000.00_GBP;
+                        if (_parkData.bankLoan > 0)
                         {
                             newLoan = std::max(0.00_GBP, newLoan);
                         }
                         auto gameAction = GameActions::ParkSetLoanAction(newLoan);
-                        GameActions::Execute(&gameAction, gameState);
+                        GameActions::Execute(&gameAction, getGameState());
                     }
                     break;
                 }
@@ -616,17 +618,17 @@ namespace OpenRCT2::Ui::Windows
 
             // Loan and interest rate
             drawText(rt, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_LOAN);
-            if (!(gameState.park.flags & PARK_FLAGS_RCT1_INTEREST))
+            if (!(_parkData.flags & PARK_FLAGS_RCT1_INTEREST))
             {
                 auto ft = Formatter();
-                ft.Add<uint16_t>(gameState.park.bankLoanInterestRate);
+                ft.Add<uint16_t>(_parkData.bankLoanInterestRate);
                 drawText(rt, windowPos + ScreenCoordsXY{ 167, titleBarBottom + 265 }, STR_FINANCES_SUMMARY_AT_X_PER_YEAR, ft);
             }
 
             // Current cash
             auto ft = Formatter();
-            ft.Add<money64>(gameState.park.cash);
-            StringId stringId = gameState.park.cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
+            ft.Add<money64>(_parkData.cash);
+            StringId stringId = _parkData.cash >= 0 ? STR_CASH_LABEL : STR_CASH_NEGATIVE_LABEL;
             drawText(rt, windowPos + ScreenCoordsXY{ 8, titleBarBottom + 280 }, stringId, ft);
 
             // Objective related financial information
@@ -643,10 +645,10 @@ namespace OpenRCT2::Ui::Windows
             {
                 // Park value and company value
                 ft = Formatter();
-                ft.Add<money64>(gameState.park.value);
+                ft.Add<money64>(_parkData.value);
                 drawText(rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 265 }, STR_PARK_VALUE_LABEL, ft);
                 ft = Formatter();
-                ft.Add<money64>(gameState.park.companyValue);
+                ft.Add<money64>(_parkData.companyValue);
                 drawText(rt, windowPos + ScreenCoordsXY{ 280, titleBarBottom + 280 }, STR_COMPANY_VALUE_LABEL, ft);
             }
         }
@@ -875,9 +877,16 @@ namespace OpenRCT2::Ui::Windows
 
     static FinancesWindow* FinancesWindowOpen(uint8_t page)
     {
+        // TODO: find by class and number (park id)
         auto* windowMgr = GetWindowManager();
-        auto* window = windowMgr->FocusOrCreate<FinancesWindow>(
-            WindowClass::finances, kWindowSizeSummary, WindowFlag::higherContrastOnPress);
+        auto* window = reinterpret_cast<FinancesWindow*>(windowMgr->BringToFrontByClass(WindowClass::finances));
+        if (window == nullptr)
+        {
+            // TODO: get parkData from parameter (park id)
+            auto& parkData = getGameState().park;
+            window = windowMgr->Create<FinancesWindow>(
+                WindowClass::finances, kWindowSizeSummary, WindowFlag::higherContrastOnPress, parkData);
+        }
 
         if (window != nullptr && page != WINDOW_FINANCES_PAGE_SUMMARY)
             window->setPage(page);
@@ -887,9 +896,7 @@ namespace OpenRCT2::Ui::Windows
 
     WindowBase* FinancesOpen()
     {
-        auto* windowMgr = GetWindowManager();
-        return windowMgr->FocusOrCreate<FinancesWindow>(
-            WindowClass::finances, kWindowSizeSummary, WindowFlag::higherContrastOnPress);
+        return FinancesWindowOpen(WINDOW_FINANCES_PAGE_SUMMARY);
     }
 
     WindowBase* FinancesResearchOpen()

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -38,10 +38,12 @@
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/world/Park.h>
 
-using namespace OpenRCT2::Drawing;
-
 namespace OpenRCT2::Ui::Windows
 {
+    using namespace OpenRCT2::Drawing;
+
+    using Park::ParkData;
+
     static constexpr StringId kWindowTitle = kStringIdNone;
     static constexpr int32_t kWindowHeight = 224;
 
@@ -163,6 +165,7 @@ namespace OpenRCT2::Ui::Windows
 
     class ParkWindow final : public Window
     {
+    private:
         int32_t _numberOfStaff = -1;
         int32_t _numberOfRides = -1;
         uint8_t _peepAnimationFrame = 0;
@@ -173,7 +176,12 @@ namespace OpenRCT2::Ui::Windows
         ScreenRect _ratingGraphBounds;
         ScreenRect _guestGraphBounds;
 
+        ParkData& _parkData;
+
     public:
+        ParkWindow(ParkData& parkData)
+            : _parkData(parkData) {};
+
         void onOpen() override
         {
             number = 0;
@@ -181,7 +189,7 @@ namespace OpenRCT2::Ui::Windows
             _numberOfRides = -1;
             _numberOfStaff = -1;
             _peepAnimationFrame = 0;
-            setPage(0);
+            setPage(WINDOW_PARK_PAGE_ENTRANCE);
 
             _ratingProps.lineCol = colours[2];
             _guestProps.lineCol = colours[2];
@@ -494,9 +502,9 @@ namespace OpenRCT2::Ui::Windows
 
             SetPressedTab();
 
-            widgets[WIDX_TITLE].setString(gameState.park.name.c_str());
+            widgets[WIDX_TITLE].setString(_parkData.name.c_str());
             // Set open / close park button state
-            const bool parkIsOpen = Park::IsOpen(gameState.park);
+            const bool parkIsOpen = Park::IsOpen(_parkData);
             widgets[WIDX_OPEN_OR_CLOSE].image = ImageId(parkIsOpen ? SPR_OPEN : SPR_CLOSED);
             const auto closeLightImage = SPR_G2_RCT1_CLOSE_BUTTON_0 + !parkIsOpen * 2
                 + widgetIsPressed(*this, WIDX_CLOSE_LIGHT);
@@ -511,7 +519,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_OPEN_LIGHT, disableOpenClose);
 
             // only allow purchase of land when there is money
-            if (gameState.park.flags & PARK_FLAGS_NO_MONEY)
+            if (_parkData.flags & PARK_FLAGS_NO_MONEY)
                 widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::empty;
             else
                 widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::flatBtn;
@@ -595,12 +603,10 @@ namespace OpenRCT2::Ui::Windows
             if (page != WINDOW_PARK_PAGE_ENTRANCE)
                 return;
 
-            const auto& gameState = getGameState();
-
             std::optional<Focus> newFocus = std::nullopt;
-            if (!gameState.park.entrances.empty())
+            if (!_parkData.entrances.empty())
             {
-                const auto& entrance = gameState.park.entrances[0];
+                const auto& entrance = _parkData.entrances[0];
                 newFocus = Focus(CoordsXYZ{ entrance.x + 16, entrance.y + 16, entrance.z + 32 });
             }
 
@@ -735,8 +741,7 @@ namespace OpenRCT2::Ui::Windows
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
 
-            const auto& gameState = getGameState();
-            _guestProps.series = gameState.park.guestsInParkHistory;
+            _guestProps.series = _parkData.guestsInParkHistory;
             const Widget* background = &widgets[WIDX_PAGE_BACKGROUND];
             _guestGraphBounds = { windowPos + ScreenCoordsXY{ background->left + 4, background->top + 15 },
                                   windowPos + ScreenCoordsXY{ background->right - 4, background->bottom - 4 } };
@@ -744,9 +749,9 @@ namespace OpenRCT2::Ui::Windows
             // Calculate Y axis max and min
             _guestProps.min = 0;
             _guestProps.max = 5000;
-            for (size_t i = 0; i < std::size(gameState.park.guestsInParkHistory); i++)
+            for (size_t i = 0; i < std::size(_parkData.guestsInParkHistory); i++)
             {
-                auto value = gameState.park.guestsInParkHistory[i];
+                auto value = _parkData.guestsInParkHistory[i];
                 if (value == kGuestsInParkHistoryUndefined)
                     continue;
                 while (value > _guestProps.max)
@@ -800,20 +805,20 @@ namespace OpenRCT2::Ui::Windows
         void onMouseDownPrice(WidgetIndex widgetIndex)
         {
             auto& gameState = getGameState();
-            auto& park = gameState.park;
+            auto& park = _parkData;
 
             switch (widgetIndex)
             {
                 case WIDX_INCREASE_PRICE:
                 {
-                    const auto newFee = std::min(kMaxEntranceFee, gameState.park.entranceFee + 1.00_GBP);
+                    const auto newFee = std::min(kMaxEntranceFee, _parkData.entranceFee + 1.00_GBP);
                     auto gameAction = GameActions::ParkSetEntranceFeeAction(newFee);
                     GameActions::Execute(&gameAction, gameState);
                     break;
                 }
                 case WIDX_DECREASE_PRICE:
                 {
-                    const auto newFee = std::max(0.00_GBP, gameState.park.entranceFee - 1.00_GBP);
+                    const auto newFee = std::max(0.00_GBP, _parkData.entranceFee - 1.00_GBP);
                     auto gameAction = GameActions::ParkSetEntranceFeeAction(newFee);
                     GameActions::Execute(&gameAction, gameState);
                     break;
@@ -938,9 +943,8 @@ namespace OpenRCT2::Ui::Windows
             auto screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PAGE_BACKGROUND].left + 4, widgets[WIDX_PAGE_BACKGROUND].top + 4 };
 
-            auto& gameState = getGameState();
             // Draw park size
-            auto parkSize = gameState.park.size * 10;
+            auto parkSize = _parkData.size * 10;
             auto stringIndex = STR_PARK_SIZE_METRIC_LABEL;
             if (Config::Get().general.measurementFormat == MeasurementFormat::Imperial)
             {
@@ -972,12 +976,12 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw number of guests in park
             ft = Formatter();
-            ft.Add<uint32_t>(gameState.park.numGuestsInPark);
+            ft.Add<uint32_t>(_parkData.numGuestsInPark);
             drawText(rt, screenCoords, STR_GUESTS_IN_PARK_LABEL, ft);
             screenCoords.y += kListRowHeight;
 
             ft = Formatter();
-            ft.Add<uint32_t>(gameState.park.totalAdmissions);
+            ft.Add<uint32_t>(_parkData.totalAdmissions);
             drawText(rt, screenCoords, STR_TOTAL_ADMISSIONS, ft);
         }
 #pragma endregion
@@ -1281,9 +1285,17 @@ namespace OpenRCT2::Ui::Windows
 
     static ParkWindow* ParkWindowOpen(uint8_t page)
     {
+        // TODO: find by class and number (park id)
         auto* windowMgr = GetWindowManager();
-        auto* wnd = windowMgr->FocusOrCreate<ParkWindow>(
-            WindowClass::parkInformation, { 230, 174 + 9 }, WindowFlag::higherContrastOnPress);
+        auto* wnd = reinterpret_cast<ParkWindow*>(windowMgr->BringToFrontByClass(WindowClass::parkInformation));
+        if (wnd == nullptr)
+        {
+            // TODO: get parkData from parameter (park id)
+            auto& parkData = getGameState().park;
+            wnd = windowMgr->Create<ParkWindow>(
+                WindowClass::parkInformation, { 230, 174 + 9 }, WindowFlag::higherContrastOnPress, parkData);
+        }
+
         if (wnd != nullptr && page != WINDOW_PARK_PAGE_ENTRANCE)
         {
             wnd->onMouseUp(WIDX_TAB_1 + page);


### PR DESCRIPTION
This changes the Park and Finances windows to hold a ParkData ref in an internal property. This is working towards potentially having more than one park in the game concurrently.

I'm thinking the windows themselves should probably store the park id as the window number as well, to differentiate open park windows for unique parks. At present, there is no `ParkId` type in develop yet, so I have omitted this, leaving a TODO note for now.