### PR TITLE
Invalidate tile when clicking on element with tile inspector

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Fix: [#26602] Crash when locating the nearest mechanic for a ride that has not previously been inspected.
 - Fix: [#26615] Missing junction path tile in Build your own Six Flags Over Texas.
 - Fix: [#26616] Fix gap in buyable land in Build your own Six Flags Magic Mountain.
+- Fix: [#26624] Tile elements selected by clicking on them with the tile inspector open do not always redraw correctly.
 
 0.5.1 (2026-05-17)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1874,6 +1874,7 @@ namespace OpenRCT2::Ui::Windows
             } while (!(element++)->isLastForTile());
             windowTileInspectorElementCount = numItems;
             invalidate();
+            MapInvalidateTileFull(_toolMap);
         }
 
         void RemoveElement(int32_t elementIndex)


### PR DESCRIPTION
This invalidates the tile when directly ctrl-clicking on an element with the tile inspector open.
This one is not that common as often something else happens to invalidate the same area, but you can get it consistently when selecting something on the same tile.

https://github.com/user-attachments/assets/3a324c53-cffe-4deb-a443-299807bff195