### PR TITLE
Set qjs stack limit to 7MB

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,7 @@
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
 - Fix: [#26410] Tiles with water can draw incorrectly when there is something underwater and nothing above water.
-- Fix: [#26418] Game crashes to desktop when a stack overflow occurs in plugin code.
+- Fix: [#26418] Game crashes when a stack overflow occurs in plugin code.
 - Fix: [#26419] Drop count & negative g’s stat requirements for Flying Roller Coaster don’t get nullified by having an inversion.
 - Fix: [#26421] Wrong scenery tab highlighted when more than 64 scenery groups are selected.
 - Fix: [#26425] Benches don’t reduce watching spots from 4 to 2 while other path additions do (should be reversed).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
 - Fix: [#26410] Tiles with water can draw incorrectly when there is something underwater and nothing above water.
+- Fix: [#26418] Game crashes to desktop when a stack overflow occurs in plugin code.
 - Fix: [#26419] Drop count & negative g’s stat requirements for Flying Roller Coaster don’t get nullified by having an inversion.
 - Fix: [#26421] Wrong scenery tab highlighted when more than 64 scenery groups are selected.
 - Fix: [#26425] Benches don’t reduce watching spots from 4 to 2 while other path additions do (should be reversed).

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -546,13 +546,17 @@ namespace OpenRCT2
 
                 // TODO: preload the title scene in another (parallel) job.
                 preloaderScene->AddJob([this]() { InitialiseRepositories(); });
-                preloaderScene->AddJob([this]() { InitialiseScriptEngine(); });
             }
             else
             {
                 InitialiseRepositories();
-                InitialiseScriptEngine();
             }
+
+#ifdef ENABLE_SCRIPTING
+            // quickjs script engine is single-threaded and must be set up on the main thread
+            _scriptEngine.Initialise();
+            _uiContext->InitialiseScriptExtensions();
+#endif
 
             return true;
         }
@@ -616,17 +620,6 @@ namespace OpenRCT2
             TitleSequenceManager::Scan();
 
             OpenProgress(STR_LOADING_GENERIC);
-        }
-
-        void InitialiseScriptEngine()
-        {
-#ifdef ENABLE_SCRIPTING
-            OpenProgress(STR_LOADING_PLUGIN_ENGINE);
-            _scriptEngine.Initialise();
-            _uiContext->InitialiseScriptExtensions();
-
-            OpenProgress(STR_LOADING_GENERIC);
-#endif
         }
 
     public:

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -490,8 +490,7 @@ void ScriptEngine::Initialise()
     #endif
     }
 
-    // Disable maximum stack size limit for the JS engine.
-    JS_SetMaxStackSize(_runtime, 0);
+    JS_SetMaxStackSize(_runtime, kJsStackSize);
 
     _replContext = JS_NewContext(_runtime);
     if (!_replContext)

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -51,6 +51,13 @@ namespace OpenRCT2::Scripting
     static constexpr int32_t kApiVersionCustomActionArgs = 68;
     static constexpr int32_t kApiVersionNetworkIDs = 77;
 
+    // This stack limit is not precise as quickjs-ng just sets a hard boundary offset from the stack frame
+    // where the limit is updated. The actual limit available to quickjs will be more or less depending on
+    // how big the native stack is relative to its size when the limit was first set.
+    // Calculating a precise limit is possible but requires platform specifc code for all possible platforms
+    // to get the end of the reserved stack space.
+    static constexpr size_t kJsStackSize = 1024 * 1024 * 7;
+
     #ifndef DISABLE_NETWORK
     struct SocketDataBase;
     #endif


### PR DESCRIPTION
Fixes #26418

For some silly reason I put this line in to remove the default 1MB stack limit for QJS and I forgot to remove it. 

Might require some testing to make sure it plays nice with big plugins, although 1MB is the QJS default. 