### PR TITLE
Update "Disable vehicle limits" tooltip to state 255 train limit

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2867,7 +2867,7 @@ STR_5807    :{WINDOW_COLOUR_2}Number of rides: {BLACK}{COMMA16}
 STR_5808    :{WINDOW_COLOUR_2}Number of shops and stalls: {BLACK}{COMMA16}
 STR_5809    :{WINDOW_COLOUR_2}Number of information kiosks and other facilities: {BLACK}{COMMA16}
 STR_5810    :Disable vehicle limits
-STR_5811    :If checked, you can have up to{NEWLINE}255 cars per train and 31{NEWLINE}trains per ride
+STR_5811    :If checked, you can have up to{NEWLINE}255 cars per train and 255{NEWLINE}trains per ride
 STR_5812    :Show multiplayer window
 STR_5813    :“{STRING}”
 STR_5814    :{WINDOW_COLOUR_1}“{STRING}”


### PR DESCRIPTION
The "Disable vehicle limits" tooltip stated an outdated limit of 31 trains. This PR changes it to say 255.

<img width="621" height="304" alt="image" src="https://github.com/user-attachments/assets/d0f28657-4eac-44f6-a93d-64d1b0ecd037" />
