### PR TITLE
Fix index bug during removal in `FootpathConnectEdges`

### DIFF
--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -762,8 +762,7 @@ namespace OpenRCT2
                         entranceIndex = item.entrance_index;
                     }
                     else if (
-                        rideIndex != item.ride_index
-                        || (entranceIndex != item.entrance_index && !item.entrance_index.IsNull()))
+                    rideIndex != item.ride_index || (entranceIndex != item.entrance_index && !item.entrance_index.IsNull()))
                     {
                         FootpathNeighbourListRemove(&neighbourList, i);
                         continue;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -751,26 +751,25 @@ namespace OpenRCT2
         {
             RideId rideIndex = RideId::GetNull();
             StationIndex entranceIndex = StationIndex::GetNull();
-            for (size_t i = 0; i < neighbourList.count; i++)
+            for (size_t i = 0; i < neighbourList.count;)
             {
-                if (!neighbourList.items[i].ride_index.IsNull())
+                auto& item = neighbourList.items[i];
+                if (!item.ride_index.IsNull())
                 {
                     if (rideIndex.IsNull())
                     {
-                        rideIndex = neighbourList.items[i].ride_index;
-                        entranceIndex = neighbourList.items[i].entrance_index;
-                    }
-                    else if (rideIndex != neighbourList.items[i].ride_index)
-                    {
-                        FootpathNeighbourListRemove(&neighbourList, i);
+                        rideIndex = item.ride_index;
+                        entranceIndex = item.entrance_index;
                     }
                     else if (
-                        rideIndex == neighbourList.items[i].ride_index && entranceIndex != neighbourList.items[i].entrance_index
-                        && !neighbourList.items[i].entrance_index.IsNull())
+                        rideIndex != item.ride_index
+                        || (entranceIndex != item.entrance_index && !item.entrance_index.IsNull()))
                     {
                         FootpathNeighbourListRemove(&neighbourList, i);
+                        continue;
                     }
                 }
+                i++;
             }
 
             neighbourList.count = std::min<size_t>(neighbourList.count, 2);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -762,7 +762,7 @@ namespace OpenRCT2
                         entranceIndex = item.entrance_index;
                     }
                     else if (
-                    rideIndex != item.ride_index || (entranceIndex != item.entrance_index && !item.entrance_index.IsNull()))
+                        rideIndex != item.ride_index || (entranceIndex != item.entrance_index && !item.entrance_index.IsNull()))
                     {
                         FootpathNeighbourListRemove(&neighbourList, i);
                         continue;


### PR DESCRIPTION
`FootpathNeighbourListRemove` shifts items in the `neighbourList` down by one, then decrements the count. So after a removal, the element that was at `[i+1]` is now at `[i]`, and the loop's `i++` skips past it without checking.

The loop now only advances `i` when no removal happens, so all elements get checked.

If I'm reading the comment right (`rct2: 0x006A6C66`) this must have been a pre-existing bug in the original code. It's up to you guys if you want to fix those.