### PR TITLE
Fix missing path tile in BYO SFOT

### DIFF
--- a/data/scenario_patches/2594e15.parkpatch
+++ b/data/scenario_patches/2594e15.parkpatch
@@ -13,5 +13,13 @@
                 [ 90, 42], [ 90, 43], [ 90, 44], [ 90, 45]
             ]
         }
-    }
+    },
+    "paths": [
+        {
+            "railings": "rct2.footpath_railings.wood",
+            "surface": "rct2.footpath_surface.tarmac",
+            "coordinates": [ [ 37, 164, 14 ] ],
+            "queue": false
+        }
+    ]
 }

--- a/data/scenario_patches/2bf0b3c.parkpatch
+++ b/data/scenario_patches/2bf0b3c.parkpatch
@@ -13,5 +13,13 @@
                 [ 90, 42], [ 90, 43], [ 90, 44], [ 90, 45]
             ]
         }
-    }
+    },
+    "paths": [
+        {
+            "railings": "rct2.footpath_railings.wood",
+            "surface": "rct2.footpath_surface.tarmac",
+            "coordinates": [ [ 37, 164, 14 ] ],
+            "queue": false
+        }
+    ]
 }

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#26566] Improve the performance of sorting sprites.
 - Fix: [#26583] The default tab is not highlighted when opening a ride window.
 - Fix: [#26602] Crash when locating the nearest mechanic for a ride that has not previously been inspected.
+- Fix: [#26615] Missing junction path tile in BYO Six Flags Over Texas.
 
 0.5.1 (2026-05-17)
 ------------------------------------------------------------------------


### PR DESCRIPTION
Before:
<img width="1920" height="1080" alt="ksnip_20260525-165251" src="https://github.com/user-attachments/assets/a962534a-5069-45b6-8459-6209d597998e" />
After:
<img width="1920" height="1080" alt="ksnip_20260525-181542" src="https://github.com/user-attachments/assets/c389a9bc-5cca-4c01-b262-c0854c913684" />
