### PR TITLE
Improve Android fullscreen sizing and safe areas

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -218,7 +218,6 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Cory Sanin (CorySanin)
 * Vinícius Hashimoto (vkhashimoto)
 * Gal B. (GalBr)
-* Gareth Hubball (londospark)
 * Rik Smeets (rik-smeets)
 * Charles Machalow (csm10495)
 * Alexander Czarnecki (alcz/zuczek4793)
@@ -261,6 +260,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Jonas Doggart
 * (pg805)
 * Sjoerd de Bruin (sjoerddebruin)
+* Gareth Hubball (londospark)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/contributors.md
+++ b/contributors.md
@@ -218,6 +218,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Cory Sanin (CorySanin)
 * Vinícius Hashimoto (vkhashimoto)
 * Gal B. (GalBr)
+* Gareth Hubball (londospark)
 * Rik Smeets (rik-smeets)
 * Charles Machalow (csm10495)
 * Alexander Czarnecki (alcz/zuczek4793)

--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -32,9 +32,9 @@
         </activity>
         <activity
             android:name=".GameActivity"
-            android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
-            android:screenOrientation="landscape"
+            android:configChanges="density|keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:preferMinimalPostProcessing="true"
+            android:resizeableActivity="true"
             >
 
         </activity>

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -20,6 +20,10 @@ public class GameActivity extends SDLActivity {
 
     private static native void nativeSetSafeAreaInsets(int left, int top, int right, int bottom);
 
+    public float getDefaultScale() {
+        return getResources().getDisplayMetrics().density;
+    }
+
     private void updateSafeAreaInsets(WindowInsets windowInsets) {
         int left = 0;
         int top = 0;

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -1,11 +1,16 @@
 package io.openrct2;
 
 import android.annotation.SuppressLint;
+import android.content.res.Configuration;
 import android.icu.util.Currency;
 import android.icu.util.LocaleData;
 import android.icu.util.ULocale;
 import android.os.Build;
+import android.os.Bundle;
+import android.view.DisplayCutout;
+import android.view.RoundedCorner;
 import android.view.View;
+import android.view.WindowInsets;
 
 import org.libsdl.app.SDLActivity;
 
@@ -13,8 +18,78 @@ import java.util.Locale;
 
 public class GameActivity extends SDLActivity {
 
-    public float getDefaultScale() {
-        return getResources().getDisplayMetrics().density;
+    private static native void nativeSetSafeAreaInsets(int left, int top, int right, int bottom);
+
+    private void updateSafeAreaInsets(WindowInsets windowInsets) {
+        int left = 0;
+        int top = 0;
+        int right = 0;
+        int bottom = 0;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            DisplayCutout displayCutout = windowInsets.getDisplayCutout();
+            if (displayCutout != null) {
+                left = Math.max(left, displayCutout.getSafeInsetLeft());
+                top = Math.max(top, displayCutout.getSafeInsetTop());
+                right = Math.max(right, displayCutout.getSafeInsetRight());
+                bottom = Math.max(bottom, displayCutout.getSafeInsetBottom());
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            RoundedCorner topLeft = windowInsets.getRoundedCorner(RoundedCorner.POSITION_TOP_LEFT);
+            RoundedCorner topRight = windowInsets.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT);
+            RoundedCorner bottomLeft = windowInsets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT);
+            RoundedCorner bottomRight = windowInsets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT);
+
+            if (topLeft != null) {
+                left = Math.max(left, topLeft.getRadius());
+                top = Math.max(top, topLeft.getRadius());
+            }
+            if (topRight != null) {
+                right = Math.max(right, topRight.getRadius());
+                top = Math.max(top, topRight.getRadius());
+            }
+            if (bottomLeft != null) {
+                left = Math.max(left, bottomLeft.getRadius());
+                bottom = Math.max(bottom, bottomLeft.getRadius());
+            }
+            if (bottomRight != null) {
+                right = Math.max(right, bottomRight.getRadius());
+                bottom = Math.max(bottom, bottomRight.getRadius());
+            }
+        }
+
+        nativeSetSafeAreaInsets(left, top, right, bottom);
+    }
+
+    private void configureSafeAreaHandling() {
+        if (mLayout == null) {
+            return;
+        }
+
+        mLayout.setOnApplyWindowInsetsListener((view, windowInsets) -> {
+            updateSafeAreaInsets(windowInsets);
+            return windowInsets;
+        });
+        mLayout.requestApplyInsets();
+    }
+
+    private void applyImmersiveMode() {
+        getWindow().getDecorView().setSystemUiVisibility(
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+            | View.SYSTEM_UI_FLAG_FULLSCREEN
+            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+            | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+        );
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        configureSafeAreaHandling();
     }
 
     @SuppressLint("ObsoleteSdkInt")
@@ -96,14 +171,22 @@ public class GameActivity extends SDLActivity {
 
         // Set app to fullscreen mode
         if (hasFocus) {
-            getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                | View.SYSTEM_UI_FLAG_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-            );
+            applyImmersiveMode();
+            if (mLayout != null) {
+                mLayout.requestApplyInsets();
+            }
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        if (hasWindowFocus()) {
+            applyImmersiveMode();
+            if (mLayout != null) {
+                mLayout.requestApplyInsets();
+            }
         }
     }
 

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -359,8 +359,8 @@ public:
                     break;
                 case SDL_WINDOWEVENT:
                 {
-                    const bool isResizeEvent
-                        = e.window.event == SDL_WINDOWEVENT_RESIZED || e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED;
+                    const bool isResizeEvent = e.window.event == SDL_WINDOWEVENT_RESIZED
+                        || e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED;
                     if (isResizeEvent)
                     {
                         LOG_VERBOSE("New Window size: %ux%u\n", e.window.data1, e.window.data2);

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -358,7 +358,10 @@ public:
                     ContextQuit();
                     break;
                 case SDL_WINDOWEVENT:
-                    if (e.window.event == SDL_WINDOWEVENT_RESIZED)
+                {
+                    const bool isResizeEvent
+                        = e.window.event == SDL_WINDOWEVENT_RESIZED || e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED;
+                    if (isResizeEvent)
                     {
                         LOG_VERBOSE("New Window size: %ux%u\n", e.window.data1, e.window.data2);
                         OnResize(e.window.data1, e.window.data2);
@@ -366,6 +369,7 @@ public:
 
                     switch (e.window.event)
                     {
+                        case SDL_WINDOWEVENT_SIZE_CHANGED:
                         case SDL_WINDOWEVENT_RESIZED:
                         case SDL_WINDOWEVENT_MOVED:
                         case SDL_WINDOWEVENT_MAXIMIZED:
@@ -394,6 +398,7 @@ public:
                         }
                     }
                     break;
+                }
                 case SDL_MOUSEMOTION:
                     _cursorState.position = { static_cast<int32_t>(e.motion.x / Config::Get().general.windowScale),
                                               static_cast<int32_t>(e.motion.y / Config::Get().general.windowScale) };
@@ -828,6 +833,8 @@ private:
         SDL_SetWindowMinimumSize(_window, 720, 480);
         SetCursorTrap(Config::Get().general.trapCursor);
         _platformUiContext->SetWindowIcon(_window);
+
+        SDL_GetWindowSize(_window, &width, &height);
 
         // Initialise the surface, palette and draw buffer
         DrawingEngineInit();

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -173,6 +173,8 @@ public:
         uint32_t format;
         SDL_QueryTexture(_screenTexture, &format, nullptr, nullptr, nullptr);
         _screenTextureFormat = SDL_AllocFormat(format);
+        SDL_RenderSetScale(_sdlRenderer, 1.0f, 1.0f);
+        SDL_RenderSetViewport(_sdlRenderer, nullptr);
 
         X8DrawingEngine::Resize(width, height);
     }

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -63,7 +63,6 @@ namespace OpenRCT2::Ui::Windows
             ScreenCoordsXY(
                 ContextGetWidth() - Platform::GetSafeAreaInsetRight() - kWindowSize.width,
                 ContextGetHeight() - Platform::GetSafeAreaInsetBottom() - kWindowSize.height),
-            kWindowSize,
-            { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
+            kWindowSize, { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -11,6 +11,7 @@
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
 #include <openrct2/SpriteIds.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/ui/WindowManager.h>
 
 namespace OpenRCT2::Ui::Windows
@@ -58,7 +59,11 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         return windowMgr->Create<TitleExitWindow>(
-            WindowClass::titleExit, ScreenCoordsXY(ContextGetWidth() - 40, ContextGetHeight() - 64), kWindowSize,
+            WindowClass::titleExit,
+            ScreenCoordsXY(
+                ContextGetWidth() - Platform::GetSafeAreaInsetRight() - kWindowSize.width,
+                ContextGetHeight() - Platform::GetSafeAreaInsetBottom() - kWindowSize.height),
+            kWindowSize,
             { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
     }
 } // namespace OpenRCT2::Ui::Windows

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -12,6 +12,7 @@
 #include <openrct2/SpriteIds.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/interface/ColourWithFlags.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/ui/WindowManager.h>
 
 namespace OpenRCT2::Ui::Windows
@@ -71,7 +72,8 @@ namespace OpenRCT2::Ui::Windows
         if (window == nullptr)
         {
             window = windowMgr->Create<TitleLogoWindow>(
-                WindowClass::titleLogo, ScreenCoordsXY(0, 0), kWindowSize,
+                WindowClass::titleLogo,
+                ScreenCoordsXY(Platform::GetSafeAreaInsetLeft(), Platform::GetSafeAreaInsetTop()), kWindowSize,
                 { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
         }
         return window;

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -72,9 +72,8 @@ namespace OpenRCT2::Ui::Windows
         if (window == nullptr)
         {
             window = windowMgr->Create<TitleLogoWindow>(
-                WindowClass::titleLogo,
-                ScreenCoordsXY(Platform::GetSafeAreaInsetLeft(), Platform::GetSafeAreaInsetTop()), kWindowSize,
-                { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
+                WindowClass::titleLogo, ScreenCoordsXY(Platform::GetSafeAreaInsetLeft(), Platform::GetSafeAreaInsetTop()),
+                kWindowSize, { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
         }
         return window;
     }

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -63,8 +63,7 @@ namespace OpenRCT2::Ui::Windows
                 WindowClass::titleOptions,
                 ScreenCoordsXY(
                     ContextGetWidth() - Platform::GetSafeAreaInsetRight() - kWindowSize.width, Platform::GetSafeAreaInsetTop()),
-                kWindowSize,
-                { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
+                kWindowSize, { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
         }
 
         return window;

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -10,6 +10,7 @@
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/ui/WindowManager.h>
 
 namespace OpenRCT2::Ui::Windows
@@ -59,7 +60,10 @@ namespace OpenRCT2::Ui::Windows
         if (window == nullptr)
         {
             window = windowMgr->Create<TitleOptionsWindow>(
-                WindowClass::titleOptions, ScreenCoordsXY(ContextGetWidth() - 80, 0), kWindowSize,
+                WindowClass::titleOptions,
+                ScreenCoordsXY(
+                    ContextGetWidth() - Platform::GetSafeAreaInsetRight() - kWindowSize.width, Platform::GetSafeAreaInsetTop()),
+                kWindowSize,
                 { WindowFlag::stickToBack, WindowFlag::transparent, WindowFlag::noTitleBar });
         }
 

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -44,6 +44,7 @@
 #include <openrct2/interface/Screenshot.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/Network.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
@@ -1315,22 +1316,29 @@ namespace OpenRCT2::Ui::Windows
 
         void AlignButtonsLeftRight()
         {
+            const auto safeAreaInsetLeft = Platform::GetSafeAreaInsetLeft();
+            const auto safeAreaInsetRight = Platform::GetSafeAreaInsetRight();
+
             // Align left hand side toolbar buttons
-            AlignButtons(kWidgetOrderLeftGroup, 0);
+            AlignButtons(kWidgetOrderLeftGroup, safeAreaInsetLeft);
 
             // Align right hand side toolbar buttons
             auto totalWidth = GetToolbarWidth(kWidgetOrderRightGroup);
-            auto xPos = ContextGetWidth() - totalWidth;
+            auto xPos = ContextGetWidth() - safeAreaInsetRight - totalWidth;
             AlignButtons(kWidgetOrderRightGroup, xPos);
         }
 
         void AlignButtonsCentre()
         {
+            const auto safeAreaInsetLeft = Platform::GetSafeAreaInsetLeft();
+            const auto safeAreaInsetRight = Platform::GetSafeAreaInsetRight();
+
             // First, we figure out how much space we'll be needing
             auto totalWidth = GetToolbarWidth(kWidgetOrderCombined);
 
             // We'll start from the centre of the UI...
-            auto xPos = (ContextGetWidth() - totalWidth) / 2;
+            auto safeAreaWidth = ContextGetWidth() - safeAreaInsetLeft - safeAreaInsetRight;
+            auto xPos = safeAreaInsetLeft + (safeAreaWidth - totalWidth) / 2;
 
             // And finally, align the buttons in the centre
             AlignButtons(kWidgetOrderCombined, xPos);

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -205,7 +205,8 @@ namespace OpenRCT2::Platform
             auto assetManager = static_cast<AAssetManager*>(GetAssetManager());
             if (assetManager != nullptr)
             {
-                std::string assetPath = NormalizeAssetPath(std::string(path).substr(Platform::kAndroidAssetPathPrefix.length()));
+                std::string assetPath = NormalizeAssetPath(
+                    std::string(path).substr(Platform::kAndroidAssetPathPrefix.length()));
                 auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_UNKNOWN);
                 if (asset != nullptr)
                 {

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -175,12 +175,6 @@ namespace OpenRCT2::Platform
         return {};
     }
 
-    static std::string NormalizeAssetPath(std::string path)
-    {
-        std::replace(path.begin(), path.end(), '\\', '/');
-        return path;
-    }
-
     uint64_t GetLastModified(std::string_view path)
     {
         if (String::startsWith(path, Platform::kAndroidAssetPathPrefix))
@@ -205,8 +199,7 @@ namespace OpenRCT2::Platform
             auto assetManager = static_cast<AAssetManager*>(GetAssetManager());
             if (assetManager != nullptr)
             {
-                std::string assetPath = NormalizeAssetPath(
-                    std::string(path).substr(Platform::kAndroidAssetPathPrefix.length()));
+                std::string assetPath = std::string(path).substr(Platform::kAndroidAssetPathPrefix.length());
                 auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_UNKNOWN);
                 if (asset != nullptr)
                 {
@@ -242,7 +235,18 @@ namespace OpenRCT2::Platform
 
     float GetDefaultScale()
     {
-        return 1.5f;
+        JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
+
+        jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+        jclass activityClass = env->GetObjectClass(activity);
+        jmethodID getDefaultScale = env->GetMethodID(activityClass, "getDefaultScale", "()F");
+
+        jfloat displayScale = env->CallFloatMethod(activity, getDefaultScale);
+
+        env->DeleteLocalRef(activity);
+        env->DeleteLocalRef(activityClass);
+
+        return displayScale;
     }
 
     int32_t GetSafeAreaInsetLeft()
@@ -298,7 +302,7 @@ namespace OpenRCT2::Platform
         }
 
         const auto& assetList = GetAssetList();
-        std::string assetPath = NormalizeAssetPath(std::string(path.substr(Platform::kAndroidAssetPathPrefix.length())));
+        std::string assetPath = std::string(path.substr(Platform::kAndroidAssetPathPrefix.length()));
         if (assetPath.empty())
         {
             return assetList.empty() ? AssetCheckResult::NotFound : AssetCheckResult::Found;
@@ -356,7 +360,7 @@ namespace OpenRCT2::Platform
             return AssetFileOpenResult{ AssetCheckResult::NotFound, nullptr, 0 };
         }
 
-        std::string assetPath = NormalizeAssetPath(std::string(path.substr(Platform::kAndroidAssetPathPrefix.length())));
+        std::string assetPath = std::string(path.substr(Platform::kAndroidAssetPathPrefix.length()));
         auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_RANDOM);
         if (asset == nullptr)
         {
@@ -461,7 +465,7 @@ namespace OpenRCT2::Platform
                                 try
                                 {
                                     AssetInfo info;
-                                    info.Path = NormalizeAssetPath(line.substr(0, sep));
+                                    info.Path = line.substr(0, sep);
                                     info.Size = std::stoull(line.substr(sep + 1));
                                     _assetList.push_back(std::move(info));
                                 }

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -39,6 +39,10 @@ static AAssetManager* _assetManager;
 static std::vector<OpenRCT2::Platform::AssetInfo> _assetList;
 static std::once_flag _assetManagerInitialized;
 static std::once_flag _assetListInitialized;
+static int32_t _safeAreaInsetLeft;
+static int32_t _safeAreaInsetTop;
+static int32_t _safeAreaInsetRight;
+static int32_t _safeAreaInsetBottom;
 
 // Initialized in JNI_OnLoad. Cannot be initialized here as JVM is not
 // available until after JNI_OnLoad is called.
@@ -171,6 +175,12 @@ namespace OpenRCT2::Platform
         return {};
     }
 
+    static std::string NormalizeAssetPath(std::string path)
+    {
+        std::replace(path.begin(), path.end(), '\\', '/');
+        return path;
+    }
+
     uint64_t GetLastModified(std::string_view path)
     {
         if (String::startsWith(path, Platform::kAndroidAssetPathPrefix))
@@ -195,7 +205,7 @@ namespace OpenRCT2::Platform
             auto assetManager = static_cast<AAssetManager*>(GetAssetManager());
             if (assetManager != nullptr)
             {
-                std::string assetPath = std::string(path).substr(Platform::kAndroidAssetPathPrefix.length());
+                std::string assetPath = NormalizeAssetPath(std::string(path).substr(Platform::kAndroidAssetPathPrefix.length()));
                 auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_UNKNOWN);
                 if (asset != nullptr)
                 {
@@ -231,18 +241,27 @@ namespace OpenRCT2::Platform
 
     float GetDefaultScale()
     {
-        JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
+        return 1.5f;
+    }
 
-        jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
-        jclass activityClass = env->GetObjectClass(activity);
-        jmethodID getDefaultScale = env->GetMethodID(activityClass, "getDefaultScale", "()F");
+    int32_t GetSafeAreaInsetLeft()
+    {
+        return _safeAreaInsetLeft;
+    }
 
-        jfloat displayScale = env->CallFloatMethod(activity, getDefaultScale);
+    int32_t GetSafeAreaInsetTop()
+    {
+        return _safeAreaInsetTop;
+    }
 
-        env->DeleteLocalRef(activity);
-        env->DeleteLocalRef(activityClass);
+    int32_t GetSafeAreaInsetRight()
+    {
+        return _safeAreaInsetRight;
+    }
 
-        return displayScale;
+    int32_t GetSafeAreaInsetBottom()
+    {
+        return _safeAreaInsetBottom;
     }
 
     jclass AndroidFindClass(JNIEnv* env, std::string_view name)
@@ -278,7 +297,7 @@ namespace OpenRCT2::Platform
         }
 
         const auto& assetList = GetAssetList();
-        std::string assetPath = std::string(path.substr(Platform::kAndroidAssetPathPrefix.length()));
+        std::string assetPath = NormalizeAssetPath(std::string(path.substr(Platform::kAndroidAssetPathPrefix.length())));
         if (assetPath.empty())
         {
             return assetList.empty() ? AssetCheckResult::NotFound : AssetCheckResult::Found;
@@ -336,7 +355,7 @@ namespace OpenRCT2::Platform
             return AssetFileOpenResult{ AssetCheckResult::NotFound, nullptr, 0 };
         }
 
-        std::string assetPath = std::string(path.substr(Platform::kAndroidAssetPathPrefix.length()));
+        std::string assetPath = NormalizeAssetPath(std::string(path.substr(Platform::kAndroidAssetPathPrefix.length())));
         auto asset = AAssetManager_open(assetManager, assetPath.c_str(), AASSET_MODE_RANDOM);
         if (asset == nullptr)
         {
@@ -441,7 +460,7 @@ namespace OpenRCT2::Platform
                                 try
                                 {
                                     AssetInfo info;
-                                    info.Path = line.substr(0, sep);
+                                    info.Path = NormalizeAssetPath(line.substr(0, sep));
                                     info.Size = std::stoull(line.substr(sep + 1));
                                     _assetList.push_back(std::move(info));
                                 }
@@ -495,6 +514,15 @@ extern "C" JNIEXPORT jstring JNICALL
     Java_io_openrct2_PlatformConstants_getAndroidAssetPathPrefix(JNIEnv* env, jclass /* clazz */)
 {
     return env->NewStringUTF(std::string(OpenRCT2::Platform::kAndroidAssetPathPrefix).c_str());
+}
+
+extern "C" JNIEXPORT void JNICALL
+    Java_io_openrct2_GameActivity_nativeSetSafeAreaInsets(JNIEnv*, jclass, jint left, jint top, jint right, jint bottom)
+{
+    _safeAreaInsetLeft = left;
+    _safeAreaInsetTop = top;
+    _safeAreaInsetRight = right;
+    _safeAreaInsetBottom = bottom;
 }
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* pjvm, void* reserved)

--- a/src/openrct2/platform/Platform.Common.cpp
+++ b/src/openrct2/platform/Platform.Common.cpp
@@ -185,6 +185,26 @@ namespace OpenRCT2::Platform
     {
         return 1;
     }
+
+    int32_t GetSafeAreaInsetLeft()
+    {
+        return 0;
+    }
+
+    int32_t GetSafeAreaInsetTop()
+    {
+        return 0;
+    }
+
+    int32_t GetSafeAreaInsetRight()
+    {
+        return 0;
+    }
+
+    int32_t GetSafeAreaInsetBottom()
+    {
+        return 0;
+    }
 #endif
 
     void Sleep(uint32_t ms)

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -171,6 +171,10 @@ namespace OpenRCT2::Platform
     int32_t Execute(const char* args[], std::string* output = nullptr);
     bool ProcessIsElevated();
     float GetDefaultScale();
+    int32_t GetSafeAreaInsetLeft();
+    int32_t GetSafeAreaInsetTop();
+    int32_t GetSafeAreaInsetRight();
+    int32_t GetSafeAreaInsetBottom();
 
     std::optional<RCT2Variant> classifyGamePath(std::string_view path);
     bool OriginalGameDataExists(std::string_view path);


### PR DESCRIPTION
## Summary
- keep the Android game activity resizable and preserve immersive mode across configuration changes
- handle Android fullscreen resize events correctly and keep title / toolbar UI inside Android safe areas
- normalize packaged Android asset paths on Android and set a 150% Android UI scale default
- add first-time contributor entry to contributors.md

## Testing
- built the Android release app
- installed the APK on a Pixel 9 Pro Fold
- verified fullscreen now uses the full inner display and title screen buttons stay within safe display bounds

Closes #26483