### PR TITLE
Fix land tool regressions

### DIFF
--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -949,11 +949,11 @@ namespace OpenRCT2
             if (surfaceElement == nullptr || minHeight <= surfaceElement->baseHeight)
                 continue;
 
-            if (gLegacyScene == LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
-                continue;
-
-            if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
-                continue;
+            if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+            {
+                if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
+                    continue;
+            }
 
             minHeight = surfaceElement->baseHeight;
         }
@@ -969,11 +969,11 @@ namespace OpenRCT2
             if (surfaceElement == nullptr)
                 continue;
 
-            if (gLegacyScene == LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
-                continue;
-
-            if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
-                continue;
+            if (gLegacyScene != LegacyScene::scenarioEditor && !getGameState().cheats.sandboxMode)
+            {
+                if (!MapIsLocationInPark(tileCoords.ToCoordsXY()))
+                    continue;
+            }
 
             uint8_t height = surfaceElement->baseHeight;
             if (surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -962,7 +962,7 @@ namespace OpenRCT2
 
     uint8_t MapGetHighestLandHeight(const MapRange& range)
     {
-        uint8_t maxHeight = 0xFF;
+        uint8_t maxHeight = 0;
         for (auto tileCoords : Map::getDrawableTileRange())
         {
             auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -943,7 +943,7 @@ namespace OpenRCT2
     uint8_t MapGetLowestLandHeight(const MapRange& range)
     {
         uint8_t minHeight = 0xFF;
-        for (auto tileCoords : Map::getDrawableTileRange())
+        for (auto tileCoords : Map::getClampedRange(range))
         {
             auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);
             if (surfaceElement == nullptr || minHeight <= surfaceElement->baseHeight)
@@ -963,7 +963,7 @@ namespace OpenRCT2
     uint8_t MapGetHighestLandHeight(const MapRange& range)
     {
         uint8_t maxHeight = 0;
-        for (auto tileCoords : Map::getDrawableTileRange())
+        for (auto tileCoords : Map::getClampedRange(range))
         {
             auto* surfaceElement = MapGetSurfaceElementAt(tileCoords);
             if (surfaceElement == nullptr)


### PR DESCRIPTION
Three regressions from #26469:

1. The land ownership checks were applied regardless of scene (editor) and sandbox mode cheat status. Completely missed this one.
2. Highest land value was wrong due to the wrong sentinel value (always 255). This must've been introduced in a rebase.
3. The entire drawable map was checked, instead of only the map range provided. Pretty sure I _wanted_ to test `getDrawableRange` at some point, and must've accidentally committed it.

Apologies for the mess.