### PR TITLE
Fix cut-away view elevation to support negative values

### DIFF
--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <algorithm>
 #include <cmath>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
@@ -48,6 +49,9 @@ namespace OpenRCT2::Ui::Windows
         DisplayRaw,
         DisplayUnits
     };
+
+    constexpr int16_t kClipHeightMin = -128;
+    constexpr int16_t kClipHeightMax = 255;
 
 #pragma region Widgets
 
@@ -162,14 +166,14 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLIP_HEIGHT_INCREASE:
-                    if (gClipHeight < 255)
+                    if (gClipHeight < kClipHeightMax)
                         SetClipHeight(gClipHeight + 1);
                     mainWindow = WindowGetMain();
                     if (mainWindow != nullptr)
                         mainWindow->invalidate();
                     break;
                 case WIDX_CLIP_HEIGHT_DECREASE:
-                    if (gClipHeight > 0)
+                    if (gClipHeight > kClipHeightMin)
                         SetClipHeight(gClipHeight - 1);
                     mainWindow = WindowGetMain();
                     if (mainWindow != nullptr)
@@ -183,8 +187,9 @@ namespace OpenRCT2::Ui::Windows
             const auto& widget = widgets[WIDX_CLIP_HEIGHT_SLIDER];
             const ScrollArea* const scroll = &this->scrolls[0];
             const int16_t scroll_width = widget.width() - 2;
-            const uint8_t clip_height = static_cast<uint8_t>(
-                (static_cast<float>(scroll->contentOffsetX) / (scroll->contentWidth - scroll_width)) * 255);
+            const float ratio = static_cast<float>(scroll->contentOffsetX) / (scroll->contentWidth - scroll_width);
+            const int16_t clip_height = static_cast<int16_t>(
+                std::round(ratio * (kClipHeightMax - kClipHeightMin) + kClipHeightMin));
             if (clip_height != gClipHeight)
             {
                 gClipHeight = clip_height;
@@ -387,11 +392,12 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void SetClipHeight(const uint8_t clipHeight)
+        void SetClipHeight(const int16_t clipHeight)
         {
-            gClipHeight = clipHeight;
+            gClipHeight = std::clamp(clipHeight, kClipHeightMin, kClipHeightMax);
             const auto& widget = widgets[WIDX_CLIP_HEIGHT_SLIDER];
-            const float clip_height_ratio = static_cast<float>(gClipHeight) / 255;
+            const float clip_height_ratio = static_cast<float>(gClipHeight - kClipHeightMin)
+                / (kClipHeightMax - kClipHeightMin);
             this->scrolls[0].contentOffsetX = static_cast<int16_t>(
                 std::ceil(clip_height_ratio * (this->scrolls[0].contentWidth - (widget.width() - 2))));
         }

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2::Drawing;
 
 extern CoordsXY gClipSelectionA;
 extern CoordsXY gClipSelectionB;
-extern uint8_t gClipHeight;
+extern int16_t gClipHeight;
 
 uint8_t gScreenshotCountdown = 0;
 

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -37,7 +37,7 @@ using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::Numerics;
 
 // Globals for paint clipping
-uint8_t gClipHeight = 128; // Default to middle value
+int16_t gClipHeight = 128; // Default to middle value
 CoordsXY gClipSelectionA = { 0, 0 };
 CoordsXY gClipSelectionB = { kMaximumTileStartXY, kMaximumTileStartXY };
 

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -237,7 +237,7 @@ struct PaintSession : public PaintSessionCore
 extern PaintSession gPaintSession;
 
 // Globals for paint clipping
-extern uint8_t gClipHeight;
+extern int16_t gClipHeight;
 extern CoordsXY gClipSelectionA;
 extern CoordsXY gClipSelectionB;
 


### PR DESCRIPTION
## Problem
Fixes #26752

Cut-away view elevation was clamped to 0-255 (), preventing negative elevation values from being used. When using feet or metric units, the display formulas can produce negative values (e.g., -35ft at gClipHeight=0), but the spinner and slider couldn't go below 0.

## Changes
- Changed  from  to  to support negative values
- Added  (-128) and  (255) constants
- Updated spinner increase/decrease button limits to use new range
- Updated slider mapping to support the full -128 to 255 range
- Updated  to clamp values and compute slider ratio correctly

## Testing
- Open cut-away view window
- Set display to feet or metric units
- Decrease elevation below 0 - should now show negative values
- Verify slider works correctly across the full range
- Verify paint clipping works correctly with negative clip heights