### PR TITLE
Fix litter placement on sloped paths

### DIFF
--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -37,7 +37,8 @@ namespace OpenRCT2
                 continue;
 
             int32_t pathZ = tileElement->getBaseZ();
-            if (pathZ < mapPos.z || pathZ >= mapPos.z + kPathClearance)
+            int32_t pathClearanceZ = tileElement->getClearanceZ();
+            if (mapPos.z < pathZ || mapPos.z >= pathClearanceZ)
                 continue;
 
             return !TileElementIsUnderground(tileElement);


### PR DESCRIPTION
## Problem
Fixes #26756

Guests cannot puke or litter on sloped paths in OpenRCT2, despite being able to in vanilla RCT2.

## Root cause
`IsLocationLitterable` in `Litter.cpp` compared the path element's `baseZ` against the entity's z position using a fixed `kPathClearance` window. On sloped paths, the path's `baseZ` is at the bottom of the slope, but entities walking on the slope can be at a higher z — causing the check to reject valid placements.

## Fix
Use the path element's actual `clearanceZ` (which already accounts for slope height via `setClearanceZ(zHigh)` where `zHigh += kPathHeightStep` for sloped paths) instead of computing the upper bound from `mapPos.z`.

The condition was changed from:

```
if (pathZ < mapPos.z || pathZ >= mapPos.z + kPathClearance)
```

to:

```
if (mapPos.z < pathZ || mapPos.z >= pathClearanceZ)
```

This correctly checks whether the entity's z falls within the path element's actual height range.