### PR TITLE
Change pitch8 and pitch16 banked45 vehicle bounding boxes to use flat banked45 bbs

### DIFF
--- a/src/openrct2/paint/vehicle/VehiclePaint.cpp
+++ b/src/openrct2/paint/vehicle/VehiclePaint.cpp
@@ -3646,7 +3646,7 @@ static void VehiclePitchUp8BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 0);
@@ -3663,7 +3663,7 @@ static void VehiclePitchUp8BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 1);
@@ -3767,7 +3767,7 @@ static void VehiclePitchUp16BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 0);
@@ -3784,7 +3784,7 @@ static void VehiclePitchUp16BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 1);
@@ -4046,7 +4046,7 @@ static void VehiclePitchDown8BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 2);
@@ -4063,7 +4063,7 @@ static void VehiclePitchDown8BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes8Banked45, imageDirection, 3);
@@ -4167,7 +4167,7 @@ static void VehiclePitchDown16BankedLeft45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 2);
@@ -4184,7 +4184,7 @@ static void VehiclePitchDown16BankedRight45(
     uint32_t boundingBoxIndex)
 {
     boundingBoxIndex = boundingBoxIndex != kBoundBoxIndexUndefined ? boundingBoxIndex
-                                                                   : YawTo16(imageDirection) + kBoundBoxIndexFlat;
+                                                                   : (YawTo16(imageDirection) ^ 8) + kBoundBoxIndexFlatBanked45;
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16Banked45))
     {
         const int32_t spriteIndex = carEntry->SpriteOffset(SpriteGroupType::Slopes16Banked45, imageDirection, 3);


### PR DESCRIPTION
This changes the pitch 8 and 16 banked 45 vehicle bounding boxes to use flat banked 45 bbs instead of flat bbs.
These are openrct2 vehicle angles added for the diagonal banked sloped pieces.
This is necessary in order to implement these pieces for inverted tracks without weird workarounds:
<img width="432" height="148" alt="current" src="https://github.com/user-attachments/assets/52ae962a-f2a8-49ab-a86a-2d59630467a7" />
<img width="432" height="148" alt="currentbb" src="https://github.com/user-attachments/assets/744ffcbc-4103-4674-9220-aaaaf5f2323a" />

<img width="432" height="148" alt="fix" src="https://github.com/user-attachments/assets/f5eda780-9eba-4f7c-b18b-f64785993353" />
<img width="432" height="148" alt="fixbb" src="https://github.com/user-attachments/assets/c8761909-81c6-47f4-8799-82ce6817eac0" />

For inverted trains, the bbs are typically above the track in these angles, so that the train draws over the track. You can see this in the vanilla vehicle angles at each end and the middle.

In my opinion it makes sense for these angles to use these bbs, it is more consistent and it can also be changed without affecting any existing upright trains/tracks.

----

The flat bbs and flat banked 45 bbs have these indexes:
https://github.com/OpenRCT2/OpenRCT2/blob/e5e79ac2374245b9cebf9a210e00fa2eb2207dc3/src/openrct2/paint/vehicle/VehiclePaint.cpp#L1046
https://github.com/OpenRCT2/OpenRCT2/blob/e5e79ac2374245b9cebf9a210e00fa2eb2207dc3/src/openrct2/paint/vehicle/VehiclePaint.cpp#L1060

For upright trains, these two ranges are exactly the same (bb set 5 here, but also true of 6, 7, 8 etc)
https://github.com/OpenRCT2/OpenRCT2/blob/e5e79ac2374245b9cebf9a210e00fa2eb2207dc3/src/openrct2/paint/vehicle/VehiclePaint.cpp#L331-L334
https://github.com/OpenRCT2/OpenRCT2/blob/e5e79ac2374245b9cebf9a210e00fa2eb2207dc3/src/openrct2/paint/vehicle/VehiclePaint.cpp#L358-L361

For inverted trains, these two ranges are different (bb set 1):
https://github.com/OpenRCT2/OpenRCT2/blob/e5e79ac2374245b9cebf9a210e00fa2eb2207dc3/src/openrct2/paint/vehicle/VehiclePaint.cpp#L95-L98
https://github.com/OpenRCT2/OpenRCT2/blob/e5e79ac2374245b9cebf9a210e00fa2eb2207dc3/src/openrct2/paint/vehicle/VehiclePaint.cpp#L122-L125
(Ride object `drawOrder` is the index for the set of bbs)

I have not added a changelog entry because this should not change anything for the end user at the moment.