### PR TITLE
Add object emptiness checks for mapRequest

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2621,13 +2621,18 @@ namespace OpenRCT2::Network
             if (generation == static_cast<uint8_t>(ObjectGeneration::DAT))
             {
                 const auto* entry = reinterpret_cast<const RCTObjectEntry*>(packet.Read(sizeof(RCTObjectEntry)));
+                if (entry == nullptr)
+                    break;
                 objectName = std::string(entry->GetName());
                 LOG_VERBOSE("Client requested object %s", objectName.c_str());
                 item = repo.FindObject(entry);
             }
             else
             {
-                objectName = std::string(packet.ReadString());
+                auto name = packet.ReadString();
+                if (name.empty())
+                    break;
+                objectName = std::string(name);
                 LOG_VERBOSE("Client requested object %s", objectName.c_str());
                 item = repo.FindObject(objectName);
             }


### PR DESCRIPTION
As mentioned in #26555, this PR splits off the object emptiness checks for `mapRequest`