### PR TITLE
[Original Bug] Guests will only watch rides if not underground

### DIFF
--- a/assets.json
+++ b/assets.json
@@ -16,7 +16,7 @@
     "sha256": "dabb9787b1576342fca4dd9f64b3f8cfa04a7e6ce9c2bb9610f47b762905c858"
   },
   "replays": {
-    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.96/replays.zip",
-    "sha256": "e5cd2564e64a8053ad73ee877618a8b1a592dc693825753d47cf82b5ddd058bb"
+    "url": "https://github.com/OpenRCT2/replays/releases/download/v0.0.97/replays.zip",
+    "sha256": "c32c93fea479c61e8ccf9f7afe09541680a6383360f39cd67420c24d7f739490"
   }
 }

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.4 (in development)
 ------------------------------------------------------------------------
 - Improved: [#26560] [Plugin] Scripts can now be used to trigger saving a game (limited to the user save folder).
+- Improved: [#26638] Guests will no longer watch rides while they’re underground.
 - Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.
 - Improved: [#26763] The ride colour/appearance tab now visually separates fields using group boxes.
 - Improved: [#26765] The ride operations tab now visually separates fields using group boxes.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5641,6 +5641,10 @@ namespace OpenRCT2
             }
         }
 
+        // Only watch rides if the guest is not underground
+        if (TileElementIsUnderground(tileElement))
+            return;
+
         int32_t positions_free = 15;
 
         if (tileElement->asPath()->HasAddition())

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5642,7 +5642,7 @@ namespace OpenRCT2
         }
 
         // Only watch rides if the guest is not underground
-        if (TileElementIsUnderground(tileElement))
+        if (MapIsLocationUnderground(NextLoc))
             return;
 
         int32_t positions_free = 15;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -885,6 +885,15 @@ namespace OpenRCT2
         return false;
     }
 
+    bool MapIsLocationUnderground(const CoordsXYZ& loc)
+    {
+        const auto* surfaceElement = MapGetSurfaceElementAt(loc);
+        if (surfaceElement == nullptr)
+            return false;
+
+        return surfaceElement->getClearanceZ() > loc.z;
+    }
+
     int32_t MapGetCornerHeight(int32_t z, int32_t slope, int32_t direction)
     {
         switch (direction)

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -90,6 +90,7 @@ namespace OpenRCT2
     bool MapIsLocationOwned(const CoordsXYZ& loc);
     bool MapIsLocationInPark(const CoordsXY& coords);
     bool MapIsLocationOwnedOrHasRights(const CoordsXY& loc);
+    bool MapIsLocationUnderground(const CoordsXYZ& loc);
     bool MapSurfaceIsBlocked(const CoordsXY& mapCoords);
     void MapRemoveAllRides();
     void MapGetBoundingBox(const MapRange& _range, int32_t* left, int32_t* top, int32_t* right, int32_t* bottom);


### PR DESCRIPTION
This is an issue I noticed and has also been noticed by the community in #3085.

This implementation prevents guests from watching a ride if they are underground. I felt this was the cleanest way to fix the issue as I can't think of any situation where a guest would be able to see a ride while underground. In the issue #3085, discussions were had about still allowing guests to watch underground if there is a ride in the next lateral tile however the ride would still be in a separate tunnel so that doesn't make sense to me. **I am happy to modify the logic if the community think that the logic should be different.**