### PR TITLE
Add RCT1 Tables & CSG tests

### DIFF
--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -1143,7 +1143,7 @@ namespace OpenRCT2::RCT1
             "rct2.scenery_small.corroof",
             "rct2.scenery_small.corroof2",
         };
-        return smallSceneryType < std::size(map) ? map[smallSceneryType] : "";
+        return map[smallSceneryType];
     }
 
     std::string_view GetLargeSceneryObject(uint8_t largeSceneryType)
@@ -1190,7 +1190,7 @@ namespace OpenRCT2::RCT1
             "rct2.scenery_large.ssig3",
             "rct2.scenery_large.ssig4",
         };
-        return largeSceneryType < std::size(map) ? map[largeSceneryType] : "";
+        return map[largeSceneryType];
     }
 
     int32_t MapSlopedWall(uint8_t wallType)
@@ -1334,8 +1334,7 @@ namespace OpenRCT2::RCT1
             "rct2.footpath_banner.bn8", // BannerType::snow
             "rct2.footpath_banner.bn9", // BannerType::space
         };
-        const auto idx = EnumValue(bannerType);
-        return idx < std::size(map) ? map[idx] : "";
+        return map[EnumValue(bannerType)];
     }
 
     std::string_view GetPathSurfaceObject(uint8_t pathType)
@@ -1372,7 +1371,7 @@ namespace OpenRCT2::RCT1
             "rct1ll.footpath_surface.tiles_red",    // RCT1_FOOTPATH_TYPE_TILE_RED
             "rct1ll.footpath_surface.tiles_green",  // RCT1_FOOTPATH_TYPE_TILE_GREEN
         };
-        return pathType < std::size(map) ? map[pathType] : "";
+        return map[pathType];
     }
 
     std::string_view GetPathAddtionObject(uint8_t pathAdditionType)
@@ -1395,7 +1394,7 @@ namespace OpenRCT2::RCT1
             "rct2.footpath_item.lamp4",       // RCT1_PATH_ADDITION_BROKEN_LAMP_4
             "rct2.footpath_item.jumpsnw1",    // RCT1_PATH_ADDITION_JUMPING_SNOW
         };
-        return pathAdditionType < std::size(map) ? map[pathAdditionType] : "";
+        return map[pathAdditionType];
     }
 
     std::string_view GetFootpathRailingsObject(uint8_t footpathRailingsType)
@@ -1407,7 +1406,7 @@ namespace OpenRCT2::RCT1
             "rct1ll.footpath_railings.space",      // RCT1_PATH_SUPPORT_TYPE_SPACE
             "rct1ll.footpath_railings.bamboo",     // RCT1_PATH_SUPPORT_TYPE_BAMBOO
         };
-        return footpathRailingsType < std::size(map) ? map[footpathRailingsType] : "";
+        return map[footpathRailingsType];
     }
 
     std::string_view GetSceneryGroupObject(uint8_t sceneryGroupType)
@@ -1433,7 +1432,7 @@ namespace OpenRCT2::RCT1
             "rct2.scenery_group.scgurban",    // RCT1_SCENERY_THEME_URBAN
             "rct2.scenery_group.scgorien",    // RCT1_SCENERY_THEME_PAGODA
         };
-        return sceneryGroupType < std::size(map) ? map[sceneryGroupType] : "";
+        return map[sceneryGroupType];
     }
 
     std::string_view GetWaterObject(uint8_t waterType)
@@ -1443,7 +1442,7 @@ namespace OpenRCT2::RCT1
             "rct2.water.wtrcyan",
             "rct2.water.wtrorng",
         };
-        return waterType < std::size(map) ? map[waterType] : "";
+        return map[waterType];
     }
 
     const std::vector<const char *> GetSceneryObjects(uint8_t sceneryType)
@@ -1492,7 +1491,7 @@ namespace OpenRCT2::RCT1
             // RCT1_SCENERY_THEME_PAGODA
             { "rct2.scenery_large.spg", "rct2.scenery_small.tly", "rct2.scenery_small.tgg", "rct2.scenery_small.toh1", "rct2.scenery_small.toh2", "rct2.scenery_small.tot1", "rct2.scenery_small.tot2", "rct2.scenery_small.tos", "rct2.scenery_small.tot3", "rct2.scenery_small.tot4", "rct2.scenery_small.toh3", "rct2.scenery_wall.wallpg32", "rct2.scenery_small.pagroof1", "rct2.footpath_banner.bn7" }
         };
-        return sceneryType < std::size(map) ? map[sceneryType] : std::vector<const char *>{};
+        return map[sceneryType];
     }
     // clang-format on
 

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -1143,7 +1143,7 @@ namespace OpenRCT2::RCT1
             "rct2.scenery_small.corroof",
             "rct2.scenery_small.corroof2",
         };
-        return map[smallSceneryType];
+        return smallSceneryType < std::size(map) ? map[smallSceneryType] : "";
     }
 
     std::string_view GetLargeSceneryObject(uint8_t largeSceneryType)
@@ -1190,7 +1190,7 @@ namespace OpenRCT2::RCT1
             "rct2.scenery_large.ssig3",
             "rct2.scenery_large.ssig4",
         };
