### PR TITLE
Publish plugin API types to NPM only on main repository

### DIFF
--- a/.github/workflows/publish-plugin-types.yml
+++ b/.github/workflows/publish-plugin-types.yml
@@ -17,6 +17,7 @@ jobs:
   publish:
     name: Publish @openrct2/types
     runs-on: ubuntu-slim
+    if: github.repository == 'OpenRCT2/OpenRCT2'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The publish task currently also runs on forks, and fails there because the forks are not allowed to publish to NPM.