### PR TITLE
Fix move semantics in GroupVector::Set

### DIFF
--- a/src/openrct2/core/GroupVector.hpp
+++ b/src/openrct2/core/GroupVector.hpp
@@ -53,7 +53,7 @@ public:
         {
             _data.resize(index + 1);
         }
-        _data[index] = values;
+        _data[index] = std::move(values);
     }
 
     std::vector<V>* GetAll(Handle handle)


### PR DESCRIPTION
Fixed `GroupVector::Set` to move-assign the provided vector instead of copying it. The function accepts an rvalue reference, but assigns from the named parameter directly which invokes a copy.

---

An example caller:
```cpp
RideUse::GetHistory().Set(dst->id, RCT12GetRidesBeenOn(src));
```

`RCT12GetRidesBeenOn` returns a temporary `std::vector<RideId>` which is binded to the `values` parameter, and then _copied_ into `_data[index]`. Now the temporary vector is binded to `values` and then _moved_ into `_data[index]`.