-        return map[largeSceneryType];
+        return largeSceneryType < std::size(map) ? map[largeSceneryType] : "";
     }
 
     int32_t MapSlopedWall(uint8_t wallType)
@@ -1334,7 +1334,8 @@ namespace OpenRCT2::RCT1
             "rct2.footpath_banner.bn8", // BannerType::snow
             "rct2.footpath_banner.bn9", // BannerType::space
         };
-        return map[EnumValue(bannerType)];
+        const auto idx = EnumValue(bannerType);
+        return idx < std::size(map) ? map[idx] : "";
     }
 
     std::string_view GetPathSurfaceObject(uint8_t pathType)
@@ -1371,7 +1372,7 @@ namespace OpenRCT2::RCT1
             "rct1ll.footpath_surface.tiles_red",    // RCT1_FOOTPATH_TYPE_TILE_RED
             "rct1ll.footpath_surface.tiles_green",  // RCT1_FOOTPATH_TYPE_TILE_GREEN
         };
-        return map[pathType];
+        return pathType < std::size(map) ? map[pathType] : "";
     }
 
     std::string_view GetPathAddtionObject(uint8_t pathAdditionType)
@@ -1394,7 +1395,7 @@ namespace OpenRCT2::RCT1
             "rct2.footpath_item.lamp4",       // RCT1_PATH_ADDITION_BROKEN_LAMP_4
             "rct2.footpath_item.jumpsnw1",    // RCT1_PATH_ADDITION_JUMPING_SNOW
         };
-        return map[pathAdditionType];
+        return pathAdditionType < std::size(map) ? map[pathAdditionType] : "";
     }
 
     std::string_view GetFootpathRailingsObject(uint8_t footpathRailingsType)
@@ -1406,7 +1407,7 @@ namespace OpenRCT2::RCT1
             "rct1ll.footpath_railings.space",      // RCT1_PATH_SUPPORT_TYPE_SPACE
             "rct1ll.footpath_railings.bamboo",     // RCT1_PATH_SUPPORT_TYPE_BAMBOO
         };
-        return map[footpathRailingsType];
+        return footpathRailingsType < std::size(map) ? map[footpathRailingsType] : "";
     }
 
     std::string_view GetSceneryGroupObject(uint8_t sceneryGroupType)
@@ -1432,7 +1433,7 @@ namespace OpenRCT2::RCT1
             "rct2.scenery_group.scgurban",    // RCT1_SCENERY_THEME_URBAN
             "rct2.scenery_group.scgorien",    // RCT1_SCENERY_THEME_PAGODA
         };
-        return map[sceneryGroupType];
+        return sceneryGroupType < std::size(map) ? map[sceneryGroupType] : "";
     }
 
     std::string_view GetWaterObject(uint8_t waterType)
@@ -1442,7 +1443,7 @@ namespace OpenRCT2::RCT1
             "rct2.water.wtrcyan",
             "rct2.water.wtrorng",
         };
-        return map[waterType];
+        return waterType < std::size(map) ? map[waterType] : "";
     }
 
     const std::vector<const char *> GetSceneryObjects(uint8_t sceneryType)
@@ -1491,7 +1492,7 @@ namespace OpenRCT2::RCT1
             // RCT1_SCENERY_THEME_PAGODA
             { "rct2.scenery_large.spg", "rct2.scenery_small.tly", "rct2.scenery_small.tgg", "rct2.scenery_small.toh1", "rct2.scenery_small.toh2", "rct2.scenery_small.tot1", "rct2.scenery_small.tot2", "rct2.scenery_small.tos", "rct2.scenery_small.tot3", "rct2.scenery_small.tot4", "rct2.scenery_small.toh3", "rct2.scenery_wall.wallpg32", "rct2.scenery_small.pagroof1", "rct2.footpath_banner.bn7" }
         };
-        return map[sceneryType];
+        return sceneryType < std::size(map) ? map[sceneryType] : std::vector<const char *>{};
     }
     // clang-format on
 

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/Pathfinding.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/Rct1CsgTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/ReplayTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/RideRatings.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/EntityImportTests.cpp"

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Rct1CsgTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/Rct1TablesTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/ReplayTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/RideRatings.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/EntityImportTests.cpp"

