### PR TITLE
Fix desyncs when placing tracks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#26504] The boosts/penalties to excitement and nausea that air time provides are calculated wrong.
 - Fix: [#26545] Game crashes when plugin API function generateGuest fails to generate a guest.
 - Fix: [#26578] Crash when drawing path elements without a valid object.
+- Fix: [#26605] Desync when placing a track design in multiplayer.
 - Fix: [#26654] Fix Alton Towers stall and Rock’n’Roll Revival toilet being closed on scenario start.
 - Fix: [objects#411] Some colours in green, acid green, pink and red water are inconsistent with natural water.
 - Fix: [objects#436] St. Basil’s Cathedral building pieces are incorrectly labelled as “Kremlin” pieces.

--- a/src/openrct2-ui/ride/Construction.cpp
+++ b/src/openrct2-ui/ride/Construction.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/ride/RideTypes.h>
 #include <openrct2/ride/TrackData.h>
 #include <openrct2/ride/ted/TrackElementDescriptor.h>
+#include <openrct2/util/Util.h>
 #include <openrct2/world/Map.h>
 #include <openrct2/world/tile_element/TrackElement.h>
 
@@ -231,7 +232,7 @@ namespace OpenRCT2
     {
         int32_t rideEntryIndex = RideGetEntryIndex(listItem.Type, listItem.EntryIndex);
         int32_t colour1 = RideGetRandomColourPresetIndex(listItem.Type);
-        int32_t colour2 = RideGetUnusedPresetVehicleColour(rideEntryIndex);
+        int32_t colour2 = RideGetUnusedPresetVehicleColour(rideEntryIndex, UtilRand());
 
         auto gameAction = GameActions::RideCreateAction(
             listItem.Type, listItem.EntryIndex, colour1, colour2, getGameState().lastEntranceStyle,

--- a/src/openrct2/actions/track/TrackDesignAction.cpp
+++ b/src/openrct2/actions/track/TrackDesignAction.cpp
@@ -17,6 +17,7 @@
 #include "../../object/ObjectManager.h"
 #include "../../ride/RideConstruction.h"
 #include "../../ride/TrackDesign.h"
+#include "../../scenario/Scenario.h"
 #include "../GameActionRunner.h"
 #include "../ride/RideCreateAction.h"
 #include "../ride/RideDemolishAction.h"
@@ -222,7 +223,8 @@ namespace OpenRCT2::GameActions
 
         if (entryIndex != kObjectEntryIndexNull)
         {
-            auto colour = RideGetUnusedPresetVehicleColour(entryIndex);
+            // This runs inside a networked game action's Execute, and therefore needs to use ScenarioRand
+            auto colour = RideGetUnusedPresetVehicleColour(entryIndex, ScenarioRand());
             auto rideSetVehicleAction = RideSetVehicleAction(ride->id, RideSetVehicleType::rideEntry, entryIndex, colour);
             ExecuteNested(&rideSetVehicleAction, gameState);
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1942,7 +1942,7 @@ static bool RideTypeVehicleColourExists(ObjectEntryIndex subType, const VehicleC
     return false;
 }
 
-int32_t RideGetUnusedPresetVehicleColour(ObjectEntryIndex subType)
+int32_t RideGetUnusedPresetVehicleColour(ObjectEntryIndex subType, uint32_t randomValue)
 {
     const auto* rideEntry = GetRideEntryByIndex(subType);
     if (rideEntry == nullptr)
@@ -1968,10 +1968,10 @@ int32_t RideGetUnusedPresetVehicleColour(ObjectEntryIndex subType)
 
     // If all presets have been used, just go with a random preset
     if (unused.empty())
-        return UtilRand() % colourPresets->count;
+        return randomValue % colourPresets->count;
 
     // Choose a random preset from the list of unused presets
-    auto unusedIndex = UtilRand() % unused.size();
+    auto unusedIndex = randomValue % unused.size();
     return unused[unusedIndex];
 }
 
@@ -4978,7 +4978,7 @@ void Ride::updateNumberOfCircuits()
 
 void Ride::setRideEntry(ObjectEntryIndex entryIndex)
 {
-    auto colour = RideGetUnusedPresetVehicleColour(entryIndex);
+    auto colour = RideGetUnusedPresetVehicleColour(entryIndex, UtilRand());
     auto rideSetVehicleAction = GameActions::RideSetVehicleAction(
         id, GameActions::RideSetVehicleType::rideEntry, entryIndex, colour);
     GameActions::Execute(&rideSetVehicleAction, getGameState());

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -823,7 +823,7 @@ void RideClearBlockedTiles(const Ride& ride);
 OpenRCT2::Staff* RideGetMechanic(const Ride& ride);
 OpenRCT2::Staff* RideGetAssignedMechanic(const Ride& ride);
 VehicleColour RideGetVehicleColour(const Ride& ride, int32_t vehicleIndex);
-int32_t RideGetUnusedPresetVehicleColour(OpenRCT2::ObjectEntryIndex subType);
+int32_t RideGetUnusedPresetVehicleColour(OpenRCT2::ObjectEntryIndex subType, uint32_t randomValue);
 void RideSetVehicleColoursToRandomPreset(Ride& ride, uint8_t preset_index);
 void RideMeasurementsUpdate();
 void RideBreakdownAddNewsItem(const Ride& ride);


### PR DESCRIPTION
When any player in multiplayer places a track design, `TrackDesignAction::Execute` runs on every client which calls `UtilRand()`, resulting in every client getting a different colo~u~r since it's non-deterministic. Each client then commits its own local colo~u~r to `Vehicle::colours`. Since that field is part of the entity checksum, `NetworkBase::CheckSRAND` will flag a desync.

This PR adds a parameter to `RideGetUnusedPresetVehicleColour` to allow the caller to pass in a random value and make the choice of determinism. The UI call sites can still use `UtilRand`, but `TrackDesignAction` should be using `ScenarioRand`.

Let me know if you would like this implemented in any other way, but I do think that `TrackDesignAction` can't use `UtilRand`.