### PR TITLE
Fix negative marketing campaign durations

### DIFF
--- a/src/openrct2/actions/park/ParkMarketingAction.cpp
+++ b/src/openrct2/actions/park/ParkMarketingAction.cpp
@@ -47,7 +47,7 @@ namespace OpenRCT2::GameActions
 
     Result ParkMarketingAction::Query(GameState_t& gameState, Park::ParkData& park) const
     {
-        if (static_cast<size_t>(_type) >= std::size(AdvertisingCampaignPricePerWeek) || _numWeeks >= 256)
+        if (static_cast<size_t>(_type) >= std::size(AdvertisingCampaignPricePerWeek) || _numWeeks <= 0 || _numWeeks >= 256)
         {
             return Result(Status::invalidParameters, STR_CANT_START_MARKETING_CAMPAIGN, STR_ERR_VALUE_OUT_OF_RANGE);
         }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -48,7 +48,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 2;
+constexpr uint8_t kStreamVersion = 3;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ParkImporter.h>
 #include <openrct2/actions/GameActionRunner.h>
+#include <openrct2/actions/park/ParkMarketingAction.h>
 #include <openrct2/actions/park/ParkSetEntranceFeeAction.h>
 #include <openrct2/actions/park/ParkSetParameterAction.h>
 #include <openrct2/actions/ride/RideSetPriceAction.h>
@@ -84,6 +85,17 @@ static void execute(Args&&... args)
 {
     GA ga(std::forward<Args>(args)...);
     GameActions::Execute(&ga, getGameState());
+}
+
+TEST_F(PlayTests, NegativeMarketingCampaignDurationIsRejected)
+{
+    auto context = localStartGame(TestData::GetParkPath("small_park_with_ferris_wheel.sv6"));
+    ASSERT_NE(context.get(), nullptr);
+
+    GameActions::ParkMarketingAction action(ADVERTISING_CAMPAIGN_PARK, 0, -1);
+    const auto result = GameActions::Query(&action, getGameState());
+
+    ASSERT_EQ(result.error, GameActions::Status::invalidParameters);
 }
 
 TEST_F(PlayTests, SecondGuestInQueueShouldNotRideIfNoFunds)


### PR DESCRIPTION
## Summary

- Reject zero and negative marketing campaign durations before action execution.
- Add a regression test for a negative duration.

## Root cause

`ParkMarketingAction` accepted signed durations below zero. The action cost became negative and the finance layer treated it as a cash credit, while storing the duration in an unsigned field.

## Checks

- `git diff --check`
