### PR TITLE
Introduce MapRangeView iterator class

### DIFF
--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -685,6 +685,7 @@
     <ClInclude Include="world\Map.h" />
     <ClInclude Include="world\MapAnimation.h" />
     <ClInclude Include="world\MapLimits.h" />
+    <ClInclude Include="world\MapRangeView.hpp" />
     <ClInclude Include="world\MapSelection.h" />
     <ClInclude Include="world\Park.h" />
     <ClInclude Include="world\ParkData.h" />
@@ -1244,6 +1245,7 @@
     <ClCompile Include="world\Footpath.cpp" />
     <ClCompile Include="world\Map.cpp" />
     <ClCompile Include="world\MapAnimation.cpp" />
+    <ClCompile Include="world\MapRangeView.cpp" />
     <ClCompile Include="world\MapSelection.cpp" />
     <ClCompile Include="world\Park.cpp" />
     <ClCompile Include="world\QuarterTile.cpp" />

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -45,6 +45,7 @@
 #include "../ride/TrackData.h"
 #include "../ride/TrackDesign.h"
 #include "../windows/Intent.h"
+#include "../world/MapRangeView.hpp"
 #include "../world/TilePointerIndex.hpp"
 #include "Banner.h"
 #include "Entrance.h"
@@ -941,29 +942,22 @@ namespace OpenRCT2
 
     uint8_t MapGetLowestLandHeight(const MapRange& range)
     {
-        auto mapSizeMax = GetMapSizeMaxXY();
-        MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
-                                std::min(range.GetY2(), mapSizeMax.y) };
-
         uint8_t minHeight = 0xFF;
-        for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
+        for (auto tileCoords : Map::getDrawableTileRange())
         {
-            for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
+            auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);
+
+            if (surfaceElement != nullptr && minHeight > surfaceElement->baseHeight)
             {
-                auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
-
-                if (surfaceElement != nullptr && minHeight > surfaceElement->baseHeight)
+                if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
                 {
-                    if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+                    if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
                     {
-                        if (!MapIsLocationInPark(CoordsXY{ xi, yi }))
-                        {
-                            continue;
-                        }
+                        continue;
                     }
-
-                    minHeight = surfaceElement->baseHeight;
                 }
+
+                minHeight = surfaceElement->baseHeight;
             }
         }
         return minHeight;
@@ -971,34 +965,27 @@ namespace OpenRCT2
 
     uint8_t MapGetHighestLandHeight(const MapRange& range)
     {
-        auto mapSizeMax = GetMapSizeMaxXY();
-        MapRange validRange = { std::max(range.GetX1(), 32), std::max(range.GetY1(), 32), std::min(range.GetX2(), mapSizeMax.x),
-                                std::min(range.GetY2(), mapSizeMax.y) };
-
-        uint8_t maxHeight = 0;
-        for (int32_t yi = validRange.GetY1(); yi <= validRange.GetY2(); yi += kCoordsXYStep)
+        uint8_t maxHeight = 0xFF;
+        for (auto tileCoords : Map::getDrawableTileRange())
         {
-            for (int32_t xi = validRange.GetX1(); xi <= validRange.GetX2(); xi += kCoordsXYStep)
+            auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);
+            if (surfaceElement != nullptr)
             {
-                auto* surfaceElement = MapGetSurfaceElementAt(CoordsXY{ xi, yi });
-                if (surfaceElement != nullptr)
+                if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
                 {
-                    if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+                    if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
                     {
-                        if (!MapIsLocationInPark(CoordsXY{ xi, yi }))
-                        {
-                            continue;
-                        }
+                        continue;
                     }
-
-                    uint8_t BaseHeight = surfaceElement->baseHeight;
-                    if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
-                        BaseHeight += 2;
-                    if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
-                        BaseHeight += 2;
-                    if (maxHeight < BaseHeight)
-                        maxHeight = BaseHeight;
                 }
+
+                uint8_t BaseHeight = surfaceElement->baseHeight;
+                if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
+                    BaseHeight += 2;
+                if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
+                    BaseHeight += 2;
+                if (maxHeight < BaseHeight)
+                    maxHeight = BaseHeight;
             }
         }
         return maxHeight;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -946,19 +946,16 @@ namespace OpenRCT2
         for (auto tileCoords : Map::getDrawableTileRange())
         {
             auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);
+            if (surfaceElement == nullptr || minHeight <= surfaceElement->baseHeight)
+                continue;
 
-            if (surfaceElement != nullptr && minHeight > surfaceElement->baseHeight)
-            {
-                if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
-                {
-                    if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
-                    {
-                        continue;
-                    }
-                }
+            if (gLegacyScene == LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+                continue;
 
-                minHeight = surfaceElement->baseHeight;
-            }
+            if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
+                continue;
+
+            minHeight = surfaceElement->baseHeight;
         }
         return minHeight;
     }
@@ -969,24 +966,23 @@ namespace OpenRCT2
         for (auto tileCoords : Map::getDrawableTileRange())
         {
             auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);
-            if (surfaceElement != nullptr)
-            {
-                if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
-                {
-                    if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
-                    {
-                        continue;
-                    }
-                }
+            if (surfaceElement == nullptr)
+                continue;
 
-                uint8_t BaseHeight = surfaceElement->baseHeight;
-                if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
-                    BaseHeight += 2;
-                if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
-                    BaseHeight += 2;
-                if (maxHeight < BaseHeight)
-                    maxHeight = BaseHeight;
-            }
+            if (gLegacyScene == LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+                continue;
+
+            if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
+                continue;
+
+            uint8_t height = surfaceElement->baseHeight;
+            if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)
+                height += 2;
+            if (surfaceElement->GetSlope() & kTileSlopeDiagonalFlag)
+                height += 2;
+
+            if (maxHeight < height)
+                maxHeight = height;
         }
         return maxHeight;
     }

