### PR TITLE
Avoid additional audio buffer copy if frequency or samples are different from what we requested

### DIFF
--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -38,7 +38,7 @@ void AudioMixer::Init(const char* device)
     want.userdata = this;
 
     SDL_AudioSpec have;
-    _deviceId = SDL_OpenAudioDevice(device, 0, &want, &have, 0);
+    _deviceId = SDL_OpenAudioDevice(device, 0, &want, &have, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_SAMPLES_CHANGE);
     _outputFormat.format = have.format;
     _outputFormat.channels = have.channels;
     _outputFormat.freq = have.freq;


### PR DESCRIPTION
We pass a requested frequence and sample rate to SDL_OpenAudioDevice(), which will then return an object that contains what we actually got. Our code properly handles this. However, unless we explicit tell SDL that we can handle a different frequency or samples, SDL may try to emulate what we requested, which incurs another copy in our already quite inefficient audio pipeline.

It’s unlikely to be triggered currently, since we still output as 22,050 Hz with 2048 samples (though theoretically possible if a device cannot go lower than 44,100 Hz), but will become more pressing once we going higher than that.

Approach discussed with @frozensnowy .