### PR TITLE
Fix #25115: Add console error message when replay fails to start

### DIFF
--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1489,6 +1489,7 @@ static void ConsoleCommandReplayStart(InteractiveConsole& console, const argumen
     catch (const std::exception& e)
     {
         console.WriteLine(e.what());
+        console.WriteFormatLine("Error: Could not start replay '{0}'.\n", name);
         return;
     }
 


### PR DESCRIPTION
Fixes #25115. Added an explicit console error message inside the catch block of ConsoleCommandReplayStart so the player is notified if a replay fails to start playback.