### PR TITLE
Move EditorStep to its own header file

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -1050,7 +1050,7 @@ public:
 
         if (gLegacyScene == LegacyScene::scenarioEditor)
         {
-            if (getGameState().editorStep != EditorStep::landscapeEditor)
+            if (getGameState().editorStep != Editor::Step::landscapeEditor)
                 return;
         }
 

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -199,7 +199,7 @@ static void ShortcutAdjustLand()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor)
+    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor)
         return;
 
     if (isInTrackDesignerOrManager())
@@ -213,7 +213,7 @@ static void ShortcutAdjustWater()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor)
+    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor)
         return;
 
     if (isInTrackDesignerOrManager())
@@ -227,7 +227,7 @@ static void ShortcutBuildScenery()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor)
+    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor)
         return;
 
     if (isInTrackDesignerOrManager())
@@ -241,7 +241,7 @@ static void ShortcutBuildPaths()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor)
+    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor)
         return;
 
     if (isInTrackDesignerOrManager())
@@ -343,7 +343,7 @@ static void ShortcutShowMap()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (gLegacyScene != LegacyScene::scenarioEditor || getGameState().editorStep == EditorStep::landscapeEditor)
+    if (gLegacyScene != LegacyScene::scenarioEditor || getGameState().editorStep == Editor::Step::landscapeEditor)
         if (!(isInTrackDesignerOrManager()))
             ContextOpenWindow(WindowClass::map);
 }
@@ -400,7 +400,7 @@ static void ShortcutClearScenery()
     if (gLegacyScene == LegacyScene::titleSequence)
         return;
 
-    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor)
+    if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor)
         return;
 
     if (isInTrackDesignerOrManager())
@@ -440,7 +440,7 @@ static void ShortcutOpenSceneryPicker()
 {
     if ((gLegacyScene == LegacyScene::titleSequence || gLegacyScene == LegacyScene::trackDesigner
          || gLegacyScene == LegacyScene::trackDesignsManager)
-        || (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor))
+        || (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor))
         return;
 
     auto* windowMgr = GetWindowManager();
@@ -762,7 +762,7 @@ void ShortcutManager::registerDefaultShortcuts()
         {
             windowMgr->CloseAll();
         }
-        else if (getGameState().editorStep == EditorStep::landscapeEditor)
+        else if (getGameState().editorStep == Editor::Step::landscapeEditor)
         {
             windowMgr->CloseTop();
         }

--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <openrct2-ui/UiStringIds.h>
 #include <openrct2-ui/windows/Windows.h>
+#include <openrct2/Editor.h>
 #include <openrct2/Game.h>
 #include <openrct2/GameState.h>
 #include <openrct2/PlatformEnvironment.h>
@@ -320,7 +321,7 @@ namespace OpenRCT2::Ui::FileBrowser
                         SetAndSaveConfigPath(Config::Get().general.lastSaveScenarioDirectory, pathBuffer);
                         int32_t parkFlagsBackup = gameState.park.flags;
                         gameState.park.flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
-                        gameState.editorStep = EditorStep::invalid;
+                        gameState.editorStep = Editor::Step::invalid;
                         gameState.scenarioFileName = std::string(String::toStringView(pathBuffer, std::size(pathBuffer)));
                         int32_t success = ScenarioSave(gameState, pathBuffer, Config::Get().general.savePluginData ? 3 : 2);
                         gameState.park.flags = parkFlagsBackup;
@@ -336,7 +337,7 @@ namespace OpenRCT2::Ui::FileBrowser
                         else
                         {
                             ContextShowError(STR_FILE_DIALOG_TITLE_SAVE_SCENARIO, STR_SCENARIO_SAVE_FAILED, {});
-                            gameState.editorStep = EditorStep::objectiveSelection;
+                            gameState.editorStep = Editor::Step::objectiveSelection;
                             InvokeCallback(ModalResult::fail, pathBuffer);
                         }
                         break;
