### PR TITLE
Refactor Focus constructor to use member initialisers

### DIFF
--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -49,9 +49,9 @@ namespace OpenRCT2
 
         template<typename T>
         constexpr explicit Focus(T newValue, ZoomLevel newZoom = {})
+            : zoom(newZoom)
+            , data(newValue)
         {
-            data = newValue;
-            zoom = newZoom;
         }
 
         CoordsXYZ GetPos() const;


### PR DESCRIPTION
When compiling for release on Linux Mint, an error would get thrown that contents of Focus may be uninitialised. This PR changes the constructor to suppress the error.