### PR TITLE
Add station style whitelist to prepare for split

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#24879] [Plugin] Add methods for showing and hiding gridlines.
 - Improved: [#26374] Add higher resolution app icons for Android.
 - Improved: [#26386] Initial window scale and toolbar options on fresh Android installations.
+- Change: [#26476] Limit creation of new station styles to prepare for more flexibility with ride stations and entrances.
 - Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don‘t draw in tunnels at some angles (original bug).
 - Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
 - Fix: [#26287] Game crashes upon connect/disconnect of physical keyboard. 

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -18,6 +18,35 @@
 
 namespace OpenRCT2
 {
+    constexpr std::array kAllowedStationIDs = std::to_array<u8string_view>({
+        "rct2.station.abstract",
+        "rct2.station.canvas_tent",
+        "rct2.station.castle_brown",
+        "rct2.station.castle_grey",
+        "rct2.station.classical",
+        "rct2.station.jungle",
+        "rct2.station.log",
+        "rct2.station.pagoda",
+        "rct2.station.plain",
+        "rct2.station.snow",
+        "rct2.station.space",
+        "rct2.station.wooden",
+        "openrct2.station.noentrance",
+        "openrct2.station.noplatformnoentrance",
+        "tygrysek90.station.abstract_open",
+        "tygrysek90.station.canvas_tent_open",
+        "tygrysek90.station.castle_brown_open",
+        "tygrysek90.station.castle_grey",
+        "tygrysek90.station.castle_grey_open",
+        "tygrysek90.station.classical_open",
+        "tygrysek90.station.jungle_open",
+        "tygrysek90.station.log_open",
+        "tygrysek90.station.pagoda_open",
+        "tygrysek90.station.snow_open",
+        "tygrysek90.station.space_open",
+        "tygrysek90.station.wooden_open",
+    });
+
     void StationObject::Load()
     {
         GetStringTable().Sort();
@@ -114,9 +143,24 @@ namespace OpenRCT2
         }
     }
 
+    static bool isKnownStationStyle(u8string_view identifier)
+    {
+        for (const auto& entry : kAllowedStationIDs)
+        {
+            if (entry == identifier)
+                return true;
+        }
+
+        return false;
+    }
+
     void StationObject::ReadJson(IReadObjectContext* context, json_t& root)
     {
         Guard::Assert(root.is_object(), "StationObject::ReadJson expects parameter root to be object");
+        if (!isKnownStationStyle(GetIdentifier()))
+        {
+            throw std::runtime_error("Unknown station style");
+        }
 
         auto properties = root["properties"];
 


### PR DESCRIPTION
Discussed with Aaron earlier. Makes sure no new station styles get created and allows preparing a clean split.