### PR TITLE
Make ride-again and really-liked gates react to guest condition

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -455,7 +455,6 @@ namespace OpenRCT2
     static void GuestUpdateRideNauseaGrowth(Guest& guest, const Ride& ride);
     static bool GuestShouldGoOnRideAgain(Guest& guest, const Ride& ride);
     static bool GuestShouldPreferredIntensityIncrease(Guest& guest);
-    static bool GuestReallyLikedRide(Guest& guest, const Ride& ride);
     static PeepThoughtType GuestAssessSurroundings(int16_t centre_x, int16_t centre_y, int16_t centre_z);
     static void GuestUpdateHunger(Guest& guest);
     static void GuestDecideWhetherToLeavePark(Guest& guest);
@@ -1156,10 +1155,10 @@ namespace OpenRCT2
              * remaining times the encompassing conditional is
              * executed (which is also every second time, but
              * the alternate time to the true branch). */
-            if (nausea >= 140)
+            if (nausea >= kPeepNauseaMildDecisionThreshold)
             {
                 PeepThoughtType thought_type = PeepThoughtType::sick;
-                if (nausea >= 200)
+                if (nausea >= kPeepNauseaSevereDecisionThreshold)
                 {
                     thought_type = PeepThoughtType::verySick;
                     GuestHeadForNearestRideWithSpecialType(*this, true, RtdSpecialType::firstAid);
@@ -2173,7 +2172,7 @@ namespace OpenRCT2
                                 }
 
                                 // Very nauseous peeps will only go on very gentle rides.
-                                if (ride.ratings.nausea >= RideRating::make(1, 40) && nausea > 160)
+                                if (ride.ratings.nausea >= RideRating::make(1, 40) && nausea > kPeepNauseaModerateDecisionThreshold)
                                 {
                                     choseNotToGoOnRide(ride, peepAtRide, false);
                                     return false;
@@ -2905,25 +2904,58 @@ namespace OpenRCT2
         guest.nauseaTarget = static_cast<uint8_t>(std::min<int32_t>(guest.nauseaTarget + nauseaGrowthRateChange, 255));
     }
 
-    static bool GuestShouldGoOnRideAgain(Guest& guest, const Ride& ride)
+    uint8_t GuestNeedsTolerance(const Guest& guest)
+    {
+        // kPeepMaxEnergy is 128 (not 255). Full energy + max hunger => 255 (identity).
+        return static_cast<uint8_t>(
+            (static_cast<uint32_t>(guest.Energy) * guest.hunger * 255u)
+            / (static_cast<uint32_t>(kPeepMaxEnergy) * static_cast<uint32_t>(kPeepMaxHunger)));
+    }
+
+    static uint8_t GuestScaleDecisionThreshold(uint8_t threshold, uint8_t tolerance)
+    {
+        return static_cast<uint8_t>((static_cast<uint16_t>(threshold) * tolerance) / 255);
+    }
+
+    static RideRating_t GuestScaleIntensityThreshold(RideRating_t threshold, uint8_t tolerance)
+    {
+        return static_cast<RideRating_t>((static_cast<int32_t>(threshold) * tolerance) / 255);
+    }
+
+    bool GuestMeetsGoOnRideAgainConditions(const Guest& guest, const Ride& ride)
     {
         if (!ride.getRideTypeDescriptor().flags.has(RtdFlag::guestsWillRideAgain))
             return false;
         if (!RideHasRatings(ride))
             return false;
-        if (ride.ratings.intensity > RideRating::make(10, 00) && !getGameState().cheats.ignoreRideIntensity)
+
+        const auto tolerance = GuestNeedsTolerance(guest);
+        const auto intensityThreshold = GuestScaleIntensityThreshold(RideRating::make(10, 00), tolerance);
+        if (ride.ratings.intensity > intensityThreshold && !getGameState().cheats.ignoreRideIntensity)
             return false;
-        if (guest.happiness < 180)
+
+        if (guest.happiness < kPeepHappinessRideAgainDecisionThreshold)
             return false;
-        if (guest.Energy < 100)
+        if (guest.Energy < kPeepEnergyDecisionThreshold)
             return false;
-        if (guest.nausea > 160)
+
+        const auto nauseaThreshold = GuestScaleDecisionThreshold(kPeepNauseaModerateDecisionThreshold, tolerance);
+        if (guest.nausea > nauseaThreshold)
             return false;
-        if (guest.hunger < 30)
+
+        if (guest.hunger < kPeepHungerDecisionThreshold)
             return false;
-        if (guest.thirst < 20)
+        if (guest.thirst < kPeepThirstDecisionThreshold)
             return false;
-        if (guest.toilet > 170)
+        if (guest.toilet > kPeepToiletDecisionThreshold)
+            return false;
+
+        return true;
+    }
+
+    static bool GuestShouldGoOnRideAgain(Guest& guest, const Ride& ride)
+    {
+        if (!GuestMeetsGoOnRideAgainConditions(guest, ride))
             return false;
 
         uint8_t r = (ScenarioRand() & 0xFF);
@@ -2942,21 +2974,27 @@ namespace OpenRCT2
     {
         if (getGameState().park.flags & PARK_FLAGS_PREF_LESS_INTENSE_RIDES)
             return false;
-        if (guest.happiness < 200)
+        if (guest.happiness < kPeepHappinessIntensityDecisionThreshold)
             return false;
 
         return (ScenarioRand() & 0xFF) >= static_cast<uint8_t>(guest.intensity);
     }
 
-    static bool GuestReallyLikedRide(Guest& guest, const Ride& ride)
+    bool GuestReallyLikedRide(const Guest& guest, const Ride& ride)
     {
-        if (guest.happiness < 215)
+        if (guest.happiness < kPeepHappinessReallyLikedDecisionThreshold)
             return false;
-        if (guest.nausea > 120)
+
+        const auto tolerance = GuestNeedsTolerance(guest);
+        const auto nauseaThreshold = GuestScaleDecisionThreshold(kPeepNauseaLowDecisionThreshold, tolerance);
+        if (guest.nausea > nauseaThreshold)
             return false;
+
         if (!RideHasRatings(ride))
             return false;
-        if (ride.ratings.intensity > RideRating::make(10, 00) && !getGameState().cheats.ignoreRideIntensity)
+
+        const auto intensityThreshold = GuestScaleIntensityThreshold(RideRating::make(10, 00), tolerance);
+        if (ride.ratings.intensity > intensityThreshold && !getGameState().cheats.ignoreRideIntensity)
             return false;
         return true;
     }
@@ -5607,7 +5645,7 @@ namespace OpenRCT2
         if (PeepFlags & PEEP_FLAGS_LEAVING_PARK)
             return;
 
-        if (nausea > 140)
+        if (nausea > kPeepNauseaMildDecisionThreshold)
             return;
 
         if (happiness < 120)
@@ -6129,7 +6167,7 @@ namespace OpenRCT2
             }
         }
 
