### PR TITLE
Ignore group boxes when determining top widget

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -1206,13 +1206,13 @@ public:
         {
             const auto& widget = w.widgets[i];
 
-            if (widget.type != WidgetType::empty && widget.isVisible())
+            if (widget.type == WidgetType::empty || widget.type == WidgetType::groupbox || !widget.isVisible())
+                continue;
+
+            if (screenCoords.x >= w.windowPos.x + widget.left && screenCoords.x <= w.windowPos.x + widget.right
+                && screenCoords.y >= w.windowPos.y + widget.top && screenCoords.y <= w.windowPos.y + widget.bottom)
             {
-                if (screenCoords.x >= w.windowPos.x + widget.left && screenCoords.x <= w.windowPos.x + widget.right
-                    && screenCoords.y >= w.windowPos.y + widget.top && screenCoords.y <= w.windowPos.y + widget.bottom)
-                {
-                    widget_index = i;
-                }
+                widget_index = i;
             }
         }
 

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -1206,6 +1206,7 @@ public:
         {
             const auto& widget = w.widgets[i];
 
+            // Group boxes may overlay previous widgets when shared. Given their appearance, we consider them empty overlays.
             if (widget.type == WidgetType::empty || widget.type == WidgetType::groupbox || !widget.isVisible())
                 continue;
 


### PR DESCRIPTION
In `WidgetManager::FindWidgetFromPoint`, the widget list for a particular window is iterated back to front to determine what widget is the top-most visible at the point specified. Generally, this logic is sound: widgets that appear first in the list are generally behind others (e.g. window frame, tab backgrounds). However, in a few windows, this hierarchy does not hold. Until this week, this wasn't a problem, though.

This week, #26763 added group boxes to the ride colour/appearance tab. The track colour widgets are reused for the entrance style group when the ride does not have customisable track. This, however, puts these widgets _before_ their group in the widget list. This, then, means `FindWidgetFromPoint` will override the 'found' widget with the groupbox, rather than the colour dropdown buttons. Conversely, the entrance style dropdown is not affected, as it is placed at the 'correct' place in the hierarchy.

I've chosen to amend `FindWidgetFromPoint` to prevent this from occurring unexpectedly in the future by excepting group boxes from this kind of thing in the future. Given they are effectively empty save for a border, I think that's implicitly expected behaviour.

If this is undesirable, though, we could also move the 'entrance style' groupbox to a lower spot in the widget list, e.g. next to its 'track style' counterpart. I think this would make the widget list less intuitive, though, which is why I did not choose this approach.

Fixes #26778