### PR TITLE
WALL_SCENERY_2_IS_OPAQUE flag denotes transparent wall object.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,7 +3,6 @@
 - Feature: [#26308] Add all new track pieces to the inverted roller coaster.
 - Feature: [#26442] Add cheat to disable grass growing.
 - Change: [#26689] A clear scenario editor can now be opened directly from the command line.
-- Fix: [#26428] WALL_SCENERY_2_IS_OPAQUE flag denotes transparent wall objects.
 - Fix: [#26494] The limits for where walls on the path side of the first tile block the view of rides/scenery are wrong (original bug).
 - Fix: [#26504] The boosts/penalties to excitement and nausea that air time provides are calculated wrong.
 - Fix: [#26545] Game crashes when plugin API function generateGuest fails to generate a guest.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#26308] Add all new track pieces to the inverted roller coaster.
 - Feature: [#26442] Add cheat to disable grass growing.
 - Change: [#26689] A clear scenario editor can now be opened directly from the command line.
+- Fix: [#26428] WALL_SCENERY_2_IS_OPAQUE flag denotes transparent wall objects.
 - Fix: [#26494] The limits for where walls on the path side of the first tile block the view of rides/scenery are wrong (original bug).
 - Fix: [#26504] The boosts/penalties to excitement and nausea that air time provides are calculated wrong.
 - Fix: [#26545] Game crashes when plugin API function generateGuest fails to generate a guest.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -6529,7 +6529,7 @@ namespace OpenRCT2
             if (tileElement->getDirection() != edge)
                 continue;
             auto wallEntry = tileElement->asWall()->GetEntry();
-            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
+            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_TRANSPARENT))
                 continue;
             if (guest.NextLoc.z + (4 * kCoordsZStep) <= tileElement->getBaseZ())
                 continue;
@@ -6569,7 +6569,7 @@ namespace OpenRCT2
             if (DirectionReverse(tileElement->getDirection()) != edge)
                 continue;
             auto wallEntry = tileElement->asWall()->GetEntry();
-            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
+            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_TRANSPARENT))
                 continue;
             if (guest.NextLoc.z + (4 * kCoordsZStep) <= tileElement->getBaseZ())
                 continue;
@@ -6647,7 +6647,7 @@ namespace OpenRCT2
             if (tileElement->getType() == TileElementType::Wall)
             {
                 auto wallEntry = tileElement->asWall()->GetEntry();
-                if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
+                if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_TRANSPARENT))
                 {
                     continue;
                 }
@@ -6687,7 +6687,7 @@ namespace OpenRCT2
             if (DirectionReverse(tileElement->getDirection()) != edge)
                 continue;
             auto wallEntry = tileElement->asWall()->GetEntry();
-            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
+            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_TRANSPARENT))
                 continue;
             if (guest.NextLoc.z + (6 * kCoordsZStep) <= tileElement->getBaseZ())
                 continue;
@@ -6764,7 +6764,7 @@ namespace OpenRCT2
             if (tileElement->getType() == TileElementType::Wall)
             {
                 auto wallEntry = tileElement->asWall()->GetEntry();
-                if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
+                if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_TRANSPARENT))
                 {
                     continue;
                 }
@@ -6803,7 +6803,7 @@ namespace OpenRCT2
             if (DirectionReverse(tileElement->getDirection()) != edge)
                 continue;
             auto wallEntry = tileElement->asWall()->GetEntry();
-            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_OPAQUE))
+            if (wallEntry == nullptr || (wallEntry->flags2 & WALL_SCENERY_2_IS_TRANSPARENT))
                 continue;
             if (guest.NextLoc.z + (8 * kCoordsZStep) <= tileElement->getBaseZ())
                 continue;

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -132,7 +132,9 @@ namespace OpenRCT2
             _legacyType.flags2 = Json::GetFlags<uint8_t>(
                 properties,
                 {
-                    { "isOpaque", WALL_SCENERY_2_IS_OPAQUE },
+                    { "isTransparent", WALL_SCENERY_2_IS_TRANSPARENT },
+                    // Deprecated because it did the opposite of what the name implied.
+                    { "isOpaque", WALL_SCENERY_2_IS_TRANSPARENT },
                     { "isAnimated", WALL_SCENERY_2_ANIMATED },
                 });
 

--- a/src/openrct2/object/WallSceneryEntry.h
+++ b/src/openrct2/object/WallSceneryEntry.h
@@ -35,8 +35,8 @@ namespace OpenRCT2
         WALL_SCENERY_2_NO_SELECT_PRIMARY_COLOUR = (1 << 0), // 0x1
         WALL_SCENERY_2_DOOR_SOUND_MASK = 0b0110,
         WALL_SCENERY_2_DOOR_SOUND_SHIFT = 1,
-        WALL_SCENERY_2_IS_OPAQUE = (1 << 3), // 0x8
-        WALL_SCENERY_2_ANIMATED = (1 << 4),  // 0x10
+        WALL_SCENERY_2_IS_TRANSPARENT = (1 << 3), // 0x8
+        WALL_SCENERY_2_ANIMATED = (1 << 4),       // 0x10
     };
 
     struct WallSceneryEntry


### PR DESCRIPTION
Fix for #26428 