### PR TITLE
Fix #26510: Air time display limit is just 655.35 seconds instead of the correct 1966.05 seconds

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#26425] Benches don’t reduce watching spots from 4 to 2 while other path additions do (should be reversed).
 - Fix: [#26432] Guests choose to head for rides they have already ridden if they don’t have a map.
 - Fix: [#26492] Drag tool shows per-tile error instead of total cost when running out of money midway through placement.
+- Fix: [#26510] Displayed air time is limited to just 655.35 seconds instead of the correct 1966.05 seconds.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,7 +19,7 @@
 - Fix: [#26425] Benches don’t reduce watching spots from 4 to 2 while other path additions do (should be reversed).
 - Fix: [#26432] Guests choose to head for rides they have already ridden if they don’t have a map.
 - Fix: [#26492] Drag tool shows per-tile error instead of total cost when running out of money midway through placement.
-- Fix: [#26510] Displayed air time is limited to just 655.35 seconds instead of the correct 1966.05 seconds.
+- Fix: [#26510] Displayed air time overflows after 655.35 seconds instead of the internal maximum of 1966.05 seconds.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2/core/UnitConversion.cpp
+++ b/src/openrct2/core/UnitConversion.cpp
@@ -66,7 +66,7 @@ namespace OpenRCT2
         return (baseSpeed * 9) >> 18;
     }
 
-    uint16_t ToHumanReadableAirTime(uint16_t airTime)
+    int32_t ToHumanReadableAirTime(uint16_t airTime)
     {
         return airTime * 3;
     }

--- a/src/openrct2/core/UnitConversion.h
+++ b/src/openrct2/core/UnitConversion.h
@@ -22,6 +22,6 @@ namespace OpenRCT2
     uint8_t MetresToBaseZ(int16_t metres);
     int32_t HeightUnitsToMetres(int32_t heightUnit);
     int32_t ToHumanReadableSpeed(int32_t baseSpeed);
-    uint16_t ToHumanReadableAirTime(uint16_t airTime);
+    int32_t ToHumanReadableAirTime(uint16_t airTime);
     int32_t ToHumanReadableRideLength(int32_t rideLength);
 } // namespace OpenRCT2


### PR DESCRIPTION
Fixes #26510