### PR TITLE
Remove manual memory allocations in object repository 

### DIFF
--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -20,7 +20,6 @@
 #include "../core/FileStream.h"
 #include "../core/Guard.hpp"
 #include "../core/IStream.hpp"
-#include "../core/Memory.hpp"
 #include "../core/MemoryStream.h"
 #include "../core/Numerics.hpp"
 #include "../core/Path.hpp"
@@ -518,23 +517,14 @@ namespace OpenRCT2
             ChunkHeader chunkHeader;
             chunkHeader.encoding = kLegacyObjectEntryGroupEncoding[EnumValue(objectType)];
             chunkHeader.length = static_cast<uint32_t>(dataSize);
-            uint8_t* encodedDataBuffer = Memory::Allocate<uint8_t>(0x600000);
-            size_t encodedDataSize = WriteChunkBuffer(encodedDataBuffer, reinterpret_cast<const uint8_t*>(data), chunkHeader);
+            const auto encodedDataBuffer = std::make_unique_for_overwrite<uint8_t[]>(0x600000);
+            const size_t encodedDataSize = WriteChunkBuffer(
+                encodedDataBuffer.get(), reinterpret_cast<const uint8_t*>(data), chunkHeader);
 
             // Save to file
-            try
-            {
-                auto fs = FileStream(std::string(path), FileMode::write);
-                fs.Write(entry, sizeof(RCTObjectEntry));
-                fs.Write(encodedDataBuffer, encodedDataSize);
-
-                Memory::Free(encodedDataBuffer);
-            }
-            catch (const std::exception&)
-            {
-                Memory::Free(encodedDataBuffer);
-                throw;
-            }
+            auto fs = FileStream(std::string(path), FileMode::write);
+            fs.Write(entry, sizeof(RCTObjectEntry));
+            fs.Write(encodedDataBuffer.get(), encodedDataSize);
         }
 
         static std::array<uint8_t, 11> calculateExtraBytesToFixChecksum(

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -496,25 +496,18 @@ namespace OpenRCT2
                     newData.insert(newData.end(), dataSpan.begin(), dataSpan.end());
                     newData.insert(newData.end(), extraBytes.begin(), extraBytes.end());
 
-                    try
+                    uint32_t newRealChecksum = ObjectCalculateChecksum(entry, newData.data(), newData.size());
+                    if (newRealChecksum != entry->checksum)
                     {
-                        uint32_t newRealChecksum = ObjectCalculateChecksum(entry, newData.data(), newData.size());
-                        if (newRealChecksum != entry->checksum)
-                        {
-                            Console::Error::WriteLine("CalculateExtraBytesToFixChecksum failed to fix checksum.");
+                        Console::Error::WriteLine("CalculateExtraBytesToFixChecksum failed to fix checksum.");
 
-                            // Save old data form
-                            SaveObject(path, entry, data, dataSize, false);
-                        }
-                        else
-                        {
-                            // Save new data form
-                            SaveObject(path, entry, newData.data(), newData.size(), false);
-                        }
+                        // Save old data form
+                        SaveObject(path, entry, data, dataSize, false);
                     }
-                    catch (const std::exception&)
+                    else
                     {
-                        throw;
+                        // Save new data form
+                        SaveObject(path, entry, newData.data(), newData.size(), false);
                     }
                     return;
                 }

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -486,15 +486,14 @@ namespace OpenRCT2
 
                     // Calculate the value of extra bytes that can be appended to the data so that the
                     // data is then valid for the object's checksum
-                    size_t extraBytesCount = 0;
-                    void* extraBytes = CalculateExtraBytesToFixChecksum(realChecksum, entry->checksum, &extraBytesCount);
+                    const auto extraBytes = calculateExtraBytesToFixChecksum(realChecksum, entry->checksum);
 
                     // Create new data blob with appended bytes
-                    size_t newDataSize = dataSize + extraBytesCount;
+                    size_t newDataSize = dataSize + extraBytes.size();
                     uint8_t* newData = Memory::Allocate<uint8_t>(newDataSize);
                     uint8_t* newDataSaltOffset = newData + dataSize;
                     std::copy_n(static_cast<const uint8_t*>(data), dataSize, newData);