@@ -409,7 +410,7 @@ namespace OpenRCT2::Ui::FileBrowser
                         SetAndSaveConfigPath(Config::Get().general.lastSaveScenarioDirectory, pathBuffer);
                         int32_t parkFlagsBackup = gameState.park.flags;
                         gameState.park.flags &= ~PARK_FLAGS_SPRITES_INITIALISED;
-                        gameState.editorStep = EditorStep::invalid;
+                        gameState.editorStep = Editor::Step::invalid;
                         gameState.scenarioFileName = std::string(String::toStringView(pathBuffer, std::size(pathBuffer)));
                         int32_t success = ScenarioSave(gameState, pathBuffer, Config::Get().general.savePluginData ? 3 : 2);
                         gameState.park.flags = parkFlagsBackup;
@@ -425,7 +426,7 @@ namespace OpenRCT2::Ui::FileBrowser
                         else
                         {
                             ContextShowError(STR_FILE_DIALOG_TITLE_SAVE_SCENARIO, STR_SCENARIO_SAVE_FAILED, {});
-                            gameState.editorStep = EditorStep::objectiveSelection;
+                            gameState.editorStep = Editor::Step::objectiveSelection;
                             InvokeCallback(ModalResult::fail, pathBuffer);
                         }
                         break;

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -88,7 +88,7 @@ namespace OpenRCT2::Ui
             return info;
 
         //
-        if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != EditorStep::rollerCoasterDesigner)
+        if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != Editor::Step::rollerCoasterDesigner)
             return info;
 
         info = GetMapCoordinatesFromPos(
@@ -275,7 +275,7 @@ namespace OpenRCT2::Ui
             return info;
 
         //
-        if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != EditorStep::rollerCoasterDesigner)
+        if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != Editor::Step::rollerCoasterDesigner)
             return info;
 
         constexpr auto flags = static_cast<int32_t>(

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -1084,7 +1084,7 @@ namespace OpenRCT2::Ui::Windows
         if (gLegacyScene == LegacyScene::titleSequence)
             return;
 
-        if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != EditorStep::landscapeEditor)
+        if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep != Editor::Step::landscapeEditor)
             return;
 
         if (gLegacyScene == LegacyScene::trackDesignsManager)

--- a/src/openrct2-ui/ride/VehicleSounds.cpp
+++ b/src/openrct2-ui/ride/VehicleSounds.cpp
@@ -109,7 +109,7 @@ namespace OpenRCT2::Audio
         if (gLegacyScene == LegacyScene::scenarioEditor)
             return false;
 
-        if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != EditorStep::rollerCoasterDesigner)
+        if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != Editor::Step::rollerCoasterDesigner)
             return false;
 
         if (vehicle.sound1_id == SoundId::null && vehicle.sound2_id == SoundId::null)

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -62,15 +62,15 @@ namespace OpenRCT2::Ui::Windows
         using FuncPtr = void (EditorBottomToolbarWindow::*)() const;
 
         static constexpr StringId kEditorStepNames[] = {
-            STR_EDITOR_STEP_OBJECT_SELECTION,       // EditorStep::objectSelection
-            STR_EDITOR_STEP_LANDSCAPE_EDITOR,       // EditorStep::landscapeEditor
-            STR_EDITOR_STEP_INVENTIONS_LIST_SET_UP, // EditorStep::inventionsListSetUp
-            STR_EDITOR_STEP_OPTIONS_SELECTION,      // EditorStep::optionsSelection
-            STR_EDITOR_STEP_OBJECTIVE_SELECTION,    // EditorStep::objectiveSelection
-            STR_EDITOR_STEP_SCENARIO_DETAILS,       // EditorStep::scenarioDetails
-            STR_EDITOR_STEP_SAVE_SCENARIO,          // EditorStep::saveScenario
-            STR_EDITOR_STEP_ROLLERCOASTER_DESIGNER, // EditorStep::rollerCoasterDesigner
-            STR_EDITOR_STEP_TRACK_DESIGNS_MANAGER,  // EditorStep::designsManager
+            STR_EDITOR_STEP_OBJECT_SELECTION,       // Editor::Step::objectSelection
+            STR_EDITOR_STEP_LANDSCAPE_EDITOR,       // Editor::Step::landscapeEditor
+            STR_EDITOR_STEP_INVENTIONS_LIST_SET_UP, // Editor::Step::inventionsListSetUp
+            STR_EDITOR_STEP_OPTIONS_SELECTION,      // Editor::Step::optionsSelection
+            STR_EDITOR_STEP_OBJECTIVE_SELECTION,    // Editor::Step::objectiveSelection
+            STR_EDITOR_STEP_SCENARIO_DETAILS,       // Editor::Step::scenarioDetails
+            STR_EDITOR_STEP_SAVE_SCENARIO,          // Editor::Step::saveScenario
+            STR_EDITOR_STEP_ROLLERCOASTER_DESIGNER, // Editor::Step::rollerCoasterDesigner
+            STR_EDITOR_STEP_TRACK_DESIGNS_MANAGER,  // Editor::Step::designsManager
         };
 
     public:
