### PR TITLE
Fix #24613 #26578: Incorrect sprites drawn or crash with paths with no object

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,9 +3,11 @@
 - Feature: [#26308] Add all new track pieces to the inverted roller coaster.
 - Feature: [#26442] Add cheat to disable grass growing.
 - Change: [#26689] A clear scenario editor can now be opened directly from the command line.
+- Fix: [#24613] Incorrect sprites drawn for path elements without a valid object.
 - Fix: [#26494] The limits for where walls on the path side of the first tile block the view of rides/scenery are wrong (original bug).
 - Fix: [#26504] The boosts/penalties to excitement and nausea that air time provides are calculated wrong.
 - Fix: [#26545] Game crashes when plugin API function generateGuest fails to generate a guest.
+- Fix: [#26578] Crash when drawing path elements without a valid object.
 
 0.5.2 (2026-06-07)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -662,15 +662,6 @@ static void PathPaintFencesAdditionsTunnels(
     }
 }
 
-static FootpathPaintInfo GetFootpathPaintInfo(const PathElement& pathEl)
-{
-    FootpathPaintInfo pathPaintInfo;
-    pathPaintInfo.surface = pathEl.GetSurfaceDescriptor();
-    pathPaintInfo.railings = pathEl.GetRailingsDescriptor();
-
-    return pathPaintInfo;
-}
-
 static bool ShouldDrawSupports(PaintSession& session, const PathElement& pathEl, uint16_t height)
 {
     auto surface = MapGetSurfaceElementAt(session.MapPosition);
@@ -801,7 +792,15 @@ void PaintPath(PaintSession& session, uint16_t height, const PathElement& tileEl
     PaintHeightMarkers(session, tileElement);
 
     auto hasSupports = ShouldDrawSupports(session, tileElement, height);
-    auto pathPaintInfo = GetFootpathPaintInfo(tileElement);
+
+    const auto* const surfaceDescriptor = tileElement.GetSurfaceDescriptor();
+    const auto* const railingsDescriptor = tileElement.GetRailingsDescriptor();
+    if (surfaceDescriptor == nullptr || railingsDescriptor == nullptr)
+    {
+        return;
+    }
+    const auto pathPaintInfo = FootpathPaintInfo{ *surfaceDescriptor, *railingsDescriptor };
+
     if (pathPaintInfo.railings.supportType == RailingEntrySupportType::pole)
     {
         PathPaintPoleSupport(session, tileElement, height, pathPaintInfo, hasSupports, imageTemplate, sceneryImageTemplate);

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -49,7 +49,6 @@ namespace OpenRCT2
         ImageIndex previewImage{};
         uint8_t flags{};
     };
-    constexpr PathSurfaceDescriptor kPathSurfaceDescriptorDummy{};
 
     struct PathRailingsDescriptor
     {
@@ -62,7 +61,6 @@ namespace OpenRCT2
         uint8_t flags{};
         uint8_t scrollingMode = kScrollingModeNone;
     };
-    constexpr PathRailingsDescriptor kPathRailingsDescriptorDummy{};
 
     using PathConstructFlags = uint8_t;
     namespace PathConstructFlag

--- a/src/openrct2/world/tile_element/PathElement.cpp
+++ b/src/openrct2/world/tile_element/PathElement.cpp
@@ -206,43 +206,43 @@ namespace OpenRCT2
         return (Flags2 & FOOTPATH_ELEMENT_FLAGS2_LEGACY_PATH_ENTRY) != 0;
     }
 
-    const PathSurfaceDescriptor& PathElement::GetSurfaceDescriptor() const
+    const PathSurfaceDescriptor* PathElement::GetSurfaceDescriptor() const
     {
         if (HasLegacyPathEntry())
         {
             const auto* legacyPathEntry = GetLegacyPathEntry();
             if (legacyPathEntry == nullptr)
-                return kPathSurfaceDescriptorDummy;
+                return nullptr;
 
             if (IsQueue())
-                return legacyPathEntry->GetQueueSurfaceDescriptor();
+                return &legacyPathEntry->GetQueueSurfaceDescriptor();
 
-            return legacyPathEntry->GetPathSurfaceDescriptor();
+            return &legacyPathEntry->GetPathSurfaceDescriptor();
         }
 
         const auto* surfaceEntry = GetSurfaceEntry();
         if (surfaceEntry == nullptr)
-            return kPathSurfaceDescriptorDummy;
+            return nullptr;
 
-        return surfaceEntry->GetDescriptor();
+        return &surfaceEntry->GetDescriptor();
     }
 
-    const PathRailingsDescriptor& PathElement::GetRailingsDescriptor() const
+    const PathRailingsDescriptor* PathElement::GetRailingsDescriptor() const
     {
         if (HasLegacyPathEntry())
         {
             const auto* legacyPathEntry = GetLegacyPathEntry();
             if (legacyPathEntry == nullptr)
-                return kPathRailingsDescriptorDummy;
+                return nullptr;
 
-            return legacyPathEntry->GetPathRailingsDescriptor();
+            return &legacyPathEntry->GetPathRailingsDescriptor();
         }
 
         const auto* railingsEntry = GetRailingsEntry();
         if (railingsEntry == nullptr)
-            return kPathRailingsDescriptorDummy;
+            return nullptr;
 
-        return railingsEntry->GetDescriptor();
+        return &railingsEntry->GetDescriptor();
     }
 
     ObjectEntryIndex PathElement::GetSurfaceEntryIndex() const
@@ -299,7 +299,8 @@ namespace OpenRCT2
     bool PathElement::ShouldDrawPathOverSupports() const
     {
         // TODO: make this an actual decision of the tile element.
-        return (GetRailingsDescriptor().flags & RAILING_ENTRY_FLAG_DRAW_PATH_OVER_SUPPORTS);
+        const auto* const railings = GetRailingsDescriptor();
+        return railings != nullptr ? railings->flags & RAILING_ENTRY_FLAG_DRAW_PATH_OVER_SUPPORTS : false;
     }
 
     void PathElement::SetShouldDrawPathOverSupports(bool on)

--- a/src/openrct2/world/tile_element/PathElement.h
+++ b/src/openrct2/world/tile_element/PathElement.h
@@ -82,8 +82,8 @@ namespace OpenRCT2
         const FootpathRailingsObject* GetRailingsEntry() const;
         void SetRailingsEntryIndex(ObjectEntryIndex newIndex);
 
-        const PathSurfaceDescriptor& GetSurfaceDescriptor() const;
-        const PathRailingsDescriptor& GetRailingsDescriptor() const;
+        const PathSurfaceDescriptor* GetSurfaceDescriptor() const;
+        const PathRailingsDescriptor* GetRailingsDescriptor() const;
 
         uint8_t GetQueueBannerDirection() const;
         void SetQueueBannerDirection(uint8_t direction);


### PR DESCRIPTION
Fixes #24613
Fixes #26578

This fixes a crash when painting paths without a valid object index, and also incorrect sprites being drawn when it doesn't crash.

Park from both these issues:
https://nedesigns.com/park/emerald-pointe

The root cause is that when a path does not have valid objects, "dummy" paint descriptors are returned instead. These descriptors have values which are invalid. This PR removes them and returns when no objects are found.

Ideally tile elements would not have invalid object indexes, but there's too many places for it to happen and the code base is not ready for it.