### PR TITLE
Remove manual memory allocs in FileClassifier and Win32 platform

### DIFF
--- a/src/openrct2/FileClassifier.cpp
+++ b/src/openrct2/FileClassifier.cpp
@@ -12,7 +12,6 @@
 #include "Diagnostic.h"
 #include "core/Console.hpp"
 #include "core/FileStream.h"
-#include "core/Memory.hpp"
 #include "core/Path.hpp"
 #include "core/String.hpp"
 #include "park/ParkFile.h"
@@ -176,8 +175,7 @@ static bool TryClassifyAsTD4_TD6(IStream* stream, ClassifiedFileInfo* result)
 
         if (ValidateTrackChecksum(data.get(), dataLength))
         {
-            std::unique_ptr<uint8_t, decltype(&Memory::Free<uint8_t>)> td6data(
-                Memory::Allocate<uint8_t>(0x10000), &Memory::Free<uint8_t>);
+            const auto td6data = std::make_unique_for_overwrite<uint8_t[]>(0x10000);
             size_t td6len = DecodeTD6(data.get(), td6data.get(), dataLength);
             if (td6data != nullptr && td6len >= 8)
             {

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -70,10 +70,9 @@ namespace OpenRCT2::Platform
         }
         else
         {
-            auto wlvalue = new wchar_t[valueSize];
-            GetEnvironmentVariableW(wname.c_str(), wlvalue, valueSize);
-            result = wlvalue;
-            delete[] wlvalue;
+            const auto buffer = std::make_unique_for_overwrite<wchar_t[]>(valueSize);
+            GetEnvironmentVariableW(wname.c_str(), buffer.get(), valueSize);
+            result = buffer.get();
         }
         return String::toUtf8(result);
     }

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -70,9 +70,9 @@ namespace OpenRCT2::Platform
         }
         else
         {
-            const auto buffer = std::make_unique_for_overwrite<wchar_t[]>(valueSize);
-            GetEnvironmentVariableW(wname.c_str(), buffer.get(), valueSize);
-            result = buffer.get();
+            const auto wBuffer = std::make_unique_for_overwrite<wchar_t[]>(valueSize);
+            GetEnvironmentVariableW(wname.c_str(), wBuffer.get(), valueSize);
+            result = wBuffer.get();
         }
         return String::toUtf8(result);
     }
@@ -754,12 +754,12 @@ namespace OpenRCT2::Platform
         }
 
         std::string outPath = "";
-        const auto steamPath = std::make_unique_for_overwrite<wchar_t[]>(size);
+        const auto wSteamPath = std::make_unique_for_overwrite<wchar_t[]>(size);
         const auto result = RegQueryValueExW(
-            hKey, L"SteamPath", nullptr, &type, reinterpret_cast<LPBYTE>(steamPath.get()), &size);
+            hKey, L"SteamPath", nullptr, &type, reinterpret_cast<LPBYTE>(wSteamPath.get()), &size);
         if (result == ERROR_SUCCESS)
         {
-            outPath = String::toUtf8(steamPath.get());
+            outPath = String::toUtf8(wSteamPath.get());
         }
         RegCloseKey(hKey);
 

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -741,10 +741,8 @@ namespace OpenRCT2::Platform
 
     SteamPaths GetSteamPaths()
     {
-        wchar_t* wSteamPath;
         HKEY hKey;
         DWORD type, size;
-        LRESULT result;
 
         if (RegOpenKeyW(HKEY_CURRENT_USER, L"Software\\Valve\\Steam", &hKey) != ERROR_SUCCESS)
             return {};
@@ -757,13 +755,13 @@ namespace OpenRCT2::Platform
         }
 
         std::string outPath = "";
-        wSteamPath = reinterpret_cast<wchar_t*>(malloc(size));
-        result = RegQueryValueExW(hKey, L"SteamPath", nullptr, &type, reinterpret_cast<LPBYTE>(wSteamPath), &size);
+        const auto steamPath = std::make_unique_for_overwrite<wchar_t[]>(size);
+        const auto result = RegQueryValueExW(
+            hKey, L"SteamPath", nullptr, &type, reinterpret_cast<LPBYTE>(steamPath.get()), &size);
         if (result == ERROR_SUCCESS)
         {
-            outPath = String::toUtf8(wSteamPath);
+            outPath = String::toUtf8(steamPath.get());
         }
-        free(wSteamPath);
         RegCloseKey(hKey);
 
         SteamPaths ret = {};


### PR DESCRIPTION
This removes 3 trivial manual memory allocations.

The one in `TryClassifyAsTD4_TD6` was already a unique_ptr, but used the `Memory` functions for no reason.
The other 2 are self expanatory.

There are only a couple of other uses of the `Memory` header (wrappers for malloc/free), which could potentially be removed eventually.