### PR TITLE
Reorder finance graph logic to remove undefined behaviour

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#26374] Add higher resolution app icons for Android.
 - Improved: [#26386] Initial window scale and toolbar options on fresh Android installations.
 - Change: [#26476] Limit creation of new station styles to prepare for more flexibility with ride stations and entrances.
+- Fix: [#25581] Chart drawing issue on some platforms due to compiler optimisation.
 - Fix: [#26019] Inverted and Inverted Flying Roller Coaster large half loops glitch with the train and don‘t draw in tunnels at some angles (original bug).
 - Fix: [#26183] The ride stat graph placeholder text is not drawn in the expected position.
 - Fix: [#26287] Game crashes upon connect/disconnect of physical keyboard. 

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -804,9 +804,9 @@ namespace OpenRCT2::Ui::Windows
             const auto series = _graphProps.series;
             for (int32_t i = 0; i < kGraphNumPoints; i++)
             {
-                auto val = std::abs(series[i]);
-                if (val == kMoney64Undefined)
+                if (series[i] == kMoney64Undefined)
                     continue;
+                auto val = std::abs(series[i]);
                 if (val > maxVal)
                     maxVal = val;
             }


### PR DESCRIPTION
Addresses the issue with graph rendering discussed in #25581

Replication of the issue is related to the compiler used to build (which seems to only be effecting the Linux release?)
Building locally in release mode with Clang 18 results in working graphs.
Building locally in release mode with Clang 20 results in broken graphs.

During graph rendering we take our series value, run it through `abs` then check if it is equal to `kMoney64Undefined`

`kMoney64Undefined` is declared as `0x8000000000000000`, which is `INT64_MIN`, which has no positive representation as an `INT64`, so running it through `abs` is undefined behavior.
Clang 20 seems to recognize that `abs(val) == INT64_MIN` should always be false and opts to remove the check.

The logic has been reordered to remove this issue.