@@ -108,19 +108,19 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_NEXT_IMAGE].type = WidgetType::imgBtn;
 
             auto& gameState = getGameState();
-            if (gLegacyScene == LegacyScene::trackDesignsManager || gameState.editorStep == EditorStep::saveScenario)
+            if (gLegacyScene == LegacyScene::trackDesignsManager || gameState.editorStep == Editor::Step::saveScenario)
             {
                 HidePreviousStepButton();
                 HideNextStepButton();
             }
             else
             {
-                if (gameState.editorStep == EditorStep::objectSelection
-                    || (GameHasEntities() && gameState.editorStep == EditorStep::optionsSelection))
+                if (gameState.editorStep == Editor::Step::objectSelection
+                    || (GameHasEntities() && gameState.editorStep == Editor::Step::optionsSelection))
                 {
                     HidePreviousStepButton();
                 }
-                else if (gameState.editorStep == EditorStep::rollerCoasterDesigner)
+                else if (gameState.editorStep == Editor::Step::rollerCoasterDesigner)
                 {
                     HideNextStepButton();
                 }
@@ -168,7 +168,7 @@ namespace OpenRCT2::Ui::Windows
             auto* windowMgr = GetWindowManager();
             windowMgr->CloseAll();
 
-            getGameState().editorStep = EditorStep::objectSelection;
+            getGameState().editorStep = Editor::Step::objectSelection;
             GfxInvalidateScreen();
         }
 
@@ -179,7 +179,7 @@ namespace OpenRCT2::Ui::Windows
 
             SetAllSceneryItemsInvented();
             WindowScenerySetDefaultPlacementConfiguration();
-            getGameState().editorStep = EditorStep::landscapeEditor;
+            getGameState().editorStep = Editor::Step::landscapeEditor;
             ContextOpenWindow(WindowClass::map);
             GfxInvalidateScreen();
         }
@@ -190,7 +190,7 @@ namespace OpenRCT2::Ui::Windows
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorInventionList);
-            getGameState().editorStep = EditorStep::inventionsListSetUp;
+            getGameState().editorStep = Editor::Step::inventionsListSetUp;
             GfxInvalidateScreen();
         }
 
@@ -200,7 +200,7 @@ namespace OpenRCT2::Ui::Windows
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
-            getGameState().editorStep = EditorStep::objectiveSelection;
+            getGameState().editorStep = Editor::Step::objectiveSelection;
             GfxInvalidateScreen();
         }
 
@@ -210,7 +210,7 @@ namespace OpenRCT2::Ui::Windows
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
-            getGameState().editorStep = EditorStep::optionsSelection;
+            getGameState().editorStep = Editor::Step::optionsSelection;
             GfxInvalidateScreen();
         }
 
@@ -242,7 +242,7 @@ namespace OpenRCT2::Ui::Windows
                 auto* windowMgr = GetWindowManager();
                 windowMgr->CloseAll();
                 ContextOpenWindow(WindowClass::editorInventionList);
-                getGameState().editorStep = EditorStep::inventionsListSetUp;
+                getGameState().editorStep = Editor::Step::inventionsListSetUp;
             }
             else
             {
@@ -258,7 +258,7 @@ namespace OpenRCT2::Ui::Windows
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
-            getGameState().editorStep = EditorStep::objectiveSelection;
+            getGameState().editorStep = Editor::Step::objectiveSelection;
             GfxInvalidateScreen();
         }
 