--- a/test/tests/Rct1CsgTests.cpp
+++ b/test/tests/Rct1CsgTests.cpp
@@ -1,0 +1,177 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <filesystem>
+#include <gtest/gtest.h>
+#include <openrct2/drawing/G1Element.h>
+#include <openrct2/rct1/Csg.h>
+#include <openrct2/rct1/Limits.h>
+
+using namespace OpenRCT2;
+namespace fs = std::filesystem;
+
+namespace
+{
+    // The spite resolution functions are exercised against synthetic directory layouts in the system temp dir.
+    // Each test gets a fresh empty layout to populate.
+    class Rct1CsgTests : public ::testing::Test
+    {
+    protected:
+        fs::path root;
+
+        void SetUp() override
+        {
+            root = fs::temp_directory_path()
+                / ("openrct2-rct1csg-" + std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + "-"
+                   + ::testing::UnitTest::GetInstance()->current_test_info()->name());
+            fs::remove_all(root);
+            fs::create_directories(root);
+        }
+
+        void TearDown() override
+        {
+            std::error_code ec;
+            fs::remove_all(root, ec);
+        }
+
+        // Create a sparse file of exactly `size` bytes at `path`
+        static void CreateSparseFile(const fs::path& path, const uint64_t size)
+        {
+            fs::create_directories(path.parent_path());
+            FILE* f = std::fopen(path.string().c_str(), "wb");
+            ASSERT_NE(f, nullptr) << "failed to open " << path;
+            ASSERT_EQ(std::fseek(f, size - 1, SEEK_SET), 0);
+            ASSERT_EQ(std::fputc(0, f), 0);
+            std::fclose(f);
+        }
+    };
+} // namespace
+
+TEST_F(Rct1CsgTests, FindCsg1dat_NotPresentReturnsEmpty)
+{
+    EXPECT_TRUE(FindCsg1datAtLocation(root.string()).empty());
+    EXPECT_FALSE(Csg1datPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, FindCsg1dat_PrimaryNameWins)
+{
+    CreateSparseFile(root / "Data" / "CSG1.DAT", 16);
+    const auto found = FindCsg1datAtLocation(root.string());
+    EXPECT_FALSE(found.empty());
+    EXPECT_NE(found.find("CSG1.DAT"), std::string::npos);
+    EXPECT_TRUE(Csg1datPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, FindCsg1dat_AltNameAlsoMatches)
+{
+    CreateSparseFile(root / "Data" / "CSG1.1", 16);
+    const auto found = FindCsg1datAtLocation(root.string());
+    EXPECT_FALSE(found.empty());
+    EXPECT_NE(found.find("CSG1.1"), std::string::npos);
+}
+
+TEST_F(Rct1CsgTests, FindCsg1idat_NotPresentReturnsEmpty)
+{
+    EXPECT_TRUE(FindCsg1idatAtLocation(root.string()).empty());
+    EXPECT_FALSE(Csg1idatPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, FindCsg1idat_PrimaryLocation)
+{
+    CreateSparseFile(root / "Data" / "CSG1I.DAT", 16);
+    const auto found = FindCsg1idatAtLocation(root.string());
+    EXPECT_FALSE(found.empty());
+    EXPECT_NE(found.find("Data"), std::string::npos);
+    EXPECT_TRUE(Csg1idatPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, FindCsg1idat_RctdeluxeFallback)
+{
+    CreateSparseFile(root / "RCTdeluxe_install" / "Data" / "CSG1I.DAT", 16);
+    const auto found = FindCsg1idatAtLocation(root.string());
+    EXPECT_FALSE(found.empty());
+    EXPECT_NE(found.find("RCTdeluxe_install"), std::string::npos);
+}
+
+TEST_F(Rct1CsgTests, CsgIsUsable_MatchingSizes)
+{
+    Gx csg = {};
+    csg.header.totalSize = RCT1::Limits::kLLCsg1DatFileSize;
+    csg.header.numEntries = RCT1::Limits::kNumLLCsgEntries;
+    EXPECT_TRUE(CsgIsUsable(csg));
+}
+
+TEST_F(Rct1CsgTests, CsgIsUsable_WrongTotalSize)
+{
+    Gx csg = {};
+    csg.header.totalSize = RCT1::Limits::kLLCsg1DatFileSize - 1;
+    csg.header.numEntries = RCT1::Limits::kNumLLCsgEntries;
+    EXPECT_FALSE(CsgIsUsable(csg));
+}
+
+TEST_F(Rct1CsgTests, CsgIsUsable_WrongEntryCount)
+{
+    Gx csg = {};
+    csg.header.totalSize = RCT1::Limits::kLLCsg1DatFileSize;
+    csg.header.numEntries = RCT1::Limits::kNumLLCsgEntries - 1;
+    EXPECT_FALSE(CsgIsUsable(csg));
+}
+
+TEST_F(Rct1CsgTests, CsgAtLocationIsUsable_MissingHeaderReturnsFalse)
+{
+    EXPECT_FALSE(CsgAtLocationIsUsable(root.string()));
+}
+
+TEST_F(Rct1CsgTests, CsgAtLocationIsUsable_MissingDataReturnsFalse)
+{
+    CreateSparseFile(root / "Data" / "CSG1I.DAT", 16);
+    EXPECT_FALSE(CsgAtLocationIsUsable(root.string()));
+}
+
+TEST_F(Rct1CsgTests, CsgAtLocationIsUsable_WrongSizesReturnsFalse)
+{
+    CreateSparseFile(root / "Data" / "CSG1I.DAT", 16);
+    CreateSparseFile(root / "Data" / "CSG1.DAT", 16);
+    EXPECT_FALSE(CsgAtLocationIsUsable(root.string()));
+}
+
+TEST_F(Rct1CsgTests, CsgAtLocationIsUsable_MatchingSizesReturnsTrue)
+{
+    // Build a layout whose file sizes match exactly what CsgIsUsable expects.
+    CreateSparseFile(
+        root / "Data" / "CSG1I.DAT", static_cast<uint64_t>(RCT1::Limits::kNumLLCsgEntries) * sizeof(StoredG1Element));
+    CreateSparseFile(root / "Data" / "CSG1.DAT", RCT1::Limits::kLLCsg1DatFileSize);
+    EXPECT_TRUE(CsgAtLocationIsUsable(root.string()));
+}
+
+TEST_F(Rct1CsgTests, RCT1DataPresent_AllConditionsMet)
+{
+    CreateSparseFile(
+        root / "Data" / "CSG1I.DAT", static_cast<uint64_t>(RCT1::Limits::kNumLLCsgEntries) * sizeof(StoredG1Element));
+    CreateSparseFile(root / "Data" / "CSG1.DAT", RCT1::Limits::kLLCsg1DatFileSize);
+    EXPECT_TRUE(RCT1DataPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, RCT1DataPresent_ShortCircuitsOnMissingFile)
+{
+    EXPECT_FALSE(RCT1DataPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, RCT1DataPresent_MissingHeaderFile)
+{
+    CreateSparseFile(root / "Data" / "CSG1.DAT", 16);
+    EXPECT_FALSE(RCT1DataPresentAtLocation(root.string()));
+}
+
+TEST_F(Rct1CsgTests, RCT1DataPresent_WrongFileSizes)
+{
+    CreateSparseFile(root / "Data" / "CSG1.DAT", 16);
+    CreateSparseFile(root / "Data" / "CSG1I.DAT", 16);
+    EXPECT_FALSE(RCT1DataPresentAtLocation(root.string()));
+}

--- a/test/tests/Rct1CsgTests.cpp
+++ b/test/tests/Rct1CsgTests.cpp
@@ -7,14 +7,13 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <filesystem>
 #include <gtest/gtest.h>
+#include <openrct2/core/FileSystem.hpp>
 #include <openrct2/drawing/G1Element.h>
 #include <openrct2/rct1/Csg.h>
 #include <openrct2/rct1/Limits.h>
 
 using namespace OpenRCT2;
-namespace fs = std::filesystem;
 
 namespace
 {

--- a/test/tests/Rct1TablesTests.cpp
+++ b/test/tests/Rct1TablesTests.cpp
@@ -16,6 +16,21 @@
 
 using namespace OpenRCT2;
 
+namespace
+{
+    constexpr uint8_t kNumRct1RideTypes = 85;
+    constexpr uint8_t kNumRct1VehicleTypes = 89;
+    constexpr uint8_t kNumRct1BannerTypes = 9;
+    constexpr uint8_t kNumRct1SceneryThemes = 18;
+    constexpr uint8_t kNumRct1SmallScenery = 244;
+    constexpr uint8_t kNumRct1LargeScenery = 39;
+    constexpr uint8_t kNumRct1PathSurfaces = 24;
+    constexpr uint8_t kNumRct1PathAdditions = 15;
+    constexpr uint8_t kNumRct1FootpathRailings = 4;
+    constexpr uint8_t kNumRct1SceneryGroups = 18;
+    constexpr uint8_t kNumRct1WaterTypes = 2;
+} // namespace
+
 TEST(Rct1TablesTests, GetColour_KnownAndOutOfRange)
 {
     EXPECT_EQ(RCT1::GetColour(0), Drawing::Colour::black);
@@ -53,10 +68,8 @@ TEST(Rct1TablesTests, GetTerrainEdgeObject_SweepFullRange)
         (void)RCT1::GetTerrainEdgeObject(static_cast<uint8_t>(i));
 }
 
-TEST(Rct1TablesTests, MapSlopedWall_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, MapSlopedWall_SweepFullRange)
 {
-    EXPECT_EQ(RCT1::MapSlopedWall(255), -1);
-
     for (uint32_t i = 0; i <= 255; ++i)
         (void)RCT1::MapSlopedWall(static_cast<uint8_t>(i));
 }
@@ -80,7 +93,7 @@ TEST(Rct1TablesTests, GetRideType_SpecialCasesAndAllRideTypes)
         RIDE_TYPE_HYPER_TWISTER);
     EXPECT_EQ(RCT1::GetRideType(RT::steelCorkscrewRollerCoaster, VT::hypercoasterTrain), RIDE_TYPE_HYPERCOASTER);
 
-    for (uint32_t i = 0; i < static_cast<uint32_t>(RT::count); ++i)
+    for (uint8_t i = 0; i < kNumRct1RideTypes; ++i)
         (void)RCT1::GetRideType(static_cast<RT>(i), VT::steelRollerCoasterTrain);
 }
 
@@ -88,7 +101,7 @@ TEST(Rct1TablesTests, RideTypeUsesVehicles_AllCases)
 {
     bool seenTrue = false;
     bool seenFalse = false;
-    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::RideType::count); ++i)
+    for (uint8_t i = 0; i < kNumRct1RideTypes; ++i)
     {
         const bool uses = RCT1::RideTypeUsesVehicles(static_cast<RCT1::RideType>(i));
         seenTrue = seenTrue || uses;
@@ -129,19 +142,18 @@ TEST(Rct1TablesTests, VehicleTypeIsReversed_KnownReversedSet)
     EXPECT_FALSE(RCT1::VehicleTypeIsReversed(VT::steelRollerCoasterTrain));
     EXPECT_FALSE(RCT1::VehicleTypeIsReversed(VT::woodenRollerCoasterTrain));
 
-    for (uint32_t i = 0; i < static_cast<uint32_t>(VT::count); ++i)
+    for (uint8_t i = 0; i < kNumRct1VehicleTypes; ++i)
         (void)RCT1::VehicleTypeIsReversed(static_cast<VT>(i));
 }
 
-TEST(Rct1TablesTests, GetVehicleSubEntryIndex_AllVehicleTypesAndSubEntries)
+TEST(Rct1TablesTests, GetVehicleSubEntryIndex_AllVehicleTypes)
 {
     using VT = RCT1::VehicleType;
 
-    // The internal map has more than 256 entries, so any uint8_t sub-entry is safe to query.
-    for (uint32_t v = 0; v < static_cast<uint32_t>(VT::count); ++v)
+    for (uint8_t v = 0; v < kNumRct1VehicleTypes; ++v)
     {
-        for (uint32_t s = 0; s <= 255; ++s)
-            (void)RCT1::GetVehicleSubEntryIndex(static_cast<VT>(v), static_cast<uint8_t>(s));
+        for (uint8_t s = 0; s < 4; ++s)
+            (void)RCT1::GetVehicleSubEntryIndex(static_cast<VT>(v), s);
     }
 
     (void)RCT1::GetVehicleSubEntryIndex(VT::heartlineTwisterCars, RCT1::HEARTLINE_TWISTER_FORWARDS);
@@ -152,13 +164,13 @@ TEST(Rct1TablesTests, GetVehicleSubEntryIndex_AllVehicleTypesAndSubEntries)
 
 TEST(Rct1TablesTests, GetColourSchemeCopyDescriptor_AllVehicleTypes)
 {
-    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::VehicleType::count); ++i)
+    for (uint8_t i = 0; i < kNumRct1VehicleTypes; ++i)
         (void)RCT1::GetColourSchemeCopyDescriptor(static_cast<RCT1::VehicleType>(i));
 }
 
 TEST(Rct1TablesTests, GetRideTypeObject_AllRideTypesBothExpansions)
 {
-    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::RideType::count); ++i)
+    for (uint8_t i = 0; i < kNumRct1RideTypes; ++i)
     {
         (void)RCT1::GetRideTypeObject(static_cast<RCT1::RideType>(i), false);
         (void)RCT1::GetRideTypeObject(static_cast<RCT1::RideType>(i), true);
@@ -167,93 +179,65 @@ TEST(Rct1TablesTests, GetRideTypeObject_AllRideTypesBothExpansions)
 
 TEST(Rct1TablesTests, GetVehicleObject_AllVehicleTypes)
 {
-    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::VehicleType::count); ++i)
+    for (uint8_t i = 0; i < kNumRct1VehicleTypes; ++i)
         (void)RCT1::GetVehicleObject(static_cast<RCT1::VehicleType>(i));
 }
 
-TEST(Rct1TablesTests, GetSmallSceneryObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetSmallSceneryObject_AllIndices)
 {
-    EXPECT_FALSE(RCT1::GetSmallSceneryObject(0).empty());
-    EXPECT_TRUE(RCT1::GetSmallSceneryObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetSmallSceneryObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1SmallScenery; ++i)
+        (void)RCT1::GetSmallSceneryObject(i);
 }
 
-TEST(Rct1TablesTests, GetLargeSceneryObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetLargeSceneryObject_AllIndices)
 {
-    EXPECT_FALSE(RCT1::GetLargeSceneryObject(0).empty());
-    EXPECT_TRUE(RCT1::GetLargeSceneryObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetLargeSceneryObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1LargeScenery; ++i)
+        (void)RCT1::GetLargeSceneryObject(i);
 }
 
-TEST(Rct1TablesTests, GetBannerObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetBannerObject_AllBannerTypes)
 {
-    EXPECT_EQ(RCT1::GetBannerObject(RCT1::BannerType::plain), "rct2.footpath_banner.bn1");
-    EXPECT_TRUE(RCT1::GetBannerObject(static_cast<RCT1::BannerType>(200)).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
+    for (uint8_t i = 0; i < kNumRct1BannerTypes; ++i)
         (void)RCT1::GetBannerObject(static_cast<RCT1::BannerType>(i));
 }
 
-TEST(Rct1TablesTests, GetPathSurfaceObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetPathSurfaceObject_AllPathTypes)
 {
-    EXPECT_FALSE(RCT1::GetPathSurfaceObject(0).empty());
-    EXPECT_TRUE(RCT1::GetPathSurfaceObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetPathSurfaceObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1PathSurfaces; ++i)
+        (void)RCT1::GetPathSurfaceObject(i);
 }
 
-TEST(Rct1TablesTests, GetPathAddtionObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetPathAddtionObject_AllPathAdditions)
 {
-    // Index 0 is RCT1_PATH_ADDITION_NONE which maps to an empty string
-    // index 1 is the first real entry.
-    EXPECT_FALSE(RCT1::GetPathAddtionObject(1).empty());
-    EXPECT_TRUE(RCT1::GetPathAddtionObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetPathAddtionObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1PathAdditions; ++i)
+        (void)RCT1::GetPathAddtionObject(i);
 }
 
-TEST(Rct1TablesTests, GetFootpathRailingsObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetFootpathRailingsObject_AllRailings)
 {
-    EXPECT_FALSE(RCT1::GetFootpathRailingsObject(0).empty());
-    EXPECT_TRUE(RCT1::GetFootpathRailingsObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetFootpathRailingsObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1FootpathRailings; ++i)
+        (void)RCT1::GetFootpathRailingsObject(i);
 }
 
-TEST(Rct1TablesTests, GetSceneryGroupObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetSceneryGroupObject_AllSceneryGroups)
 {
-    // Index 0 is RCT1_SCENERY_THEME_GENERAL which maps to an empty string
-    // index 1 is the first real entry.
-    EXPECT_FALSE(RCT1::GetSceneryGroupObject(1).empty());
-    EXPECT_TRUE(RCT1::GetSceneryGroupObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetSceneryGroupObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1SceneryGroups; ++i)
+        (void)RCT1::GetSceneryGroupObject(i);
 }
 
-TEST(Rct1TablesTests, GetWaterObject_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetWaterObject_AllWaterTypes)
 {
-    EXPECT_FALSE(RCT1::GetWaterObject(0).empty());
-    EXPECT_TRUE(RCT1::GetWaterObject(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetWaterObject(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1WaterTypes; ++i)
+        (void)RCT1::GetWaterObject(i);
 }
 
-TEST(Rct1TablesTests, GetSceneryObjects_SweepFullRangeAndOutOfRange)
+TEST(Rct1TablesTests, GetSceneryObjects_AllSceneryThemes)
 {
-    EXPECT_FALSE(RCT1::GetSceneryObjects(0).empty());
-    EXPECT_TRUE(RCT1::GetSceneryObjects(255).empty());
-
-    for (uint32_t i = 0; i <= 255; ++i)
-        (void)RCT1::GetSceneryObjects(static_cast<uint8_t>(i));
+    for (uint8_t i = 0; i < kNumRct1SceneryThemes; ++i)
+    {
+        const auto objects = RCT1::GetSceneryObjects(i);
+        EXPECT_FALSE(objects.empty());
+    }
 }
 
 TEST(Rct1TablesTests, RCT1TrackTypeToOpenRCT2_FlatAndNonFlatRides)

--- a/test/tests/Rct1TablesTests.cpp
+++ b/test/tests/Rct1TablesTests.cpp
@@ -1,0 +1,263 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <openrct2/drawing/Colour.h>
+#include <openrct2/rct1/RCT1.h>
+#include <openrct2/rct1/Tables.h>
+#include <openrct2/rct12/RCT12.h>
+#include <openrct2/ride/Ride.h>
+
+using namespace OpenRCT2;
+
+TEST(Rct1TablesTests, GetColour_KnownAndOutOfRange)
+{
+    EXPECT_EQ(RCT1::GetColour(0), Drawing::Colour::black);
+    EXPECT_EQ(RCT1::GetColour(31), Drawing::Colour::icyBlue);
+    EXPECT_EQ(RCT1::GetColour(32), Drawing::Colour::black);
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetColour(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetPeepAnimationGroup_KnownAndOutOfRange)
+{
+    EXPECT_EQ(RCT1::GetPeepAnimationGroup(static_cast<RCT1::PeepAnimationGroup>(0)), RCT12PeepAnimationGroup::normal);
+    EXPECT_EQ(RCT1::GetPeepAnimationGroup(static_cast<RCT1::PeepAnimationGroup>(0xFF)), RCT12PeepAnimationGroup::normal);
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetPeepAnimationGroup(static_cast<RCT1::PeepAnimationGroup>(i));
+}
+
+TEST(Rct1TablesTests, GetTerrainSurfaceObject_SweepFullRange)
+{
+    EXPECT_EQ(RCT1::GetTerrainSurfaceObject(0), "rct2.terrain_surface.grass");
+    EXPECT_EQ(RCT1::GetTerrainSurfaceObject(255), RCT1::GetTerrainSurfaceObject(0));
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetTerrainSurfaceObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetTerrainEdgeObject_SweepFullRange)
+{
+    EXPECT_EQ(RCT1::GetTerrainEdgeObject(0), "rct2.terrain_edge.rock");
+    EXPECT_EQ(RCT1::GetTerrainEdgeObject(255), RCT1::GetTerrainEdgeObject(0));
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetTerrainEdgeObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, MapSlopedWall_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_EQ(RCT1::MapSlopedWall(255), -1);
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::MapSlopedWall(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetWallObject_SweepFullRange)
+{
+    EXPECT_FALSE(RCT1::GetWallObject(0).empty());
+    EXPECT_FALSE(RCT1::GetWallObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetWallObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetRideType_SpecialCasesAndAllRideTypes)
+{
+    using RT = RCT1::RideType;
+    using VT = RCT1::VehicleType;
+
+    EXPECT_EQ(
+        RCT1::GetRideType(RT::steelTwisterRollerCoaster, VT::nonLoopingSteelTwisterRollerCoasterTrain),
+        RIDE_TYPE_HYPER_TWISTER);
+    EXPECT_EQ(RCT1::GetRideType(RT::steelCorkscrewRollerCoaster, VT::hypercoasterTrain), RIDE_TYPE_HYPERCOASTER);
+
+    for (uint32_t i = 0; i < static_cast<uint32_t>(RT::count); ++i)
+        (void)RCT1::GetRideType(static_cast<RT>(i), VT::steelRollerCoasterTrain);
+}
+
+TEST(Rct1TablesTests, RideTypeUsesVehicles_AllCases)
+{
+    bool seenTrue = false;
+    bool seenFalse = false;
+    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::RideType::count); ++i)
+    {
+        const bool uses = RCT1::RideTypeUsesVehicles(static_cast<RCT1::RideType>(i));
+        seenTrue = seenTrue || uses;
+        seenFalse = seenFalse || !uses;
+    }
+    EXPECT_TRUE(seenTrue);
+    EXPECT_TRUE(seenFalse);
+}
+
+TEST(Rct1TablesTests, PathIsQueue_AllPathTypes)
+{
+    EXPECT_TRUE(RCT1::PathIsQueue(0));
+    EXPECT_TRUE(RCT1::PathIsQueue(1));
+    EXPECT_TRUE(RCT1::PathIsQueue(2));
+    EXPECT_TRUE(RCT1::PathIsQueue(3));
+    for (uint32_t i = 4; i <= 255; ++i)
+        EXPECT_FALSE(RCT1::PathIsQueue(static_cast<uint8_t>(i)));
+}
+
+TEST(Rct1TablesTests, NormalisePathAddition_BrokenIdsMapToWhole)
+{
+    for (uint32_t i = 0; i <= 255; ++i)
+    {
+        const uint8_t in = static_cast<uint8_t>(i);
+        const uint8_t out = RCT1::NormalisePathAddition(in);
+        EXPECT_TRUE(out == in || out < in);
+    }
+}
+
+TEST(Rct1TablesTests, VehicleTypeIsReversed_KnownReversedSet)
+{
+    using VT = RCT1::VehicleType;
+
+    EXPECT_TRUE(RCT1::VehicleTypeIsReversed(VT::steelRollerCoasterTrainBackwards));
+    EXPECT_TRUE(RCT1::VehicleTypeIsReversed(VT::woodenRollerCoasterTrainBackwards));
+    EXPECT_TRUE(RCT1::VehicleTypeIsReversed(VT::heartlineTwisterCarsReversed));
+
+    EXPECT_FALSE(RCT1::VehicleTypeIsReversed(VT::steelRollerCoasterTrain));
+    EXPECT_FALSE(RCT1::VehicleTypeIsReversed(VT::woodenRollerCoasterTrain));
+
+    for (uint32_t i = 0; i < static_cast<uint32_t>(VT::count); ++i)
+        (void)RCT1::VehicleTypeIsReversed(static_cast<VT>(i));
+}
+
+TEST(Rct1TablesTests, GetVehicleSubEntryIndex_AllVehicleTypesAndSubEntries)
+{
+    using VT = RCT1::VehicleType;
+
+    // The internal map has more than 256 entries, so any uint8_t sub-entry is safe to query.
+    for (uint32_t v = 0; v < static_cast<uint32_t>(VT::count); ++v)
+    {
+        for (uint32_t s = 0; s <= 255; ++s)
+            (void)RCT1::GetVehicleSubEntryIndex(static_cast<VT>(v), static_cast<uint8_t>(s));
+    }
+
+    (void)RCT1::GetVehicleSubEntryIndex(VT::heartlineTwisterCars, RCT1::HEARTLINE_TWISTER_FORWARDS);
+    (void)RCT1::GetVehicleSubEntryIndex(VT::heartlineTwisterCars, 0);
+    (void)RCT1::GetVehicleSubEntryIndex(VT::heartlineTwisterCarsReversed, RCT1::HEARTLINE_TWISTER_BACKWARDS);
+    (void)RCT1::GetVehicleSubEntryIndex(VT::heartlineTwisterCarsReversed, 0);
+}
+
+TEST(Rct1TablesTests, GetColourSchemeCopyDescriptor_AllVehicleTypes)
+{
+    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::VehicleType::count); ++i)
+        (void)RCT1::GetColourSchemeCopyDescriptor(static_cast<RCT1::VehicleType>(i));
+}
+
+TEST(Rct1TablesTests, GetRideTypeObject_AllRideTypesBothExpansions)
+{
+    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::RideType::count); ++i)
+    {
+        (void)RCT1::GetRideTypeObject(static_cast<RCT1::RideType>(i), false);
+        (void)RCT1::GetRideTypeObject(static_cast<RCT1::RideType>(i), true);
+    }
+}
+
+TEST(Rct1TablesTests, GetVehicleObject_AllVehicleTypes)
+{
+    for (uint32_t i = 0; i < static_cast<uint32_t>(RCT1::VehicleType::count); ++i)
+        (void)RCT1::GetVehicleObject(static_cast<RCT1::VehicleType>(i));
+}
+
+TEST(Rct1TablesTests, GetSmallSceneryObject_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_FALSE(RCT1::GetSmallSceneryObject(0).empty());
+    EXPECT_TRUE(RCT1::GetSmallSceneryObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetSmallSceneryObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetLargeSceneryObject_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_FALSE(RCT1::GetLargeSceneryObject(0).empty());
+    EXPECT_TRUE(RCT1::GetLargeSceneryObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetLargeSceneryObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetBannerObject_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_EQ(RCT1::GetBannerObject(RCT1::BannerType::plain), "rct2.footpath_banner.bn1");
+    EXPECT_TRUE(RCT1::GetBannerObject(static_cast<RCT1::BannerType>(200)).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetBannerObject(static_cast<RCT1::BannerType>(i));
+}
+
+TEST(Rct1TablesTests, GetPathSurfaceObject_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_FALSE(RCT1::GetPathSurfaceObject(0).empty());
+    EXPECT_TRUE(RCT1::GetPathSurfaceObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetPathSurfaceObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetPathAddtionObject_SweepFullRangeAndOutOfRange)
+{
+    // Index 0 is RCT1_PATH_ADDITION_NONE which maps to an empty string
+    // index 1 is the first real entry.
+    EXPECT_FALSE(RCT1::GetPathAddtionObject(1).empty());
+    EXPECT_TRUE(RCT1::GetPathAddtionObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetPathAddtionObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetFootpathRailingsObject_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_FALSE(RCT1::GetFootpathRailingsObject(0).empty());
+    EXPECT_TRUE(RCT1::GetFootpathRailingsObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetFootpathRailingsObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetSceneryGroupObject_SweepFullRangeAndOutOfRange)
+{
+    // Index 0 is RCT1_SCENERY_THEME_GENERAL which maps to an empty string
+    // index 1 is the first real entry.
+    EXPECT_FALSE(RCT1::GetSceneryGroupObject(1).empty());
+    EXPECT_TRUE(RCT1::GetSceneryGroupObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetSceneryGroupObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetWaterObject_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_FALSE(RCT1::GetWaterObject(0).empty());
+    EXPECT_TRUE(RCT1::GetWaterObject(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetWaterObject(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, GetSceneryObjects_SweepFullRangeAndOutOfRange)
+{
+    EXPECT_FALSE(RCT1::GetSceneryObjects(0).empty());
+    EXPECT_TRUE(RCT1::GetSceneryObjects(255).empty());
+
+    for (uint32_t i = 0; i <= 255; ++i)
+        (void)RCT1::GetSceneryObjects(static_cast<uint8_t>(i));
+}
+
+TEST(Rct1TablesTests, RCT1TrackTypeToOpenRCT2_FlatAndNonFlatRides)
+{
+    (void)RCT1::RCT1TrackTypeToOpenRCT2(static_cast<RCT12::TrackElemType>(0), RIDE_TYPE_FERRIS_WHEEL);
+    (void)RCT1::RCT1TrackTypeToOpenRCT2(static_cast<RCT12::TrackElemType>(0), RIDE_TYPE_LOOPING_ROLLER_COASTER);
+}

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -98,6 +98,7 @@
     <ClCompile Include="NetworkTests.cpp" />
     <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
+    <ClCompile Include="Rct1CsgTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
     <ClCompile Include="RideRatings.cpp" />
     <ClCompile Include="EntityImportTests.cpp" />

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Rct1CsgTests.cpp" />
+    <ClCompile Include="Rct1TablesTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />
     <ClCompile Include="RideRatings.cpp" />
     <ClCompile Include="EntityImportTests.cpp" />


### PR DESCRIPTION
This PR adds unit tests for:
- RCT1 CSG loading functions (`src/openrct2/rct1/Csg.cpp`)
  - Each test builds a synthetic RCT1 install layout in a per-test temp directory using sparse files, then asserts what the lookup functions report.
- RCT1 Table lookup functions (`src/openrct2/rct1/Tables.cpp`)
  - Exercises the RCT1 --> OpenRCT2 lookup tables
  - Most map-sizes are hard-coded but this should be fine as I don't imagine these values will ever change.

Coverage increases:
| Filename | Function Coverage | Line Coverage | Region Coverage | Line Coverage |
| --------- | ------------------- | -------------- | ----------------- | --------------- |
| `rct1/Csg.cpp` | 0.00% --> 100.00% | 0.00% --> 100.00% | 0.00% --> 100.00% | 0.00% --> 100.00% |
| `rct1/Tables.cpp` | 0.00% --> 100.00% | 0.00% --> 100.00% | 0.00% --> 100.00% | 0.00% --> 100.00% |

Overall coverage:
| Function Coverage | Line Coverage | Region Coverage | Line Coverage |
| ------------------- | -------------- | ----------------- | --------------- |
| 28.01% --> 28.26% | 11.69% --> 12.07% | 18.27% --> 18.39% | 9.98% --> 10.09% |

The purpose of this PR is to add additional tests to increase overall code coverage for the project and to build confidence in regressions.