### PR TITLE
Export a JSON file on `sprite exportall`, allowing for round-trip Gx conversion

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.4 (in development)
 ------------------------------------------------------------------------
+- Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.
 - Fix: [#26756] Guests cannot puke or litter on sloped path.
 - Fix: [#26758] [Plugin] IPv6 addresses are reported incorrectly.
 

--- a/src/openrct2/command_line/sprite/SpriteExportAll.cpp
+++ b/src/openrct2/command_line/sprite/SpriteExportAll.cpp
@@ -9,6 +9,7 @@
 
 #include "../../Context.h"
 #include "../../core/FileStream.h"
+#include "../../core/Json.hpp"
 #include "../../core/Path.hpp"
 #include "../../core/StringTypes.h"
 #include "../../drawing/Drawing.h"
@@ -19,6 +20,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 
 namespace OpenRCT2::CommandLine::Sprite
 {
@@ -46,24 +48,70 @@ namespace OpenRCT2::CommandLine::Sprite
             return ExitCode::fail;
         }
 
-        const uint32_t maxIndex = spriteFile->Header.numEntries;
-        const int32_t numbers = static_cast<int32_t>(std::floor(std::log10(maxIndex) + 1));
+        const uint32_t numEntries = spriteFile->Header.numEntries;
+        const int32_t numbers = static_cast<int32_t>(std::floor(std::log10(numEntries) + 1));
+
+        auto jsonEntries = nlohmann::json::array();
 
         std::ostringstream oss; // TODO: Remove when C++20 is enabled and std::format can be used
-        for (uint32_t spriteIndex = 0; spriteIndex < maxIndex; spriteIndex++)
+        for (uint32_t spriteIndex = 0; spriteIndex < numEntries; spriteIndex++)
         {
             // Status indicator
-            printf("\r%u / %u, %u%%", spriteIndex + 1, maxIndex, ((spriteIndex + 1) * 100) / maxIndex);
+            printf("\r%u / %u, %u%%", spriteIndex + 1, numEntries, ((spriteIndex + 1) * 100) / numEntries);
 
             oss << std::setw(numbers) << std::setfill('0') << spriteIndex << ".png";
+            auto localFilename = PopStr(oss);
 
             const auto& spriteHeader = spriteFile->Entries[spriteIndex];
-            if (!SpriteImageExport(spriteHeader, Path::Combine(outputPath, PopStr(oss))))
+
+            if (spriteHeader.flags.has(G1Flag::isPalette))
             {
-                fprintf(stderr, "Could not export\n");
-                return ExitCode::fail;
+                auto palette = spriteHeader.asPalette();
+                auto jsonColours = nlohmann::json::array();
+
+                for (auto colourIndex = 0; colourIndex < palette->numColours; colourIndex++)
+                {
+                    auto& colour = palette->palette[colourIndex];
+                    utf8 colourString[8];
+                    snprintf(colourString, sizeof(colourString), "#%02X%02X%02X", colour.red, colour.green, colour.blue);
+                    jsonColours.push_back(colourString);
+                }
+
+                jsonEntries.push_back(
+                    {
+                        { "index", palette->startIndex },
+                        { "colours", jsonColours },
+                    });
+            }
+            else
+            {
+                if (!SpriteImageExport(spriteHeader, Path::Combine(outputPath, localFilename)))
+                {
+                    fprintf(stderr, "Could not export\n");
+                    return ExitCode::fail;
+                }
+
+                u8string format = spriteHeader.flags.has(G1Flag::hasRLECompression) ? "rle" : "raw";
+                json_t entry = {
+                    { "path", localFilename },
+                    { "format", format },
+                };
+                if (spriteHeader.xOffset != 0)
+                    entry["x"] = spriteHeader.xOffset;
+                if (spriteHeader.yOffset != 0)
+                    entry["y"] = spriteHeader.yOffset;
+                if (spriteHeader.flags.has(G1Flag::hasZoomSprite) && spriteHeader.zoomedOffset != 0)
+                    entry["zoom"] = spriteHeader.zoomedOffset;
+                if (spriteHeader.flags.has(G1Flag::noZoomDraw))
+                    entry["noDrawOnZoom"] = true;
+
+                jsonEntries.push_back(entry);
             }
         }
+
+        auto outputResourcesPath = Path::Combine(outputPath, "sprites.json");
+        Json::WriteToFile(outputResourcesPath, jsonEntries);
+
         return ExitCode::ok;
     }
 } // namespace OpenRCT2::CommandLine::Sprite

--- a/src/openrct2/command_line/sprite/SpriteFile.cpp
+++ b/src/openrct2/command_line/sprite/SpriteFile.cpp
@@ -106,17 +106,23 @@ namespace OpenRCT2::CommandLine::Sprite
             {
                 ScopedRelativeSpriteFile scopedRelative(*this);
 
+                // To simulate how Sawyer’s tools built g1, and make comparing outputs easier,
+                // re-use the same structure and allow some values to linger.
+                StoredG1Element entry32bit{};
                 for (const auto& entry : Entries)
                 {
-                    StoredG1Element entry32bit{};
-
                     entry32bit.offset = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(const_cast<uint8_t*>(entry.offset)));
                     entry32bit.width = entry.width;
-                    entry32bit.height = entry.height;
+                    if (!entry.flags.has(G1Flag::isPalette))
+                    {
+                        entry32bit.height = entry.height;
+                        entry32bit.yOffset = entry.yOffset;
+                    }
+
                     entry32bit.xOffset = entry.xOffset;
-                    entry32bit.yOffset = entry.yOffset;
                     entry32bit.flags = entry.flags;
-                    entry32bit.zoomedOffset = entry.zoomedOffset;
+                    if (entry.flags.has(G1Flag::hasZoomSprite))
+                        entry32bit.zoomedOffset = entry.zoomedOffset;
 
                     stream.Write(&entry32bit, sizeof(entry32bit));
                 }


### PR DESCRIPTION
Together with the second commit, which replicates an implementation detail in Sawyer’s tools, disassembling g1.dat and rebuilding it produces a _byte-for-byte identical_ result.

Should be useful for anyone who wants to make modifications to g1.dat.