-                    std::copy_n(static_cast<const uint8_t*>(extraBytes), extraBytesCount, newDataSaltOffset);
+                    std::copy_n(extraBytes.data(), extraBytes.size(), newDataSaltOffset);
 
                     try
                     {
@@ -512,12 +511,10 @@ namespace OpenRCT2
                             SaveObject(path, entry, newData, newDataSize, false);
                         }
                         Memory::Free(newData);
-                        Memory::Free(extraBytes);
                     }
                     catch (const std::exception&)
                     {
                         Memory::Free(newData);
-                        Memory::Free(extraBytes);
                         throw;
                     }
                     return;
@@ -548,14 +545,12 @@ namespace OpenRCT2
             }
         }
 
-        static void* CalculateExtraBytesToFixChecksum(int32_t currentChecksum, int32_t targetChecksum, size_t* outSize)
+        static std::array<uint8_t, 11> calculateExtraBytesToFixChecksum(
+            const int32_t currentChecksum, const int32_t targetChecksum)
         {
-            // Allocate 11 extra bytes to manipulate the checksum
-            uint8_t* salt = Memory::Allocate<uint8_t>(11);
-            if (outSize != nullptr)
-                *outSize = 11;
+            std::array<uint8_t, 11> salt{};
 
-            // Next work out which bits need to be flipped to make the current checksum match the one in the file
+            // Work out which bits need to be flipped to make the current checksum match the one in the file
             // The bitwise rotation compensates for the rotation performed during the checksum calculation*/
             int32_t bitsToFlip = targetChecksum ^ ((currentChecksum << 25) | (currentChecksum >> 7));
 

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -489,15 +489,16 @@ namespace OpenRCT2
                     const auto extraBytes = calculateExtraBytesToFixChecksum(realChecksum, entry->checksum);
 
                     // Create new data blob with appended bytes
-                    size_t newDataSize = dataSize + extraBytes.size();
-                    uint8_t* newData = Memory::Allocate<uint8_t>(newDataSize);
-                    uint8_t* newDataSaltOffset = newData + dataSize;
-                    std::copy_n(static_cast<const uint8_t*>(data), dataSize, newData);
-                    std::copy_n(extraBytes.data(), extraBytes.size(), newDataSaltOffset);
+                    std::vector<uint8_t> newData;
+                    newData.reserve(dataSize + extraBytes.size());
+
+                    const auto dataSpan = std::span(static_cast<const uint8_t*>(data), dataSize);
+                    newData.insert(newData.end(), dataSpan.begin(), dataSpan.end());
+                    newData.insert(newData.end(), extraBytes.begin(), extraBytes.end());
 
                     try
                     {
-                        uint32_t newRealChecksum = ObjectCalculateChecksum(entry, newData, newDataSize);
+                        uint32_t newRealChecksum = ObjectCalculateChecksum(entry, newData.data(), newData.size());
                         if (newRealChecksum != entry->checksum)
                         {
                             Console::Error::WriteLine("CalculateExtraBytesToFixChecksum failed to fix checksum.");
@@ -508,13 +509,11 @@ namespace OpenRCT2
                         else
                         {
                             // Save new data form
-                            SaveObject(path, entry, newData, newDataSize, false);
+                            SaveObject(path, entry, newData.data(), newData.size(), false);
                         }
-                        Memory::Free(newData);
                     }
                     catch (const std::exception&)
                     {
-                        Memory::Free(newData);
                         throw;
                     }
                     return;


### PR DESCRIPTION
This removes the manual memory allocations in ObjectRepository.cpp.

`calculateExtraBytesToFixChecksum` always allocated and used 11 bytes so this returns an array rather than the weird alloc and out parameter.

The first alloc in `SaveObject` is replaced with a vector to make things slightly clearer. The second is replaced by a unique_ptr array.

The exception capture and rethrow has been removed on both of these now that it is not necessary to manually free the memory.

`SaveObject` is used to extract object dats from sv6 files. I've tested a few parks for example [this one](https://nedesigns.com/park/jaguar-2) that has an object which requires the checksum fix.