### PR TITLE
Fixing crash when removing null socket

### DIFF
--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -2114,16 +2114,17 @@ void ScriptEngine::UpdateSockets()
 void ScriptEngine::RemoveSockets(const std::shared_ptr<Plugin>& plugin)
 {
     #ifndef DISABLE_NETWORK
-    std::erase_if(_sockets, [plugin](const std::shared_ptr<SocketDataBase>& data) {
-        if (data == nullptr)
-            return true;
-        if (data->_plugin == plugin)
-        {
-            data->Dispose();
-            return true;
-        }
-        return false;
-    });
+    // Remove sockets from the _plugins vector by first moving them, then clearing the vector
+    std::vector<std::shared_ptr<SocketDataBase>> removed;
+    for (auto& data : _sockets)
+    {
+        if (data != nullptr && data->_plugin == plugin)
+            removed.push_back(std::move(data));
+    }
+    std::erase_if(_sockets, [](const std::shared_ptr<SocketDataBase>& data) { return data == nullptr; });
+    // Dispose of the moved sockets safely
+    for (const auto& data : removed)
+        data->Dispose();
     #endif
 }
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -2115,6 +2115,8 @@ void ScriptEngine::RemoveSockets(const std::shared_ptr<Plugin>& plugin)
 {
     #ifndef DISABLE_NETWORK
     std::erase_if(_sockets, [plugin](const std::shared_ptr<SocketDataBase>& data) {
+        if (data == nullptr)
+            return true;
         if (data->_plugin == plugin)
         {
             data->Dispose();


### PR DESCRIPTION
Calling `Dispose()` has the potential to mutate the `_sockets` vector while it's being traversed by `std::erase_if`. This PR moves the items from the `_sockets` vector first before safely calling `Dispose`.

Fixes #26477 
Fixes #26519 
Fixes #26525  
Fixes #26466
Fixes #26391
Fixes #26531
Fixes #26447 
Fixes #26541 
Fixes #26413 
Fixes #26383 
Fixes #26390 
Fixes #26415 
Fixes #26399 