### PR TITLE
Rename MoneyEffect members

### DIFF
--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -473,12 +473,12 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         const MoneyEffect& spriteBase, const MoneyEffect& spriteCmp, GameStateSpriteChange& changeData) const
     {
         COMPARE_FIELD(MoneyEffect, frame);
-        COMPARE_FIELD(MoneyEffect, MoveDelay);
-        COMPARE_FIELD(MoneyEffect, NumMovements);
-        COMPARE_FIELD(MoneyEffect, GuestPurchase);
-        COMPARE_FIELD(MoneyEffect, Value);
-        COMPARE_FIELD(MoneyEffect, OffsetX);
-        COMPARE_FIELD(MoneyEffect, Wiggle);
+        COMPARE_FIELD(MoneyEffect, moveDelay);
+        COMPARE_FIELD(MoneyEffect, numMovements);
+        COMPARE_FIELD(MoneyEffect, guestPurchase);
+        COMPARE_FIELD(MoneyEffect, value);
+        COMPARE_FIELD(MoneyEffect, offsetX);
+        COMPARE_FIELD(MoneyEffect, wiggle);
     }
 
     void CompareSpriteDataSteamParticle(

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -53,7 +53,7 @@ namespace OpenRCT2
         if (moneyEffect == nullptr)
             return;
 
-        moneyEffect->GuestPurchase = (guestPurchase ? 1 : 0);
+        moneyEffect->guestPurchase = (guestPurchase ? 1 : 0);
         moneyEffect->MoveTo(effectPos);
         moneyEffect->SetValue(value);
     }
@@ -94,25 +94,25 @@ namespace OpenRCT2
     /**
      * Set the value of the money effect
      */
