### PR TITLE
GCC 16 fixes

### DIFF
--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -36,7 +36,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_ABOUT_PAGE_RCT2,
     };
 
-    enum WindowAboutWidgetIdx
+    enum WindowAboutWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -30,7 +30,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_ASSET_PACKS;
     static constexpr ScreenSize kWindowSize = { 400, 200 };
 
-    enum WindowAssetPacksWidgetIdx
+    enum WindowAssetPacksWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -35,7 +35,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_BANNER_WINDOW_TITLE;
     static constexpr ScreenSize kWindowSize = { 113, 96 };
 
-    enum WindowBannerWidgetIdx
+    enum WindowBannerWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -27,7 +27,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum
+    enum WindowChangelogWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -79,7 +79,7 @@ static constexpr auto kWeatherTypes = std::to_array<WeatherInfo>({
     { SPR_G2_WEATHER_BLIZZARD_SMALL, SPR_G2_WEATHER_BLIZZARD, STR_BLIZZARD },
 });
 
-enum WindowCheatsWidgetIdx
+enum WindowCheatsWidgetIdx : WidgetIndex
 {
     WIDX_BACKGROUND,
     WIDX_TITLE,

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -25,7 +25,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_CUSTOM_CURRENCY_WINDOW_TITLE;
     static constexpr ScreenSize kWindowSize = { 400, 100 };
 
-    enum WindowCustomCurrencyWidgetIdx
+    enum WindowCustomCurrencyWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -23,7 +23,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowDebugPaintWidgetIdx
+    enum WindowDebugPaintWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TOGGLE_SHOW_WIDE_PATHS,

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -24,7 +24,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 200, 100 };
 
-    enum WindowRideDemolishWidgetIdx
+    enum WindowRideDemolishWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2::Ui::Windows
         9, 9, 9, 9, 9, 9, 9,          // 56
     };
 
-    enum
+    enum WindowDropdownWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
     };

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr int32_t kToolbarHeight = 32;
 
-    enum
+    enum WindowEditorBottomToolbarWidgetIdx : WidgetIndex
     {
         WIDX_PREVIOUS_IMAGE,       // 1
         WIDX_PREVIOUS_STEP_BUTTON, // 2

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -42,7 +42,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize kWindowSize = { 600, 400 };
     static constexpr StringId kWindowTitle = STR_INVENTION_LIST;
 
-    enum
+    enum WindowEditorInventionsListWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -196,7 +196,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum WindowEditorObjectSelectionWidgetIndex
+    enum WindowEditorObjectSelectionWidgetIndex : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/EditorParkEntrance.cpp
+++ b/src/openrct2-ui/windows/EditorParkEntrance.cpp
@@ -54,7 +54,7 @@ namespace OpenRCT2::Ui::Windows
         ImageIndex imageId = kImageIndexUndefined;
     };
 
-    enum WindowEditorParkEntranceListWidgetIdx
+    enum WindowEditorParkEntranceListWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -102,7 +102,7 @@ namespace OpenRCT2::Ui::Windows
         STR_OBJECTIVE_DROPDOWN_MONTHLY_PROFIT_FROM_FOOD_MERCHANDISE,
     };
 
-    enum
+    enum WindowEditorScenarioOptionsWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -24,7 +24,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum
+    enum WindowErrorWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
     };

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_FINANCES_PAGE_COUNT
     };
 
-    enum
+    enum WindowFinancesWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -41,7 +41,7 @@ using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowGameBottomToolbarWidgetIdx
+    enum WindowGameBottomToolbarWidgetIdx : WidgetIndex
     {
         WIDX_LEFT_OUTSET,
         WIDX_LEFT_INSET,

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -68,7 +68,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_GUEST_PAGE_COUNT,
     };
 
-    enum WindowGuestWidgetIdx
+    enum WindowGuestWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -41,7 +41,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_GUESTS;
     static constexpr ScreenSize kWindowSize = { 350, 330 };
 
-    enum WindowGuestListWidgetIdx
+    enum WindowGuestListWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -38,7 +38,7 @@ using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum
+    enum WindowInstallTrackWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize kWindowSize = kInGameSize;
     static constexpr StringId kWindowTitle = STR_LAND_RIGHTS;
 
-    enum WindowLandRightsWidgetIdx
+    enum WindowLandRightsWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -83,7 +83,7 @@ namespace OpenRCT2::Ui::Windows
     static u8string _defaultPath;
     static TrackDesign* _trackDesign;
 
-    enum
+    enum WindowLoadSaveWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -44,7 +44,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_MAPGEN_PAGE_COUNT
     };
 
-    enum
+    enum WindowMapGenWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -45,7 +45,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = kStringIdNone;
     static constexpr ScreenSize kWindowSize = { 166, 200 };
 
-    enum : WidgetIndex
+    enum WindowMazeConstructionWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_MULTIPLAYER_PAGE_OPTIONS
     };
 
