### PR TITLE
Introduce SceneManager class

### DIFF
--- a/src/openrct2-ui/interface/FileBrowser.cpp
+++ b/src/openrct2-ui/interface/FileBrowser.cpp
@@ -28,6 +28,7 @@
 #include <openrct2/rct2/T6Exporter.h>
 #include <openrct2/ride/TrackDesign.h>
 #include <openrct2/scenario/Scenario.h>
+#include <openrct2/scenes/SceneManager.h>
 #include <openrct2/ui/UiContext.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
@@ -331,8 +332,8 @@ namespace OpenRCT2::Ui::FileBrowser
                             windowMgr->CloseByClass(WindowClass::loadsave);
                             InvokeCallback(ModalResult::ok, pathBuffer);
 
-                            auto* context = GetContext();
-                            context->SetActiveScene(context->GetTitleScene());
+                            auto* sceneMgr = GetContext()->GetSceneManager();
+                            sceneMgr->setActiveScene(sceneMgr->getTitleScene());
                         }
                         else
                         {
@@ -420,8 +421,8 @@ namespace OpenRCT2::Ui::FileBrowser
                             windowMgr->CloseByClass(WindowClass::loadsave);
                             InvokeCallback(ModalResult::ok, pathBuffer);
 
-                            auto* context = GetContext();
-                            context->SetActiveScene(context->GetTitleScene());
+                            auto* sceneMgr = GetContext()->GetSceneManager();
+                            sceneMgr->setActiveScene(sceneMgr->getTitleScene());
                         }
                         else
                         {

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -44,6 +44,7 @@
 #include <openrct2/object/SceneryGroupObject.h>
 #include <openrct2/platform/Platform.h>
 #include <openrct2/ride/RideData.h>
+#include <openrct2/scenes/SceneManager.h>
 #include <openrct2/scenes/title/TitleScene.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
@@ -399,8 +400,8 @@ namespace OpenRCT2::Ui::Windows
                         GameNotifyMapChange();
                         GameUnloadScripts();
 
-                        auto* context = GetContext();
-                        context->SetActiveScene(context->GetTitleScene());
+                        auto* sceneMgr = GetContext()->GetSceneManager();
+                        sceneMgr->setActiveScene(sceneMgr->getTitleScene());
                     }
                     break;
                 }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -66,6 +66,7 @@
 #include "ride/TrackDesignRepository.h"
 #include "scenario/Scenario.h"
 #include "scenario/ScenarioRepository.h"
+#include "scenes/SceneManager.h"
 #include "scenes/game/GameScene.h"
 #include "scenes/intro/IntroScene.h"
 #include "scenes/preloader/PreloaderScene.h"
@@ -114,6 +115,7 @@ namespace OpenRCT2
         std::unique_ptr<IObjectManager> _objectManager;
         std::unique_ptr<ITrackDesignRepository> _trackDesignRepository;
         std::unique_ptr<IScenarioRepository> _scenarioRepository;
+        std::unique_ptr<ISceneManager> _sceneManager;
         std::unique_ptr<IReplayManager> _replayManager;
         std::unique_ptr<IGameStateSnapshots> _gameStateSnapshots;
         std::unique_ptr<AssetPackManager> _assetPackManager;
@@ -127,13 +129,6 @@ namespace OpenRCT2
 #ifndef DISABLE_NETWORK
         Network::NetworkBase _network;
 #endif
-
-        // Scenes
-        std::unique_ptr<PreloaderScene> _preloaderScene;
-        std::unique_ptr<IntroScene> _introScene;
-        std::unique_ptr<TitleScene> _titleScene;
-        std::unique_ptr<GameScene> _gameScene;
-        IScene* _activeScene = nullptr;
 
         DrawingEngine _drawingEngineType = DrawingEngine::SoftwareWithHardwareDisplay;
         std::unique_ptr<Drawing::IDrawingEngine> _drawingEngine;
@@ -273,6 +268,11 @@ namespace OpenRCT2
             return _scenarioRepository.get();
         }
 
+        ISceneManager* GetSceneManager() override
+        {
+            return _sceneManager.get();
+        }
+
         IReplayManager* GetReplayManager() override
         {
             return _replayManager.get();
@@ -318,62 +318,6 @@ namespace OpenRCT2
                 return EXIT_SUCCESS;
             }
             return EXIT_FAILURE;
