### PR TITLE
Build fix for macOS Tahoe

### DIFF
--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -11,11 +11,20 @@
 
     #include "UiContext.h"
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+    #pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
+    #pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    #pragma clang diagnostic ignored "-Wold-style-cast"
+    #pragma clang diagnostic ignored "-Wundef"
+    #pragma clang diagnostic ignored "-Wmissing-method-return-type"
+    #pragma clang diagnostic ignored "-Wavailability"
     #include <ApplicationServices/ApplicationServices.h>
     #include <Cocoa/Cocoa.h>
     #include <CoreFoundation/CFBundle.h>
     #include <SDL.h>
     #include <mach-o/dyld.h>
+    #pragma clang diagnostic pop
     #include <openrct2/Diagnostic.h>
     #include <openrct2/ui/UiContext.h>
     #include <string>

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -182,7 +182,7 @@ namespace OpenRCT2::Network
         {
             LOG_ERROR("Failed to create hash of public key: %s", e.what());
         }
-        return nullptr;
+        return {};
     }
 
     bool Key::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const


### PR DESCRIPTION
I have some build errors on macOS system headers being treated as errors.

[CMakeLists.txt]( — Added -Wno- flags to suppress warnings from macOS system SDK headers that were being treated as errors via -Werror. These only apply to the .mm Objective-C++ sources.

[NetworkKey.cpp] — Changed return nullptr to return {} in [Key::PublicKeyHash()]