### PR TITLE
Revert fix for malformed mapRequest decoding

### DIFF
--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -55,6 +55,7 @@ namespace OpenRCT2::Network
             case Command::objectsList:
             case Command::scriptsHeader:
             case Command::scriptsData:
+            case Command::mapRequest:
             case Command::heartbeat:
                 return false;
             default:

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -46,17 +46,7 @@ add_executable(OpenRCT2::OpenRCT2Tests ALIAS OpenRCT2Tests)
 target_link_libraries(OpenRCT2Tests GTest::gtest GTest::gtest_main libopenrct2)
 target_include_directories(OpenRCT2Tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-# NetworkTests bind hardcoded ports (TCP 11760, UDP 11754 for LAN broadcast),
-# so parallel CTest workers collide. Serialize them via RESOURCE_LOCK while
-# leaving the rest of the suite parallelizable.
 gtest_discover_tests(OpenRCT2Tests
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    DISCOVERY_MODE PRE_TEST
-    PROPERTIES RESOURCE_LOCK network_server
-    TEST_FILTER NetworkTests.*)
-
-gtest_discover_tests(OpenRCT2Tests
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    DISCOVERY_MODE PRE_TEST
-    TEST_FILTER -NetworkTests.*)
+    DISCOVERY_MODE PRE_TEST)
 

