### PR TITLE
Fix block sections label for powered launch

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3545,7 +3545,8 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_MODE_DROPDOWN].moveTo({ 297, startY + 1 });
             startY += 17;
 
-            if (ride->isBlockSectioned())
+            const bool poweredLaunch = ride->mode == RideMode::poweredLaunchBlockSectioned;
+            if (ride->isBlockSectioned() && !poweredLaunch)
             {
                 startY += 17;
             }
@@ -3671,6 +3672,11 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_MODE_TWEAK].type = WidgetType::empty;
                 widgets[WIDX_MODE_TWEAK_INCREASE].type = WidgetType::empty;
                 widgets[WIDX_MODE_TWEAK_DECREASE].type = WidgetType::empty;
+            }
+
+            if (ride->isBlockSectioned() && poweredLaunch)
+            {
+                startY += 17;
             }
 
             if (startY != initStartY + 15)


### PR DESCRIPTION
This PR fixes the 'Block sections' label when powered launch is selected as the operating mode.

Latest release (v0.5.3):
<img width="316" height="201" alt="Forest Frontiers 2026-07-13 20-17-48" src="https://github.com/user-attachments/assets/dcad30a7-02cc-489e-a54f-5e3c2b5817d5" />

Current develop:
<img width="316" height="229" alt="Forest Frontiers 2026-07-13 20-14-44" src="https://github.com/user-attachments/assets/bed6744e-a62b-4b19-8449-d5536a2a2473" />

This PR:
<img width="316" height="229" alt="Forest Frontiers 2026-07-13 20-17-36" src="https://github.com/user-attachments/assets/15dff8d5-576d-4b9c-b742-c11e71dda87c" />
