### PR TITLE
Fix build error on riscv64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,10 @@ else ()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=objc-method-access")
     endif()
 
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=stringop-overflow")
+    endif()
+
     # Clang -Wmissing-declarations differs from GCC, set -Wmissing-prototypes for parity
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-prototypes")


### PR DESCRIPTION
Fixes error on Arch Linux RISC-V, but not on x86_64:

```text
In function ‘constexpr void std::_Construct(_Tp*, _Args&& ...) [with _Tp = unsigned char; _Args = {unsigned char}]’,
    inlined from ‘constexpr _ForwardIterator std::__do_uninit_copy(_InputIterator, _Sentinel, _ForwardIterator) [with _InputIterator = move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> > >; _Sentinel = move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> > >; _ForwardIterator = unsigned char*]’ at /usr/include/c++/16.1.1/bits/stl_uninitialized.h:165:17,
    inlined from ‘_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> > >; _ForwardIterator = unsigned char*]’ at /usr/include/c++/16.1.1/bits/stl_uninitialized.h:324:30,
    inlined from ‘constexpr _ForwardIterator std::__uninitialized_copy_a(_InputIterator, _Sentinel, _ForwardIterator, allocator<_Tp>&) [with _InputIterator = move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> > >; _Sentinel = move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, vector<unsigned char> > >; _ForwardIterator = unsigned char*; _Tp = unsigned char]’ at /usr/include/c++/16.1.1/bits/stl_uninitialized.h:659:32,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::_M_range_initialize_n(_Iterator, _Sentinel, size_type) [with _Iterator = std::move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char> > >; _Sentinel = std::move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char> > >; _Tp = unsigned char; _Alloc = std::allocator<unsigned char>]’ at /usr/include/c++/16.1.1/bits/stl_vector.h:1979:37,
    inlined from ‘constexpr std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with _InputIterator = std::move_iterator<__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char> > >; <template-parameter-2-2> = void; _Tp = unsigned char; _Alloc = std::allocator<unsigned char>]’ at /usr/include/c++/16.1.1/bits/stl_vector.h:736:29,
    inlined from ‘static constexpr bool std::__shrink_to_fit_aux<_Tp, true>::_S_do_it(_Tp&) [with _Tp = std::vector<unsigned char>]’ at /usr/include/c++/16.1.1/bits/alloc_traits.h:1043:6,
    inlined from ‘constexpr bool std::vector<_Tp, _Alloc>::_M_shrink_to_fit() [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>]’ at /usr/include/c++/16.1.1/bits/vector.tcc:924:56,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::shrink_to_fit() [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>]’ at /usr/include/c++/16.1.1/bits/stl_vector.h:1189:25,
    inlined from ‘void EditorObjectFlagsClear()’ at /build/openrct2/src/OpenRCT2-0.5.1/src/openrct2/EditorObjectSelectionSession.cpp:368:40,
    inlined from ‘void EditorObjectFlagsClear()’ at /build/openrct2/src/OpenRCT2-0.5.1/src/openrct2/EditorObjectSelectionSession.cpp:365:6:
/usr/include/c++/16.1.1/bits/stl_construct.h:133:7: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  133 |       ::new(static_cast<void*>(__p)) _Tp(std::forward<_Args>(__args)...);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```