--- a/src/openrct2/world/MapRangeView.cpp
+++ b/src/openrct2/world/MapRangeView.cpp
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "MapRangeView.hpp"
+
+#include "../GameState.h"
+
+namespace OpenRCT2::Map
+{
+    MapRangeView getClampedRange(const TileCoordsXY& posA, const TileCoordsXY& posB)
+    {
+        constexpr auto clampTileCoord = [](int32_t coord, int32_t numTiles) -> int32_t {
+            return std::clamp<int32_t>(coord, 0, numTiles - 1);
+        };
+
+        auto mapSize = getGameState().mapSize;
+        auto clampedA = TileCoordsXY(clampTileCoord(posA.x, mapSize.x), clampTileCoord(posA.y, mapSize.y));
+        auto clampedB = TileCoordsXY(clampTileCoord(posB.x, mapSize.x), clampTileCoord(posB.y, mapSize.y));
+        return MapRangeView(clampedA, clampedB);
+    }
+
+    MapRangeView getClampedRange(const CoordsXY& posA, const CoordsXY& posB)
+    {
+        constexpr auto clampCoord = [](int32_t coord, int32_t numTiles) -> int32_t {
+            return std::clamp<int32_t>(coord, 0, (numTiles * kCoordsXYStep) - 1);
+        };
+
+        auto mapSize = getGameState().mapSize;
+        auto clampedA = CoordsXY(clampCoord(posA.x, mapSize.x), clampCoord(posA.y, mapSize.y));
+        auto clampedB = CoordsXY(clampCoord(posB.x, mapSize.x), clampCoord(posB.y, mapSize.y));
+        return MapRangeView(TileCoordsXY(clampedA), TileCoordsXY(clampedB));
+    }
+
+    MapRangeView getClampedRange(const MapRange& range)
+    {
+        return getClampedRange(range.Point1, range.Point2);
+    }
+
+    MapRangeView getDrawableTileRange()
+    {
+        auto mapSize = getGameState().mapSize;
+        return MapRangeView({ 1, 1 }, { mapSize.x - 2, mapSize.y - 2 });
+    }
+
+    MapRangeView getWorldRange()
+    {
+        auto mapSize = getGameState().mapSize;
+        return MapRangeView({ 0, 0 }, { mapSize.x - 1, mapSize.y - 1 });
+    }
+} // namespace OpenRCT2::Map

--- a/src/openrct2/world/MapRangeView.hpp
+++ b/src/openrct2/world/MapRangeView.hpp
@@ -1,0 +1,103 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "Location.hpp"
+
+#include <iterator>
+
+namespace OpenRCT2::Map
+{
+    // Loops over a range from bottomLeft to topRight inclusive
+    struct MapRangeView
+    {
+    private:
+        TileCoordsXY _bottomLeft;
+        TileCoordsXY _topRight;
+
+        class Iterator
+        {
+        private:
+            const TileCoordsXY _bottomLeft;
+            const TileCoordsXY _topRight;
+            TileCoordsXY _pos;
+
+        public:
+            Iterator(const TileCoordsXY& bottomLeft, const TileCoordsXY& topRight)
+                : _bottomLeft(bottomLeft)
+                , _topRight(topRight)
+                , _pos(bottomLeft)
+            {
+            }
+
+            Iterator& operator++()
+            {
+                if (_pos.x >= _topRight.x)
+                {
+                    _pos.x = _bottomLeft.x;
+                    _pos.y++;
+                }
+                else
+                {
+                    _pos.x++;
+                }
+                return *this;
+            }
+
+            Iterator operator++(int)
+            {
+                Iterator retval = *this;
+                ++(*this);
+                return retval;
+            }
+
+            bool operator==(const Iterator& other) const
+            {
+                return _pos == other._pos;
+            }
+
+            const TileCoordsXY& operator*()
+            {
+                return _pos;
+            }
+            // iterator traits
+            using difference_type = std::ptrdiff_t;
+            using value_type = const TileCoordsXY;
+            using pointer = TileCoordsXY*;
+            using reference = const TileCoordsXY&;
+            using iterator_category = std::forward_iterator_tag;
+        };
+
+    public:
+        MapRangeView(const TileCoordsXY& bottomLeft, const TileCoordsXY& topRight)
+            : _bottomLeft(bottomLeft)
+            , _topRight(topRight)
+        {
+            assert(bottomLeft.x <= topRight.x);
+            assert(bottomLeft.y <= topRight.y);
+        }
+
+        Iterator begin() const
+        {
+            return Iterator(_bottomLeft, _topRight);
+        }
+        Iterator end() const
+        {
+            // End iterator must be 1 step past the end so that loop is inclusive
+            return Iterator(TileCoordsXY(_bottomLeft.x, _topRight.y + 1), _topRight);
+        }
+    };
+
+    MapRangeView getClampedRange(const TileCoordsXY& posA, const TileCoordsXY& posB);
+    MapRangeView getClampedRange(const CoordsXY& posA, const CoordsXY& posB);
+    MapRangeView getClampedRange(const MapRange& range);
+    MapRangeView getDrawableTileRange();
+    MapRangeView getWorldRange();
+} // namespace OpenRCT2::Map


### PR DESCRIPTION
This is an effort to allow tile-based iteration over the entire map without having to write Y/X for loops. This is intended to replace pointer-based iteration inherited from the C days.

Primarily written for #26467. However, I have applied `MapRangeView` to the `MapGetLowestLandHeight` and `MapgetHighestLandHeight` functions as well, cleaning them up nicely.