### PR TITLE
Remove redundant pair in ReplayManager::AddChecksum

### DIFF
--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -172,7 +172,7 @@ namespace OpenRCT2
 
         void AddChecksum(uint32_t tick, EntitiesChecksum&& checksum)
         {
-            _currentRecording->checksums.emplace_back(std::make_pair(tick, std::move(checksum)));
+            _currentRecording->checksums.emplace_back(tick, std::move(checksum));
         }
 
         // Function runs each Tick.


### PR DESCRIPTION
`emplace_back` already forwards to the `std::pair` constructor, so there's no need to construct an intermediate here