-    enum WindowMultiplayerWidgetIdx
+    enum WindowMultiplayerWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -18,7 +18,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowNetworkStatusWidgetIdx
+    enum WindowNetworkStatusWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2::Ui::Windows
 
     constexpr uint16_t kSelectedItemUndefined = 0xFFFF;
 
-    enum WindowNewCampaignWidgetIdx
+    enum WindowNewCampaignWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -196,7 +196,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum
+    enum WindowNewRideWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -35,7 +35,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize kWindowSize = { 400, 300 };
     static constexpr uint8_t kItemSeparatorHeight = 2;
 
-    enum WindowNewsWidgetIdx
+    enum WindowNewsWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -83,7 +83,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum WindowOptionsWidgetIdx
+    enum WindowOptionsWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -23,7 +23,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 200, 100 };
 
-    enum
+    enum WindowOverwritePromptWidgetIdx : WidgetIndex
     {
         WIDX_OVERWRITE_BACKGROUND,
         WIDX_OVERWRITE_TITLE,

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -61,7 +61,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_PARK_PAGE_COUNT,
     };
 
-    enum WindowParkWidgetIdx
+    enum WindowParkWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -36,7 +36,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_SET_PATROL_AREA;
     static constexpr ScreenSize kWindowSize = { 104, 54 };
 
-    enum WindowPatrolAreaWidgetIdx
+    enum WindowPatrolAreaWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -36,7 +36,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum WindowPlayerWidgetIdx
+    enum WindowPlayerWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -23,7 +23,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum ProgressWindowWidgetIdx
+    enum ProgressWindowWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -23,7 +23,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 200, 100 };
 
-    enum WindowRideRefurbishWidgetIdx
+    enum WindowRideRefurbishWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -40,7 +40,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_RESEARCH_PAGE_COUNT
     };
 
-    enum
+    enum WindowResearchWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -108,7 +108,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum
+    enum WindowRideWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -98,7 +98,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum
+    enum WindowRideConstructionWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -48,7 +48,7 @@ namespace OpenRCT2::Ui::Windows
         PAGE_COUNT
     };
 
-    enum WindowRideListWidgetIdx
+    enum WindowRideListWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -26,7 +26,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize kWindowSizeSave = { 260, 54 };
     static constexpr ScreenSize kWindowSizeQuit = { 177, 38 };
 
-    enum WindowSavePromptWidgetIdx
+    enum WindowSavePromptWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -80,7 +80,7 @@ namespace OpenRCT2::Ui::Windows
         };
     };
 
-    enum
+    enum WindowScenarioSelectWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLEBAR,

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -21,7 +21,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowSceneryScatterWidgetIdx
+    enum WindowSceneryScatterWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -42,7 +42,7 @@ namespace OpenRCT2::Ui::Windows
 
     static constexpr size_t kMaxPlayerNameLength = 32;
 
-    enum
+    enum WindowServerListWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -27,7 +27,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum
+    enum WindowServerStartWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -32,7 +32,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr ScreenSize kWindowSize = { 420, 280 };
     static constexpr ScreenSize kMaximumWindowSize = { 1200, 800 };
 
-    enum WindowShortcutWidgetIdx
+    enum WindowShortcutWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -36,7 +36,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_SIGN;
     static constexpr ScreenSize kWindowSize = { 113, 96 };
 
-    enum WindowSignWidgetIdx
+    enum WindowSignWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -56,7 +56,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_STAFF_PAGE_COUNT,
     };
 
-    enum WindowStaffWidgetIdx
+    enum WindowStaffWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -25,7 +25,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr StringId kWindowTitle = STR_SACK_STAFF;
     static constexpr ScreenSize kWindowSize = { 200, 100 };
 
-    enum WindowStaffFireWidgetIdx
+    enum WindowStaffFireWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -60,7 +60,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_STAFF_LIST_TAB_ENTERTAINERS
     };
 
-    enum WindowStaffListWidgetIdx
+    enum WindowStaffListWidgetIdx : WidgetIndex
     {
         WIDX_STAFF_LIST_BACKGROUND,
         WIDX_STAFF_LIST_TITLE,

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -31,7 +31,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 250, 90 };
 
-    enum WindowTextInputWidgetIdx
+    enum WindowTextInputWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Ui::Windows
         WINDOW_THEMES_TAB_COUNT
     };
 
-    enum WindowThemesWidgetIdx
+    enum WindowThemesWidgetIdx : WidgetIndex
     {
         WIDX_THEMES_BACKGROUND,
         WIDX_THEMES_TITLE,

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -82,7 +82,7 @@ namespace OpenRCT2::Ui::Windows
         STR_TILE_INSPECTOR_WALL_ANIMATION_FRAME,
     };
 
-    enum WindowTileInspectorWidgetIdx
+    enum WindowTileInspectorWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -17,7 +17,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 40, 64 };
 
