### PR TITLE
Fix #26494: The limits for when walls block the view of rides/scenery on the path side of the first tile make no sense

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -16,7 +16,7 @@
     "sha256": "dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858"
   },
   "replays": {
-    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.93/replays.zip",
-    "sha256": "5295f115045eb6945b36b48ca2105c7059e7f6cf8a88832997d6cf878817e1b5"
+    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.94/replays.zip",
+    "sha256": "884bea28c8c6fe69b360d9700c6d571118e09c5fc0b4d216658808b8b23772d0"
   }
 }

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#26308] Add all new track pieces to the inverted roller coaster.
 - Feature: [#26442] Add cheat to disable grass growing.
+- Fix: [#26494] The limits for where walls on the path side of the first tile block the view of rides/scenery are wrong (original bug).
 
 0.5.2 (2026-06-07)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -6554,6 +6554,7 @@ namespace OpenRCT2
             return false;
         }
 
+        // TODO: Extract loop A
         do
         {
             // Ghosts are purely this-client-side and should not cause any interaction,

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -6570,8 +6570,7 @@ namespace OpenRCT2
             auto wallEntry = tileElement->asWall()->GetEntry();
             if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
                 continue;
-            // TODO: Check whether this shouldn't be <=, as the other loops use. If so, also extract as loop A.
-            if (guest.NextLoc.z + (4 * kCoordsZStep) >= tileElement->getBaseZ())
+            if (guest.NextLoc.z + (4 * kCoordsZStep) <= tileElement->getBaseZ())
                 continue;
             if (guest.NextLoc.z + (1 * kCoordsZStep) >= tileElement->getClearanceZ())
                 continue;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -48,7 +48,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 1;
+constexpr uint8_t kStreamVersion = 2;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Fixes #26494

In RCT2 vanilla these limits make no sense. The OpenRCT2 code already has a comment about a comparison sign potentially being the wrong way around, and changing that changes the limits to something that makes much more sense.

The original vanilla limits are in red on the left, where any wall above those, no matter how high up, will block the view of the coaster pieces. The new limits are in blue. Guests can no longer see through walls to watch a thing on the first tile, and both now allow wall pieces above the viewing area as well.

<img width="1215" height="1092" alt="image" src="https://github.com/user-attachments/assets/8b2cac19-99b9-4ae3-a3e7-5d566beb1da5" />

------

The 1.5 unit gap for when the thing to watch is on the same tile as the wall is now the exact same as the 1.5 unit gap you can have in the wall that is on the path tile itself, and the bigger gap for when the thing is further away is the exact same as it already is for any other wall or scenery item on the first tile.

We go from these upper and lower limits (notice the missing purple side for when the coaster is 2 or 3 tiles away):
<img width="1637" height="1182" alt="image" src="https://github.com/user-attachments/assets/82285127-1925-4cca-86c2-ca9c547f2ce9" />

To these limits:
<img width="1523" height="1190" alt="image" src="https://github.com/user-attachments/assets/1295510c-ba1e-4e2a-87f2-d11ba1afe86c" />
