### PR TITLE
Fix #26602: Crash when finding mechanic for ride that hasn't been inspected

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#26566] Improve the performance of sorting sprites.
 - Fix: [#26583] The default tab is not highlighted when opening a ride window.
+- Fix: [#26602] Crash when locating the nearest mechanic for a ride that has not previously been inspected.
 
 0.5.1 (2026-05-17)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1487,8 +1487,12 @@ static void RideCallClosestMechanic(Ride& ride)
 
 Staff* RideFindClosestMechanic(const Ride& ride, int32_t forInspection)
 {
+    const auto stationIndex = ride.inspectionStation.IsNull() ? RideGetFirstValidStationExit(ride) : ride.inspectionStation;
+    if (stationIndex.IsNull())
+        return nullptr;
+
     // Get either exit position or entrance position if there is no exit
-    auto& station = ride.getStation(ride.inspectionStation);
+    const auto& station = ride.getStation(stationIndex);
     TileCoordsXYZD location = station.Exit;
     if (location.IsNull())
     {


### PR DESCRIPTION
Fixes #26602.

`ride.inspectionStation` can be null if a ride has not previously been inspected. When locating the closest mechanic from the ride window, this null value is passed in to `ride.getStation`:
https://github.com/OpenRCT2/OpenRCT2/blob/d841b2dcecb5b6ea18b92ec0a364ed9dd4b4dc08/src/openrct2/ride/Ride.cpp#L779-L782
resulting in an out of bounds read on this array.

This checks `ride.inspectionStation` for null in `RideFindClosestMechanic`. This handles the case where it is null but an exit exists, and also when there are no exits.