### PR TITLE
Fix `DEBUG` flag checks

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -341,7 +341,7 @@ AtlasTextureInfo TextureCache::AllocateImage(int32_t imageWidth, int32_t imageHe
     auto atlasIndex = static_cast<int32_t>(_atlases.size());
     int32_t atlasSize = powf(2, static_cast<float>(Atlas::CalculateImageSizeOrder(imageWidth, imageHeight)));
 
-    #ifdef DEBUG
+    #if DEBUG > 0
     LOG_VERBOSE("new texture atlas #%d (size %d) allocated", atlasIndex, atlasSize);
     #endif
 

--- a/src/openrct2/core/Guard.cpp
+++ b/src/openrct2/core/Guard.cpp
@@ -107,7 +107,7 @@ namespace OpenRCT2::Guard
             _lastAssertMessage = std::make_optional(formattedMessage);
         }
 
-#ifdef DEBUG
+#if DEBUG > 0
         Debug::Break();
 #endif
 

--- a/src/openrct2/core/Http.WinHttp.cpp
+++ b/src/openrct2/core/Http.WinHttp.cpp
@@ -230,7 +230,7 @@ namespace OpenRCT2::Http
         }
         catch ([[maybe_unused]] const std::exception& e)
         {
-    #ifdef DEBUG
+    #if DEBUG > 0
             Console::Error::WriteLine("HTTP request failed: %s", e.what());
     #endif
             WinHttpCloseHandle(hSession);

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -492,7 +492,7 @@ namespace OpenRCT2::String
             // current character.
             size_t newStringSize = (nextCh - 1) - firstNonWhitespace;
 
-#ifdef DEBUG
+#if DEBUG > 0
             size_t currentStringSize = sizeOf(str);
             Guard::Assert(newStringSize < currentStringSize, GUARD_LINE);
 #endif

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -1149,7 +1149,7 @@ void GfxSetG1Element(ImageIndex imageId, const G1Element* g1)
     bool isValid = (imageId >= SPR_IMAGE_LIST_BEGIN && imageId < SPR_IMAGE_LIST_END)
         || (imageId >= SPR_SCROLLING_TEXT_START && imageId < SPR_SCROLLING_TEXT_END);
 
-#ifdef DEBUG
+#if DEBUG > 0
     Guard::Assert(!gOpenRCT2NoGraphics, "GfxSetG1Element called on headless instance");
     Guard::Assert(isValid || isTemp, "GfxSetG1Element called with unexpected image id");
     Guard::Assert(g1 != nullptr, "g1 was nullptr");

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -88,7 +88,7 @@ namespace OpenRCT2
 
             if (index >= static_cast<size_t>(getObjectEntryGroupCount(objectType)))
             {
-#ifdef DEBUG
+#if DEBUG > 0
                 if (index != kObjectEntryIndexNull)
                 {
                     LOG_WARNING("Object index %u exceeds maximum for type %d.", index, objectType);


### PR DESCRIPTION
On non-MVSC builds, the `DEBUG` flag is set unconditionally: https://github.com/OpenRCT2/OpenRCT2/blob/d841b2dcecb5b6ea18b92ec0a364ed9dd4b4dc08/CMakeLists.txt#L346-L349

Normally, this would be fine, but it seems that a few sections of code check for just the _definition_ of the flag, not that the flag is set to a debug value.

For example:

https://github.com/OpenRCT2/OpenRCT2/blob/d841b2dcecb5b6ea18b92ec0a364ed9dd4b4dc08/src/openrct2/object/ObjectManager.cpp#L91-L96

This PR replaces those usages with `#if DEBUG > 0` instead