### PR TITLE
fix: [Bug] Vertical lines erased in Korean text when using UI zoom feature (Software & OpenGL)

### DIFF
--- a/src/openrct2/drawing/TTFSDLPort.cpp
+++ b/src/openrct2/drawing/TTFSDLPort.cpp
@@ -774,6 +774,7 @@ static FT_Error Load_Glyph(TTF_Font* font, uint16_t ch, c_glyph* cached, int wan
                     unsigned int j;
                     if (src->pixel_mode == FT_PIXEL_MODE_MONO)
                     {
+                        // Process full bytes (8 pixels per byte)
                         for (j = 0; j < src->width; j += 8)
                         {
                             unsigned char c = *srcp++;
@@ -792,6 +793,17 @@ static FT_Error Load_Glyph(TTF_Font* font, uint16_t ch, c_glyph* cached, int wan
                             *dstp++ = (c & 0x80) >> 7;
                             c <<= 1;
                             *dstp++ = (c & 0x80) >> 7;
+                        }
+                        // Handle any remaining pixels when width is not a multiple of 8
+                        unsigned int remaining = src->width % 8;
+                        if (remaining)
+                        {
+                            unsigned char c = *srcp++;
+                            for (unsigned int k = 0; k < remaining; ++k)
+                            {
+                                *dstp++ = (c & 0x80) >> 7;
+                                c <<= 1;
+                            }
                         }
                     }
                     else if (src->pixel_mode == FT_PIXEL_MODE_GRAY2)


### PR DESCRIPTION
Closes https://github.com/OpenRCT2/OpenRCT2/issues/26707

### Area(s) with this issue?

This bug is a graphical glitch or error

### Describe the issue

Hello OpenRCT2 maintainers and contributors,

Thank you for your amazing work on this project. I am always enjoying OpenRCT2!

I found an issue where vertical lines in Korean text get erased/cut off when using the UI zoom feature. This issue occurs in both Software and OpenGL rendering modes.

I have found a solution that fixes this for both Software and OpenGL renderers, and I would love to submit a Pull Request (PR) for it. Please let me know if there are any specific guidelines or procedures I should follow before opening the PR.

I have attached screenshots of the text before and after the fix below.

Thank you!

- Related issue: https://github.com/OpenRCT2/OpenRCT2/issues/26637

### Steps to reproduce

1. Start the game
2. Set language to Korean
3. Open any settings or game window
4. You can find it
