### PR TITLE
Fix issue with scenario completion 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.2 (in development)
 ------------------------------------------------------------------------
 - Improved: [#26566] Improve the performance of sorting sprites.
+- Fix: [#17281, #19243, #24833] Completing a scenario saved in the .park format does not prompt for a name and is never marked as completed.
 - Fix: [#26565] Game crashes when switching to another tab in the guest window.
 - Fix: [#26583] The default tab is not highlighted when opening a ride window.
 - Fix: [#26602] Crash when locating the nearest mechanic for a ride that has not previously been inspected.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -839,6 +839,19 @@ namespace OpenRCT2
                 // TODO: Have a separate GameState and exchange once loaded.
                 auto& gameState = ::getGameState();
                 parkImporter->Import(gameState);
+
+                // .park files serialise scenarioFileName inside the file itself, so the stored value
+                // drifts if the file is renamed, re-downloaded under a different name, or saved empty
+                // by the scenario editor. That stale name makes ScenarioRepositoryTryRecordHighscore's
+                // GetByFilename lookup miss, so winning a .park scenario is never recorded and never
+                // prompts for a name (issues #17281, #19243, #24833). When loading a .park as a
+                // scenario, correct scenarioFileName to the real on-disk filename. Savegames are left
+                // untouched: their own filename is arbitrary, so the stored value is the only link back
+                // to the originating scenario and must be preserved.
+                if (asScenario && info.Type == FileType::park)
+                {
+                    gameState.scenarioFileName = Path::GetFileName(path);
+                }
                 SetProgress(100, 100, STR_STRING_M_PERCENT);
 
                 // Reset viewport rendering inhibition


### PR DESCRIPTION
## Summary

When a scenario saved in the `.park` format is won, the player is never prompted to enter their name and the scenario is never marked complete in the scenario list. The original RCT1/2 formats (`.sc4`, `.sc6`, `.sea`) work correctly. Fixes #17281, #19243, #24833.

## Root cause

On a win, `ScenarioSuccess` (`src/openrct2/scenario/Scenario.cpp`) only records the result (and prompts for a name) if `ScenarioRepositoryTryRecordHighscore(...)` succeeds. That call locates the scenario in the index via `GetByFilename`, comparing `gameState.scenarioFileName` against each indexed scenario's real on-disk filename.

- `.sc6` / `.sc4` derive `scenarioFileName` from the real file path at import time (e.g. `S6Importer` uses `Path::GetFileName(_s6Path)` for `S6_TYPE_SCENARIO`), so it can never drift.
- `.park` reads `scenarioFileName` from a value serialised **inside** the file (`ParkFile.cpp`, general chunk). That stored copy drifts when the file is renamed, re-downloaded under a different name, or saved empty by the scenario editor → `GetByFilename` misses → the win is never recorded.

The stored value is still required for **savegames**: a savegame's filename is arbitrary, so the stored name is its only link back to the originating scenario. The fix therefore applies only when a park is loaded **as a scenario**.

## The fix

In `Context.cpp`'s `LoadParkFromStream`, immediately after `parkImporter->Import(gameState)`, correct `scenarioFileName` to the real on-disk filename when (and only when) a `.park` is loaded as a scenario. Savegames keep the serialised value.

This is a load-time correction only — no change to the `.park` file format, the scenario index version, the `IParkImporter` interface, or the `isScenario` flag passed to the importer (which must keep matching the detected file type for correct RCT1/2 chunk parsing).

## Out of scope

`.park` scenarios are classified `SourceGame::Other` in `ReadScenarioChunk`, so they sort alphabetically rather than by difficulty. That is a separate bug left for a follow-up.

## Testing

- Built locally on macOS (full build, links cleanly).
- `Context.cpp` compiles cleanly with the change.

Manual verification to run before merge:
- Scenario Editor → create scenario → save as `.park` → play → win → name prompt appears and scenario marked complete.
- Rename a `.park` scenario file, then play and win → still records.
- Resume a mid-scenario `.park` savegame and win → still matches the originating scenario.
- Regression: `.sc6`/`.sea` scenarios and ordinary savegames behave as before.
