### PR TITLE
Fix #26492: Drag tool shows per tile error when running out of money midway

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#26421] Wrong scenery tab highlighted when more than 64 scenery groups are selected.
 - Fix: [#26425] Benches don’t reduce watching spots from 4 to 2 while other path additions do (should be reversed).
 - Fix: [#26432] Guests choose to head for rides they have already ridden if they don’t have a map.
+- Fix: [#26492] Drag tool shows per-tile error instead of total cost when running out of money midway through placement.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -1319,6 +1319,18 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
+            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY) && totalCost > getGameState().park.cash)
+            {
+                Audio::Play3D(Audio::SoundId::error, lastLocation);
+                _footpathErrorOccured = true;
+
+                auto* windowMgr = GetWindowManager();
+                Formatter ft;
+                ft.Add<money64>(totalCost);
+                windowMgr->ShowError(STR_CANT_BUILD_FOOTPATH_HERE, STR_NOT_ENOUGH_CASH_REQUIRES, ft);
+                return;
+            }
+
             // All queries passed, now execute
             bool anySuccess = false;
             money64 cost = 0;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -3291,6 +3291,20 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
+            if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY) && totalCost > getGameState().park.cash)
+            {
+                Audio::Play3D(Audio::SoundId::error, lastLocation);
+
+                auto* windowMgr = GetWindowManager();
+                Formatter ft;
+                ft.Add<money64>(totalCost);
+                windowMgr->ShowError(STR_CANT_BUILD_THIS_HERE, STR_NOT_ENOUGH_CASH_REQUIRES, ft);
+
+                _provisionalTiles.clear();
+                _inDragMode = false;
+                return;
+            }
+
             // All queries passed, now execute
             bool anySuccessful = false;
 


### PR DESCRIPTION
Fixes #26492 

Before:


https://github.com/user-attachments/assets/c852c04a-c06c-49e1-bdb6-4ae4b38b732d



After:


https://github.com/user-attachments/assets/eb8e4476-96e2-4c03-bfad-17c44d68a13a





This also fixes it for the fence drag tool.