@@ -268,7 +268,7 @@ namespace OpenRCT2::Ui::Windows
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
-            getGameState().editorStep = EditorStep::optionsSelection;
+            getGameState().editorStep = Editor::Step::optionsSelection;
             GfxInvalidateScreen();
         }
 
@@ -278,7 +278,7 @@ namespace OpenRCT2::Ui::Windows
             windowMgr->CloseAll();
 
             ContextOpenWindow(WindowClass::editorScenarioOptions);
-            getGameState().editorStep = EditorStep::scenarioDetails;
+            getGameState().editorStep = Editor::Step::scenarioDetails;
             GfxInvalidateScreen();
         }
 
@@ -290,14 +290,14 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                getGameState().editorStep = EditorStep::scenarioDetails;
+                getGameState().editorStep = Editor::Step::scenarioDetails;
             }
         }
 
         void JumpForwardToSaveScenario() const
         {
             auto& gameState = getGameState();
-            gameState.editorStep = EditorStep::saveScenario;
+            gameState.editorStep = Editor::Step::saveScenario;
             GfxInvalidateScreen();
 
             const auto savePrepareResult = ScenarioPrepareForSave(gameState);

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1610,7 +1610,7 @@ namespace OpenRCT2::Ui::Windows
             SetEveryRideTypeInvented();
             SetEveryRideEntryInvented();
 
-            getGameState().editorStep = EditorStep::designsManager;
+            getGameState().editorStep = Editor::Step::designsManager;
 
             int32_t entry_index = 0;
             for (; ObjectEntryGetChunk(ObjectType::ride, entry_index) == nullptr; entry_index++)

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -522,8 +522,8 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             auto step = getGameState().editorStep;
-            bool isObjectiveSelection = step == EditorStep::objectiveSelection;
-            bool isScenarioDetails = step == EditorStep::scenarioDetails;
+            bool isObjectiveSelection = step == Editor::Step::objectiveSelection;
+            bool isScenarioDetails = step == Editor::Step::scenarioDetails;
             bool isOtherTab = !isObjectiveSelection && !isScenarioDetails;
 
             // Disable tabs based on current editor step

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -426,7 +426,7 @@ namespace OpenRCT2::Ui::Windows
             auto i = 0;
             gDropdown.items[i++] = Dropdown::PlainMenuLabel(STR_SHORTCUT_SHOW_MAP);
             gDropdown.items[i++] = Dropdown::PlainMenuLabel(STR_EXTRA_VIEWPORT);
-            if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep == EditorStep::landscapeEditor)
+            if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep == Editor::Step::landscapeEditor)
             {
                 gDropdown.items[i++] = Dropdown::PlainMenuLabel(STR_MAPGEN_MENU_ITEM);
             }
@@ -456,7 +456,7 @@ namespace OpenRCT2::Ui::Windows
         void mapMenuDropdown(int16_t dropdownIndex)
         {
             int32_t customStartIndex = 3;
-            if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep == EditorStep::landscapeEditor)
+            if (gLegacyScene == LegacyScene::scenarioEditor && getGameState().editorStep == Editor::Step::landscapeEditor)
             {
                 customStartIndex++;
             }
@@ -1168,21 +1168,21 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_NETWORK].type = WidgetType::empty;
 
             auto& gameState = getGameState();
-            if (gameState.editorStep != EditorStep::landscapeEditor)
+            if (gameState.editorStep != Editor::Step::landscapeEditor)
             {
                 widgets[WIDX_LAND].type = WidgetType::empty;
                 widgets[WIDX_WATER].type = WidgetType::empty;
             }
 
-            if (gameState.editorStep != EditorStep::rollerCoasterDesigner)
+            if (gameState.editorStep != Editor::Step::rollerCoasterDesigner)
             {
                 widgets[WIDX_RIDES].type = WidgetType::empty;
                 widgets[WIDX_CONSTRUCT_RIDE].type = WidgetType::empty;
                 widgets[WIDX_FASTFORWARD].type = WidgetType::empty;
             }
 