-    enum WindowTitleExitWidgetIdx
+    enum WindowTitleExitWidgetIdx : WidgetIndex
     {
         WIDX_EXIT,
     };

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -18,7 +18,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 232, 136 };
 
-    enum
+    enum WindowTitleLogoWidgetIdx : WidgetIndex
     {
         WIDX_LOGO
     };

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -29,7 +29,7 @@ namespace OpenRCT2::Ui::Windows
 {
     using namespace OpenRCT2::Drawing;
 
-    enum
+    enum WindowTitleMenuWidgetIdx : WidgetIndex
     {
         WIDX_START_NEW_GAME,
         WIDX_CONTINUE_SAVED_GAME,

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -16,7 +16,7 @@ namespace OpenRCT2::Ui::Windows
 {
     static constexpr ScreenSize kWindowSize = { 80, 15 };
 
-    enum WindowTitleOptionsWidgetIdx
+    enum WindowTitleOptionsWidgetIdx : WidgetIndex
     {
         WIDX_OPTIONS,
     };

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -26,7 +26,7 @@ using namespace OpenRCT2::Drawing;
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum
+    enum WindowTooltipWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND
     };

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -63,7 +63,7 @@ using namespace OpenRCT2::Numerics;
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum
+    enum WindowTopToolbarWidgetIdx : WidgetIndex
     {
         WIDX_PAUSE,
         WIDX_FILE_MENU,

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -27,7 +27,7 @@ namespace OpenRCT2::Ui::Windows
 
 #pragma region Widgets
 
-    enum
+    enum WindowTrackManageWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -60,7 +60,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr auto kPaletteIndexColourTrack = PaletteIndex::primaryRemap5;   // Grey (dark)
     static constexpr auto kPaletteIndexColourStation = PaletteIndex::primaryRemap9; // Grey (light)
 
-    enum
+    enum WindowTrackDesignPlaceWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -43,7 +43,7 @@ namespace OpenRCT2::Ui::Windows
     static constexpr int32_t kRotateAndSceneryButtonSize = 24;
     static constexpr int32_t kWindowPadding = 5;
 
-    enum
+    enum WindowTrackListWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -30,7 +30,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowTransparencyWidgetIndex
+    enum WindowTransparencyWidgetIndex : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -26,7 +26,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowViewClippingWidgetIdx
+    enum WindowViewClippingWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -20,7 +20,7 @@
 
 namespace OpenRCT2::Ui::Windows
 {
-    enum WindowViewportWidgetIdx
+    enum WindowViewportWidgetIdx : WidgetIndex
     {
         WIDX_BACKGROUND,
         WIDX_TITLE,

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -233,8 +233,11 @@ static RenderTarget CreateRT(const Viewport& viewport)
     RenderTarget rt;
     rt.width = viewport.width;
     rt.height = viewport.height;
-    rt.bits = new (std::nothrow) PaletteIndex[rt.width * rt.height];
-    if (rt.bits == nullptr)
+    try
+    {
+        rt.bits = new PaletteIndex[rt.width * rt.height];
+    }
+    catch (...)
     {
         throw std::runtime_error("Giant screenshot failed, unable to allocate memory for image.");
     }


### PR DESCRIPTION
The screenshot.cpp looks like a GCC bug, but haven't filed it upstream yet.
```
/home/janisozaur/workspace/openrct2/src/openrct2/interface/Screenshot.cpp: In function ‘OpenRCT2::Drawing::RenderTarget CreateRT(const OpenRCT2::Viewport&)’:
/home/janisozaur/workspace/openrct2/src/openrct2/interface/Screenshot.cpp:236:67: error: this condition has identical branches [-Werror=duplicated-branches]
  236 |     rt.bits = new (std::nothrow) PaletteIndex[rt.width * rt.height];
      |                                                                   ^
cc1plus: all warnings being treated as errors
```
```
/home/janisozaur/workspace/openrct2/src/openrct2-ui/windows/Ride.cpp:112:5: error: type ‘OpenRCT2::Ui::Windows::{enum:unsigned int{WIDX_BACKGROUND}}’ violates the C++ One Definition Rule [-Werror=odr]
  112 |     {
      |     ^
/home/janisozaur/workspace/openrct2/src/openrct2-ui/windows/RideConstruction.cpp:102:5: note: an enum with different value name is defined in another translation unit
  102 |     {
      |     ^
/home/janisozaur/workspace/openrct2/src/openrct2-ui/windows/Ride.cpp:116:9: note: name ‘WIDX_PAGE_BACKGROUND’ differs from name ‘WIDX_DIRECTION_GROUPBOX’ defined in another translation unit
  116 |         WIDX_PAGE_BACKGROUND,
      |         ^
/home/janisozaur/workspace/openrct2/src/openrct2-ui/windows/RideConstruction.cpp:106:9: note: mismatching definition
  106 |         WIDX_DIRECTION_GROUPBOX,
      |         ^
lto1: all warnings being treated as errors
```

While the second one only required fixing the two affected files, I unified all of our windows.