### PR TITLE
refactor: rename Litter::SubType to subType

### DIFF
--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -90,7 +90,7 @@ namespace OpenRCT2
         litter->spriteData.width = 6;
         litter->spriteData.heightMin = 6;
         litter->spriteData.heightMax = 3;
-        litter->SubType = type;
+        litter->subType = type;
         litter->moveTo(offsetLitterPos);
         litter->creationTick = gameState.currentTicks;
     }
@@ -138,9 +138,9 @@ namespace OpenRCT2
 
     StringId Litter::GetName() const
     {
-        if (EnumValue(SubType) >= std::size(litterNames))
+        if (EnumValue(subType) >= std::size(litterNames))
             return kStringIdNone;
-        return litterNames[EnumValue(SubType)];
+        return litterNames[EnumValue(subType)];
     }
 
     uint32_t Litter::GetAge() const
@@ -152,7 +152,7 @@ namespace OpenRCT2
     {
         EntityBase::serialise(stream);
 
-        stream << SubType;
+        stream << subType;
         stream << creationTick;
     }
 } // namespace OpenRCT2

--- a/src/openrct2/entity/Litter.h
+++ b/src/openrct2/entity/Litter.h
@@ -39,7 +39,7 @@ namespace OpenRCT2
         };
 
         static constexpr auto cEntityType = EntityType::litter;
-        Type SubType;
+        Type subType;
         uint32_t creationTick;
         static void Create(const CoordsXYZD& litterPos, Type type);
         static void RemoveAt(const CoordsXYZ& litterPos);

--- a/src/openrct2/paint/entity/Paint.Litter.cpp
+++ b/src/openrct2/paint/entity/Paint.Litter.cpp
@@ -50,9 +50,9 @@ namespace OpenRCT2
         imageDirection >>= 3;
         // Some litter types have only 1 direction so remove
         // anything that isn't required.
-        imageDirection &= kLitterSprites[EnumValue(litter.SubType)].direction_mask;
+        imageDirection &= kLitterSprites[EnumValue(litter.subType)].direction_mask;
 
-        uint32_t image_id = imageDirection + kLitterSprites[EnumValue(litter.SubType)].base_id;
+        uint32_t image_id = imageDirection + kLitterSprites[EnumValue(litter.subType)].base_id;
 
         // In the following call to PaintAddImageAsParent, we add 4 (instead of 2) to the
         // bound_box_offset_z to make sure litter is drawn on top of railways


### PR DESCRIPTION
     1|This is an independent contribution not affiliated with any organization or competition.
     2|
     3|## Summary
     4|
     5|Renames `Litter::SubType` to `Litter::subType` to conform to the project's lowerCamelCase naming convention for struct fields.
     6|
     7|## Root Cause
     8|
     9|The Litter struct was using PascalCase for its `SubType` field, inconsistent with the target style defined in #26521. The code style guide specifies lowerCamelCase for struct fields and methods.
    10|
    11|## Fix
    12|
    13|Renamed `SubType` to `subType` across three files:
    14|- `src/openrct2/entity/Litter.h` — field declaration
    15|- `src/openrct2/entity/Litter.cpp` — field usage in Create(), GetName(), and Serialise()
    16|- `src/openrct2/paint/entity/Paint.Litter.cpp` — field access in PaintLitter()
    17|
    18|Seven occurrences total. No behavioral changes.
    19|
    20|## Testing
    21|
    22|- All references to `SubType` in the affected files have been verified absent via grep
    23|- Mechanical rename with no logic changes; existing CI will confirm correctness
    24|- Part of the incremental work tracking in #26521
    25|
    26|Closes: Part of #26521
    27|