### PR TITLE
Add RideTypeDescriptor interface to plugin api

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -129,6 +129,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Harry Hopkinson (Harry-Hopkinson) - Added Cheat for guests ignoring price of rides and stalls.
 * Kendall Frey (kendfrey) - Add plugin API for spawning guests
 * Marino Rottier (rinode) - Plugin API & UI
+* Smitty Penman (ltsSmitty) - Plugin RTD expansion.
 
 ## Bug fixes & Refactors
 * Claudio Tiecher (janclod)
@@ -296,7 +297,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Catalan - Joan Josep (J0anJosep)
 * Chinese (Simplified) - Naiji Ma (naijim), (izhangfei), Eric Zhao (sczyh30), (Muhhan), Arnold Zhou (mrmagic2020)
 * Chinese (Traditional) - Harry Lam (daihakken)
-* Czech - Martin Černáč (octaroot), (Clonewayx), Tomáš Pazdiora (Aroidzap), Ríša Szlachta (tygrysek90) 
+* Czech - Martin Černáč (octaroot), (Clonewayx), Tomáš Pazdiora (Aroidzap), Ríša Szlachta (tygrysek90)
 * Danish - Lars P. Sørensen (LPSGizmo)
 * Dutch - Michael Steenbeek (Gymnasiast), Yannic Geurts (xzbobzx), (mrtnptrs), Thomas den Hollander (ThomasdenH), (hostbrute),  Marijn van der Werf (marijnvdwerf), Tom Kroes (ThePsionic), Karst van Galen Last (AuraSpecs); reviewing and discussion: Aaron van Geffen (AaronVanGeffen), (Balletie) and Sijmen Schoon (SijmenSchoon)
 * Esperanto - (tellovishous), Raymond Zhao (rzhao271)

