### PR TITLE
Turn off optimizations for MSVC to fix miscompilation

### DIFF
--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -575,6 +575,11 @@ static void Flush_Cache(TTF_Font* font)
     }
 }
 
+#if defined(_MSC_VER) && _MSC_VER == 1951
+// MSVC bug in 19.51, using different optimization setting fixes the codegen
+// see https://github.com/OpenRCT2/OpenRCT2/issues/26637
+#pragma optimize("", off)
+#endif
 static FT_Error Load_Glyph(TTF_Font* font, uint16_t ch, c_glyph* cached, int want)
 {
     FT_Face face;
@@ -964,6 +969,9 @@ static FT_Error Load_Glyph(TTF_Font* font, uint16_t ch, c_glyph* cached, int wan
 
     return 0;
 }
+#if defined(_MSC_VER) && _MSC_VER == 1951
+#pragma optimize("", on)
+#endif
 
 static FT_Error Find_Glyph(TTF_Font* font, uint16_t ch, int want)
 {


### PR DESCRIPTION
This adds a workaround for the MSVC bug reported here: https://developercommunity.visualstudio.com/t/MSVC-amd64-O2-miscompiles-SDL_ttf-deriv/11104938

Fixes #26637