### PR TITLE
fix(ui): prevent out-of-bounds widget crash when switching guest tabs…

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -487,10 +487,13 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            const bool disablePickup = !peep->CanBePickedUp();
-            if (disablePickup != isWidgetDisabled(WIDX_PICKUP))
-                invalidate();
-            setWidgetDisabled(WIDX_PICKUP, disablePickup);
+            if (page == WINDOW_GUEST_OVERVIEW)
+            {
+                const bool disablePickup = !peep->CanBePickedUp();
+                if (disablePickup != isWidgetDisabled(WIDX_PICKUP))
+                    invalidate();
+                setWidgetDisabled(WIDX_PICKUP, disablePickup);
+            }
             setWidgetDisabled(WIDX_TAB_4, (getGameState().park.flags & PARK_FLAGS_NO_MONEY) != 0);
             setWidgetDisabled(WIDX_TAB_7, !Config::Get().general.debuggingTools);
         }


### PR DESCRIPTION
**What was changed:**
- Added a guard for `WIDX_PICKUP` operations within `DisableWidgets`.
- This ensures that page-specific widget lookups are safely bypassed when non-overview tabs are active.

**Why this change is valuable:**
By preventing these lookups on irrelevant tabs, we eliminate the root cause of the out-of-bounds access,
significantly improving the stability of the guest UI and preventing the game from crashing during
standard UI interactions.