### PR TITLE
Fix verbose console error messages truncating the first byte

### DIFF
--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -108,7 +108,7 @@ namespace OpenRCT2::Ui::Windows
             buffer.append(message);
         }
 
-        LOG_VERBOSE("show error, %s", buffer.c_str() + 1);
+        LOG_VERBOSE("show error, %s", buffer.c_str());
 
         // Don't do unnecessary work in headless. Also saves checking if cursor state is null.
         if (gOpenRCT2Headless)


### PR DESCRIPTION
As reported, the first character of error window messages is skipped in the verbose log. I think this is a remnant of the time where format codes used to be encoded as single bytes within the strings. Given we have since changed it to parse format codes ad-hoc instead, the first byte was skipped overzealously.

Fixes #26361