### PR TITLE
Free StreamReadBuffer/StreamWriteBuffer buffer during reassignment

### DIFF
--- a/src/openrct2/core/StreamBuffer.cpp
+++ b/src/openrct2/core/StreamBuffer.cpp
@@ -57,6 +57,9 @@ namespace OpenRCT2
     {
         if (&other != this)
         {
+            if (_bufferLength > 0)
+                Memory::Free(_buffer);
+
             _buffer = other._buffer;
             _bufferLength = other._bufferLength;
             _remaining = other._remaining;
@@ -125,6 +128,9 @@ namespace OpenRCT2
     {
         if (&other != this)
         {
+            if (_bufferLength > 0)
+                Memory::Free(_buffer);
+
             _buffer = other._buffer;
             _bufferLength = other._bufferLength;
             _remaining = other._remaining;


### PR DESCRIPTION
This fixes two `=` overloads that don't free the existing buffer before reassigning. I don't think it's causing any issues/inefficiencies the way the stream buffers are used now, but it's good defensive practice