-        if (nausea <= 170 && Energy > 50)
+        if (nausea <= kPeepNauseaHighDecisionThreshold && Energy > 50)
         {
             return false;
         }
@@ -7001,13 +7039,13 @@ namespace OpenRCT2
             return;
         }
 
-        if (nausea > 170)
+        if (nausea > kPeepNauseaHighDecisionThreshold)
         {
             setAnimationGroup(PeepAnimationGroup::veryNauseous);
             return;
         }
 
-        if (nausea > 140)
+        if (nausea > kPeepNauseaMildDecisionThreshold)
         {
             setAnimationGroup(PeepAnimationGroup::nauseous);
             return;
@@ -7480,15 +7518,15 @@ namespace OpenRCT2
             return PEEP_FACE_OFFSET_ANGRY;
 
         // VERY_VERY_SICK
-        if (peep->nausea > 200)
+        if (peep->nausea > kPeepNauseaSevereDecisionThreshold)
             return PEEP_FACE_OFFSET_VERY_VERY_SICK;
 
         // VERY_SICK
-        if (peep->nausea > 170)
+        if (peep->nausea > kPeepNauseaHighDecisionThreshold)
             return PEEP_FACE_OFFSET_VERY_SICK;
 
         // SICK
-        if (peep->nausea > 140)
+        if (peep->nausea > kPeepNauseaMildDecisionThreshold)
             return PEEP_FACE_OFFSET_SICK;
 
         // VERY_TIRED

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -19,6 +19,8 @@ struct CarEntry;
 
 namespace OpenRCT2
 {
+    struct Guest;
+
     constexpr int8_t kPeepMaxThoughts = 5;
 
     constexpr int8_t kPeepHungerWarningThreshold = 25;
@@ -31,11 +33,37 @@ namespace OpenRCT2
     constexpr int8_t kPeepLostWarningThreshold = 8;
     constexpr int8_t kPeepTooLongQueueThreshold = 25;
 
+    // Guest decision thresholds (ride-again, preferences, nausea behaviour)
+    constexpr uint8_t kPeepHungerDecisionThreshold = 30;
+    constexpr uint8_t kPeepThirstDecisionThreshold = 20;
+    constexpr uint8_t kPeepToiletDecisionThreshold = 170;
+    constexpr uint8_t kPeepNauseaLowDecisionThreshold = 120;
+    constexpr uint8_t kPeepNauseaMildDecisionThreshold = 140;
+    constexpr uint8_t kPeepNauseaModerateDecisionThreshold = 160;
+    constexpr uint8_t kPeepNauseaHighDecisionThreshold = 170;
+    constexpr uint8_t kPeepNauseaSevereDecisionThreshold = 200;
+    constexpr uint8_t kPeepHappinessRideAgainDecisionThreshold = 180;
+    constexpr uint8_t kPeepHappinessIntensityDecisionThreshold = 200;
+    constexpr uint8_t kPeepHappinessReallyLikedDecisionThreshold = 215;
+    constexpr uint8_t kPeepEnergyDecisionThreshold = 100;
+
     constexpr int kPeepMaxHappiness = 255;
     constexpr int kPeepMaxHunger = 255;
     constexpr int16_t kPeepMaxToilet = 255;
     constexpr int16_t kPeepMaxNausea = 255;
     constexpr int kPeepMaxThirst = 255;
+
+    /**
+     * 0–255 modifier for condition-sensitive decision gates.
+     * Full Energy (kPeepMaxEnergy) and high hunger (kPeepMaxHunger) yield 255 (identity).
+     * Tired / hungry guests yield a lower value and stricter nausea / intensity gates.
+     */
+    uint8_t GuestNeedsTolerance(const Guest& guest);
+
+    /** Deterministic ride-again gates (no ScenarioRand). */
+    bool GuestMeetsGoOnRideAgainConditions(const Guest& guest, const Ride& ride);
+
+    bool GuestReallyLikedRide(const Guest& guest, const Ride& ride);
 
     enum class PeepThoughtType : uint8_t
     {

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/Endianness.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/EnumMapTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/FormattingTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/GuestNeedsToleranceTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/ImageImporterTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/IniReaderTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/IniWriterTest.cpp"

--- a/test/tests/GuestNeedsToleranceTests.cpp
+++ b/test/tests/GuestNeedsToleranceTests.cpp
@@ -1,0 +1,235 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/GameState.h>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/entity/Guest.h>
+#include <openrct2/ride/Ride.h>
+#include <openrct2/ride/RideRatings.h>
+
+using namespace OpenRCT2;
+
+namespace
+{
+    Guest MakeGuest(uint8_t energy, uint8_t hunger, uint8_t nausea, uint8_t happiness)
+    {
+        Guest guest{};
+        guest.Energy = energy;
+        guest.hunger = hunger;
+        guest.nausea = nausea;
+        guest.happiness = happiness;
+        // Satisfy non-tolerance gates so only routed checks matter when asserted.
+        guest.thirst = 255;
+        guest.toilet = 0;
+        return guest;
+    }
+
+    Ride MakeRatedRide(RideRating_t intensity)
+    {
+        Ride ride{};
+        ride.type = RIDE_TYPE_LOG_FLUME;
+        ride.ratings.excitement = RideRating::make(5, 00);
+        ride.ratings.intensity = intensity;
+        ride.ratings.nausea = RideRating::make(3, 00);
+        return ride;
+    }
+} // namespace
+
+// Hand-computed: tolerance = (Energy * hunger * 255) / (kPeepMaxEnergy * kPeepMaxHunger)
+// with kPeepMaxEnergy = 128, kPeepMaxHunger = 255  =>  (Energy * hunger) / 128
+//
+// | Energy | hunger | tolerance |
+// |     128 |    255 |       255 |  identity (healthy path)
+// |     128 |    254 |       254 |
+// |     128 |    128 |       128 |
+// |     128 |      0 |         0 |
+// |      64 |    255 |       127 |
+// |      64 |    128 |        64 |
+// |      32 |    255 |        63 |
+// |     100 |    200 |       156 |
+// |     127 |    255 |       253 |
+// |       1 |    255 |         1 |
+// |     128 |      1 |         1 |
+
+TEST(GuestNeedsToleranceTests, ToleranceTable)
+{
+    static constexpr struct
+    {
+        uint8_t energy;
+        uint8_t hunger;
+        uint8_t expectedTolerance;
+    } kTable[] = {
+        { 128, 255, 255 },
+        { 128, 254, 254 },
+        { 128, 128, 128 },
+        { 128, 0, 0 },
+        { 64, 255, 127 },
+        { 64, 128, 64 },
+        { 32, 255, 63 },
+        { 100, 200, 156 },
+        { 127, 255, 253 },
+        { 1, 255, 1 },
+        { 128, 1, 1 },
+    };
+
+    for (const auto& row : kTable)
+    {
+        auto guest = MakeGuest(row.energy, row.hunger, 0, 255);
+        EXPECT_EQ(GuestNeedsTolerance(guest), row.expectedTolerance)
+            << "Energy=" << int(row.energy) << " hunger=" << int(row.hunger);
+    }
+}
+
+// GuestReallyLikedRide: happiness must be >= 215. Nausea gate uses
+//   nauseaThr = (120 * tolerance) / 255
+// Intensity gate uses
+//   intensityThr = (1000 * tolerance) / 255   // RideRating::make(10, 00)
+// Hand-computed gate rows (no ScenarioRand on this path):
+//
+// | Energy | hunger | T | nausea | nauseaThr | intensity | intThr | happiness | liked? |
+// |    128 |    255 | 255 |    120 |       120 |       1000 |  1000 |       255 | true   |  equal not >
+// |    128 |    255 | 255 |    121 |       120 |          0 |  1000 |       255 | false  | nausea
+// |    128 |    255 | 255 |      0 |       120 |       1001 |  1000 |       255 | false  | intensity
+// |    128 |    255 | 255 |      0 |       120 |          0 |  1000 |       214 | false  | happiness
+// |     64 |    128 |  64 |     30 |        30 |          0 |   250 |       255 | true   |
+// |     64 |    128 |  64 |     31 |        30 |          0 |   250 |       255 | false  | nausea
+// |     64 |    128 |  64 |      0 |        30 |        251 |   250 |       255 | false  | intensity
+// |     64 |    128 |  64 |      0 |        30 |        250 |   250 |       255 | true   | equal not >
+// |    128 |    128 | 128 |     60 |        60 |        501 |   501 |       255 | true   |
+// |    128 |    128 | 128 |     61 |        60 |          0 |   501 |       255 | false  |
+// |     32 |    255 |  63 |     29 |        29 |        247 |   247 |       255 | true   |
+// |     32 |    255 |  63 |     30 |        29 |          0 |   247 |       255 | false  |
+// |      1 |    255 |   1 |      0 |         0 |          3 |     3 |       255 | true   | nauseaThr 0, nausea not >
+// |      1 |    255 |   1 |      1 |         0 |          0 |     3 |       255 | false  |
+// |      1 |    255 |   1 |      0 |         0 |          4 |     3 |       255 | false  |
+
+TEST(GuestNeedsToleranceTests, ReallyLikedRideGateTable)
+{
+    gOpenRCT2Headless = true;
+    gOpenRCT2NoGraphics = true;
+    auto context = CreateContext();
+    ASSERT_TRUE(context->Initialise());
+    getGameState().cheats.ignoreRideIntensity = false;
+
+    static constexpr struct
+    {
+        uint8_t energy;
+        uint8_t hunger;
+        uint8_t nausea;
+        int16_t intensityWhole;
+        uint8_t intensityFrac;
+        uint8_t happiness;
+        bool expectedLiked;
+    } kTable[] = {
+        { 128, 255, 120, 10, 0, 255, true },
+        { 128, 255, 121, 0, 0, 255, false },
+        { 128, 255, 0, 10, 1, 255, false },
+        { 128, 255, 0, 0, 0, 214, false },
+        { 64, 128, 30, 0, 0, 255, true },
+        { 64, 128, 31, 0, 0, 255, false },
+        { 64, 128, 0, 2, 51, 255, false },
+        { 64, 128, 0, 2, 50, 255, true },
+        { 128, 128, 60, 5, 1, 255, true },
+        { 128, 128, 61, 0, 0, 255, false },
+        { 32, 255, 29, 2, 47, 255, true },
+        { 32, 255, 30, 0, 0, 255, false },
+        { 1, 255, 0, 0, 3, 255, true },
+        { 1, 255, 1, 0, 0, 255, false },
+        { 1, 255, 0, 0, 4, 255, false },
+    };
+
+    for (const auto& row : kTable)
+    {
+        auto guest = MakeGuest(row.energy, row.hunger, row.nausea, row.happiness);
+        auto ride = MakeRatedRide(RideRating::make(row.intensityWhole, row.intensityFrac));
+        EXPECT_EQ(GuestReallyLikedRide(guest, ride), row.expectedLiked)
+            << "Energy=" << int(row.energy) << " hunger=" << int(row.hunger) << " nausea=" << int(row.nausea)
+            << " intensity=" << row.intensityWhole << "." << int(row.intensityFrac)
+            << " happiness=" << int(row.happiness);
+    }
+}
+
+// GuestMeetsGoOnRideAgainConditions (deterministic; no ScenarioRand):
+// requires Energy >= 100, happiness >= 180, hunger >= 30, plus nausea/intensity via tolerance.
+// nauseaThr = (160 * T) / 255, intensityThr = (1000 * T) / 255
+//
+// | Energy | hunger | T | nausea | nauseaThr | intensity | intThr | happiness | meets? |
+// |    128 |    255 | 255 |    160 |       160 |       1000 |  1000 |       255 | true   |
+// |    128 |    255 | 255 |    161 |       160 |          0 |  1000 |       255 | false  |
+// |    128 |    255 | 255 |      0 |       160 |       1001 |  1000 |       255 | false  |
+// |    128 |    255 | 255 |      0 |       160 |          0 |  1000 |       179 | false  |
+// |    100 |    255 | 199 |     99 |       124 |          0 |   780 |       255 | true? wait
+// Energy 100 hunger 255: T = (100*255)/128 = 25500/128 = 199
+// nauseaThr = 160*199/255 = 31840/255 = 124
+// intThr = 1000*199/255 = 199000/255 = 780
+// |    100 |    255 | 199 |    124 |       124 |        780 |   780 |       255 | true   |
+// |    100 |    255 | 199 |    125 |       124 |          0 |   780 |       255 | false  |
+// |     99 |    255 | 197 |      0 |       123 |          0 |   772 |       255 | false  | Energy gate
+// |    128 |    128 | 128 |     80 |        80 |        501 |   501 |       255 | true   |
+// |    128 |    128 | 128 |     81 |        80 |          0 |   501 |       255 | false  |
+// |    128 |     29 |  57 |      0 |        35 |          0 |   223 |       255 | false  | hunger gate (29 < 30)
+// |    128 |     30 |  60 |     37 |        37 |        235 |   235 |       255 | true   | T=(128*30)/128=30; wait
+// Energy 128 hunger 30: T = (128*30)/128 = 30
+// nauseaThr = 160*30/255 = 4800/255 = 18
+// intThr = 1000*30/255 = 30000/255 = 117
+// Recalculate row for hunger 30:
+// |    128 |     30 |  30 |     18 |        18 |        117 |   117 |       255 | true   |
+// |    128 |     30 |  30 |     19 |        18 |          0 |   117 |       255 | false  |
+// |     64 |    255 | 127 |     79 |        79 |        498 |   498 |       255 | true? Energy 64 < 100 false
+// Energy gate fails for 64.
+
+TEST(GuestNeedsToleranceTests, GoOnRideAgainGateTable)
+{
+    gOpenRCT2Headless = true;
+    gOpenRCT2NoGraphics = true;
+    auto context = CreateContext();
+    ASSERT_TRUE(context->Initialise());
+    getGameState().cheats.ignoreRideIntensity = false;
+
+    static constexpr struct
+    {
+        uint8_t energy;
+        uint8_t hunger;
+        uint8_t nausea;
+        int16_t intensityWhole;
+        uint8_t intensityFrac;
+        uint8_t happiness;
+        bool expectedMeets;
+    } kTable[] = {
+        { 128, 255, 160, 10, 0, 255, true },
+        { 128, 255, 161, 0, 0, 255, false },
+        { 128, 255, 0, 10, 1, 255, false },
+        { 128, 255, 0, 0, 0, 179, false },
+        { 100, 255, 124, 7, 80, 255, true },
+        { 100, 255, 125, 0, 0, 255, false },
+        { 99, 255, 0, 0, 0, 255, false },
+        { 128, 128, 80, 5, 1, 255, true },
+        { 128, 128, 81, 0, 0, 255, false },
+        { 128, 29, 0, 0, 0, 255, false },
+        { 128, 30, 18, 1, 17, 255, true },
+        { 128, 30, 19, 0, 0, 255, false },
+        { 64, 255, 0, 0, 0, 255, false },
+        // Healthy identity: intensity exactly at legacy 10.00 still allowed
+        { 128, 255, 0, 10, 0, 255, true },
+        // Degraded: same intensity 10.00 fails once tolerance tightens (intThr=501 for T=128)
+        { 128, 128, 0, 10, 0, 255, false },
+    };
+
+    for (const auto& row : kTable)
+    {
+        auto guest = MakeGuest(row.energy, row.hunger, row.nausea, row.happiness);
+        auto ride = MakeRatedRide(RideRating::make(row.intensityWhole, row.intensityFrac));
+        EXPECT_EQ(GuestMeetsGoOnRideAgainConditions(guest, ride), row.expectedMeets)
+            << "Energy=" << int(row.energy) << " hunger=" << int(row.hunger) << " nausea=" << int(row.nausea)
+            << " intensity=" << row.intensityWhole << "." << int(row.intensityFrac)
+            << " happiness=" << int(row.happiness);
+    }
+}

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -89,6 +89,7 @@
     <ClCompile Include="Endianness.cpp" />
     <ClCompile Include="EnumMapTest.cpp" />
     <ClCompile Include="FormattingTests.cpp" />
+    <ClCompile Include="GuestNeedsToleranceTests.cpp" />
     <ClCompile Include="LanguagePackTest.cpp" />
     <ClCompile Include="ImageImporterTests.cpp" />
     <ClCompile Include="IniReaderTest.cpp" />


### PR DESCRIPTION
## Summary
- Add `GuestNeedsTolerance` (Energy × hunger, identity at `kPeepMaxEnergy` / max hunger) and scale nausea / intensity thresholds in go-on-ride-again and really-liked gates so tired or hungry guests face stricter decisions while healthy guests stay byte-identical.
- Table-driven unit tests for tolerance and deterministic gate decisions at hand-computed boundaries.

## Test plan
- [x] `GuestNeedsToleranceTests` (tolerance + gate tables)
- [x] `MultiLaunch` / `PlayTests`
- [ ] Note: `bpb1000Ticks` replay desyncs when non-identity guests hit the tightened gates (expected for this behaviour change)