### PR TITLE
Fix #26743: Korean text in scenarios and saved games is garbled

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#26605] Desync when placing a track design in multiplayer.
 - Fix: [#26654] Fix Alton Towers stall and Rock’n’Roll Revival toilet being closed on scenario start.
 - Fix: [#26722] Missing construction rights owned on UCES Sand Dune scenario.
+- Fix: [#26743] Korean text in scenarios and saved games is garbled.
 - Fix: [objects#411] Some colours in green, acid green, pink and red water are inconsistent with natural water.
 - Fix: [objects#436] St. Basil’s Cathedral building pieces are incorrectly labelled as “Kremlin” pieces.
 - Fix: [objects#438] Some walls are not marked as see-through while they don’t fully block the view.

--- a/src/openrct2/rct12/CSStringConverter.cpp
+++ b/src/openrct2/rct12/CSStringConverter.cpp
@@ -230,9 +230,86 @@ namespace OpenRCT2
         return String::toUtf8(u16);
     }
 
+    /**
+     * RCT2 strings do not record their own charset, and the S6/S4 importers assume the Western
+     * code page (englishUK) for everything. Two real-world cases break under that assumption:
+     *   1. Parks saved by OpenRCT2 itself may already contain UTF-8 (e.g. scenario name and
+     *      details typed in the scenario editor) — converting them again mangles the text.
+     *   2. Parks made with the Korean release of RCT2 contain raw CP949 byte pairs.
+     * IsValidNonAsciiUTF8 detects case 1 by strict UTF-8 validation with at least one non-ASCII
+     * sequence, so plain ASCII still goes through the RCT2 format-code table as before.
+     */
+    static bool IsValidNonAsciiUTF8(std::string_view src)
+    {
+        bool hasNonAscii = false;
+        size_t i = 0;
+        while (i < src.size())
+        {
+            auto b = static_cast<uint8_t>(src[i]);
+            if (b < 0x80)
+            {
+                i++;
+                continue;
+            }
+            hasNonAscii = true;
+            size_t len = (b >= 0xF0 && b <= 0xF4) ? 4 : (b >= 0xE0) ? 3 : (b >= 0xC2) ? 2 : 0;
+            if (len == 0 || i + len > src.size())
+            {
+                return false;
+            }
+            for (size_t j = 1; j < len; j++)
+            {
+                auto t = static_cast<uint8_t>(src[i + j]);
+                if (t < 0x80 || t > 0xBF)
+                {
+                    return false;
+                }
+            }
+            i += len;
+        }
+        return hasNonAscii;
+    }
+
+    /**
+     * Detects raw CP949 (Korean) text by looking for byte pairs in the KS X 1001 hangul zone
+     * (lead 0xB0-0xC8, trail 0xA1-0xFE). Strings containing 0xFF escapes are excluded: those
+     * already carry two-byte wide chars (e.g. UTF-16 code units written by OpenRCT2 for user
+     * strings) which the table path passes through intact.
+     */
+    static bool IsLikelyCP949Korean(std::string_view src)
+    {
+        bool found = false;
+        for (size_t i = 0; i + 1 < src.size(); i++)
+        {
+            auto b1 = static_cast<uint8_t>(src[i]);
+            if (b1 == 0xFF)
+            {
+                return false;
+            }
+            auto b2 = static_cast<uint8_t>(src[i + 1]);
+            if (b1 >= 0xB0 && b1 <= 0xC8 && b2 >= 0xA1 && b2 <= 0xFE)
+            {
+                found = true;
+            }
+        }
+        return found;
+    }
+
     std::string RCT2StringToUTF8(std::string_view src, RCT2LanguageId languageId)
     {
         auto codePage = GetCodePageForRCT2Language(languageId);
+        if (codePage == CodePage::CP_1252)
+        {
+            if (IsValidNonAsciiUTF8(src))
+            {
+                // Already UTF-8 (saved by OpenRCT2), nothing to convert.
+                return std::string(src);
+            }
+            if (IsLikelyCP949Korean(src))
+            {
+                codePage = CodePage::CP_949;
+            }
+        }
         if (codePage == CodePage::CP_1252)
         {
             // The code page used by RCT2 was not quite 1252 as some codes were used for Polish characters.

--- a/test/tests/LocalisationTest.cpp
+++ b/test/tests/LocalisationTest.cpp
@@ -63,3 +63,33 @@ TEST_F(Localisation, RCT2_to_UTF8_ZH_TW_PREMATURE_END)
     auto actual = RCT2StringToUTF8(input, RCT2LanguageId::chineseTraditional);
     ASSERT_EQ(expected, actual);
 }
+
+TEST_F(Localisation, RCT2_to_UTF8_ALREADY_UTF8)
+{
+    // Scenario names/details written by OpenRCT2 itself are stored as UTF-8; they must pass
+    // through unchanged even though the importer requests the englishUK conversion.
+    auto input = StringFromHex("ebaaa8eb9190ec9d9820ed8380ec9db4ecbfa4");
+    auto expected = u8"모두의 타이쿤";
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::englishUK);
+    ASSERT_EQ(expected, actual);
+}
+
+TEST_F(Localisation, RCT2_to_UTF8_KO_RAW_CP949)
+{
+    // Parks made with the Korean release of RCT2 store raw CP949 byte pairs, but the importer
+    // hardcodes englishUK; the CP949 hangul zone must be auto-detected.
+    auto input = StringFromHex("b8f0b5cec0c720c5b8c0ccc4ef");
+    auto expected = u8"모두의 타이쿤";
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::englishUK);
+    ASSERT_EQ(expected, actual);
+}
+
+TEST_F(Localisation, RCT2_to_UTF8_KO_WIDECHAR_ESCAPED)
+{
+    // User strings (park/ride names) written by OpenRCT2 encode non-ASCII as 0xFF-escaped
+    // UTF-16 code units; the table path passes those through and CP949 detection must not fire.
+    auto input = StringFromHex("ffbaa8ffb450ffc75820ffd0c0ffc774ffcfe4");
+    auto expected = u8"모두의 타이쿤";
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::englishUK);
+    ASSERT_EQ(expected, actual);
+}


### PR DESCRIPTION
Fixes #26743.

`RCT2StringToUTF8` is always called with `RCT2LanguageId::englishUK` by the S6/S4 importers, so Korean scenario names, descriptions and park/ride names turn into mojibake. The CP949 conversion infrastructure has existed since #6857 but no import path ever selects it, and strings that are already UTF-8 (written by OpenRCT2's own scenario editor) get converted a second time.

This PR handles both cases inside `RCT2StringToUTF8` so every call site benefits without signature changes:

1. **UTF-8 passthrough** — strict UTF-8 validation (requiring at least one non-ASCII sequence, so plain ASCII still goes through the RCT2 format-code table as before). Fixes scenario name/details saved by OpenRCT2 being double-converted (e.g. via `ConvertScenarioStringsToUTF8`, which has no `IsLikelyUTF8` guard).
2. **CP949 detection** — raw byte pairs in the KS X 1001 hangul zone (lead `0xB0-0xC8`, trail `0xA1-0xFE`) switch the code page to `CP_949`. Strings containing `0xFF` escapes are excluded because those carry two-byte wide chars (e.g. UTF-16 code units written for user strings) that the existing table path already passes through intact — verified with real park files where the park name bytes are `FF BA A8 FF B4 50 ...` (0xFF + UTF-16BE "모두의 타이쿤").

### Tests

Three new unit tests in `LocalisationTest.cpp` cover the UTF-8 passthrough, raw CP949 detection, and the 0xFF-escaped wide-char case (guarding against misclassification). All existing conversion tests (UK/JP/ZH_TW/PL/premature-end) still pass:

```
[  PASSED  ] 8 tests.
```

The Polish test is the interesting regression check: its non-ASCII CP1252 bytes are neither valid UTF-8 nor inside the hangul zone, so it still takes the table path.

### Verified in game

Tested on Linux against Korean community scenarios from rctsc.telk.kr ("모두의 타이쿤", "마블 존"): scenario list, description window, park name and ride names all display correctly; Western scenarios unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
