### PR TITLE
fix result.position.z of WallPlaceAction

### DIFF
--- a/src/openrct2/actions/scenery/WallPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/WallPlaceAction.cpp
@@ -84,11 +84,6 @@ namespace OpenRCT2::GameActions
         res.position.x += 16;
         res.position.y += 16;
 
-        if (_loc.z == 0)
-        {
-            res.position.z = TileElementHeight(res.position);
-        }
-
         if (!LocationValid(_loc))
         {
             return Result(Status::invalidParameters, STR_CANT_BUILD_THIS_HERE, STR_OFF_EDGE_OF_MAP);
@@ -141,6 +136,7 @@ namespace OpenRCT2::GameActions
                 edgeSlope &= ~EDGE_SLOPE_ELEVATED;
             }
         }
+        res.position.z = targetHeight;
 
         auto* surfaceElement = MapGetSurfaceElementAt(_loc);
         if (surfaceElement == nullptr)
@@ -286,11 +282,6 @@ namespace OpenRCT2::GameActions
         res.position.x += 16;
         res.position.y += 16;
 
-        if (res.position.z == 0)
-        {
-            res.position.z = TileElementHeight(res.position);
-        }
-
         uint8_t edgeSlope = 0;
         auto targetHeight = _loc.z;
         if (targetHeight == 0)
@@ -311,6 +302,7 @@ namespace OpenRCT2::GameActions
                 edgeSlope &= ~EDGE_SLOPE_ELEVATED;
             }
         }
+        res.position.z = targetHeight;
         auto targetLoc = CoordsXYZ(_loc, targetHeight);
 
         auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(_wallType);


### PR DESCRIPTION
If WallPlaceAction does not have a `z` parameter (more precisely it is zero, and it means that it should be placed on top of the surface element), `result.position.z` of WallPlaceAction is calculated as `TileElementHeight(res.position)` which returns the height of the southwest corner (i.e. the default one, index 0) of the surface element. This can of course not be correct in all cases since wall elements placed on top of surface elements can be at different heights on the same tile, if the surface is sloped.
Later in query/execute, the actual height of the wall element is calculated, which this PR uses to set `result.position.z`.