### PR TITLE
invalidate custom listview when selected cell changes

### DIFF
--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -283,6 +283,20 @@ void CustomListView::SetItems(std::vector<ListViewItem>&& items, bool initialisi
     }
 }
 
+std::optional<RowColumn> CustomListView::GetSelectedCell() const
+{
+    return SelectedCell;
+}
+
+void CustomListView::SetSelectedCell(const std::optional<RowColumn>& value, bool initialising)
+{
+    SelectedCell = value;
+    if (!initialising)
+    {
+        Invalidate();
+    }
+}
+
 bool CustomListView::SortItem(size_t indexA, size_t indexB, int32_t column)
 {
     const auto& cellA = Items[indexA].Cells[column];
@@ -495,8 +509,7 @@ void CustomListView::MouseDown(const ScreenCoordsXY& pos)
         {
             if (CanSelect)
             {
-                SelectedCell = hitResult;
-                Invalidate();
+                SetSelectedCell(hitResult);
             }
 
             auto ctx = OnClick.context;

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -100,13 +100,13 @@ namespace OpenRCT2::Ui::Windows
         std::vector<ListViewColumn> Columns;
         std::vector<ListViewItem> Items;
         ScrollbarType Scrollbars = ScrollbarType::Vertical;
+        std::optional<RowColumn> SelectedCell;
 
     public:
         std::shared_ptr<Plugin> Owner;
         std::vector<size_t> SortedItems;
         std::optional<RowColumn> HighlightedCell;
         std::optional<RowColumn> LastHighlightedCell;
-        std::optional<RowColumn> SelectedCell;
         std::optional<int32_t> ColumnHeaderPressed;
         bool ColumnHeaderPressedCurrentState{};
         bool ShowColumnHeaders{};
@@ -129,6 +129,8 @@ namespace OpenRCT2::Ui::Windows
         const std::vector<ListViewItem>& GetItems() const;
         void SetItems(const std::vector<ListViewItem>& items, bool initialising = false);
         void SetItems(std::vector<ListViewItem>&& items, bool initialising = false);
+        std::optional<RowColumn> GetSelectedCell() const;
+        void SetSelectedCell(const std::optional<RowColumn>& value, bool initialising = false);
         bool SortItem(size_t indexA, size_t indexB, int32_t column);
         void SortItems(int32_t column);
         void SortItems(int32_t column, ColumnSortOrder order);

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -929,7 +929,7 @@ namespace OpenRCT2::Ui::Windows
                     listView.SetScrollbars(widgetDesc.Scrollbars, true);
                     listView.SetColumns(widgetDesc.ListViewColumns, true);
                     listView.SetItems(widgetDesc.ListViewItems, true);
-                    listView.SelectedCell = widgetDesc.SelectedCell;
+                    listView.SetSelectedCell(widgetDesc.SelectedCell, true);
                     listView.ShowColumnHeaders = widgetDesc.ShowColumnHeaders;
                     listView.IsStriped = widgetDesc.IsStriped;
                     listView.OnClick = widgetDesc.OnClick;

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -955,9 +955,13 @@ namespace OpenRCT2::Scripting
         static JSValue selectedCell_get(JSContext* ctx, JSValue thisVal)
         {
             auto listView = GetListView(thisVal);
-            if (listView != nullptr && listView->SelectedCell.has_value())
+            if (listView != nullptr)
             {
-                return RowColumnToJS(ctx, listView->SelectedCell.value());
+                auto selectedCell = listView->GetSelectedCell();
+                if (selectedCell.has_value())
+                {
+                    return RowColumnToJS(ctx, selectedCell.value());
+                }
             }
             return JS_NULL;
         }
@@ -967,7 +971,7 @@ namespace OpenRCT2::Scripting
             auto listView = GetListView(thisVal);
             if (listView != nullptr)
             {
-                listView->SelectedCell = RowColumnFromJS(ctx, value);
+                listView->SetSelectedCell(RowColumnFromJS(ctx, value));
             }
             return JS_UNDEFINED;
         }


### PR DESCRIPTION
After setting the selected cell of a custom listview, the listview is not invalidated properly, which produces visual glitches as below. In this example, the first column has not been updated, but the other two have. Depending on what is happening on the screen, for example where the cursor is, sometimes the change is not visible at all.

<img width="517" height="389" alt="image" src="https://github.com/user-attachments/assets/5218075a-8170-4fab-b0c6-871dcee29f01" />

This PR wraps calls to `CustomListView::SelectedCell` in getter/setter methods. The setter properly invalidates the listview.