-        }
-
-        IScene* GetPreloaderScene() override
-        {
-            if (auto* scene = _preloaderScene.get())
-                return scene;
-
-            _preloaderScene = std::make_unique<PreloaderScene>(*this);
-            return _preloaderScene.get();
-        }
-
-        IScene* GetIntroScene() override
-        {
-            if (auto* scene = _introScene.get())
-                return scene;
-
-            _introScene = std::make_unique<IntroScene>(*this);
-            return _introScene.get();
-        }
-
-        IScene* GetTitleScene() override
-        {
-            if (auto* scene = _titleScene.get())
-                return scene;
-
-            _titleScene = std::make_unique<TitleScene>(*this);
-            return _titleScene.get();
-        }
-
-        IScene* GetGameScene() override
-        {
-            if (auto* scene = _gameScene.get())
-                return scene;
-
-            _gameScene = std::make_unique<GameScene>(*this);
-            return _gameScene.get();
-        }
-
-        IScene* GetEditorScene() override
-        {
-            // TODO: Implement me.
-            return nullptr;
-        }
-
-        IScene* GetActiveScene() override
-        {
-            return _activeScene;
-        }
-
-        void SetActiveScene(IScene* screen) override
-        {
-            if (_activeScene != nullptr)
-                _activeScene->Stop();
-            _activeScene = screen;
-            if (_activeScene)
-                _activeScene->Load();
         }
 
         void WriteLine(const std::string& s) override
@@ -469,6 +413,7 @@ namespace OpenRCT2
             _objectManager = CreateObjectManager(*_objectRepository);
             _trackDesignRepository = CreateTrackDesignRepository(*_env);
             _scenarioRepository = CreateScenarioRepository(*_env);
+            _sceneManager = createSceneManager(this);
 
             if (!gOpenRCT2Headless)
             {
@@ -541,8 +486,8 @@ namespace OpenRCT2
 
             if (!gOpenRCT2Headless)
             {
-                auto* preloaderScene = static_cast<PreloaderScene*>(GetPreloaderScene());
-                SetActiveScene(preloaderScene);
+                auto* preloaderScene = static_cast<PreloaderScene*>(_sceneManager->getPreloaderScene());
+                _sceneManager->setActiveScene(preloaderScene);
 
                 // TODO: preload the title scene in another (parallel) job.
                 preloaderScene->AddJob([this]() { InitialiseRepositories(); });
@@ -777,7 +722,7 @@ namespace OpenRCT2
                 Console::Error::WriteLine(e.what());
                 if (loadTitleScreenOnFail)
                 {
-                    SetActiveScene(GetTitleScene());
+                    _sceneManager->setActiveScene(_sceneManager->getTitleScene());
                 }
                 auto windowManager = _uiContext->GetWindowManager();
                 windowManager->ShowError(STR_FAILED_TO_LOAD_FILE_CONTAINS_INVALID_DATA, kStringIdNone, {});
@@ -927,7 +872,7 @@ namespace OpenRCT2
                 // If loading the SV6 or SV4 failed return to the title screen if requested.
                 if (loadTitleScreenFirstOnFail)
                 {
-                    SetActiveScene(GetTitleScene());
+                    _sceneManager->setActiveScene(_sceneManager->getTitleScene());
                 }
                 // The path needs to be duplicated as it's a const here
                 // which the window function doesn't like
@@ -946,7 +891,7 @@ namespace OpenRCT2
                 // If loading the SV6 or SV4 failed return to the title screen if requested.
                 if (loadTitleScreenFirstOnFail)
                 {
-                    SetActiveScene(GetTitleScene());
+                    _sceneManager->setActiveScene(_sceneManager->getTitleScene());
                 }
                 auto windowManager = _uiContext->GetWindowManager();
                 windowManager->ShowError(STR_FILE_CONTAINS_UNSUPPORTED_RIDE_TYPES, kStringIdNone, {});
@@ -957,7 +902,7 @@ namespace OpenRCT2
 
                 if (loadTitleScreenFirstOnFail)
                 {
-                    SetActiveScene(GetTitleScene());
+                    _sceneManager->setActiveScene(_sceneManager->getTitleScene());
                 }
                 auto windowManager = _uiContext->GetWindowManager();
                 Formatter ft;
@@ -988,7 +933,7 @@ namespace OpenRCT2
                 // If loading the SV6 or SV4 failed return to the title screen if requested.
                 if (loadTitleScreenFirstOnFail)
                 {
-                    SetActiveScene(GetTitleScene());
+                    _sceneManager->setActiveScene(_sceneManager->getTitleScene());
                 }
                 Console::Error::WriteLine(e.what());
             }
@@ -1081,13 +1026,13 @@ namespace OpenRCT2
             {
                 case StartupAction::intro:
                 {
-                    nextScene = GetIntroScene();
+                    nextScene = _sceneManager->getIntroScene();
                     break;
                 }
 
                 case StartupAction::title:
                 {
-                    nextScene = GetTitleScene();
+                    nextScene = _sceneManager->getTitleScene();
                     break;
                 }
 
@@ -1102,7 +1047,7 @@ namespace OpenRCT2
                         auto data = DownloadPark(gOpenRCT2StartupActionPath);
                         if (data.empty())
                         {
-                            nextScene = GetTitleScene();
+                            nextScene = _sceneManager->getTitleScene();
                             break;
                         }
 
@@ -1110,7 +1055,7 @@ namespace OpenRCT2
                         if (!LoadParkFromStream(&ms, gOpenRCT2StartupActionPath, true))
                         {
                             Console::Error::WriteLine("Failed to load '%s'", gOpenRCT2StartupActionPath);
-                            nextScene = GetTitleScene();
+                            nextScene = _sceneManager->getTitleScene();
                             break;
                         }
 #endif
@@ -1121,7 +1066,7 @@ namespace OpenRCT2
                         {
                             if (!LoadParkFromFile(gOpenRCT2StartupActionPath, true))
                             {
-                                nextScene = GetTitleScene();
+                                nextScene = _sceneManager->getTitleScene();
                                 break;
                             }
                         }
@@ -1129,13 +1074,13 @@ namespace OpenRCT2
                         {
                             Console::Error::WriteLine("Failed to load '%s'", gOpenRCT2StartupActionPath);
                             Console::Error::WriteLine("%s", ex.what());
-                            nextScene = GetTitleScene();
+                            nextScene = _sceneManager->getTitleScene();
                             break;
                         }
                     }
 
                     // Successfully loaded a file
-                    nextScene = GetGameScene();
+                    nextScene = _sceneManager->getGameScene();
                     break;
                 }
 