-            if (gameState.editorStep != EditorStep::landscapeEditor
-                && gameState.editorStep != EditorStep::rollerCoasterDesigner)
+            if (gameState.editorStep != Editor::Step::landscapeEditor
+                && gameState.editorStep != Editor::Step::rollerCoasterDesigner)
             {
                 widgets[WIDX_MAP].type = WidgetType::empty;
                 widgets[WIDX_SCENERY].type = WidgetType::empty;

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -115,7 +115,7 @@ namespace OpenRCT2::Editor
         Audio::StopAll();
         gameStateInitAll(gameState, kDefaultMapSize);
         gLegacyScene = LegacyScene::scenarioEditor;
-        gameState.editorStep = EditorStep::objectSelection;
+        gameState.editorStep = Editor::Step::objectSelection;
         gameState.park.flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
         gameState.scenarioOptions.category = Scenario::Category::other;
         ObjectListLoad();
@@ -160,7 +160,7 @@ namespace OpenRCT2::Editor
         ScenarioReset(gameState);
 
         gLegacyScene = LegacyScene::scenarioEditor;
-        gameState.editorStep = EditorStep::optionsSelection;
+        gameState.editorStep = Editor::Step::optionsSelection;
         gameState.scenarioOptions.category = Scenario::Category::other;
         ContextResetSubsystems();
         OpenEditorWindows();
@@ -193,7 +193,7 @@ namespace OpenRCT2::Editor
 
         auto& gameState = getGameState();
         gameStateInitAll(gameState, kDefaultMapSize);
-        gameState.editorStep = EditorStep::objectSelection;
+        gameState.editorStep = Editor::Step::objectSelection;
         SetAllLandOwned();
         ObjectListLoad();
         ContextResetSubsystems();
@@ -222,7 +222,7 @@ namespace OpenRCT2::Editor
         auto& gameState = getGameState();
         gameStateInitAll(gameState, kDefaultMapSize);
         SetAllLandOwned();
-        gameState.editorStep = EditorStep::objectSelection;
+        gameState.editorStep = Editor::Step::objectSelection;
         ObjectListLoad();
         ContextResetSubsystems();
         WindowBase* mainWindow = OpenEditorWindows();
@@ -261,7 +261,7 @@ namespace OpenRCT2::Editor
         auto* context = GetContext();
         context->SetActiveScene(context->GetGameScene());
 
-        getGameState().editorStep = EditorStep::landscapeEditor;
+        getGameState().editorStep = Editor::Step::landscapeEditor;
         gScreenAge = 0;
         gLegacyScene = LegacyScene::scenarioEditor;
         ContextResetSubsystems();
@@ -361,7 +361,7 @@ namespace OpenRCT2::Editor
 
         switch (getGameState().editorStep)
         {
-            case EditorStep::objectSelection:
+            case Editor::Step::objectSelection:
                 if (windowMgr->FindByClass(WindowClass::editorObjectSelection) != nullptr)
                 {
                     return;
@@ -379,7 +379,7 @@ namespace OpenRCT2::Editor
 
                 ContextOpenWindow(WindowClass::editorObjectSelection);
                 break;
-            case EditorStep::inventionsListSetUp:
+            case Editor::Step::inventionsListSetUp:
                 if (windowMgr->FindByClass(WindowClass::editorInventionList) != nullptr)
                 {
                     return;
@@ -387,9 +387,9 @@ namespace OpenRCT2::Editor
 
                 ContextOpenWindow(WindowClass::editorInventionList);
                 break;
-            case EditorStep::optionsSelection:
-            case EditorStep::objectiveSelection:
-            case EditorStep::scenarioDetails:
+            case Editor::Step::optionsSelection:
+            case Editor::Step::objectiveSelection:
+            case Editor::Step::scenarioDetails:
                 if (windowMgr->FindByClass(WindowClass::editorScenarioOptions) != nullptr)
                 {
                     return;
@@ -397,11 +397,11 @@ namespace OpenRCT2::Editor
 
                 ContextOpenWindow(WindowClass::editorScenarioOptions);
                 break;
-            case EditorStep::landscapeEditor:
-            case EditorStep::saveScenario:
-            case EditorStep::rollerCoasterDesigner:
-            case EditorStep::designsManager:
-            case EditorStep::invalid:
+            case Editor::Step::landscapeEditor:
+            case Editor::Step::saveScenario:
+            case Editor::Step::rollerCoasterDesigner:
+            case Editor::Step::designsManager:
+            case Editor::Step::invalid:
                 break;
         }
     }
@@ -574,8 +574,3 @@ namespace OpenRCT2::Editor
         }
     }
 } // namespace OpenRCT2::Editor
