### PR TITLE
Handymen now check if a tile is being serviced by another handyman before starting their task

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -263,6 +263,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Sjoerd de Bruin (sjoerddebruin)
 * Alex Harvey (loonyduck1)
 * Daniel Rödl (danielroedl)
+* Michael Hlas (mhlas7)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.
 - Improved: [#26763] The ride colour/appearance tab now visually separates fields using group boxes.
 - Improved: [#26765] The ride operations tab now visually separates fields using group boxes.
+- Fix: [#26639] Handymen now check if a tile is already being serviced by another handyman before starting their task.
 - Fix: [#26756] Guests cannot puke or litter on sloped path.
 - Fix: [#26758] [Plugin] IPv6 addresses are reported incorrectly.
 - Fix: [#26775] Maze gets wrong intensity boost from size (0.02 per tile instead of 0.01 per 2 tiles).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.
 - Improved: [#26763] The ride colour/appearance tab now visually separates fields using group boxes.
 - Improved: [#26765] The ride operations tab now visually separates fields using group boxes.
-- Fix: [#26639] Handymen now check if a tile is already being serviced by another handyman before starting their task.
+- Fix: [#26639] Handymen could begin a task while another handyman was already doing the exact same task.
 - Fix: [#26756] Guests cannot puke or litter on sloped path.
 - Fix: [#26758] [Plugin] IPv6 addresses are reported incorrectly.
 - Fix: [#26775] Maze gets wrong intensity boost from size (0.02 per tile instead of 0.01 per 2 tiles).

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1631,7 +1631,8 @@ namespace OpenRCT2
         auto surfaceElement = MapGetSurfaceElementAt(NextLoc);
         if (surfaceElement != nullptr && surfaceElement->CanGrassGrow())
         {
-            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1 && !isHandymanAlreadyServicingTile(CoordsXY{ NextLoc }, PeepState::mowing))
+            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1
+                && !isHandymanAlreadyServicingTile(CoordsXY{ NextLoc }, PeepState::mowing))
             {
                 SetState(PeepState::mowing);
                 Var37 = 0;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -387,6 +387,16 @@ namespace OpenRCT2
         return nextDirection;
     }
 
+    static bool isTileBeingMowed(const CoordsXYZ& tile)
+    {
+        for (auto* staff : EntityList<Staff>())
+        {
+            if (staff->State == PeepState::mowing && staff->NextLoc == tile)
+                return true;
+        }
+        return false;
+    }
+
     /**
      *
      *  rct2: 0x006BF931
@@ -433,7 +443,10 @@ namespace OpenRCT2
                 {
                     if (surfaceElement->CanGrassGrow() && (surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1)
                     {
-                        return chosenDirection;
+                        // Only mow if the tile is not being mowed by another handyman
+                        CoordsXYZ tileWithZ{ chosenTile, surfaceElement->getBaseZ() };
+                        if (!isTileBeingMowed(tileWithZ))
+                            return chosenDirection;
                     }
                 }
             }
@@ -1602,7 +1615,8 @@ namespace OpenRCT2
         auto surfaceElement = MapGetSurfaceElementAt(NextLoc);
         if (surfaceElement != nullptr && surfaceElement->CanGrassGrow())
         {
-            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1)
+            // Only start mowing if the grass is long enough and the tile is not being mowed by another handyman
+            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1 && isTileBeingMowed(NextLoc))
             {
                 SetState(PeepState::mowing);
                 Var37 = 0;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -389,9 +389,23 @@ namespace OpenRCT2
 
     static bool isHandymanAlreadyServicingTile(const CoordsXY& tile, PeepState state)
     {
+        // Watering handymen stand adjacent to the plant, not on its tile — use isPlantBeingWatered instead.
+        assert(state != PeepState::watering);
         for (auto* staff : EntityTileList<Staff>(tile))
         {
             if (staff->State == state)
+                return true;
+        }
+        return false;
+    }
+
+    static bool isPlantBeingWatered(const CoordsXY& plantTile)
+    {
+        for (auto* staff : EntityList<Staff>())
+        {
+            if (staff->State != PeepState::watering)
+                continue;
+            if (CoordsXY{ staff->NextLoc } + CoordsDirectionDelta[staff->Var37] == plantTile)
                 return true;
         }
         return false;
@@ -1518,7 +1532,7 @@ namespace OpenRCT2
                     }
                 }
 
-                if (isHandymanAlreadyServicingTile(chosenLoc, PeepState::watering))
+                if (isPlantBeingWatered(chosenLoc))
                     continue;
 
                 SetState(PeepState::watering);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -389,24 +389,23 @@ namespace OpenRCT2
 
     static bool isHandymanAlreadyServicingTile(const CoordsXY& tile, PeepState state)
     {
-        // Watering handymen stand adjacent to the plant, not on its tile — use isPlantBeingWatered instead.
-        assert(state != PeepState::watering);
-        for (auto* staff : EntityTileList<Staff>(tile))
+        if (state == PeepState::watering)
         {
-            if (staff->State == state)
-                return true;
+            for (auto* staff : EntityList<Staff>())
+            {
+                if (staff->State == PeepState::watering
+                    && CoordsXY{ staff->NextLoc } + CoordsDirectionDelta[staff->Var37] == tile)
+                    return true;
+            }
+            return false;
         }
-        return false;
-    }
-
-    static bool isPlantBeingWatered(const CoordsXY& plantTile)
-    {
-        for (auto* staff : EntityList<Staff>())
+        else
         {
-            if (staff->State != PeepState::watering)
-                continue;
-            if (CoordsXY{ staff->NextLoc } + CoordsDirectionDelta[staff->Var37] == plantTile)
-                return true;
+            for (auto* staff : EntityTileList<Staff>(tile))
+            {
+                if (staff->State == state)
+                    return true;
+            }
         }
         return false;
     }
@@ -1532,7 +1531,7 @@ namespace OpenRCT2
                     }
                 }
 
-                if (isPlantBeingWatered(chosenLoc))
+                if (isHandymanAlreadyServicingTile(chosenLoc, PeepState::watering))
                     continue;
 
                 SetState(PeepState::watering);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -397,7 +397,6 @@ namespace OpenRCT2
                     && CoordsXY{ staff->NextLoc } + CoordsDirectionDelta[staff->Var37] == tile)
                     return true;
             }
-            return false;
         }
         else
         {

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -387,11 +387,11 @@ namespace OpenRCT2
         return nextDirection;
     }
 
-    static bool isTileBeingMowed(const CoordsXY& tile)
+    static bool isHandymanAlreadyServicingTile(const CoordsXY& tile, PeepState state)
     {
         for (auto* staff : EntityTileList<Staff>(tile))
         {
-            if (staff->State == PeepState::mowing)
+            if (staff->State == state)
                 return true;
         }
         return false;
@@ -443,7 +443,7 @@ namespace OpenRCT2
                 {
                     if (surfaceElement->CanGrassGrow() && (surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1)
                     {
-                        if (!isTileBeingMowed(chosenTile))
+                        if (!isHandymanAlreadyServicingTile(chosenTile, PeepState::mowing))
                             return chosenDirection;
                     }
                 }
@@ -1518,6 +1518,9 @@ namespace OpenRCT2
                     }
                 }
 
+                if (isHandymanAlreadyServicingTile(chosenLoc, PeepState::watering))
+                    continue;
+
                 SetState(PeepState::watering);
                 Var37 = chosen_position;
 
@@ -1586,6 +1589,9 @@ namespace OpenRCT2
         if (chosen_position == 4)
             return false;
 
+        if (isHandymanAlreadyServicingTile(CoordsXY{ NextLoc }, PeepState::emptyingBin))
+            return false;
+
         Var37 = chosen_position;
         SetState(PeepState::emptyingBin);
 
@@ -1613,7 +1619,7 @@ namespace OpenRCT2
         auto surfaceElement = MapGetSurfaceElementAt(NextLoc);
         if (surfaceElement != nullptr && surfaceElement->CanGrassGrow())
         {
-            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1 && !isTileBeingMowed(CoordsXY{ NextLoc }))
+            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1 && !isHandymanAlreadyServicingTile(CoordsXY{ NextLoc }, PeepState::mowing))
             {
                 SetState(PeepState::mowing);
                 Var37 = 0;
@@ -1641,6 +1647,9 @@ namespace OpenRCT2
             uint16_t z_diff = abs(z - litter->z);
 
             if (z_diff >= 16)
+                continue;
+
+            if (isHandymanAlreadyServicingTile(litter->getLocation(), PeepState::sweeping))
                 continue;
 
             SetState(PeepState::sweeping);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -387,11 +387,11 @@ namespace OpenRCT2
         return nextDirection;
     }
 
-    static bool isTileBeingMowed(const CoordsXYZ& tile)
+    static bool isTileBeingMowed(const CoordsXY& tile)
     {
-        for (auto* staff : EntityList<Staff>())
+        for (auto* staff : EntityTileList<Staff>(tile))
         {
-            if (staff->State == PeepState::mowing && staff->NextLoc == tile)
+            if (staff->State == PeepState::mowing)
                 return true;
         }
         return false;
@@ -443,9 +443,7 @@ namespace OpenRCT2
                 {
                     if (surfaceElement->CanGrassGrow() && (surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1)
                     {
-                        // Only mow if the tile is not being mowed by another handyman
-                        CoordsXYZ tileWithZ{ chosenTile, surfaceElement->getBaseZ() };
-                        if (!isTileBeingMowed(tileWithZ))
+                        if (!isTileBeingMowed(chosenTile))
                             return chosenDirection;
                     }
                 }
@@ -1615,8 +1613,7 @@ namespace OpenRCT2
         auto surfaceElement = MapGetSurfaceElementAt(NextLoc);
         if (surfaceElement != nullptr && surfaceElement->CanGrassGrow())
         {
-            // Only start mowing if the grass is long enough and the tile is not being mowed by another handyman
-            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1 && isTileBeingMowed(NextLoc))
+            if ((surfaceElement->GetGrassLength() & 0x7) >= GRASS_LENGTH_CLEAR_1 && !isTileBeingMowed(CoordsXY{ NextLoc }))
             {
                 SetState(PeepState::mowing);
                 Var37 = 0;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -48,7 +48,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 2;
+constexpr uint8_t kStreamVersion = 3;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Handymen now check if a tile is being serviced by another handyman before starting their task (sweeping, emptying bins, watering, mowing).

This is a bug that existed in the original game and has bothering me for decades (literally)!

Previously, if a tile was in process of being mowed, another handyman could come along and start mowing the same tile before the first handyman had finished. This change adds a helper function that checks for other handymen mowing the same tile while deciding which tiles need mowing.

Watering uses slightly different logic since staff water the adjacent tile.

Built and tested on Arch Linux.

**Other options considered:**

I considered setting `GRASS_LENGTH_MOWED` to 0 the moment a handyman starts mowing. That eliminates the high complexity loop of checking every handyman every time however, it does mean that the grass would appear mowed at the beginning of the mowing animation rather than the end.

**Before:**
[MowingOverlap.webm](https://github.com/user-attachments/assets/23278b6b-8a40-477e-b5ae-ef04461dc7ee)

**After:**
[MowingFixed.webm](https://github.com/user-attachments/assets/aca64290-fb85-4cd5-8975-27a770e333d8)
