### PR TITLE
Fix JS socket issues

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#26432] Guests choose to head for rides they have already ridden if they don’t have a map.
 - Fix: [#26492] Drag tool shows per-tile error instead of total cost when running out of money midway through placement.
 - Fix: [#26510] Displayed air time overflows after 655.35 seconds instead of the internal maximum of 1966.05 seconds.
+- Fix: [#26396] [Plugin] Socket interfaces were not closing properly and firing up correctly in parallel.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#26352] Large scenery items are incorrectly labelled as ‘banners’ in the tile inspector.
 - Fix: [#26352] The label for path additions is using the wrong text colour in the tile inspector.
 - Fix: [#26360] Inverted Lay-down Roller Coaster helices are invisible when loading old saves.
+- Fix: [#26396] [Plugin] Socket interfaces were not closing properly and firing up correctly in parallel.
 - Fix: [#26410] Tiles with water can draw incorrectly when there is something underwater and nothing above water.
 - Fix: [#26419] Drop count & negative g’s stat requirements for Flying Roller Coaster don’t get nullified by having an inversion.
 - Fix: [#26421] Wrong scenery tab highlighted when more than 64 scenery groups are selected.
@@ -20,7 +21,6 @@
 - Fix: [#26432] Guests choose to head for rides they have already ridden if they don’t have a map.
 - Fix: [#26492] Drag tool shows per-tile error instead of total cost when running out of money midway through placement.
 - Fix: [#26510] Displayed air time overflows after 655.35 seconds instead of the internal maximum of 1966.05 seconds.
-- Fix: [#26396] [Plugin] Socket interfaces were not closing properly and firing up correctly in parallel.
 
 0.5.0 (2026-04-12)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -169,9 +169,13 @@ namespace OpenRCT2::Scripting
         ScriptEngine(ScriptEngine&) = delete;
         ~ScriptEngine();
 
-        JSContext* GetContext()
+        JSContext* GetContext() const
         {
             return _replContext;
+        }
+        static JSRuntime* GetRuntime()
+        {
+            return _runtime;
         }
         HookEngine& GetHookEngine()
         {

--- a/src/openrct2/scripting/bindings/network/ScSocket.hpp
+++ b/src/openrct2/scripting/bindings/network/ScSocket.hpp
@@ -46,10 +46,14 @@ namespace OpenRCT2::Scripting
             auto listeners = GetListenerList(id);
             for (size_t i = 0; i < listeners.size(); i++)
             {
-                scriptEngine.ExecutePluginCall(plugin, listeners[i].callback, args, isGameStateMutable);
+                scriptEngine.ExecutePluginCall(plugin, listeners[i].callback, args, isGameStateMutable, true);
 
                 // Safety, listeners might get reallocated
                 listeners = GetListenerList(id);
+            }
+            for (const JSValue& arg : args)
+            {
+                JS_FreeValueRT(ScriptEngine::GetRuntime(), arg);
             }
         }
 
@@ -425,6 +429,7 @@ namespace OpenRCT2::Scripting
             auto data = std::make_shared<SocketData>();
             data->_plugin = plugin;
             data->_socket = std::move(socket);
+            data->_wasConnected = true;
             GetContext()->GetScriptEngine().AddSocket(data);
             return MakeWithOpaque(ctx, new std::shared_ptr(data));
         }


### PR DESCRIPTION
This should fix two socket issues.

Firstly, sockets accepted by listeners never have their close events fired. This is because they never have the `_wasConnected` flag set and this flag guards running the close event. Corrected by setting `_wasConnected = true` when accepting a socket from a listener.

Secondly, there is a double free which is likely responsible for #26396 and the backtrace issues [here](https://github.com/OpenRCT2/OpenRCT2/issues?q=is%3Aissue%20state%3Aopen%20JS). This is caused when there are multiple callbacks listening for a single socket event. `ExecutePluginCall` frees its arguments, and since its called multiple times in a loop, the subsequent calls will use and then free invalid arguments. The fix is instead to ask `ExecutePluginCall` to keep the arguments alive and then free them after running all callbacks.