-
-void EditorOpenWindowsForCurrentStep()
-{
-    Editor::OpenWindowsForCurrentStep();
-}

--- a/src/openrct2/Editor.h
+++ b/src/openrct2/Editor.h
@@ -33,18 +33,4 @@ namespace OpenRCT2::Editor
     void SetSelectedObject(ObjectType objectType, size_t index, uint32_t flags);
 } // namespace OpenRCT2::Editor
 
-enum class EditorStep : uint8_t
-{
-    objectSelection,       // 0
-    landscapeEditor,       // 1
-    inventionsListSetUp,   // 2
-    optionsSelection,      // 3
-    objectiveSelection,    // 4
-    scenarioDetails,       // 5
-    saveScenario,          // 6
-    rollerCoasterDesigner, // 7
-    designsManager,        // 8
-    invalid = 255,         // 255
-};
-
 void EditorOpenWindowsForCurrentStep();

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -533,7 +533,7 @@ void FinishObjectSelection()
             gameState.lastEntranceStyle = 0;
         }
 
-        gameState.editorStep = EditorStep::rollerCoasterDesigner;
+        gameState.editorStep = Editor::Step::rollerCoasterDesigner;
         GfxInvalidateScreen();
     }
     else
@@ -543,7 +543,7 @@ void FinishObjectSelection()
         auto intent = Intent(INTENT_ACTION_SET_DEFAULT_SCENERY_CONFIG);
         ContextBroadcastIntent(&intent);
 
-        gameState.editorStep = EditorStep::landscapeEditor;
+        gameState.editorStep = Editor::Step::landscapeEditor;
         GfxInvalidateScreen();
     }
 }

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -9,6 +9,7 @@
 
 #include "GameState.h"
 
+#include "Editor.h"
 #include "Game.h"
 #include "GameStateSnapshots.h"
 #include "Input.h"
@@ -337,7 +338,7 @@ namespace OpenRCT2
         VehicleSoundsUpdate();
         PeepUpdateCrowdNoise();
         Weather::updateSound();
-        EditorOpenWindowsForCurrentStep();
+        Editor::OpenWindowsForCurrentStep();
 
         // Update windows
         // WindowDispatchUpdateAll();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -11,7 +11,6 @@
 
 #include "Cheats.h"
 #include "Date.h"
-#include "Editor.h"
 #include "Limits.h"
 #include "core/Random.hpp"
 #include "entity/EntityRegistry.h"
@@ -21,6 +20,7 @@
 #include "ride/Ride.h"
 #include "ride/RideRatings.h"
 #include "scenario/ScenarioOptions.h"
+#include "scenes/editor/EditorStep.h"
 #include "world/Banner.h"
 #include "world/Location.hpp"
 #include "world/ParkData.h"
@@ -56,7 +56,7 @@ namespace OpenRCT2
 
         TileCoordsXY mapSize;
 
-        EditorStep editorStep;
+        Editor::Step editorStep;
 
         std::string scenarioCompletedBy;
         std::string scenarioFileName;

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -615,6 +615,7 @@
     <ClInclude Include="scenario\ScenarioRepository.h" />
     <ClInclude Include="scenario\ScenarioSources.h" />
     <ClInclude Include="scenes\Scene.h" />
