### PR TITLE
Fix EXCEPTION_ACCESS_VIOLATION_READ in BlitPixel

### DIFF
--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -43,11 +43,11 @@ template<DrawBlendOp TBlendOp>
 static void FASTCALL DrawBMPSpriteMinify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
-    
+
     // FIX: Use ptrdiff_t to safely handle potentially negative SrcX or SrcY values
     ptrdiff_t start_offset = (static_cast<ptrdiff_t>(g1.width) * args.SrcY) + args.SrcX;
     auto* src = reinterpret_cast<PaletteIndex*>(g1.offset) + start_offset;
-    
+
     auto* dst = reinterpret_cast<PaletteIndex*>(args.DestinationBits);
     auto& paletteMap = args.PalMap;
 
@@ -65,15 +65,15 @@ static void FASTCALL DrawBMPSpriteMinify(RenderTarget& rt, const DrawSpriteArgs&
     {
         auto nextSrc = src + srcLineWidth;
         auto nextDst = dst + dstLineWidth;
-        
+
         for (int32_t widthRemaining = width; widthRemaining > 0; widthRemaining -= zoom, src += zoom, dst++)
         {
-            if (src >= src_start && src < src_end) 
+            if (src >= src_start && src < src_end)
             {
                 BlitPixel<TBlendOp>(src, dst, paletteMap);
             }
         }
-        
+
         src = nextSrc;
         dst = nextDst;
     }

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -43,28 +43,47 @@ template<DrawBlendOp TBlendOp>
 static void FASTCALL DrawBMPSpriteMinify(RenderTarget& rt, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
-    auto* src = reinterpret_cast<PaletteIndex*>(g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX));
+    
+    auto* src_base = reinterpret_cast<PaletteIndex*>(g1.offset);
+    size_t max_offset = static_cast<size_t>(g1.width) * std::max(1, static_cast<int>(g1.height));
+    auto* src_end = src_base + max_offset;
+
+    auto* src = src_base + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
     auto* dst = reinterpret_cast<PaletteIndex*>(args.DestinationBits);
     auto& paletteMap = args.PalMap;
+    
     auto width = args.Width;
     auto height = args.Height;
     auto zoomLevel = rt.zoom_level;
     size_t srcLineWidth = zoomLevel.ApplyTo(g1.width);
     size_t dstLineWidth = rt.LineStride();
     uint8_t zoom = zoomLevel.ApplyTo(1);
+
     for (; height > 0; height -= zoom)
     {
+        if (src >= src_end || src < src_base) 
+        {
+            break; 
+        }
+
         auto nextSrc = src + srcLineWidth;
         auto nextDst = dst + dstLineWidth;
-        for (int32_t widthRemaining = width; widthRemaining > 0; widthRemaining -= zoom, src += zoom, dst++)
+        
+        size_t available_pixels = src_end - src;
+        int32_t max_safe_iterations = static_cast<int32_t>(available_pixels / zoom);
+        int32_t requested_iterations = (width + zoom - 1) / zoom; 
+        
+        int32_t iterations = std::min(max_safe_iterations, requested_iterations);
+
+        for (int i = 0; i < iterations; ++i, src += zoom, dst++)
         {
             BlitPixel<TBlendOp>(src, dst, paletteMap);
         }
+        
         src = nextSrc;
         dst = nextDst;
     }
 }
-
 template<DrawBlendOp TBlendOp>
 static void FASTCALL DrawBMPSprite(RenderTarget& rt, const DrawSpriteArgs& args)
 {

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -44,14 +44,13 @@ static void FASTCALL DrawBMPSpriteMinify(RenderTarget& rt, const DrawSpriteArgs&
 {
     auto& g1 = args.SourceImage;
     
-    auto* src_base = reinterpret_cast<PaletteIndex*>(g1.offset);
-    size_t max_offset = static_cast<size_t>(g1.width) * std::max(1, static_cast<int>(g1.height));
-    auto* src_end = src_base + max_offset;
-
-    auto* src = src_base + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
+    // FIX: Use ptrdiff_t to safely handle potentially negative SrcX or SrcY values
+    ptrdiff_t start_offset = (static_cast<ptrdiff_t>(g1.width) * args.SrcY) + args.SrcX;
+    auto* src = reinterpret_cast<PaletteIndex*>(g1.offset) + start_offset;
+    
     auto* dst = reinterpret_cast<PaletteIndex*>(args.DestinationBits);
     auto& paletteMap = args.PalMap;
-    
+
     auto width = args.Width;
     auto height = args.Height;
     auto zoomLevel = rt.zoom_level;
@@ -59,25 +58,20 @@ static void FASTCALL DrawBMPSpriteMinify(RenderTarget& rt, const DrawSpriteArgs&
     size_t dstLineWidth = rt.LineStride();
     uint8_t zoom = zoomLevel.ApplyTo(1);
 
+    auto* src_start = reinterpret_cast<PaletteIndex*>(g1.offset);
+    auto* src_end = src_start + (static_cast<size_t>(g1.width) * std::max(1, static_cast<int>(g1.height)));
+
     for (; height > 0; height -= zoom)
     {
-        if (src >= src_end || src < src_base) 
-        {
-            break; 
-        }
-
         auto nextSrc = src + srcLineWidth;
         auto nextDst = dst + dstLineWidth;
         
-        size_t available_pixels = src_end - src;
-        int32_t max_safe_iterations = static_cast<int32_t>(available_pixels / zoom);
-        int32_t requested_iterations = (width + zoom - 1) / zoom; 
-        
-        int32_t iterations = std::min(max_safe_iterations, requested_iterations);
-
-        for (int i = 0; i < iterations; ++i, src += zoom, dst++)
+        for (int32_t widthRemaining = width; widthRemaining > 0; widthRemaining -= zoom, src += zoom, dst++)
         {
-            BlitPixel<TBlendOp>(src, dst, paletteMap);
+            if (src >= src_start && src < src_end) 
+            {
+                BlitPixel<TBlendOp>(src, dst, paletteMap);
+            }
         }
         
         src = nextSrc;

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -781,12 +781,11 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
     int32_t x = coords.x;
     int32_t y = coords.y;
 
-    const auto* g1 = GfxGetG1Element(imageId);
-    if (g1 == nullptr)
+   const auto* g1 = GfxGetG1Element(imageId);
+    if (g1 == nullptr || g1->offset == nullptr || g1->width <= 0 || g1->height <= 0)
     {
         return;
     }
-
     if (zoomLevel > ZoomLevel{ 0 } && g1->flags.has(G1Flag::hasZoomSprite))
     {
         RenderTarget zoomedRT = rt;

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -781,7 +781,7 @@ void FASTCALL GfxDrawSpritePaletteSetSoftware(
     int32_t x = coords.x;
     int32_t y = coords.y;
 
-   const auto* g1 = GfxGetG1Element(imageId);
+    const auto* g1 = GfxGetG1Element(imageId);
     if (g1 == nullptr || g1->offset == nullptr || g1->width <= 0 || g1->height <= 0)
     {
         return;


### PR DESCRIPTION
Hey folks, taking a look at backtrace #26695, it looks like this EXCEPTION_ACCESS_VIOLATION_READ is being triggered when the engine tries to generate a minified sprite preview for a custom object with corrupted or missing dimensions.

Since the crash happens deep in the renderer at BlitPixel, I've added stricter bounds checking and early-outs to the software rendering path (GfxDrawSpriteSoftware and DrawBMPSpriteMinify). Instead of branching on every pixel, the minifier now calculates the absolute buffer limits up front, which completely prevents the out-of-bounds memory read without impacting hot-path performance.

Fixes #26695