@@ -1144,27 +1089,27 @@ namespace OpenRCT2
                     if (String::sizeOf(gOpenRCT2StartupActionPath) == 0)
                     {
                         Editor::Load();
-                        nextScene = GetGameScene();
+                        nextScene = _sceneManager->getGameScene();
                     }
                     else if (Editor::LoadLandscape(gOpenRCT2StartupActionPath))
                     {
-                        nextScene = GetGameScene();
+                        nextScene = _sceneManager->getGameScene();
                     }
                     else
                     {
-                        nextScene = GetTitleScene();
+                        nextScene = _sceneManager->getTitleScene();
                     }
                     break;
                 }
 
                 default:
                 {
-                    nextScene = GetTitleScene();
+                    nextScene = _sceneManager->getTitleScene();
                 }
             }
 
-            SetActiveScene(nextScene);
-            InitNetworkGame(nextScene == GetGameScene());
+            _sceneManager->setActiveScene(nextScene);
+            InitNetworkGame(nextScene == _sceneManager->getGameScene());
         }
 
         void InitNetworkGame(bool isGameScene)
@@ -1232,7 +1177,7 @@ namespace OpenRCT2
 
             if (!gOpenRCT2Headless)
             {
-                GetPreloaderScene()->SetOnComplete([&]() { SwitchToStartUpScene(); });
+                _sceneManager->getPreloaderScene()->SetOnComplete([&]() { SwitchToStartUpScene(); });
             }
             else
             {
@@ -1438,8 +1383,8 @@ namespace OpenRCT2
 
             DateUpdateRealTimeOfDay();
 
-            if (_activeScene)
-                _activeScene->Tick();
+            if (auto* activeScene = _sceneManager->getActiveScene())
+                activeScene->Tick();
 
 #ifdef __ENABLE_DISCORD__
             if (_discordService != nullptr)
@@ -1450,7 +1395,7 @@ namespace OpenRCT2
 
             ChatUpdate();
 #ifdef ENABLE_SCRIPTING
-            if (GetActiveScene() != GetPreloaderScene())
+            if (auto* activeScene = _sceneManager->getActiveScene(); activeScene != _sceneManager->getPreloaderScene())
             {
                 _scriptEngine.Tick();
             }

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -33,12 +33,13 @@ namespace OpenRCT2
     class AssetPackManager;
     class Formatter;
     class Intent;
+    class ISceneManager;
+
     struct CursorState;
     struct IObjectManager;
     struct IObjectRepository;
     struct IPlatformEnvironment;
     struct IReplayManager;
-    struct IScene;
     struct IStream;
     struct TextInputSession;
     struct WindowBase;
@@ -98,6 +99,7 @@ namespace OpenRCT2
         virtual ITrackDesignRepository* GetTrackDesignRepository() = 0;
         virtual IScenarioRepository* GetScenarioRepository() = 0;
         virtual IReplayManager* GetReplayManager() = 0;
+        virtual ISceneManager* GetSceneManager() = 0;
         virtual AssetPackManager* GetAssetPackManager() = 0;
         virtual IGameStateSnapshots* GetGameStateSnapshots() = 0;
         virtual DrawingEngine GetDrawingEngineType() = 0;
@@ -106,15 +108,6 @@ namespace OpenRCT2
 #ifndef DISABLE_NETWORK
         virtual Network::NetworkBase& GetNetwork() = 0;
 #endif
-
-        virtual IScene* GetPreloaderScene() = 0;
-        virtual IScene* GetIntroScene() = 0;
-        virtual IScene* GetTitleScene() = 0;
-        virtual IScene* GetGameScene() = 0;
-        virtual IScene* GetEditorScene() = 0;
-
-        virtual IScene* GetActiveScene() = 0;
-        virtual void SetActiveScene(IScene* screen) = 0;
 
         virtual int32_t RunOpenRCT2(int argc, const char** argv) = 0;
 

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -40,6 +40,7 @@
 #include "peep/PeepAnimations.h"
 #include "rct1/RCT1.h"
 #include "scenario/Scenario.h"
+#include "scenes/SceneManager.h"
 #include "scripting/ScriptEngine.h"
 #include "ui/WindowManager.h"
 #include "windows/Intent.h"
@@ -108,8 +109,8 @@ namespace OpenRCT2::Editor
     void Load()
     {
         // TODO: replace with dedicated scene
-        auto* context = GetContext();
-        context->SetActiveScene(context->GetGameScene());
+        auto* sceneMgr = GetContext()->GetSceneManager();
+        sceneMgr->setActiveScene(sceneMgr->getGameScene());
 
         auto& gameState = getGameState();
         Audio::StopAll();
@@ -184,8 +185,8 @@ namespace OpenRCT2::Editor
     void LoadTrackDesigner()
     {
         // TODO: replace with dedicated scene
-        auto* context = GetContext();
-        context->SetActiveScene(context->GetGameScene());
+        auto* sceneMgr = GetContext()->GetSceneManager();
+        sceneMgr->setActiveScene(sceneMgr->getGameScene());
 
         Audio::StopAll();
         gLegacyScene = LegacyScene::trackDesigner;
@@ -212,8 +213,8 @@ namespace OpenRCT2::Editor
     void LoadTrackManager()
     {
         // TODO: replace with dedicated scene
-        auto* context = GetContext();
-        context->SetActiveScene(context->GetGameScene());
+        auto* sceneMgr = GetContext()->GetSceneManager();
+        sceneMgr->setActiveScene(sceneMgr->getGameScene());
 
         Audio::StopAll();
         gLegacyScene = LegacyScene::trackDesignsManager;
@@ -258,8 +259,8 @@ namespace OpenRCT2::Editor
         ClearMapForEditing(loadedFromSave);
 
         // TODO: replace with dedicated scene
-        auto* context = GetContext();
-        context->SetActiveScene(context->GetGameScene());
+        auto* sceneMgr = GetContext()->GetSceneManager();
+        sceneMgr->setActiveScene(sceneMgr->getGameScene());
 
         getGameState().editorStep = Editor::Step::landscapeEditor;
         gScreenAge = 0;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -59,6 +59,7 @@
 #include "ride/Vehicle.h"
 #include "sawyer_coding/SawyerCoding.h"
 #include "scenario/Scenario.h"
+#include "scenes/SceneManager.h"
 #include "scenes/title/TitleScene.h"
 #include "scripting/ScriptEngine.h"
 #include "ui/UiContext.h"
@@ -361,7 +362,8 @@ void GameLoadInit()
     IGameStateSnapshots* snapshots = context->GetGameStateSnapshots();
     snapshots->Reset();
 
-    context->SetActiveScene(context->GetGameScene());
+    auto* sceneMgr = context->GetSceneManager();
+    sceneMgr->setActiveScene(sceneMgr->getGameScene());
 
     // Invalidate scrolling text cache to prevent stale text from previous park
     // being displayed due to pointer value reuse in the cache matching logic
@@ -724,8 +726,8 @@ void GameLoadOrQuitNoSavePrompt()
             EmscriptenResetAutosave();
 #endif
 
-            auto* context = GetContext();
-            context->SetActiveScene(context->GetTitleScene());
+            auto* sceneMgr = GetContext()->GetSceneManager();
+            sceneMgr->setActiveScene(sceneMgr->getTitleScene());
             break;
         }
         case PromptMode::saveBeforeNewGame:

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -615,6 +615,7 @@
     <ClInclude Include="scenario\ScenarioRepository.h" />
     <ClInclude Include="scenario\ScenarioSources.h" />
     <ClInclude Include="scenes\Scene.h" />
+    <ClInclude Include="scenes\SceneManager.h" />
     <ClInclude Include="scenes\editor\EditorStep.h" />
     <ClInclude Include="scenes\game\GameScene.h" />
     <ClInclude Include="scenes\intro\IntroScene.h" />
@@ -1206,6 +1207,7 @@
     <ClCompile Include="scenario\ScenarioRepository.cpp" />
     <ClCompile Include="scenario\ScenarioSources.cpp" />
     <ClCompile Include="scenes\Scene.cpp" />
+    <ClCompile Include="scenes\SceneManager.cpp" />
     <ClCompile Include="scenes\game\GameScene.cpp" />
     <ClCompile Include="scenes\intro\IntroScene.cpp" />
     <ClCompile Include="scenes\preloader\PreloaderScene.cpp" />

--- a/src/openrct2/scenes/SceneManager.cpp
+++ b/src/openrct2/scenes/SceneManager.cpp
@@ -28,7 +28,8 @@ namespace OpenRCT2
         std::unique_ptr<TitleScene> _titleScene;
 
     public:
-        explicit SceneManager(IContext* context) : _sceneContext(context)
+        explicit SceneManager(IContext* context)
+            : _sceneContext(context)
         {
         }
 

--- a/src/openrct2/scenes/SceneManager.cpp
+++ b/src/openrct2/scenes/SceneManager.cpp
@@ -1,0 +1,96 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "SceneManager.h"
+
+#include "../Context.h"
+#include "game/GameScene.h"
+#include "intro/IntroScene.h"
+#include "preloader/PreloaderScene.h"
+#include "title/TitleScene.h"
+
+namespace OpenRCT2
+{
+    class SceneManager final : public ISceneManager
+    {
+    private:
+        IScene* _activeScene = nullptr;
+        IContext* _sceneContext = nullptr;
+        std::unique_ptr<GameScene> _gameScene;
+        std::unique_ptr<IntroScene> _introScene;
+        std::unique_ptr<PreloaderScene> _preloaderScene;
+        std::unique_ptr<TitleScene> _titleScene;
+
+    public:
+        explicit SceneManager(IContext* context) : _sceneContext(context)
+        {
+        }
+
+        IScene* getActiveScene() override
+        {
+            return _activeScene;
+        }
+
+        IScene* getEditorScene() override
+        {
+            // TODO: Implement me.
+            return nullptr;
+        }
+
+        IScene* getGameScene() override
+        {
+            if (auto* scene = _gameScene.get())
+                return scene;
+
+            _gameScene = std::make_unique<GameScene>(*_sceneContext);
+            return _gameScene.get();
+        }
+
+        IScene* getIntroScene() override
+        {
+            if (auto* scene = _introScene.get())
+                return scene;
+
+            _introScene = std::make_unique<IntroScene>(*_sceneContext);
+            return _introScene.get();
+        }
+
+        IScene* getPreloaderScene() override
+        {
+            if (auto* scene = _preloaderScene.get())
+                return scene;
+
+            _preloaderScene = std::make_unique<PreloaderScene>(*_sceneContext);
+            return _preloaderScene.get();
+        }
+
+        IScene* getTitleScene() override
+        {
+            if (auto* scene = _titleScene.get())
+                return scene;
+
+            _titleScene = std::make_unique<TitleScene>(*_sceneContext);
+            return _titleScene.get();
+        }
+
+        void setActiveScene(IScene* screen) override
+        {
+            if (_activeScene != nullptr)
+                _activeScene->Stop();
+            _activeScene = screen;
+            if (_activeScene)
+                _activeScene->Load();
+        }
+    };
+
+    std::unique_ptr<ISceneManager> createSceneManager(IContext* context)
+    {
+        return std::make_unique<SceneManager>(context);
+    }
+} // namespace OpenRCT2

--- a/src/openrct2/scenes/SceneManager.h
+++ b/src/openrct2/scenes/SceneManager.h
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <memory>
+
+namespace OpenRCT2
+{
+    struct IContext;
+    struct IScene;
+
+    class ISceneManager
+    {
+    public:
+        virtual ~ISceneManager() = default;
+
+        virtual IScene* getActiveScene() = 0;
+        virtual IScene* getEditorScene() = 0;
+        virtual IScene* getGameScene() = 0;
+        virtual IScene* getIntroScene() = 0;
+        virtual IScene* getPreloaderScene() = 0;
+        virtual IScene* getTitleScene() = 0;
+        virtual void setActiveScene(IScene* screen) = 0;
+    };
+
+    std::unique_ptr<ISceneManager> createSceneManager(IContext* context);
+} // namespace OpenRCT2

--- a/src/openrct2/scenes/intro/IntroScene.cpp
+++ b/src/openrct2/scenes/intro/IntroScene.cpp
@@ -18,6 +18,7 @@
 #include "../../audio/AudioMixer.h"
 #include "../../drawing/Drawing.h"
 #include "../../drawing/Rectangle.h"
+#include "../../scenes/SceneManager.h"
 
 #include <cstdint>
 
@@ -239,7 +240,8 @@ namespace OpenRCT2
                 break;
             case IntroState::Finish:
             {
-                sceneContext.SetActiveScene(sceneContext.GetTitleScene());
+                auto* sceneMgr = sceneContext.GetSceneManager();
+                sceneMgr->setActiveScene(sceneMgr->getTitleScene());
                 break;
             }
             default:

--- a/src/openrct2/scenes/title/TitleScene.cpp
+++ b/src/openrct2/scenes/title/TitleScene.cpp
@@ -24,6 +24,7 @@
 #include "../../network/Network.h"
 #include "../../network/NetworkBase.h"
 #include "../../scenario/ScenarioRepository.h"
+#include "../../scenes/SceneManager.h"
 #include "../../ui/UiContext.h"
 #include "../../ui/WindowManager.h"
 #include "../../util/Util.h"
@@ -334,8 +335,8 @@ bool TitleScene::TryLoadSequence(bool loadPreview)
 
 void TitleCreateWindows()
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         titleScene->CreateWindows();
@@ -344,8 +345,8 @@ void TitleCreateWindows()
 
 void* TitleGetSequencePlayer()
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         return titleScene->GetSequencePlayer();
@@ -355,8 +356,8 @@ void* TitleGetSequencePlayer()
 
 void TitleSequenceChangePreset(size_t preset)
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         titleScene->ChangePresetSequence(preset);
@@ -370,8 +371,8 @@ size_t TitleGetConfigSequence()
 
 size_t TitleGetCurrentSequence()
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         return titleScene->GetCurrentSequence();
@@ -381,8 +382,8 @@ size_t TitleGetCurrentSequence()
 
 bool TitlePreviewSequence(size_t value)
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         return titleScene->PreviewSequence(value);
@@ -392,8 +393,8 @@ bool TitlePreviewSequence(size_t value)
 
 void TitleStopPreviewingSequence()
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         titleScene->StopPreviewingSequence();
@@ -402,8 +403,8 @@ void TitleStopPreviewingSequence()
 
 bool TitleIsPreviewingSequence()
 {
-    auto* context = GetContext();
-    auto* titleScene = static_cast<TitleScene*>(context->GetTitleScene());
+    auto* sceneMgr = GetContext()->GetSceneManager();
+    auto* titleScene = static_cast<TitleScene*>(sceneMgr->getTitleScene());
     if (titleScene != nullptr)
     {
         return titleScene->IsPreviewingSequence();


### PR DESCRIPTION
This moves scene management out of `Context`, delegating it to a new `SceneManager` class. This makes it easier to achieve scene extensions in the future without overburdening `Context` further.

(Part of an upcoming scene refactor PR.)