+    <ClInclude Include="scenes\editor\EditorStep.h" />
     <ClInclude Include="scenes\game\GameScene.h" />
     <ClInclude Include="scenes\intro\IntroScene.h" />
     <ClInclude Include="scenes\preloader\PreloaderScene.h" />

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -345,7 +345,7 @@ namespace OpenRCT2::RCT1
 
             // Do map initialisation, same kind of stuff done when loading scenario editor
             gameStateInitAll(gameState, { mapSize, mapSize });
-            gameState.editorStep = EditorStep::objectSelection;
+            gameState.editorStep = Editor::Step::objectSelection;
             gameState.park.flags |= PARK_FLAGS_SHOW_REAL_GUEST_NAMES;
             gameState.scenarioOptions.category = Scenario::Category::other;
         }

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -21,7 +21,6 @@
 
 struct RideObjectEntry;
 enum class Breakdown : uint8_t;
-enum class EditorStep : uint8_t;
 enum class MechanicStatus : uint8_t;
 enum class RideInvalidateFlag : uint8_t;
 enum class VehicleColourSettings : uint8_t;
@@ -29,6 +28,11 @@ enum class VehicleColourSettings : uint8_t;
 template<typename THolderType, typename TEnumType>
 struct FlagHolder;
 using RideInvalidateFlags = FlagHolder<uint8_t, RideInvalidateFlag>;
+
+namespace OpenRCT2::Editor
+{
+    enum class Step : uint8_t;
+}
 
 namespace OpenRCT2::Scenario
 {
@@ -781,7 +785,7 @@ namespace OpenRCT2::RCT2
      */
     struct S6Info
     {
-        ::EditorStep EditorStep;
+        Editor::Step EditorStep;
         Scenario::Category Category;           // 0x01
         Scenario::ObjectiveType ObjectiveType; // 0x02
         uint8_t ObjectiveArg1;                 // 0x03

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -699,21 +699,21 @@ void Ride::updateAll()
     {
         switch (getGameState().editorStep)
         {
-            case EditorStep::objectSelection:
-            case EditorStep::landscapeEditor:
-            case EditorStep::inventionsListSetUp:
+            case Editor::Step::objectSelection:
+            case Editor::Step::landscapeEditor:
+            case Editor::Step::inventionsListSetUp:
             {
                 for (auto& ride : RideManager(gameState))
                     ride.remove();
                 break;
             }
-            case EditorStep::optionsSelection:
-            case EditorStep::objectiveSelection:
-            case EditorStep::scenarioDetails:
-            case EditorStep::saveScenario:
-            case EditorStep::rollerCoasterDesigner:
-            case EditorStep::designsManager:
-            case EditorStep::invalid:
+            case Editor::Step::optionsSelection:
+            case Editor::Step::objectiveSelection:
+            case Editor::Step::scenarioDetails:
+            case Editor::Step::saveScenario:
+            case Editor::Step::rollerCoasterDesigner:
+            case Editor::Step::designsManager:
+            case Editor::Step::invalid:
                 break;
         }
         return;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -251,7 +251,7 @@ void VehicleUpdateAll()
     if (gLegacyScene == LegacyScene::scenarioEditor)
         return;
 
-    if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != EditorStep::rollerCoasterDesigner)
+    if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != Editor::Step::rollerCoasterDesigner)
         return;
 
     for (auto vehicle : TrainManager::View())

--- a/src/openrct2/scenes/editor/EditorStep.h
+++ b/src/openrct2/scenes/editor/EditorStep.h
@@ -1,0 +1,29 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+namespace OpenRCT2::Editor
+{
+    enum class Step : uint8_t
+    {
+        objectSelection,       // 0
+        landscapeEditor,       // 1
+        inventionsListSetUp,   // 2
+        optionsSelection,      // 3
+        objectiveSelection,    // 4
+        scenarioDetails,       // 5
+        saveScenario,          // 6
+        rollerCoasterDesigner, // 7
+        designsManager,        // 8
+        invalid = 255,         // 255
+    };
+}


### PR DESCRIPTION
This moves the `EditorStep` enum class to its own header file, and moves it into the `Editor` namespace as `Step`.

(Cherry-picked from an upcoming scene refactor PR.)