-    void MoneyEffect::SetValue(money64 value)
+    void MoneyEffect::SetValue(money64 newValue)
     {
-        Value = value;
+        value = newValue;
         SpriteData.Width = 64;
         SpriteData.HeightMin = 20;
         SpriteData.HeightMax = 30;
-        MoveDelay = 0;
-        NumMovements = 0;
+        moveDelay = 0;
+        numMovements = 0;
 
         int16_t offsetX = 0;
         if (!gOpenRCT2NoGraphics)
         {
-            auto [stringId, newValue] = GetStringId();
+            auto [stringId, pairValue] = GetStringId();
             char buffer[128];
-            FormatStringLegacy(buffer, 128, stringId, &newValue);
+            FormatStringLegacy(buffer, 128, stringId, &pairValue);
             offsetX = -(Drawing::getStringWidth(buffer, FontStyle::medium) / 2);
         }
-        OffsetX = offsetX;
-        Wiggle = 0;
+        this->offsetX = offsetX;
+        wiggle = 0;
     }
 
     /**
@@ -121,14 +121,14 @@ namespace OpenRCT2
      */
     void MoneyEffect::Update()
     {
-        Wiggle++;
-        if (Wiggle >= 22)
+        wiggle++;
+        if (wiggle >= 22)
         {
-            Wiggle = 0;
+            wiggle = 0;
         }
 
-        MoveDelay++;
-        if (MoveDelay < 2)
+        moveDelay++;
+        if (moveDelay < 2)
         {
             return;
         }
@@ -136,9 +136,9 @@ namespace OpenRCT2
         int32_t newX = x;
         int32_t newY = y;
         int32_t newZ = z;
-        MoveDelay = 0;
+        moveDelay = 0;
 
-        if (GuestPurchase)
+        if (guestPurchase)
         {
             newZ += 1;
         }
@@ -147,8 +147,8 @@ namespace OpenRCT2
 
         MoveTo({ newX, newY, newZ });
 
-        NumMovements++;
-        if (NumMovements < 55)
+        numMovements++;
+        if (numMovements < 55)
         {
             return;
         }
@@ -158,11 +158,11 @@ namespace OpenRCT2
 
     std::pair<StringId, money64> MoneyEffect::GetStringId() const
     {
-        StringId spentStringId = GuestPurchase ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
-        StringId receiveStringId = GuestPurchase ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
+        StringId spentStringId = guestPurchase ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
+        StringId receiveStringId = guestPurchase ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
         StringId stringId = receiveStringId;
-        money64 outValue = Value;
-        if (Value < 0)
+        money64 outValue = value;
+        if (value < 0)
         {
             outValue *= -1;
             stringId = spentStringId;
@@ -175,12 +175,12 @@ namespace OpenRCT2
     {
         EntityBase::Serialise(stream);
         stream << frame;
-        stream << MoveDelay;
-        stream << NumMovements;
-        stream << GuestPurchase;
-        stream << Value;
-        stream << OffsetX;
-        stream << Wiggle;
+        stream << moveDelay;
+        stream << numMovements;
+        stream << guestPurchase;
+        stream << value;
+        stream << offsetX;
+        stream << wiggle;
     }
 
     void MoneyEffect::Paint(PaintSession& session, int32_t imageDirection) const
@@ -193,7 +193,7 @@ namespace OpenRCT2
             return;
         }
 
-        if (GuestPurchase && !Config::Get().general.showGuestPurchases)
+        if (guestPurchase && !Config::Get().general.showGuestPurchases)
         {
             // Don't show the money effect for guest purchases when the option is disabled.
             return;
@@ -211,8 +211,8 @@ namespace OpenRCT2
             0, 1, 2, 2, 3, 3, 3, 3, 2, 2, 1, 0, -1, -2, -2, -3, -3, -3, -3, -2, -2, -1,
         };
 
-        auto [stringId, value] = GetStringId();
+        auto [stringId, stringValue] = GetStringId();
         PaintFloatingMoneyEffect(
-            session, value, stringId, y, z, const_cast<int8_t*>(&waveOffset[Wiggle % 22]), OffsetX, session.CurrentRotation);
+            session, stringValue, stringId, y, z, const_cast<int8_t*>(&waveOffset[wiggle % 22]), offsetX, session.CurrentRotation);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -213,6 +213,7 @@ namespace OpenRCT2
 
         auto [stringId, stringValue] = GetStringId();
         PaintFloatingMoneyEffect(
-            session, stringValue, stringId, y, z, const_cast<int8_t*>(&waveOffset[wiggle % 22]), offsetX, session.CurrentRotation);
+            session, stringValue, stringId, y, z, const_cast<int8_t*>(&waveOffset[wiggle % 22]), offsetX,
+            session.CurrentRotation);
     }
 } // namespace OpenRCT2

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -111,7 +111,7 @@ namespace OpenRCT2
             FormatStringLegacy(buffer, 128, stringId, &pairValue);
             newOffsetX = -(Drawing::getStringWidth(buffer, FontStyle::medium) / 2);
         }
-        this->offsetX = newOffsetX;
+        offsetX = newOffsetX;
         wiggle = 0;
     }
 

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -103,15 +103,15 @@ namespace OpenRCT2
         moveDelay = 0;
         numMovements = 0;
 
-        int16_t offsetX = 0;
+        int16_t newOffsetX = 0;
         if (!gOpenRCT2NoGraphics)
         {
             auto [stringId, pairValue] = GetStringId();
             char buffer[128];
             FormatStringLegacy(buffer, 128, stringId, &pairValue);
-            offsetX = -(Drawing::getStringWidth(buffer, FontStyle::medium) / 2);
+            newOffsetX = -(Drawing::getStringWidth(buffer, FontStyle::medium) / 2);
         }
-        this->offsetX = offsetX;
+        this->offsetX = newOffsetX;
         wiggle = 0;
     }
 

--- a/src/openrct2/entity/MoneyEffect.h
+++ b/src/openrct2/entity/MoneyEffect.h
@@ -27,12 +27,12 @@ namespace OpenRCT2
         static constexpr auto cEntityType = EntityType::moneyEffect;
 
         uint16_t frame;
