### PR TITLE
Allow starting editor directly from command line

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#26308] Add all new track pieces to the inverted roller coaster.
 - Feature: [#26442] Add cheat to disable grass growing.
+- Change: [#26689] A clear scenario editor can now be opened directly from the command line.
 - Fix: [#26494] The limits for where walls on the path side of the first tile block the view of rides/scenery are wrong (original bug).
 - Fix: [#26504] The boosts/penalties to excitement and nausea that air time provides are calculated wrong.
 

--- a/src/openrct2/command_line/RootCommands.cpp
+++ b/src/openrct2/command_line/RootCommands.cpp
@@ -261,12 +261,10 @@ namespace OpenRCT2
         }
 
         const char* parkUri;
-        if (!enumerator->TryPopString(&parkUri))
+        if (enumerator->TryPopString(&parkUri))
         {
-            Console::Error::WriteLine("Expected path or URL to a saved park.");
-            return EXITCODE_FAIL;
+            String::set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
         }
-        String::set(gOpenRCT2StartupActionPath, sizeof(gOpenRCT2StartupActionPath), parkUri);
 
         gOpenRCT2StartupAction = StartupAction::edit;
         return EXITCODE_CONTINUE;


### PR DESCRIPTION
The scenario editor can be opened directly from the command line by means of the `edit` keyword. A save game currently needs to be provided. This PR changes this such that the latter is now optional, allowing players to start the scenario editor directly from the command line without specifying a save game.

(Cherry-picked from an upcoming scene refactor PR.)