### PR TITLE
Fix widget state regressions from #26443

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2079,7 +2079,7 @@ namespace OpenRCT2::Ui::Windows
                                          WIDX_BANKING_GROUPBOX, WIDX_CONSTRUCT, WIDX_DEMOLISH, WIDX_PREVIOUS_SECTION,
                                          WIDX_NEXT_SECTION, WIDX_ENTRANCE_EXIT_GROUPBOX, WIDX_ENTRANCE, WIDX_EXIT })
             {
-                if (isWidgetPressed(preservedIndex))
+                if (widgets[preservedIndex].flags.has(WidgetFlag::isPressed))
                     newPressedWidgets |= (1uLL << preservedIndex);
             }
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -474,16 +474,21 @@ namespace OpenRCT2::Ui::Windows
         ViewportInteractionItem::footpath, ViewportInteractionItem::pathAddition, ViewportInteractionItem::parkEntrance,
         ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery, ViewportInteractionItem::banner);
 
+    static constexpr WidgetIndex kDisabledWidgetsDefault[] = {
+        WIDX_BUTTON_MOVE_UP, WIDX_BUTTON_MOVE_DOWN, WIDX_BUTTON_REMOVE, WIDX_BUTTON_ROTATE, WIDX_BUTTON_COPY,
+    };
+    static constexpr WidgetIndex kDisabledWidgetsLargeScenery[] = { WIDX_BUTTON_ROTATE };
+
     // clang-format off
-    static constexpr std::initializer_list<WidgetIndex> kDisabledWidgetsByPage[] = {
-        { WIDX_BUTTON_MOVE_UP, WIDX_BUTTON_MOVE_DOWN, WIDX_BUTTON_REMOVE, WIDX_BUTTON_ROTATE, WIDX_BUTTON_COPY },
+    static constexpr std::span<const WidgetIndex> kDisabledWidgetsByPage[] = {
+        kDisabledWidgetsDefault,
         {},
         {},
         {},
         {},
         {},
         {},
-        { WIDX_BUTTON_ROTATE },
+        kDisabledWidgetsLargeScenery,
         {},
     };
     // clang-format on


### PR DESCRIPTION
Had a quick look on the road, unfortunately can't look into testing whether this fixes it until Thursday

- Stop latching the persistent isPressed flag onto holdable RideConstruction buttons by reading the raw flag
- Replace TileInspector's namespace-scope std::initializer_list disabled-widgets table