### PR TITLE
Document ListViewItem shape for multi-column list views

### DIFF
--- a/distribution/scripting/openrct2.d.ts
+++ b/distribution/scripting/openrct2.d.ts
@@ -5093,6 +5093,12 @@ declare global {
         column: number;
     }
 
+    /**
+     * A single row of a list view.
+     * - Use a `string` for a single-column list (one label for the row).
+     * - Use a `string[]` for a multi-column list, with one entry per column, in the same order as `columns`.
+     * - Use a {@link ListViewItemSeparator} to render a separator row instead of data.
+     */
     type ListViewItem = ListViewItemSeparator | string[] | string;
 
     interface ListViewWidget extends WidgetBase {
@@ -5101,6 +5107,10 @@ declare global {
         isStriped: boolean;
         showColumnHeaders: boolean;
         columns: ListViewColumn[];
+        /**
+         * The rows of the list. For a list with multiple `columns`, this is an array of rows,
+         * where each row is a `string[]` containing one value per column (i.e. `string[][]` overall).
+         */
         items: ListViewItem[];
         selectedCell: RowColumn | null;
         readonly highlightedCell: RowColumn;


### PR DESCRIPTION
Fixes #17855

The `items` property of `ListViewWidget`/`ListViewDesc` is typed as `ListViewItem[]`, where `ListViewItem = ListViewItemSeparator | string[] | string`. For lists with multiple `columns`, each row must be a `string[]` (one entry per column), making the overall shape effectively `string[][]` — but this wasn't documented anywhere, which was confusing (per the issue).

This adds JSDoc comments on the `ListViewItem` type alias and the `items` property explaining the expected shape. No behavioural or type changes.