### PR TITLE
Fixing out-of-bounds enum lookup

### DIFF
--- a/src/openrct2/core/EnumMap.hpp
+++ b/src/openrct2/core/EnumMap.hpp
@@ -94,6 +94,8 @@ public:
     std::string_view operator[](T k) const
     {
         auto it = find(k);
+        if (it == end())
+            return {};
         return it->first;
     }
 
@@ -146,6 +148,8 @@ public:
             if (_continiousValueIndex)
             {
                 auto index = static_cast<size_t>(k);
+                if (index >= _map.size())
+                    return end();
                 return _map.begin() + index;
             }
 

--- a/src/openrct2/scripting/bindings/entity/ScGuest.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScGuest.cpp
@@ -607,16 +607,24 @@ namespace OpenRCT2::Scripting
                 if (shopItem == ShopItem::voucher)
                 {
                     // Voucher
-                    JS_SetPropertyStr(ctx, obj, "voucherType", JSFromStdString(ctx, VoucherTypeMap[peep->VoucherType]));
-                    if (peep->VoucherType == VOUCHER_TYPE_RIDE_FREE)
+                    auto voucherType = VoucherTypeMap[peep->VoucherType];
+                    if (!voucherType.empty())
                     {
-                        // RideVoucher
-                        JS_SetPropertyStr(ctx, obj, "rideId", JS_NewUint32(ctx, peep->VoucherRideId.ToUnderlying()));
-                    }
-                    else if (peep->VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
-                    {
-                        // FoodDrinkVoucher
-                        JS_SetPropertyStr(ctx, obj, "item", JSFromStdString(ctx, ShopItemMap[peep->VoucherShopItem]));
+                        JS_SetPropertyStr(ctx, obj, "voucherType", JSFromStdString(ctx, voucherType));
+                        if (peep->VoucherType == VOUCHER_TYPE_RIDE_FREE)
+                        {
+                            // RideVoucher
+                            JS_SetPropertyStr(ctx, obj, "rideId", JS_NewUint32(ctx, peep->VoucherRideId.ToUnderlying()));
+                        }
+                        else if (peep->VoucherType == VOUCHER_TYPE_FOOD_OR_DRINK_FREE)
+                        {
+                            // FoodDrinkVoucher
+                            auto voucherItem = ShopItemMap[peep->VoucherShopItem];
+                            if (!voucherItem.empty())
+                            {
+                                JS_SetPropertyStr(ctx, obj, "item", JSFromStdString(ctx, voucherItem));
+                            }
+                        }
                     }
                 }
                 else if (GetShopItemDescriptor(shopItem).IsPhoto())


### PR DESCRIPTION
This PR fixes a crash due to an out-of-bounds lookup with the `EnumMap`. Also prevents an unmappable voucher field from being emitted to a plugin.

Fixes #26544 
Fixes #26537 
Fixes #26448 
Fixes #26364 