### PR TITLE
Skip separator between load and save landscape options

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -586,7 +586,6 @@ namespace OpenRCT2::Ui::Windows
             else if (gLegacyScene == LegacyScene::scenarioEditor)
             {
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_LOAD_LANDSCAPE);
-                gDropdown.items[numItems++] = Dropdown::Separator();
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_SAVE_LANDSCAPE);
                 gDropdown.items[numItems++] = Dropdown::Separator();
                 gDropdown.items[numItems++] = Dropdown::PlainMenuLabel(STR_SCREENSHOT);
@@ -930,7 +929,7 @@ namespace OpenRCT2::Ui::Windows
                     // Quicksave is only available in the normal game. Skip one position to avoid incorrect mappings in the
                     // menus of the other modes.
                     if (gLegacyScene == LegacyScene::scenarioEditor && selectedIndex > DDIDX_LOAD_GAME)
-                        selectedIndex += 1;
+                        selectedIndex += 2;
 
                     // Track designer and track designs manager start with Screenshot, not Load/save
                     if (isInTrackDesignerOrManager())


### PR DESCRIPTION
Bit of polish for the scenario editor.

Before:
<img width="123" height="188" alt="Unnamed park 2026-06-27 11-16-43" src="https://github.com/user-attachments/assets/754dbc7b-c290-4d44-a0a9-7591a1bf50c0" />

After:
<img width="123" height="176" alt="Unnamed park 2026-06-27 11-16-31" src="https://github.com/user-attachments/assets/be9514e1-6e9e-4904-9718-662594ba5d50" />
