### PR TITLE
Fix IPv6 addresses in the plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.4 (in development)
 ------------------------------------------------------------------------
 - Fix: [#26756] Guests cannot puke or litter on sloped path.
+- Fix: [#26758] [Plugin] IPv6 addresses are reported incorrectly.
 
 0.5.3 (2026-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -663,7 +663,7 @@ namespace OpenRCT2::Network
             }
             else if (addr->sin_family == AF_INET6)
             {
-                auto addrv6 = reinterpret_cast<const sockaddr_in6*>(&addr);
+                auto addrv6 = reinterpret_cast<const sockaddr_in6*>(addr);
                 char str[INET6_ADDRSTRLEN]{};
                 inet_ntop(AF_INET6, &addrv6->sin6_addr, str, sizeof(str));
                 result = str;


### PR DESCRIPTION
This fixes https://github.com/OpenRCT2/OpenRCT2/issues/26753 (Plugin API player IP addresses are nonsensical)

- Properly pass the `sockaddr_in` pointer instead of its address to `reinterpret_cast`.

Please note: The fix for this was originally found by @rinode in the OpenRCT2 discord.
I tested it and it works nicely.