--- a/test/tests/NetworkTests.cpp
+++ b/test/tests/NetworkTests.cpp
@@ -7,107 +7,15 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#ifndef DISABLE_NETWORK
-
-    #include "TestData.h"
-
-    #include <chrono>
-    #include <gtest/gtest.h>
-    #include <memory>
-    #include <openrct2/Context.h>
-    #include <openrct2/Game.h>
-    #include <openrct2/OpenRCT2.h>
-    #include <openrct2/config/Config.h>
-    #include <openrct2/core/Crypt.h>
-    #include <openrct2/network/Network.h>
-    #include <openrct2/network/NetworkBase.h>
-    #include <openrct2/network/NetworkConnection.h>
-    #include <openrct2/network/NetworkPacket.h>
-    #include <openrct2/network/NetworkTypes.h>
-    #include <openrct2/network/Socket.h>
-    #include <thread>
+#include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/network/NetworkBase.h>
+#include <openrct2/network/NetworkConnection.h>
+#include <openrct2/network/NetworkPacket.h>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Network;
-
-// Drives the server's accept/read/process loop for a short period.
-static void PumpServer(const int iterations = 20)
-{
-    for (int i = 0; i < iterations; ++i)
-    {
-        Network::Update();
-        Network::Tick();
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-}
-
-// Build a Connection acting as the test client
-static std::unique_ptr<Connection> ConnectTestClient(uint16_t port)
-{
-    auto client = std::make_unique<Connection>();
-    client->socket = CreateTcpSocket();
-    client->socket->Connect("127.0.0.1", port);
-    client->authStatus = Auth::ok;
-    return client;
-}
-
-// Pump the server while letting the client send/receive until a packet of
-// the expected command id has been parsed into client.InboundPacket.
-static bool WaitForPacket(Connection& client, const Command expectedId, int maxIterations = 50)
-{
-    for (int i = 0; i < maxIterations; ++i)
-    {
-        PumpServer(2);
-        client.update();
-        while (client.readPacket() == ReadPacket::success)
-        {
-            if (client.inboundPacket.getCommand() == expectedId)
-                return true;
-            client.inboundPacket.clear();
-        }
-    }
-    return false;
-}
-
-// Drive the full token + auth handshake. Returns true on Auth::ok.
-static bool AuthenticateClient(Connection& client, const std::string_view playerName)
-{
-    // Send token request, receive challenge
-    client.queuePacket(Packet(Command::token));
-    if (!WaitForPacket(client, Command::token))
-        return false;
-    uint32_t challengeSize = 0;
-    client.inboundPacket >> challengeSize;
-    if (challengeSize == 0)
-        return false;
-    const auto* challengeBytes = client.inboundPacket.read(challengeSize);
-    if (challengeBytes == nullptr)
-        return false;
-    const std::vector<uint8_t> challenge(challengeBytes, challengeBytes + challengeSize);
-
-    // Sign the challenge
-    const auto key = Crypt::CreateRSAKey();
-    key->Generate();
-    const auto rsa = Crypt::CreateRSA();
-    const auto signature = rsa->SignData(*key, challenge.data(), challenge.size());
-    const std::string pubkey = key->GetPublic();
-
-    // Send the auth packet
-    Packet authPacket(Command::auth);
-    authPacket.writeString(Network::GetVersion());
-    authPacket.writeString(playerName);
-    authPacket.writeString("");
-    authPacket.writeString(pubkey);
-    authPacket << static_cast<uint32_t>(signature.size());
-    authPacket.write(signature.data(), signature.size());
-    client.queuePacket(authPacket);
-
-    if (!WaitForPacket(client, Command::auth))
-        return false;
-    uint32_t authStatus = 0;
-    client.inboundPacket >> authStatus;
-    return static_cast<Auth>(authStatus) == Auth::ok;
-}
 
 class MockTcpSocket final : public ITcpSocket
 {
@@ -201,66 +109,22 @@ private:
 class NetworkTests : public testing::Test
 {
 protected:
-    static constexpr uint16_t kTestPort = 11760;
-
     void SetUp() override
     {
         gOpenRCT2Headless = true;
         gOpenRCT2NoGraphics = true;
         _context = CreateContext();
-
-        ASSERT_TRUE(_context->Initialise());
-
-        const auto parkPath = TestData::GetParkPath("EverythingPark.park");
-        GetContext()->LoadParkFromFile(parkPath);
-        GameLoadInit();
-
-        // Don't broadcast to the master server during tests.
-        Config::Get().network.advertise = false;
-
-        ASSERT_NE(Network::BeginServer(kTestPort, "127.0.0.1"), 0);
-        PumpServer(5);
+        try
+        {
+            _context->Initialise();
+        }
+        catch (...)
+        {
+        }
     }
 
     std::unique_ptr<IContext> _context;
 };
-
-// A misbehaving client sends a `mapRequest` packet without authenticating.
-TEST_F(NetworkTests, UnauthenticatedMapRequest_DoesNotCrashServer)
-{
-    const auto client = ConnectTestClient(kTestPort);
-    ASSERT_EQ(client->socket->GetStatus(), SocketStatus::connected);
-
-    PumpServer(5);
-
-    // Empty mapRequest payload (claims 0 objects)
-    client->queuePacket(Packet(Command::mapRequest));
-    client->update();
-
-    PumpServer(20);
-
-    SUCCEED();
-}
-
-// An authenticated client sends a malformed `mapRequest`: the declared object
-// count is larger than the actual data.
-TEST_F(NetworkTests, AuthenticatedMalformedMapRequest_DoesNotCrashServer)
-{
-    const auto client = ConnectTestClient(kTestPort);
-    ASSERT_EQ(client->socket->GetStatus(), SocketStatus::connected);
-
-    ASSERT_TRUE(AuthenticateClient(*client, "tester"));
-
-    // Claim 1000 DAT objects, supply only the generation byte for one.
-    Packet malformed(Command::mapRequest);
-    malformed << static_cast<uint32_t>(1000);
-    malformed << static_cast<uint8_t>(0); // generation = DAT, no RCTObjectEntry data follows
-    client->queuePacket(malformed);
-    client->update();
-    PumpServer(20);
-
-    SUCCEED();
-}
 
 TEST_F(NetworkTests, MapRequestWithoutPlayerDisconnectsAndDoesNotCrash)
 {
@@ -281,4 +145,3 @@ TEST_F(NetworkTests, MapRequestWithoutPlayerDisconnectsAndDoesNotCrash)
 
     EXPECT_TRUE(connection.shouldDisconnect);
 }
-#endif // !DISABLE_NETWORK


### PR DESCRIPTION
This reverts commit 8e64399c50b6806a3f362253ab7197f0bafef614 (#26555), as it was causing people not to be able to join servers.