### PR TITLE
Fix types of a couple of command line string options

### DIFF
--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2
     std::string gNetworkStartAddress;
 
     static uint32_t _port = 0;
-    static char* _address = nullptr;
+    static u8string _address;
 #endif
 
     static bool _help = false;
@@ -307,7 +307,7 @@ namespace OpenRCT2
 
         gNetworkStart = Network::Mode::server;
         gNetworkStartPort = _port;
-        gNetworkStartAddress = String::toStd(_address);
+        gNetworkStartAddress = _address;
 
         return EXITCODE_CONTINUE;
     }

--- a/src/openrct2/command_line/sprite/SpriteCommands.cpp
+++ b/src/openrct2/command_line/sprite/SpriteCommands.cpp
@@ -11,7 +11,6 @@
 
 #include "../../Context.h"
 #include "../../OpenRCT2.h"
-#include "../../core/Memory.hpp"
 #include "../../core/String.hpp"
 #include "../../drawing/Drawing.h"
 #include "../../object/ObjectFactory.h"
@@ -36,7 +35,7 @@ namespace OpenRCT2::CommandLine::Sprite
 {
     using namespace OpenRCT2::Drawing;
 
-    static const char* _mode;
+    static u8string _mode;
 
     // clang-format off
     static constexpr CommandLineOptionDefinition kSpriteOptions[]
@@ -70,7 +69,6 @@ namespace OpenRCT2::CommandLine::Sprite
             spriteMode = ImportMode::Closest;
         else if (String::iequals(_mode, SZ_DITHERING))
             spriteMode = ImportMode::Dithering;
-        Memory::Free(_mode);
 
         const char** argv = const_cast<const char**>(argEnumerator->GetArguments()) + argEnumerator->GetIndex() - 1;
         int32_t argc = argEnumerator->GetCount() - argEnumerator->GetIndex() + 1;


### PR DESCRIPTION
This fixes the types of a couple of command line string options.

The type of these is supposed to be `u8string`, not `char*`, for example:
https://github.com/OpenRCT2/OpenRCT2/blob/432baaaa61e22ad8551ae1c5f6df4b39ddfbca68/src/openrct2/command_line/RootCommands.cpp#L60-L64
https://github.com/OpenRCT2/OpenRCT2/blob/432baaaa61e22ad8551ae1c5f6df4b39ddfbca68/src/openrct2/command_line/RootCommands.cpp#L80-L86

the underlying code that handles them:
https://github.com/OpenRCT2/OpenRCT2/blob/432baaaa61e22ad8551ae1c5f6df4b39ddfbca68/src/openrct2/command_line/CommandLine.cpp#L489-L490