-        uint16_t MoveDelay;
-        uint8_t NumMovements;
-        uint8_t GuestPurchase;
-        money64 Value;
-        int16_t OffsetX;
-        uint16_t Wiggle;
+        uint16_t moveDelay;
+        uint8_t numMovements;
+        uint8_t guestPurchase;
+        money64 value;
+        int16_t offsetX;
+        uint16_t wiggle;
 
         static void CreateAt(money64 value, const CoordsXYZ& effectPos, bool guestPurchase);
         static void Create(money64 value, const CoordsXYZ& loc);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2547,12 +2547,12 @@ namespace OpenRCT2
     void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, MoneyEffect& moneyEffect)
     {
         ReadWriteEntityCommon(cs, moneyEffect);
-        cs.readWrite(moneyEffect.MoveDelay);
-        cs.readWrite(moneyEffect.NumMovements);
-        cs.readWrite(moneyEffect.GuestPurchase);
-        cs.readWrite(moneyEffect.Value);
-        cs.readWrite(moneyEffect.OffsetX);
-        cs.readWrite(moneyEffect.Wiggle);
+        cs.readWrite(moneyEffect.moveDelay);
+        cs.readWrite(moneyEffect.numMovements);
+        cs.readWrite(moneyEffect.guestPurchase);
+        cs.readWrite(moneyEffect.value);
+        cs.readWrite(moneyEffect.offsetX);
+        cs.readWrite(moneyEffect.wiggle);
     }
 
     template<>

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -3062,12 +3062,12 @@ namespace OpenRCT2::RCT1
         auto* src = static_cast<const RCT12EntityMoneyEffect*>(&srcBase);
 
         ImportEntityCommonProperties(dst, src);
-        dst->MoveDelay = src->MoveDelay;
-        dst->NumMovements = src->NumMovements;
-        dst->GuestPurchase = src->Vertical;
-        dst->Value = src->Value;
-        dst->OffsetX = src->OffsetX;
-        dst->Wiggle = src->Wiggle;
+        dst->moveDelay = src->MoveDelay;
+        dst->numMovements = src->NumMovements;
+        dst->guestPurchase = src->Vertical;
+        dst->value = src->Value;
+        dst->offsetX = src->OffsetX;
+        dst->wiggle = src->Wiggle;
     }
 
     template<>

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -2217,12 +2217,12 @@ namespace OpenRCT2::RCT2
         auto dst = getGameState().entities.CreateEntityAt<::MoneyEffect>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT12EntityMoneyEffect*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
-        dst->MoveDelay = src->MoveDelay;
-        dst->NumMovements = src->NumMovements;
-        dst->GuestPurchase = src->Vertical;
-        dst->Value = src->Value;
-        dst->OffsetX = src->OffsetX;
-        dst->Wiggle = src->Wiggle;
+        dst->moveDelay = src->MoveDelay;
+        dst->numMovements = src->NumMovements;
+        dst->guestPurchase = src->Vertical;
+        dst->value = src->Value;
+        dst->offsetX = src->OffsetX;
+        dst->wiggle = src->Wiggle;
     }
 
     template<>

--- a/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScMoneyEffect.cpp
@@ -39,7 +39,7 @@ namespace OpenRCT2::Scripting
     JSValue ScMoneyEffect::value_get(JSContext* ctx, JSValue thisVal)
     {
         auto moneyEffect = GetMoneyEffect(thisVal);
-        return JS_NewInt64(ctx, moneyEffect == nullptr ? 0 : moneyEffect->Value);
+        return JS_NewInt64(ctx, moneyEffect == nullptr ? 0 : moneyEffect->value);
     }
 
     JSValue ScMoneyEffect::value_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)


### PR DESCRIPTION
Continuing to refactor code according to #26521.

The project has no build errors.

 Also renamed a local variable of `MoneyEffect.cpp`, `offsetX` to `newOffsetX` in `SetValue()` to avoid shadowing the new member field.

