### PR TITLE
Fix Windows clang64 build

### DIFF
--- a/src/openrct2/core/FileWatcher.h
+++ b/src/openrct2/core/FileWatcher.h
@@ -68,7 +68,7 @@ public:
     ~FileWatcher();
 
 private:
-#if defined(_WIN32) || defined(__linux__)
+#if defined(__linux__)
     bool _finished{};
 #elif defined(__APPLE__)
     static void FSEventsCallback(


### PR DESCRIPTION
installing is still broken