--- a/distribution/scripting/openrct2.d.ts
+++ b/distribution/scripting/openrct2.d.ts
@@ -276,6 +276,12 @@ declare global {
          */
         getTrackSegment(type: number): TrackSegment | null;
 
+        /**
+         * Gets track segment compatibility information for a ride type.
+         * @param rideType The ride type.
+         */
+        getRideTypeDescriptor(rideType: number): RideTypeDescriptor | null;
+
         getAllTrackSegments(): TrackSegment[];
 
         /**
@@ -846,7 +852,7 @@ declare global {
         object: number;
         railingsObject: number;
         /** 0 if flat, 1 if sloped */
-        slopeType: number; // 
+        slopeType: number; //
         /** direction if sloped, otherwise ignored */
         slopeDirection: Direction;
         constructFlags: number;
@@ -1649,7 +1655,7 @@ declare global {
 		readonly rideId: number;
 		breakdownReason: string;
 	}
- 
+
     interface RideRatingsCalculateArgs {
         readonly rideId: number;
         excitement: number;
@@ -2568,6 +2574,68 @@ declare global {
         entrance: CoordsXYZD;
         exit: CoordsXYZD;
     }
+
+    interface RideTypeDescriptor {
+					/**
+					 * The ride type this descriptor describes.
+					 */
+					readonly rideType: number;
+
+					/**
+					 * The stable internal ride type name, typically snake case. E.g. "car_ride", "cash_machine", "river_rafts"
+					 */
+					readonly name: string;
+
+					/**
+					 * The ride type category. Slightly more descriptive than @RideClassification
+					 */
+					readonly category: RideTypeCategory;
+
+					/**
+					 * The starting track segment type for this ride type when opening the ride builder window.
+					 * Typically an end station for tracked rides (not beginning or middle station),
+					 * flat track 1x1 or 3x3 & variants for shops/stalls,
+					 * tower base for drops/launched rides,
+					 * maze for maze,
+					 * null if no valid starting segment.
+					 */
+					readonly startTrackSegment: TrackSegment | null;
+
+					/**
+					 * Standard track segments included for this ride type.
+					 */
+					readonly standardTrackSegments: TrackSegment[];
+
+					/**
+					 * Pieces that this ride type _can_ draw, but are disabled because their vehicles lack the relevant sprites,
+					 * or because they are not realistic for the ride type (e.g. LIM boosters in Mini Roller Coasters).
+					 */
+					readonly extraTrackSegments: TrackSegment[];
+
+					/**
+					 * Advanced metadata: Track segments are actually assigned by groups (e.g. "halfLoopMedium", "liftHillCurve"),
+					 * so that a ride will have a whole set of pieces that go together, e.g. corkscrew left & right.
+					 * Unless you really want to know which track segments are included in which groups, you probably don't need this,
+					 * and can just enumerate through the standardTrackSegments.
+					 *
+					 * see @TrackSegment trackGroup.
+					 *
+					 * This is the standard tracks' groups for this ride type.
+					 */
+					readonly standardTrackGroups: number[];
+
+					/**
+					 * Advanced metadata: Track segments are actually assigned by groups (e.g. "corkscrew", "liftHillCurve"),
+					 * so that a ride will have a whole set of pieces that go together, e.g. corkscrew left & right.
+					 * Unless you really want to know which track segments are included in which groups, you probably don't need this,
+					 * and can just enumerate through the standardTrackSegments.
+					 *
+					 * see @TrackSegment trackGroup.
+					 *
+					 * This is the extra tracks' groups for this ride type.
+					 */
+					readonly extraTrackGroups: number[];
+				}
 
     interface TrackSegment {
         /**
@@ -4525,6 +4593,8 @@ declare global {
         "thrill" |
         "water" |
         "shop";
+
+    type RideTypeCategory = RideResearchCategory | "none";
 
     type ResearchCategory = RideResearchCategory | "scenery";
 

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -657,6 +657,7 @@
     <ClInclude Include="scripting\bindings\object\ScObjectManager.h" />
     <ClInclude Include="scripting\bindings\ride\ScRide.hpp" />
     <ClInclude Include="scripting\bindings\ride\ScRideStation.hpp" />
+    <ClInclude Include="scripting\bindings\ride\ScRideTypeDescriptor.h" />
     <ClInclude Include="scripting\bindings\ride\ScTrackIterator.h" />
     <ClInclude Include="scripting\bindings\ride\ScTrackSegment.h" />
     <ClInclude Include="scripting\bindings\world\ScAward.hpp" />
@@ -1237,6 +1238,7 @@
     <ClCompile Include="scripting\bindings\object\ScObjectManager.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRide.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRideStation.cpp" />
+    <ClCompile Include="scripting\bindings\ride\ScRideTypeDescriptor.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScTrackIterator.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScTrackSegment.cpp" />
     <ClCompile Include="scripting\bindings\world\ScAward.cpp" />

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -53,6 +53,7 @@
     #include "bindings/object/ScObjectManager.h"
     #include "bindings/ride/ScRide.hpp"
     #include "bindings/ride/ScRideStation.hpp"
+    #include "bindings/ride/ScRideTypeDescriptor.h"
     #include "bindings/world/ScAward.hpp"
     #include "bindings/world/ScDate.hpp"
     #include "bindings/world/ScMap.hpp"
@@ -530,6 +531,7 @@ ScProfiler Scripting::gScProfiler;
 ScResearch Scripting::gScResearch;
 ScRide Scripting::gScRide;
 ScRideStation Scripting::gScRideStation;
+ScRideTypeDescriptor Scripting::gScRideTypeDescriptor;
 ScRideObjectVehicle Scripting::gScRideObjectVehicle;
 ScTile Scripting::gScTile;
 ScTileElement Scripting::gScTileElement;
@@ -571,6 +573,7 @@ void ScriptEngine::RegisterClasses(JSContext* ctx)
     gScResearch.Register(ctx);
     gScRide.Register(ctx);
     gScRideStation.Register(ctx);
+    gScRideTypeDescriptor.Register(ctx);
     gScRideObjectVehicle.Register(ctx);
     gScTile.Register(ctx);
     gScTileElement.Register(ctx);
@@ -624,6 +627,7 @@ void ScriptEngine::UnregisterClasses()
     gScResearch.Unregister();
     gScRide.Unregister();
     gScRideStation.Unregister();
+    gScRideTypeDescriptor.Unregister();
     gScRideObjectVehicle.Unregister();
     gScTile.Unregister();
     gScTileElement.Unregister();

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -43,7 +43,7 @@ namespace OpenRCT2
 namespace OpenRCT2::Scripting
 {
     // Grepped from CI (.github/workflows/publish-plugin-types.yml); keep the format `kPluginApiVersion = N`.
-    static constexpr int32_t kPluginApiVersion = 114;
+    static constexpr int32_t kPluginApiVersion = 115;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -24,6 +24,7 @@
     #include "../game/ScConfiguration.hpp"
     #include "../game/ScDisposable.hpp"
     #include "../object/ScObjectManager.h"
+    #include "../ride/ScRideTypeDescriptor.h"
     #include "../ride/ScTrackSegment.h"
 
     #include <cstdio>
@@ -191,6 +192,18 @@ namespace OpenRCT2::Scripting
             {
                 return gScTrackSegment.New(ctx, static_cast<TrackElemType>(type));
             }
+        }
+
+        static JSValue getRideTypeDescriptor(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
+        {
+            JS_UNPACK_INT32(rideType, ctx, argv[0]);
+
+            if (rideType < 0 || rideType >= RIDE_TYPE_COUNT)
+            {
+                return JS_NULL;
+            }
+
+            return gScRideTypeDescriptor.New(ctx, static_cast<ride_type_t>(rideType));
         }
 
         static JSValue getAllTrackSegments(JSContext* ctx, JSValue thisVal, int argc, JSValue* argv)
@@ -432,6 +445,7 @@ namespace OpenRCT2::Scripting
                 JS_CFUNC_DEF("getObject", 2, ScContext::getObject),
                 JS_CFUNC_DEF("getAllObjects", 2, ScContext::getAllObjects),
                 JS_CFUNC_DEF("getTrackSegment", 1, ScContext::getTrackSegment),
+                JS_CFUNC_DEF("getRideTypeDescriptor", 1, ScContext::getRideTypeDescriptor),
                 JS_CFUNC_DEF("getAllTrackSegments", 0, ScContext::getAllTrackSegments),
                 JS_CFUNC_DEF("getRandom", 2, ScContext::getRandom),
                 JS_CFUNC_DEF("formatString", 0, ScContext::formatString),

--- a/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.cpp
@@ -1,0 +1,178 @@
+/*****************************************************************************
+ * Copyright (c) 2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "ScRideTypeDescriptor.h"
+
+    #include "../../../core/EnumUtils.hpp"
+    #include "../../../ride/RideData.h"
+    #include "../../../ride/ted/TrackElementDescriptor.h"
+    #include "../../ScriptUtil.hpp"
+    #include "ScTrackSegment.h"
+
+using namespace OpenRCT2;
+using namespace OpenRCT2::Scripting;
+using namespace OpenRCT2::TrackMetadata;
+
+namespace
+{
+    const RideTypeDescriptor& GetDescriptor(ride_type_t rideType)
+    {
+        return GetRideTypeDescriptor(rideType);
+    }
+
+    const TrackDrawerEntry& GetRegularTrackDrawerEntry(ride_type_t rideType)
+    {
+        return GetDescriptor(rideType).TrackPaintFunctions.Regular;
+    }
+
+    JSValue TrackGroupSetToArray(JSContext* ctx, const RideTrackGroups& groups)
+    {
+        auto result = JS_NewArray(ctx);
+        int64_t index = 0;
+        for (uint8_t i = 0; i < EnumValue(TrackGroup::count); i++)
+        {
+            if (groups.get(i))
+            {
+                JS_SetPropertyInt64(ctx, result, index++, JS_NewInt32(ctx, i));
+            }
+        }
+        return result;
+    }
+
+    JSValue TrackSegmentsForGroupsToArray(JSContext* ctx, const RideTrackGroups& groups)
+    {
+        auto result = JS_NewArray(ctx);
+        int64_t index = 0;
+        for (uint16_t type = 0; type < EnumValue(TrackElemType::count); type++)
+        {
+            auto trackType = static_cast<TrackElemType>(type);
+            const auto& ted = GetTrackElementDescriptor(trackType);
+            if (groups.get(EnumValue(ted.definition.group)))
+            {
+                JS_SetPropertyInt64(ctx, result, index++, gScTrackSegment.New(ctx, trackType));
+            }
+        }
+        return result;
+    }
+
+    std::string_view RideCategoryToString(RideCategory category)
+    {
+        switch (category)
+        {
+            case RideCategory::transport:
+                return "transport";
+            case RideCategory::gentle:
+                return "gentle";
+            case RideCategory::rollerCoaster:
+                return "rollercoaster";
+            case RideCategory::thrill:
+                return "thrill";
+            case RideCategory::water:
+                return "water";
+            case RideCategory::shop:
+                return "shop";
+            case RideCategory::none:
+                return "none";
+        }
+        return "none";
+    }
+} // namespace
+
+void ScRideTypeDescriptor::Register(JSContext* ctx)
+{
+    static constexpr JSCFunctionListEntry funcs[] = {
+        JS_CGETSET_DEF("rideType", ScRideTypeDescriptor::rideType_get, nullptr),
+        JS_CGETSET_DEF("name", ScRideTypeDescriptor::name_get, nullptr),
+        JS_CGETSET_DEF("category", ScRideTypeDescriptor::category_get, nullptr),
+        JS_CGETSET_DEF("startTrackSegment", ScRideTypeDescriptor::startTrackSegment_get, nullptr),
+        JS_CGETSET_DEF("standardTrackSegments", ScRideTypeDescriptor::standardTrackSegments_get, nullptr),
+        JS_CGETSET_DEF("extraTrackSegments", ScRideTypeDescriptor::extraTrackSegments_get, nullptr),
+        JS_CGETSET_DEF("standardTrackGroups", ScRideTypeDescriptor::standardTrackGroups_get, nullptr),
+        JS_CGETSET_DEF("extraTrackGroups", ScRideTypeDescriptor::extraTrackGroups_get, nullptr),
+    };
+    RegisterBase(ctx, "RideTypeDescriptor", Finalize, funcs);
+}
+
+JSValue ScRideTypeDescriptor::New(JSContext* ctx, ride_type_t rideType)
+{
+    return MakeWithOpaque(ctx, new RideTypeDescriptorData{ rideType });
+}
+
+void ScRideTypeDescriptor::Finalize(JSRuntime* rt, JSValue thisVal)
+{
+    RideTypeDescriptorData* data = GetRideTypeDescriptorData(thisVal);
+    if (data != nullptr)
+    {
+        delete data;
+    }
+}
+
+ScRideTypeDescriptor::RideTypeDescriptorData* ScRideTypeDescriptor::GetRideTypeDescriptorData(JSValue thisVal)
+{
+    return gScRideTypeDescriptor.GetOpaque<RideTypeDescriptorData*>(thisVal);
+}
+
+JSValue ScRideTypeDescriptor::rideType_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return JS_NewInt32(ctx, data->_rideType);
+}
+
+JSValue ScRideTypeDescriptor::name_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return JSFromStdString(ctx, GetDescriptor(data->_rideType).Name);
+}
+
+// is this duplicative? i feel like we can already get ride categories some other way?
+// i see that it can return "none". i wonder which ones do that. do we need to cover this, or can we fall back to null?
+JSValue ScRideTypeDescriptor::category_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return JSFromStdString(ctx, RideCategoryToString(GetDescriptor(data->_rideType).Category));
+}
+
+JSValue ScRideTypeDescriptor::startTrackSegment_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    const auto startTrackPiece = GetDescriptor(data->_rideType).StartTrackPiece;
+    if (startTrackPiece >= TrackElemType::count)
+    {
+        return JS_NULL;
+    }
+    return gScTrackSegment.New(ctx, startTrackPiece);
+}
+
+JSValue ScRideTypeDescriptor::standardTrackSegments_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return TrackSegmentsForGroupsToArray(ctx, GetRegularTrackDrawerEntry(data->_rideType).enabledTrackGroups);
+}
+
+JSValue ScRideTypeDescriptor::extraTrackSegments_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return TrackSegmentsForGroupsToArray(ctx, GetRegularTrackDrawerEntry(data->_rideType).extraTrackGroups);
+}
+
+JSValue ScRideTypeDescriptor::standardTrackGroups_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return TrackGroupSetToArray(ctx, GetRegularTrackDrawerEntry(data->_rideType).enabledTrackGroups);
+}
+
+JSValue ScRideTypeDescriptor::extraTrackGroups_get(JSContext* ctx, JSValue thisVal)
+{
+    const auto* data = GetRideTypeDescriptorData(thisVal);
+    return TrackGroupSetToArray(ctx, GetRegularTrackDrawerEntry(data->_rideType).extraTrackGroups);
+}
+
+#endif

--- a/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.cpp
@@ -88,7 +88,7 @@ namespace
 
 void ScRideTypeDescriptor::Register(JSContext* ctx)
 {
-    static constexpr JSCFunctionListEntry funcs[] = {
+    static constexpr JSCFunctionListEntry kFuncs[] = {
         JS_CGETSET_DEF("rideType", ScRideTypeDescriptor::rideType_get, nullptr),
         JS_CGETSET_DEF("name", ScRideTypeDescriptor::name_get, nullptr),
         JS_CGETSET_DEF("category", ScRideTypeDescriptor::category_get, nullptr),
@@ -98,7 +98,7 @@ void ScRideTypeDescriptor::Register(JSContext* ctx)
         JS_CGETSET_DEF("standardTrackGroups", ScRideTypeDescriptor::standardTrackGroups_get, nullptr),
         JS_CGETSET_DEF("extraTrackGroups", ScRideTypeDescriptor::extraTrackGroups_get, nullptr),
     };
-    RegisterBase(ctx, "RideTypeDescriptor", Finalize, funcs);
+    RegisterBase(ctx, "RideTypeDescriptor", Finalize, kFuncs);
 }
 
 JSValue ScRideTypeDescriptor::New(JSContext* ctx, ride_type_t rideType)

--- a/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.h
+++ b/src/openrct2/scripting/bindings/ride/ScRideTypeDescriptor.h
@@ -1,0 +1,52 @@
+/*****************************************************************************
+ * Copyright (c) 2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+    #include "../../../ride/RideTypes.h"
+    #include "../../ScriptEngine.h"
+
+    #include <cstdint>
+
+namespace OpenRCT2::Scripting
+{
+    class ScRideTypeDescriptor;
+    extern ScRideTypeDescriptor gScRideTypeDescriptor;
+
+    class ScRideTypeDescriptor final : public ScBase
+    {
+    private:
+        struct RideTypeDescriptorData
+        {
+            ride_type_t _rideType;
+        };
+
+    public:
+        void Register(JSContext* ctx);
+        JSValue New(JSContext* ctx, ride_type_t rideType);
+
+    private:
+        static void Finalize(JSRuntime* rt, JSValue thisVal);
+        static RideTypeDescriptorData* GetRideTypeDescriptorData(JSValue thisVal);
+
+        static JSValue rideType_get(JSContext* ctx, JSValue thisVal);
+        static JSValue name_get(JSContext* ctx, JSValue thisVal);
+        static JSValue category_get(JSContext* ctx, JSValue thisVal);
+        static JSValue startTrackSegment_get(JSContext* ctx, JSValue thisVal);
+        static JSValue standardTrackSegments_get(JSContext* ctx, JSValue thisVal);
+        static JSValue extraTrackSegments_get(JSContext* ctx, JSValue thisVal);
+        static JSValue standardTrackGroups_get(JSContext* ctx, JSValue thisVal);
+        static JSValue extraTrackGroups_get(JSContext* ctx, JSValue thisVal);
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif


### PR DESCRIPTION
This PR exposes some of the remaining data from the ride type descriptor that isn't already in the plugin API, especially **which ride types include which track groups/pieces**. If a user wants to build a plugin to replicate the ride construction window, there's no way for them to know if a wooden coaster has boosters in it's drawable-but-technically-extra list or not without this PR.

It also exposes the starting build piece (the end station or e.g. 1x1/3x3/1x5 base, etc), and the ride category which is used in research.

I've attached a (vibe-coded) plugin that you can use to pick a ride and see its standard and extra track pieces. (As an aside, it also displays some of the TrackSegment data, which reveals that many pieces don't actually have descriptions, which can make trying to work with them awkward, hence the mostly empty left column in the screenshot.)
[ride-type-descriptor-inspector.js](https://github.com/user-attachments/files/28960607/ride-type-descriptor-inspector.js)

Here's a screenshot of the plugin for additional context. 
<img width="642" height="466" alt="image" src="https://github.com/user-attachments/assets/f8ace751-08b6-4d42-a06b-bb226cb7991a" />


I'd like some additional feedback on nomenclature from the plugin devs regarding calling the ts type "RideTypeDescriptor". While this is match for the C++ side, there could be another name that is more useful for this ride metadata, especially since it's generally about what/how the ride can be built with which pieces. I'm satisfied as is, but since it's a new interface I'll ask the discord for any feedback there.

