### PR TITLE
Use flags for widget visibility instead of empty widget type

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1063,6 +1063,10 @@ namespace OpenRCT2
 
         const auto& widget = w->widgets[widgetIndex];
 
+        // Invisible widgets are non-interactible
+        if (!widget.isVisible())
+            return;
+
         switch (widget.type)
         {
             case WidgetType::frame:

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -93,7 +93,7 @@ static void ShortcutRotateConstructionObject()
     // Rotate scenery
     WindowBase* w = windowMgr->FindByClass(WindowClass::scenery);
     if (w != nullptr && !widgetIsDisabled(*w, WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON)
-        && w->widgets[WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type != WidgetType::empty)
+        && w->widgets[WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].isVisible())
     {
         w->onMouseUp(WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON);
         return;
@@ -102,7 +102,7 @@ static void ShortcutRotateConstructionObject()
     // Rotate construction track piece
     w = windowMgr->FindByClass(WindowClass::rideConstruction);
     if (w != nullptr && !widgetIsDisabled(*w, WC_RIDE_CONSTRUCTION__WIDX_ROTATE)
-        && w->widgets[WC_RIDE_CONSTRUCTION__WIDX_ROTATE].type != WidgetType::empty)
+        && w->widgets[WC_RIDE_CONSTRUCTION__WIDX_ROTATE].isVisible())
     {
         // Check if building a maze...
         if (w->widgets[WC_RIDE_CONSTRUCTION__WIDX_ROTATE].tooltip != STR_RIDE_CONSTRUCTION_BUILD_MAZE_IN_THIS_DIRECTION_TIP)
@@ -115,7 +115,7 @@ static void ShortcutRotateConstructionObject()
     // Rotate track design preview
     w = windowMgr->FindByClass(WindowClass::trackDesignList);
     if (w != nullptr && !widgetIsDisabled(*w, WC_TRACK_DESIGN_LIST__WIDX_ROTATE)
-        && w->widgets[WC_TRACK_DESIGN_LIST__WIDX_ROTATE].type != WidgetType::empty)
+        && w->widgets[WC_TRACK_DESIGN_LIST__WIDX_ROTATE].isVisible())
     {
         w->onMouseUp(WC_TRACK_DESIGN_LIST__WIDX_ROTATE);
         return;
@@ -124,7 +124,7 @@ static void ShortcutRotateConstructionObject()
     // Rotate track design placement
     w = windowMgr->FindByClass(WindowClass::trackDesignPlace);
     if (w != nullptr && !widgetIsDisabled(*w, WC_TRACK_DESIGN_PLACE__WIDX_ROTATE)
-        && w->widgets[WC_TRACK_DESIGN_PLACE__WIDX_ROTATE].type != WidgetType::empty)
+        && w->widgets[WC_TRACK_DESIGN_PLACE__WIDX_ROTATE].isVisible())
     {
         w->onMouseUp(WC_TRACK_DESIGN_PLACE__WIDX_ROTATE);
         return;
@@ -133,7 +133,7 @@ static void ShortcutRotateConstructionObject()
     // Rotate park entrance
     w = windowMgr->FindByClass(WindowClass::editorParkEntrance);
     if (w != nullptr && !widgetIsDisabled(*w, WC_EDITOR_PARK_ENTRANCE__WIDX_ROTATE_ENTRANCE_BUTTON)
-        && w->widgets[WC_EDITOR_PARK_ENTRANCE__WIDX_ROTATE_ENTRANCE_BUTTON].type != WidgetType::empty)
+        && w->widgets[WC_EDITOR_PARK_ENTRANCE__WIDX_ROTATE_ENTRANCE_BUTTON].isVisible())
     {
         w->onMouseUp(WC_EDITOR_PARK_ENTRANCE__WIDX_ROTATE_ENTRANCE_BUTTON);
         return;
@@ -142,7 +142,7 @@ static void ShortcutRotateConstructionObject()
     // Rotate selected element in tile inspector
     w = windowMgr->FindByClass(WindowClass::tileInspector);
     if (w != nullptr && !widgetIsDisabled(*w, WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE)
-        && w->widgets[WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE].type != WidgetType::empty)
+        && w->widgets[WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE].isVisible())
     {
         w->onMouseUp(WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE);
         return;
@@ -480,7 +480,7 @@ static void TileInspectorMouseUp(WidgetIndex widgetIndex)
 {
     auto* windowMgr = GetWindowManager();
     auto w = windowMgr->FindByClass(WindowClass::tileInspector);
-    if (w != nullptr && !widgetIsDisabled(*w, widgetIndex) && w->widgets[widgetIndex].type != WidgetType::empty)
+    if (w != nullptr && !widgetIsDisabled(*w, widgetIndex) && w->widgets[widgetIndex].isVisible())
     {
         w->onMouseUp(widgetIndex);
     }
@@ -490,7 +490,7 @@ static void TileInspectorMouseDown(WidgetIndex widgetIndex)
 {
     auto* windowMgr = GetWindowManager();
     auto w = windowMgr->FindByClass(WindowClass::tileInspector);
-    if (w != nullptr && !widgetIsDisabled(*w, widgetIndex) && w->widgets[widgetIndex].type != WidgetType::empty)
+    if (w != nullptr && !widgetIsDisabled(*w, widgetIndex) && w->widgets[widgetIndex].isVisible())
     {
         w->onMouseDown(widgetIndex);
     }
@@ -563,7 +563,7 @@ static void ShortcutIncreaseElementHeight()
                 action = WC_TILE_INSPECTOR__WIDX_BANNER_SPINNER_HEIGHT_INCREASE;
                 break;
         }
-        if (action != -1 && !widgetIsDisabled(*w, action) && w->widgets[action].type != WidgetType::empty)
+        if (action != -1 && !widgetIsDisabled(*w, action) && w->widgets[action].isVisible())
             w->onMouseDown(action);
         return;
     }
@@ -603,7 +603,7 @@ static void ShortcutDecreaseElementHeight()
                 action = WC_TILE_INSPECTOR__WIDX_BANNER_SPINNER_HEIGHT_DECREASE;
                 break;
         }
-        if (action != -1 && !widgetIsDisabled(*w, action) && w->widgets[action].type != WidgetType::empty)
+        if (action != -1 && !widgetIsDisabled(*w, action) && w->widgets[action].isVisible())
             w->onMouseDown(action);
         return;
     }

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -72,6 +72,9 @@ namespace OpenRCT2::Ui
             return;
         }
 
+        if (!widget->isVisible())
+            return;
+
         switch (widget->type)
         {
             case WidgetType::frame:

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -278,22 +278,20 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
 
-            Widget& colourBtn = widgets[WIDX_MAIN_COLOUR];
-            colourBtn.type = WidgetType::empty;
-
             auto* bannerEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(banner->type);
-            if (bannerEntry != nullptr && (bannerEntry->flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR))
-            {
-                colourBtn.type = WidgetType::colourBtn;
-            }
+            const bool visible = bannerEntry != nullptr && (bannerEntry->flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR);
+            widgets[WIDX_MAIN_COLOUR].setVisible(visible);
+
             const bool noEntry = banner->flags.has(BannerFlag::noEntry);
             setWidgetPressed(WIDX_BANNER_NO_ENTRY, noEntry);
             setWidgetDisabled(WIDX_BANNER_TEXT, noEntry);
             setWidgetDisabled(WIDX_TEXT_COLOUR_DROPDOWN, noEntry);
             setWidgetDisabled(WIDX_TEXT_COLOUR_DROPDOWN_BUTTON, noEntry);
-            colourBtn.image = getColourButtonImage(banner->colour);
-            Widget& dropDownWidget = widgets[WIDX_TEXT_COLOUR_DROPDOWN];
-            dropDownWidget.text = kBannerColouredTextFormats[EnumValue(banner->textColour)];
+
+            widgets[WIDX_MAIN_COLOUR].image = getColourButtonImage(banner->colour);
+
+            Widget& dropdownWidget = widgets[WIDX_TEXT_COLOUR_DROPDOWN];
+            dropdownWidget.text = kBannerColouredTextFormats[EnumValue(banner->textColour)];
         }
     };
 

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -128,8 +128,8 @@ namespace OpenRCT2::Ui::Windows
 
         void onDraw(RenderTarget& rt) override
         {
-            auto drawPreviousButton = widgets[WIDX_PREVIOUS_STEP_BUTTON].type != WidgetType::empty;
-            auto drawNextButton = widgets[WIDX_NEXT_STEP_BUTTON].type != WidgetType::empty;
+            auto drawPreviousButton = widgets[WIDX_PREVIOUS_STEP_BUTTON].isVisible();
+            auto drawNextButton = widgets[WIDX_NEXT_STEP_BUTTON].isVisible();
 
             if (drawPreviousButton)
                 DrawLeftButtonBack(rt);

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -101,10 +101,10 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_NEXT_STEP_BUTTON].left = screenWidth - 198;
             widgets[WIDX_NEXT_STEP_BUTTON].right = screenWidth - 3;
 
-            widgets[WIDX_PREVIOUS_STEP_BUTTON].type = WidgetType::flatBtn;
-            widgets[WIDX_NEXT_STEP_BUTTON].type = WidgetType::flatBtn;
-            widgets[WIDX_PREVIOUS_IMAGE].type = WidgetType::imgBtn;
-            widgets[WIDX_NEXT_IMAGE].type = WidgetType::imgBtn;
+            widgets[WIDX_PREVIOUS_STEP_BUTTON].setHidden(false);
+            widgets[WIDX_NEXT_STEP_BUTTON].setHidden(false);
+            widgets[WIDX_PREVIOUS_IMAGE].setHidden(false);
+            widgets[WIDX_NEXT_IMAGE].setHidden(false);
 
             auto& gameState = getGameState();
             if (gLegacyScene == LegacyScene::trackDesignsManager || gameState.editorStep == Editor::Step::saveScenario)
@@ -325,14 +325,14 @@ namespace OpenRCT2::Ui::Windows
 
         void HidePreviousStepButton()
         {
-            widgets[WIDX_PREVIOUS_STEP_BUTTON].type = WidgetType::empty;
-            widgets[WIDX_PREVIOUS_IMAGE].type = WidgetType::empty;
+            widgets[WIDX_PREVIOUS_STEP_BUTTON].setHidden(true);
+            widgets[WIDX_PREVIOUS_IMAGE].setHidden(true);
         }
 
         void HideNextStepButton()
         {
-            widgets[WIDX_NEXT_STEP_BUTTON].type = WidgetType::empty;
-            widgets[WIDX_NEXT_IMAGE].type = WidgetType::empty;
+            widgets[WIDX_NEXT_STEP_BUTTON].setHidden(true);
+            widgets[WIDX_NEXT_IMAGE].setHidden(true);
         }
 
         void DrawLeftButtonBack(RenderTarget& rt)

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -449,7 +449,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].setHidden(gLegacyScene == LegacyScene::scenarioEditor);
 
             int16_t scrollListHeight = (height - 88) / 2;
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -866,12 +866,12 @@ namespace OpenRCT2::Ui::Windows
             if (gLegacyScene == LegacyScene::trackDesignsManager)
             {
                 titleWidget.setString(STR_TRACK_DESIGNS_MANAGER_SELECT_RIDE_TYPE);
-                installTrackWidget.type = WidgetType::button;
+                installTrackWidget.setVisible();
             }
             else if (gLegacyScene == LegacyScene::trackDesigner)
             {
                 titleWidget.setString(STR_ROLLER_COASTER_DESIGNER_SELECT_RIDE_TYPES_VEHICLES);
-                installTrackWidget.type = WidgetType::empty;
+                installTrackWidget.setHidden();
             }
             else
             {
@@ -884,7 +884,7 @@ namespace OpenRCT2::Ui::Windows
 
                 _windowTitle = FormatStringID(STR_OBJECT_SELECTION, stringId);
                 titleWidget.setString(_windowTitle.c_str());
-                installTrackWidget.type = WidgetType::empty;
+                installTrackWidget.setHidden();
             }
 
             // Set filter dropdown caption
@@ -917,27 +917,22 @@ namespace OpenRCT2::Ui::Windows
             for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
             {
                 auto& widget = widgets[WIDX_TAB_1 + i];
-                if (ObjectSelectionPages[i].Image != kImageIndexUndefined)
+                widget.setVisible(ObjectSelectionPages[i].Image != kImageIndexUndefined);
+                if (widget.isVisible())
                 {
-                    widget.type = WidgetType::tab;
                     widget.left = x;
                     widget.right = x + 30;
                     x += 31;
                 }
-                else
-                    widget.type = WidgetType::empty;
             }
 
-            if (Config::Get().general.debuggingTools)
-                widgets[WIDX_RELOAD_OBJECT].type = WidgetType::imgBtn;
-            else
-                widgets[WIDX_RELOAD_OBJECT].type = WidgetType::empty;
+            widgets[WIDX_RELOAD_OBJECT].setVisible(Config::Get().general.debuggingTools);
 
             if (gLegacyScene == LegacyScene::trackDesignsManager || gLegacyScene == LegacyScene::trackDesigner)
             {
                 for (size_t i = 1; i < std::size(ObjectSelectionPages); i++)
                 {
-                    widgets[WIDX_TAB_1 + i].type = WidgetType::empty;
+                    widgets[WIDX_TAB_1 + i].setHidden();
                 }
             }
 
@@ -961,18 +956,14 @@ namespace OpenRCT2::Ui::Windows
             for (int8_t i = 0; i <= 6; i++)
             {
                 widgets[WIDX_SUB_TAB_0 + i].tooltip = i < numSubTabs ? currentPage.subTabs[i].tooltip : kStringIdNone;
-                widgets[WIDX_SUB_TAB_0 + i].type = i < numSubTabs ? WidgetType::tab : WidgetType::empty;
+                widgets[WIDX_SUB_TAB_0 + i].setVisible(i < numSubTabs);
                 setWidgetPressed(WIDX_SUB_TAB_0 + i, false);
             }
 
             // Mark current sub-tab as active, and toggle tab frame
+            widgets[WIDX_FILTER_RIDE_TAB_FRAME].setVisible(hasSubTabs);
             if (hasSubTabs)
-            {
                 setWidgetPressed(WIDX_SUB_TAB_0 + _selectedSubTab, true);
-                widgets[WIDX_FILTER_RIDE_TAB_FRAME].type = WidgetType::imgBtn;
-            }
-            else
-                widgets[WIDX_FILTER_RIDE_TAB_FRAME].type = WidgetType::empty;
 
             // The ride tab has two headers for the list
             bool isRideTab = GetSelectedObjectType() == ObjectType::ride;
@@ -980,13 +971,13 @@ namespace OpenRCT2::Ui::Windows
             {
                 int32_t width_limit = (widgets[WIDX_LIST].width() - 16) / 2;
 
-                widgets[WIDX_LIST_SORT_TYPE].type = WidgetType::tableHeader;
+                widgets[WIDX_LIST_SORT_TYPE].setVisible();
                 widgets[WIDX_LIST_SORT_TYPE].top = widgets[WIDX_FILTER_TEXT_BOX].bottom + 3;
                 widgets[WIDX_LIST_SORT_TYPE].bottom = widgets[WIDX_LIST_SORT_TYPE].top + 13;
                 widgets[WIDX_LIST_SORT_TYPE].left = 4;
                 widgets[WIDX_LIST_SORT_TYPE].right = widgets[WIDX_LIST_SORT_TYPE].left + width_limit;
 
-                widgets[WIDX_LIST_SORT_RIDE].type = WidgetType::tableHeader;
+                widgets[WIDX_LIST_SORT_RIDE].setVisible();
                 widgets[WIDX_LIST_SORT_RIDE].top = widgets[WIDX_LIST_SORT_TYPE].top;
                 widgets[WIDX_LIST_SORT_RIDE].bottom = widgets[WIDX_LIST_SORT_TYPE].bottom;
                 widgets[WIDX_LIST_SORT_RIDE].left = widgets[WIDX_LIST_SORT_TYPE].right + 1;
@@ -996,8 +987,8 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_LIST_SORT_TYPE].type = WidgetType::empty;
-                widgets[WIDX_LIST_SORT_RIDE].type = WidgetType::empty;
+                widgets[WIDX_LIST_SORT_TYPE].setHidden();
+                widgets[WIDX_LIST_SORT_RIDE].setHidden();
 
                 widgets[WIDX_LIST].top = widgets[WIDX_FILTER_TEXT_BOX].bottom + 2;
             }
@@ -1035,7 +1026,7 @@ namespace OpenRCT2::Ui::Windows
                 for (auto i = 0u; i < currentPage.subTabs.size(); i++)
                 {
                     const auto& widget = widgets[WIDX_SUB_TAB_0 + i];
-                    if (widget.type == WidgetType::empty)
+                    if (widget.isHidden())
                         continue;
 
                     auto& subTabDef = currentPage.subTabs[i];

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1016,7 +1016,7 @@ namespace OpenRCT2::Ui::Windows
             for (size_t i = 0; i < std::size(ObjectSelectionPages); i++)
             {
                 const auto& widget = widgets[WIDX_TAB_1 + i];
-                if (widget.type != WidgetType::empty)
+                if (widget.isVisible())
                 {
                     auto image = ImageId(ObjectSelectionPages[i].Image);
                     auto screenPos = windowPos + ScreenCoordsXY{ widget.left, widget.top };
@@ -1084,7 +1084,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw sort button text
             const auto& listSortTypeWidget = widgets[WIDX_LIST_SORT_TYPE];
-            if (listSortTypeWidget.type != WidgetType::empty)
+            if (listSortTypeWidget.isVisible())
             {
                 auto ft = Formatter();
                 auto stringId = _listSortType == RIDE_SORT_TYPE ? static_cast<StringId>(_listSortDescending ? STR_DOWN : STR_UP)
@@ -1094,7 +1094,7 @@ namespace OpenRCT2::Ui::Windows
                 drawTextEllipsised(rt, screenPos, listSortTypeWidget.width() - 1, STR_OBJECTS_SORT_TYPE, ft, { colours[1] });
             }
             const auto& listSortRideWidget = widgets[WIDX_LIST_SORT_RIDE];
-            if (listSortRideWidget.type != WidgetType::empty)
+            if (listSortRideWidget.isVisible())
             {
                 auto ft = Formatter();
                 auto stringId = _listSortType == RIDE_SORT_RIDE ? static_cast<StringId>(_listSortDescending ? STR_DOWN : STR_UP)

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -223,9 +223,9 @@ namespace OpenRCT2::Ui::Windows
         makeWidget        ({ 98,  47}, {344,  14}, WidgetType::dropdownMenu, WindowColour::secondary, kStringIdNone,                STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP),
         makeWidget        ({430,  48}, { 11,  12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,           STR_SELECT_OBJECTIVE_FOR_THIS_SCENARIO_TIP),
         makeWidget                ({ 28,  66}, {140,  12}, WidgetType::label,        WindowColour::secondary, kStringIdEmpty                                                          ),
-        makeHoldableSpinnerWidgets({158,  65}, {120,  14}, WidgetType::button,       WindowColour::secondary                                                                          ), // NB: 3 widgets
+        makeHoldableSpinnerWidgets({158,  65}, {120,  14}, WidgetType::spinner,      WindowColour::secondary                                                                          ), // NB: 3 widgets
         makeWidget                ({ 28,  85}, {140,  12}, WidgetType::label,        WindowColour::secondary, STR_WINDOW_OBJECTIVE_DATE                                               ),
-        makeHoldableSpinnerWidgets({158,  84}, {120,  14}, WidgetType::button,       WindowColour::secondary                                                                          ), // NB: 3 widgets
+        makeHoldableSpinnerWidgets({158,  84}, {120,  14}, WidgetType::spinner,      WindowColour::secondary                                                                          ), // NB: 3 widgets
         makeWidget        ({ 14, 103}, {340,  12}, WidgetType::checkbox,     WindowColour::secondary, STR_HARD_PARK_RATING,         STR_HARD_PARK_RATING_TIP                  )
     );
 
@@ -1031,18 +1031,15 @@ namespace OpenRCT2::Ui::Windows
 
             SetPressedTab();
 
+            bool hasPrimaryObjectiveArg = false;
+            bool hasSecondaryObjectiveArg = false;
+
             switch (gameState.scenarioOptions.objective.Type)
             {
                 case Scenario::ObjectiveType::guestsBy:
                 case Scenario::ObjectiveType::parkValueBy:
-                    widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type = WidgetType::label;
-                    widgets[WIDX_OBJECTIVE_ARG_1].type = WidgetType::spinner;
-                    widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WidgetType::button;
-                    widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WidgetType::button;
-                    widgets[WIDX_OBJECTIVE_ARG_2_LABEL].type = WidgetType::label;
-                    widgets[WIDX_OBJECTIVE_ARG_2].type = WidgetType::spinner;
-                    widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WidgetType::button;
-                    widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WidgetType::button;
+                    hasPrimaryObjectiveArg = true;
+                    hasSecondaryObjectiveArg = true;
                     break;
                 case Scenario::ObjectiveType::guestsAndRating:
                 case Scenario::ObjectiveType::monthlyRideIncome:
@@ -1050,26 +1047,21 @@ namespace OpenRCT2::Ui::Windows
                 case Scenario::ObjectiveType::finishFiveRollercoasters:
                 case Scenario::ObjectiveType::repayLoanAndParkValue:
                 case Scenario::ObjectiveType::monthlyFoodIncome:
-                    widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type = WidgetType::label;
-                    widgets[WIDX_OBJECTIVE_ARG_1].type = WidgetType::spinner;
-                    widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WidgetType::button;
-                    widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WidgetType::button;
-                    widgets[WIDX_OBJECTIVE_ARG_2_LABEL].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WidgetType::empty;
+                    hasPrimaryObjectiveArg = true;
                     break;
                 default:
-                    widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_1].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2_LABEL].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WidgetType::empty;
-                    widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WidgetType::empty;
                     break;
             }
+
+            widgets[WIDX_OBJECTIVE_ARG_1_LABEL].setVisible(hasPrimaryObjectiveArg);
+            widgets[WIDX_OBJECTIVE_ARG_1].setVisible(hasPrimaryObjectiveArg);
+            widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].setVisible(hasPrimaryObjectiveArg);
+            widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].setVisible(hasPrimaryObjectiveArg);
+
+            widgets[WIDX_OBJECTIVE_ARG_2_LABEL].setVisible(hasSecondaryObjectiveArg);
+            widgets[WIDX_OBJECTIVE_ARG_2].setVisible(hasSecondaryObjectiveArg);
+            widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].setVisible(hasSecondaryObjectiveArg);
+            widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].setVisible(hasSecondaryObjectiveArg);
 
             auto arg1StringId = kStringIdEmpty;
             if (widgets[WIDX_OBJECTIVE_ARG_1_LABEL].isVisible())
@@ -1102,7 +1094,7 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_OBJECTIVE_ARG_1_LABEL].text = arg1StringId;
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].setHidden(gLegacyScene == LegacyScene::scenarioEditor);
 
             setWidgetPressed(WIDX_HARD_PARK_RATING, gameState.park.flags & PARK_FLAGS_DIFFICULT_PARK_RATING);
         }
@@ -1599,23 +1591,20 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_MAXIMUM_LOAN_INCREASE, noMoney);
             setWidgetDisabled(WIDX_MAXIMUM_LOAN_DECREASE, noMoney);
 
-            if (park.flags & PARK_FLAGS_RCT1_INTEREST)
+            const bool rct1Interest = park.flags & PARK_FLAGS_RCT1_INTEREST;
+            widgets[WIDX_RCT1_INTEREST].setVisible(rct1Interest);
+            widgets[WIDX_INTEREST_RATE_LABEL].setHidden(rct1Interest);
+            widgets[WIDX_INTEREST_RATE].setHidden(rct1Interest);
+            widgets[WIDX_INTEREST_RATE_INCREASE].setHidden(rct1Interest);
+            widgets[WIDX_INTEREST_RATE_DECREASE].setHidden(rct1Interest);
+
+            if (rct1Interest)
             {
-                widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::empty;
-                widgets[WIDX_INTEREST_RATE].type = WidgetType::empty;
-                widgets[WIDX_INTEREST_RATE_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_INTEREST_RATE_DECREASE].type = WidgetType::empty;
-                widgets[WIDX_RCT1_INTEREST].type = WidgetType::checkbox;
                 setWidgetPressed(WIDX_RCT1_INTEREST, true);
                 setWidgetDisabled(WIDX_RCT1_INTEREST, noMoney);
             }
             else
             {
-                widgets[WIDX_INTEREST_RATE_LABEL].type = WidgetType::label;
-                widgets[WIDX_INTEREST_RATE].type = WidgetType::spinner;
-                widgets[WIDX_INTEREST_RATE_INCREASE].type = WidgetType::button;
-                widgets[WIDX_INTEREST_RATE_DECREASE].type = WidgetType::button;
-                widgets[WIDX_RCT1_INTEREST].type = WidgetType::empty;
                 setWidgetDisabled(WIDX_INTEREST_RATE_LABEL, noMoney);
                 setWidgetDisabled(WIDX_INTEREST_RATE, noMoney);
                 setWidgetDisabled(WIDX_INTEREST_RATE_INCREASE, noMoney);
@@ -1632,19 +1621,14 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN, noMoney);
             setWidgetDisabled(WIDX_FORBID_MARKETING, noMoney);
 
-            if (!Park::EntranceFeeUnlocked(park))
+            const bool entranceFeeUnlocked = Park::EntranceFeeUnlocked(park);
+            widgets[WIDX_ENTRY_PRICE_LABEL].setVisible(entranceFeeUnlocked);
+            widgets[WIDX_ENTRY_PRICE].setVisible(entranceFeeUnlocked);
+            widgets[WIDX_ENTRY_PRICE_INCREASE].setVisible(entranceFeeUnlocked);
+            widgets[WIDX_ENTRY_PRICE_DECREASE].setVisible(entranceFeeUnlocked);
+
+            if (entranceFeeUnlocked)
             {
-                widgets[WIDX_ENTRY_PRICE_LABEL].type = WidgetType::empty;
-                widgets[WIDX_ENTRY_PRICE].type = WidgetType::empty;
-                widgets[WIDX_ENTRY_PRICE_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_ENTRY_PRICE_DECREASE].type = WidgetType::empty;
-            }
-            else
-            {
-                widgets[WIDX_ENTRY_PRICE_LABEL].type = WidgetType::label;
-                widgets[WIDX_ENTRY_PRICE].type = WidgetType::spinner;
-                widgets[WIDX_ENTRY_PRICE_INCREASE].type = WidgetType::button;
-                widgets[WIDX_ENTRY_PRICE_DECREASE].type = WidgetType::button;
                 setWidgetDisabled(WIDX_ENTRY_PRICE_LABEL, noMoney);
                 setWidgetDisabled(WIDX_ENTRY_PRICE, noMoney);
                 setWidgetDisabled(WIDX_ENTRY_PRICE_INCREASE, noMoney);
@@ -1653,7 +1637,7 @@ namespace OpenRCT2::Ui::Windows
 
             setWidgetPressed(WIDX_FORBID_MARKETING, park.flags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].setHidden(gLegacyScene == LegacyScene::scenarioEditor);
         }
 
         void FinancialDraw(RenderTarget& rt)
@@ -1937,7 +1921,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_CASH_PER_GUEST_INCREASE, noMoney);
             setWidgetDisabled(WIDX_CASH_PER_GUEST_DECREASE, noMoney);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].setHidden(gLegacyScene == LegacyScene::scenarioEditor);
 
             setWidgetPressed(WIDX_HARD_GUEST_GENERATION, gameState.park.flags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION);
         }
@@ -2142,7 +2126,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_FORBID_LANDSCAPE_CHANGES, gameState.park.flags & PARK_FLAGS_FORBID_LANDSCAPE_CHANGES);
             setWidgetPressed(WIDX_FORBID_HIGH_CONSTRUCTION, gameState.park.flags & PARK_FLAGS_FORBID_HIGH_CONSTRUCTION);
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].setHidden(gLegacyScene == LegacyScene::scenarioEditor);
         }
 
         void LandDraw(RenderTarget& rt)
@@ -2292,7 +2276,7 @@ namespace OpenRCT2::Ui::Windows
         {
             SetPressedTab();
 
-            widgets[WIDX_CLOSE].type = gLegacyScene == LegacyScene::scenarioEditor ? WidgetType::empty : WidgetType::closeBox;
+            widgets[WIDX_CLOSE].setHidden(gLegacyScene == LegacyScene::scenarioEditor);
         }
 
         /**

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -1072,7 +1072,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             auto arg1StringId = kStringIdEmpty;
-            if (widgets[WIDX_OBJECTIVE_ARG_1_LABEL].type != WidgetType::empty)
+            if (widgets[WIDX_OBJECTIVE_ARG_1_LABEL].isVisible())
             {
                 // Objective argument 1 label
                 switch (gameState.scenarioOptions.objective.Type)
@@ -1125,7 +1125,7 @@ namespace OpenRCT2::Ui::Windows
             ft.Add<StringId>(ObjectiveDropdownOptionNames[EnumValue(scenarioOptions.objective.Type)]);
             drawText(rt, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
 
-            if (widgets[WIDX_OBJECTIVE_ARG_1].type != WidgetType::empty)
+            if (widgets[WIDX_OBJECTIVE_ARG_1].isVisible())
             {
                 const auto wColour2 = colours[1];
                 StringId stringId = kStringIdEmpty;
@@ -1164,7 +1164,7 @@ namespace OpenRCT2::Ui::Windows
                 drawText(rt, screenCoords, stringId, ft, wColour2);
             }
 
-            if (widgets[WIDX_OBJECTIVE_ARG_2].type != WidgetType::empty)
+            if (widgets[WIDX_OBJECTIVE_ARG_2].isVisible())
             {
                 // Objective argument 2 value
                 screenCoords = windowPos
@@ -1667,7 +1667,7 @@ namespace OpenRCT2::Ui::Windows
             const auto wColour2 = colours[1];
 
             const auto& initialCashWidget = widgets[WIDX_INITIAL_CASH];
-            if (initialCashWidget.type != WidgetType::empty)
+            if (initialCashWidget.isVisible())
             {
                 screenCoords = windowPos + ScreenCoordsXY{ initialCashWidget.left + 1, initialCashWidget.top + 1 };
                 auto ft = Formatter();
@@ -1677,7 +1677,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& initialLoanWidget = widgets[WIDX_INITIAL_LOAN];
-            if (initialLoanWidget.type != WidgetType::empty)
+            if (initialLoanWidget.isVisible())
             {
                 screenCoords = windowPos + ScreenCoordsXY{ initialLoanWidget.left + 1, initialLoanWidget.top + 1 };
                 auto ft = Formatter();
@@ -1687,7 +1687,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& maximumLoanWidget = widgets[WIDX_MAXIMUM_LOAN];
-            if (maximumLoanWidget.type != WidgetType::empty)
+            if (maximumLoanWidget.isVisible())
             {
                 screenCoords = windowPos + ScreenCoordsXY{ maximumLoanWidget.left + 1, maximumLoanWidget.top + 1 };
                 auto ft = Formatter();
@@ -1697,7 +1697,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& interestRateWidget = widgets[WIDX_INTEREST_RATE];
-            if (interestRateWidget.type != WidgetType::empty)
+            if (interestRateWidget.isVisible())
             {
                 screenCoords = windowPos + ScreenCoordsXY{ interestRateWidget.left + 1, interestRateWidget.top + 1 };
 
@@ -1709,7 +1709,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& payForParkOrRidesWidget = widgets[WIDX_PAY_FOR_PARK_OR_RIDES];
-            if (payForParkOrRidesWidget.type != WidgetType::empty)
+            if (payForParkOrRidesWidget.isVisible())
             {
                 // Pay for park or rides label
                 screenCoords = windowPos + ScreenCoordsXY{ payForParkOrRidesWidget.left + 1, payForParkOrRidesWidget.top + 1 };
@@ -1729,7 +1729,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& entryPriceWidget = widgets[WIDX_ENTRY_PRICE];
-            if (entryPriceWidget.type != WidgetType::empty)
+            if (entryPriceWidget.isVisible())
             {
                 // Entry price value
                 screenCoords = windowPos + ScreenCoordsXY{ entryPriceWidget.left + 1, entryPriceWidget.top + 1 };
@@ -1953,7 +1953,7 @@ namespace OpenRCT2::Ui::Windows
             const auto wColour2 = colours[1];
 
             const auto& cashPerGuestWidget = widgets[WIDX_CASH_PER_GUEST];
-            if (cashPerGuestWidget.type != WidgetType::empty)
+            if (cashPerGuestWidget.isVisible())
             {
                 // Cash per guest value
                 screenCoords = windowPos + ScreenCoordsXY{ cashPerGuestWidget.left + 1, cashPerGuestWidget.top + 1 };
@@ -2156,7 +2156,7 @@ namespace OpenRCT2::Ui::Windows
             const auto wColour2 = colours[1];
 
             const auto& landCostWidget = widgets[WIDX_LAND_COST];
-            if (landCostWidget.type != WidgetType::empty)
+            if (landCostWidget.isVisible())
             {
                 // Cost to buy land value
                 screenCoords = windowPos + ScreenCoordsXY{ landCostWidget.left + 1, landCostWidget.top + 1 };
@@ -2167,7 +2167,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             const auto& constructionRightsCostWidget = widgets[WIDX_CONSTRUCTION_RIGHTS_COST];
-            if (constructionRightsCostWidget.type != WidgetType::empty)
+            if (constructionRightsCostWidget.isVisible())
             {
                 // Cost to buy construction rights value
                 screenCoords = windowPos

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -681,18 +681,18 @@ namespace OpenRCT2::Ui::Windows
             y += 3;
             for (int32_t i = 0; i < ADVERTISING_CAMPAIGN_COUNT; i++)
             {
-                auto campaignButton = &widgets[WIDX_CAMPAIGN_1 + i];
-                auto marketingCampaign = MarketingGetCampaign(i);
+                auto& campaignButton = widgets[WIDX_CAMPAIGN_1 + i];
+                auto* marketingCampaign = MarketingGetCampaign(i);
                 if (marketingCampaign == nullptr && MarketingIsCampaignTypeApplicable(i))
                 {
-                    campaignButton->type = WidgetType::button;
-                    campaignButton->top = y;
-                    campaignButton->bottom = y + kButtonFaceHeight + 1;
+                    campaignButton.setVisible();
+                    campaignButton.top = y;
+                    campaignButton.bottom = y + kButtonFaceHeight + 1;
                     y += kButtonFaceHeight + 2;
                 }
                 else
                 {
-                    campaignButton->type = WidgetType::empty;
+                    campaignButton.setHidden();
                 }
             }
         }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -760,7 +760,7 @@ namespace OpenRCT2::Ui::Windows
             for (int32_t i = 0; i < ADVERTISING_CAMPAIGN_COUNT; i++)
             {
                 auto campaignButton = &widgets[WIDX_CAMPAIGN_1 + i];
-                if (campaignButton->type != WidgetType::empty)
+                if (campaignButton->isVisible())
                 {
                     // Draw button text
                     screenCoords = windowPos + ScreenCoordsXY{ campaignButton->left, campaignButton->textTop() };

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -531,9 +531,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_QUEUELINE_TYPE, gFootpathSelection.isQueueSelected);
 
             // Enable / disable construct button
-            widgets[WIDX_CONSTRUCT].type = _footpathConstructionMode == PathConstructionMode::bridgeOrTunnel
-                ? WidgetType::imgBtn
-                : WidgetType::empty;
+            widgets[WIDX_CONSTRUCT].setVisible(_footpathConstructionMode == PathConstructionMode::bridgeOrTunnel);
 
 #ifndef DISABLE_NETWORK
             bool canDrag = true;
@@ -544,14 +542,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_CONSTRUCT_DRAG_AREA, !canDrag);
 #endif
 
-            if (gFootpathSelection.legacyPath == kObjectEntryIndexNull)
-            {
-                widgets[WIDX_RAILINGS_TYPE].type = WidgetType::flatBtn;
-            }
-            else
-            {
-                widgets[WIDX_RAILINGS_TYPE].type = WidgetType::empty;
-            }
+            widgets[WIDX_RAILINGS_TYPE].setVisible(gFootpathSelection.legacyPath == kObjectEntryIndexNull);
         }
 
         void onDraw(Drawing::RenderTarget& rt) override
@@ -1779,7 +1770,7 @@ namespace OpenRCT2::Ui::Windows
         void KeyboardShortcutShortcutSlopeDown()
         {
             if (isWidgetDisabled(WIDX_SLOPEDOWN) || isWidgetDisabled(WIDX_LEVEL) || isWidgetDisabled(WIDX_SLOPEUP)
-                || widgets[WIDX_LEVEL].type == WidgetType::empty)
+                || widgets[WIDX_LEVEL].isHidden())
             {
                 return;
             }
@@ -1801,7 +1792,7 @@ namespace OpenRCT2::Ui::Windows
         void KeyboardShortcutSlopeUp()
         {
             if (isWidgetDisabled(WIDX_SLOPEDOWN) || isWidgetDisabled(WIDX_LEVEL) || isWidgetDisabled(WIDX_SLOPEUP)
-                || widgets[WIDX_LEVEL].type == WidgetType::empty)
+                || widgets[WIDX_LEVEL].isHidden())
             {
                 return;
             }
@@ -1823,7 +1814,7 @@ namespace OpenRCT2::Ui::Windows
         void KeyboardShortcutSlopeLevel()
         {
             if (isWidgetDisabled(WIDX_SLOPEDOWN) || isWidgetDisabled(WIDX_LEVEL) || isWidgetDisabled(WIDX_SLOPEUP)
-                || widgets[WIDX_LEVEL].type == WidgetType::empty || _footpathConstructSlope == SlopePitch::flat)
+                || widgets[WIDX_LEVEL].isHidden() || _footpathConstructSlope == SlopePitch::flat)
             {
                 return;
             }
@@ -1833,7 +1824,7 @@ namespace OpenRCT2::Ui::Windows
 
         void KeyboardShortcutDemolishCurrent()
         {
-            if (isWidgetDisabled(WIDX_REMOVE) || widgets[WIDX_REMOVE].type == WidgetType::empty
+            if (isWidgetDisabled(WIDX_REMOVE) || widgets[WIDX_REMOVE].isHidden()
                 || (!getGameState().cheats.buildInPauseMode && GameIsPaused()))
             {
                 return;
@@ -1844,7 +1835,7 @@ namespace OpenRCT2::Ui::Windows
 
         void KeyboardShortcutBuildCurrent()
         {
-            if (isWidgetDisabled(WIDX_CONSTRUCT) || widgets[WIDX_CONSTRUCT].type == WidgetType::empty)
+            if (isWidgetDisabled(WIDX_CONSTRUCT) || widgets[WIDX_CONSTRUCT].isHidden())
             {
                 return;
             }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -63,7 +63,7 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr Widget window_game_bottom_toolbar_widgets[] =
     {
-        makeWidget({  0,  0}, {142, 34}, WidgetType::empty,       WindowColour::primary                                                     ), // Left outset panel
+        makeWidget({  0,  0}, {142, 34}, WidgetType::imgBtn,      WindowColour::primary                                                     ), // Left outset panel
         makeWidget({  2,  2}, {138, 30}, WidgetType::empty,       WindowColour::primary                                                     ), // Left inset panel
         makeWidget({  2,  1}, {138, 12}, WidgetType::hiddenButton,WindowColour::primary , 0xFFFFFFFF, STR_PROFIT_PER_WEEK_AND_PARK_VALUE_TIP), // Money window
         makeWidget({  2, 11}, {138, 12}, WidgetType::hiddenButton,WindowColour::primary                                                     ), // Guests window
@@ -75,7 +75,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({469,  5}, { 24, 24}, WidgetType::flatBtn,     WindowColour::secondary, ImageId(SPR_LOCATE), STR_LOCATE_SUBJECT_TIP      ), // Scroll to news item target
 
         makeWidget({498,  0}, {142, 34}, WidgetType::imgBtn,      WindowColour::primary                                                     ), // Right outset panel
-        makeWidget({500,  2}, {138, 30}, WidgetType::imgBtn,      WindowColour::primary                                                     ), // Right inset panel
+        makeWidget({500,  2}, {138, 30}, WidgetType::empty,       WindowColour::primary                                                     ), // Right inset panel
         makeWidget({500,  2}, {138, 12}, WidgetType::hiddenButton,WindowColour::primary                                                     ), // Date
     };
     // clang-format on

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -63,8 +63,8 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr Widget window_game_bottom_toolbar_widgets[] =
     {
-        makeWidget({  0,  0}, {142, 34}, WidgetType::imgBtn,      WindowColour::primary                                                     ), // Left outset panel
-        makeWidget({  2,  2}, {138, 30}, WidgetType::imgBtn,      WindowColour::primary                                                     ), // Left inset panel
+        makeWidget({  0,  0}, {142, 34}, WidgetType::empty,       WindowColour::primary                                                     ), // Left outset panel
+        makeWidget({  2,  2}, {138, 30}, WidgetType::empty,       WindowColour::primary                                                     ), // Left inset panel
         makeWidget({  2,  1}, {138, 12}, WidgetType::hiddenButton,WindowColour::primary , 0xFFFFFFFF, STR_PROFIT_PER_WEEK_AND_PARK_VALUE_TIP), // Money window
         makeWidget({  2, 11}, {138, 12}, WidgetType::hiddenButton,WindowColour::primary                                                     ), // Guests window
         makeWidget({  2, 21}, {138, 11}, WidgetType::hiddenButton,WindowColour::primary , 0xFFFFFFFF, STR_PARK_RATING_TIP                   ), // Park rating window
@@ -435,7 +435,7 @@ namespace OpenRCT2::Ui::Windows
 
             // Reset the middle widget to not show by default.
             // If it is required to be shown news_update will reshow it.
-            widgets[WIDX_MIDDLE_OUTSET].type = WidgetType::empty;
+            widgets[WIDX_MIDDLE_OUTSET].setHidden();
         }
 
         void onMouseUp(WidgetIndex widgetIndex) override
@@ -530,7 +530,7 @@ namespace OpenRCT2::Ui::Windows
             // Reposition left widgets in accordance with line height... depending on whether there is money in play.
             if (getGameState().park.flags & PARK_FLAGS_NO_MONEY)
             {
-                widgets[WIDX_MONEY].type = WidgetType::empty;
+                widgets[WIDX_MONEY].setHidden();
                 widgets[WIDX_GUESTS].top = 1;
                 widgets[WIDX_GUESTS].bottom = line_height + 7;
                 widgets[WIDX_PARK_RATING].top = line_height + 8;
@@ -538,7 +538,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_MONEY].type = WidgetType::hiddenButton;
+                widgets[WIDX_MONEY].setVisible();
                 widgets[WIDX_MONEY].bottom = widgets[WIDX_MONEY].top + line_height;
                 widgets[WIDX_GUESTS].top = widgets[WIDX_MONEY].bottom + 1;
                 widgets[WIDX_GUESTS].bottom = widgets[WIDX_GUESTS].top + line_height;
@@ -571,24 +571,16 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_DATE].left = widgets[WIDX_RIGHT_OUTSET].left + 2;
             widgets[WIDX_DATE].right = widgets[WIDX_RIGHT_OUTSET].right - 2;
 
-            widgets[WIDX_LEFT_INSET].type = WidgetType::empty;
-            widgets[WIDX_RIGHT_INSET].type = WidgetType::empty;
-
             if (News::IsQueueEmpty())
             {
-                if (!(ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR))
+                bool useFullToolbar = ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR;
+                widgets[WIDX_MIDDLE_OUTSET].setVisible(useFullToolbar);
+                widgets[WIDX_MIDDLE_INSET].setVisible(useFullToolbar);
+                widgets[WIDX_NEWS_SUBJECT].setHidden();
+                widgets[WIDX_NEWS_LOCATE].setHidden();
+
+                if (useFullToolbar)
                 {
-                    widgets[WIDX_MIDDLE_OUTSET].type = WidgetType::empty;
-                    widgets[WIDX_MIDDLE_INSET].type = WidgetType::empty;
-                    widgets[WIDX_NEWS_SUBJECT].type = WidgetType::empty;
-                    widgets[WIDX_NEWS_LOCATE].type = WidgetType::empty;
-                }
-                else
-                {
-                    widgets[WIDX_MIDDLE_OUTSET].type = WidgetType::imgBtn;
-                    widgets[WIDX_MIDDLE_INSET].type = WidgetType::hiddenButton;
-                    widgets[WIDX_NEWS_SUBJECT].type = WidgetType::empty;
-                    widgets[WIDX_NEWS_LOCATE].type = WidgetType::empty;
                     widgets[WIDX_MIDDLE_OUTSET].colour = 0;
                     widgets[WIDX_MIDDLE_INSET].colour = 0;
                 }
@@ -596,10 +588,10 @@ namespace OpenRCT2::Ui::Windows
             else
             {
                 News::Item* newsItem = News::GetItem(0);
-                widgets[WIDX_MIDDLE_OUTSET].type = WidgetType::imgBtn;
-                widgets[WIDX_MIDDLE_INSET].type = WidgetType::hiddenButton;
-                widgets[WIDX_NEWS_SUBJECT].type = WidgetType::flatBtn;
-                widgets[WIDX_NEWS_LOCATE].type = WidgetType::flatBtn;
+                widgets[WIDX_MIDDLE_OUTSET].setVisible();
+                widgets[WIDX_MIDDLE_INSET].setVisible();
+                widgets[WIDX_NEWS_SUBJECT].setVisible();
+                widgets[WIDX_NEWS_LOCATE].setVisible();
                 widgets[WIDX_MIDDLE_OUTSET].colour = 2;
                 widgets[WIDX_MIDDLE_INSET].colour = 2;
                 setWidgetDisabled(WIDX_NEWS_SUBJECT, false);
@@ -614,7 +606,7 @@ namespace OpenRCT2::Ui::Windows
                 if (!(newsItem->typeHasSubject()))
                 {
                     setWidgetDisabled(WIDX_NEWS_SUBJECT, true);
-                    widgets[WIDX_NEWS_SUBJECT].type = WidgetType::empty;
+                    widgets[WIDX_NEWS_SUBJECT].setHidden();
                 }
 
                 if (newsItem->hasButton())

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -170,10 +170,9 @@ namespace OpenRCT2::Ui::Windows
             _selectedTab = TabId::Summarised;
             _selectedView = GuestViewType::Thoughts;
             _numPages = 1;
-            widgets[WIDX_TRACKING].type = WidgetType::flatBtn;
-            widgets[WIDX_FILTER_BY_NAME].type = WidgetType::flatBtn;
-            widgets[WIDX_PAGE_DROPDOWN].type = WidgetType::empty;
-            widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WidgetType::empty;
+
+            widgets[WIDX_PAGE_DROPDOWN].setHidden();
+            widgets[WIDX_PAGE_DROPDOWN_BUTTON].setHidden();
 
             WindowSetResize(*this, kWindowSize, { 500, 450 });
 
@@ -311,23 +310,11 @@ namespace OpenRCT2::Ui::Windows
                 {
                     if (_selectedFilter && _selectedTab == static_cast<TabId>(widgetIndex - WIDX_TAB_1))
                         break;
+
                     _selectedTab = static_cast<TabId>(widgetIndex - WIDX_TAB_1);
                     _selectedPage = 0;
                     _numPages = 1;
-                    widgets[WIDX_TRACKING].type = WidgetType::empty;
-                    if (_selectedTab == TabId::Summarised)
-                    {
-                        widgets[WIDX_FILTER_BY_NAME].type = WidgetType::empty;
-                        setWidgetPressed(WIDX_FILTER_BY_NAME, false);
-                        _filterName.clear();
-                    }
-                    else if (_selectedTab == TabId::Individual)
-                    {
-                        widgets[WIDX_TRACKING].type = WidgetType::flatBtn;
-                        widgets[WIDX_FILTER_BY_NAME].type = WidgetType::flatBtn;
-                    }
-                    widgets[WIDX_PAGE_DROPDOWN].type = WidgetType::empty;
-                    widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WidgetType::empty;
+
                     _tabAnimationIndex = 0;
                     _selectedFilter = {};
                     invalidate();
@@ -404,9 +391,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_TAB_1 + static_cast<int32_t>(_selectedTab), true);
 
             widgets[WIDX_INFO_TYPE_DROPDOWN].text = GetViewName(_selectedView);
-            widgets[WIDX_MAP].type = WidgetType::empty;
-            if (_selectedTab == TabId::Individual && _selectedFilter)
-                widgets[WIDX_MAP].type = WidgetType::flatBtn;
+            widgets[WIDX_MAP].setVisible(_selectedTab == TabId::Individual && _selectedFilter);
 
             widgets[WIDX_GUEST_LIST].right = width - 4;
             widgets[WIDX_GUEST_LIST].bottom = height - 15;
@@ -417,17 +402,23 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_TRACKING].left = 321 - kWindowSize.width + width;
             widgets[WIDX_TRACKING].right = 344 - kWindowSize.width + width;
 
-            if (_numPages > 1)
+            widgets[WIDX_TRACKING].setVisible(_selectedTab == TabId::Individual);
+            widgets[WIDX_FILTER_BY_NAME].setVisible(_selectedTab == TabId::Individual);
+
+            if (_selectedTab == TabId::Summarised)
             {
-                widgets[WIDX_PAGE_DROPDOWN].type = WidgetType::dropdownMenu;
-                widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WidgetType::button;
+                setWidgetPressed(WIDX_FILTER_BY_NAME, false);
+                _filterName.clear();
+            }
+
+            bool haveMultiplePages = _numPages > 1;
+            widgets[WIDX_PAGE_DROPDOWN].setVisible(haveMultiplePages);
+            widgets[WIDX_PAGE_DROPDOWN_BUTTON].setVisible(haveMultiplePages);
+
+            if (haveMultiplePages)
+            {
                 _pageDropdownCaption = FormatStringID(STR_PAGE_X, static_cast<uint16_t>(_selectedPage + 1));
                 widgets[WIDX_PAGE_DROPDOWN].setString(_pageDropdownCaption.c_str());
-            }
-            else
-            {
-                widgets[WIDX_PAGE_DROPDOWN].type = WidgetType::empty;
-                widgets[WIDX_PAGE_DROPDOWN_BUTTON].type = WidgetType::empty;
             }
         }
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -63,16 +63,16 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr auto window_land_rights_widgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
-        makeWidget     ({ 27, 17}, { 44, 32}, WidgetType::imgBtn, WindowColour::primary, ImageId(SPR_LAND_TOOL_SIZE_0)                                                   ), // preview box
-        makeRemapWidget({ 28, 18}, { 16, 16}, WidgetType::trnBtn, WindowColour::primary, SPR_LAND_TOOL_DECREASE,          STR_ADJUST_SMALLER_LAND_RIGHTS_TIP             ), // decrement size
-        makeRemapWidget({ 54, 32}, { 16, 16}, WidgetType::trnBtn, WindowColour::primary, SPR_LAND_TOOL_INCREASE,          STR_ADJUST_LARGER_LAND_RIGHTS_TIP              ), // increment size
-        makeRemapWidget({ 22, 53}, { 24, 24}, WidgetType::imgBtn, WindowColour::primary, SPR_BUY_LAND_RIGHTS,             STR_BUY_LAND_RIGHTS_TIP                        ), // land rights
-        makeRemapWidget({ 52, 53}, { 24, 24}, WidgetType::imgBtn, WindowColour::primary, SPR_BUY_CONSTRUCTION_RIGHTS,     STR_BUY_CONSTRUCTION_RIGHTS_TIP                ), // construction rights
-        makeWidget     ({100, 22}, {170, 12}, WidgetType::empty,  WindowColour::primary, STR_LAND_OWNED,                  STR_SET_LAND_TO_BE_OWNED_TIP                   ),
-        makeWidget     ({100, 38}, {170, 12}, WidgetType::empty,  WindowColour::primary, STR_LAND_SALE,                   STR_SET_LAND_TO_BE_AVAILABLE_TIP               ),
-        makeWidget     ({100, 54}, {170, 12}, WidgetType::empty,  WindowColour::primary, STR_CONSTRUCTION_RIGHTS_OWNED,   STR_SET_CONSTRUCTION_RIGHTS_TO_BE_OWNED_TIP    ),
-        makeWidget     ({100, 70}, {170, 12}, WidgetType::empty,  WindowColour::primary, STR_CONSTRUCTION_RIGHTS_SALE,    STR_SET_CONSTRUCTION_RIGHTS_TO_BE_AVAILABLE_TIP),
-        makeWidget     ({100, 86}, {170, 12}, WidgetType::empty,  WindowColour::primary, STR_LAND_NOT_OWNED,              STR_SET_LAND_TO_BE_NOT_OWNED_TIP               )
+        makeWidget     ({ 27, 17}, { 44, 32}, WidgetType::imgBtn,   WindowColour::primary, ImageId(SPR_LAND_TOOL_SIZE_0)                                                   ), // preview box
+        makeRemapWidget({ 28, 18}, { 16, 16}, WidgetType::trnBtn,   WindowColour::primary, SPR_LAND_TOOL_DECREASE,          STR_ADJUST_SMALLER_LAND_RIGHTS_TIP             ), // decrement size
+        makeRemapWidget({ 54, 32}, { 16, 16}, WidgetType::trnBtn,   WindowColour::primary, SPR_LAND_TOOL_INCREASE,          STR_ADJUST_LARGER_LAND_RIGHTS_TIP              ), // increment size
+        makeRemapWidget({ 22, 53}, { 24, 24}, WidgetType::imgBtn,   WindowColour::primary, SPR_BUY_LAND_RIGHTS,             STR_BUY_LAND_RIGHTS_TIP                        ), // land rights
+        makeRemapWidget({ 52, 53}, { 24, 24}, WidgetType::imgBtn,   WindowColour::primary, SPR_BUY_CONSTRUCTION_RIGHTS,     STR_BUY_CONSTRUCTION_RIGHTS_TIP                ), // construction rights
+        makeWidget     ({100, 22}, {170, 12}, WidgetType::checkbox, WindowColour::primary, STR_LAND_OWNED,                  STR_SET_LAND_TO_BE_OWNED_TIP                   ),
+        makeWidget     ({100, 38}, {170, 12}, WidgetType::checkbox, WindowColour::primary, STR_LAND_SALE,                   STR_SET_LAND_TO_BE_AVAILABLE_TIP               ),
+        makeWidget     ({100, 54}, {170, 12}, WidgetType::checkbox, WindowColour::primary, STR_CONSTRUCTION_RIGHTS_OWNED,   STR_SET_CONSTRUCTION_RIGHTS_TO_BE_OWNED_TIP    ),
+        makeWidget     ({100, 70}, {170, 12}, WidgetType::checkbox, WindowColour::primary, STR_CONSTRUCTION_RIGHTS_SALE,    STR_SET_CONSTRUCTION_RIGHTS_TO_BE_AVAILABLE_TIP),
+        makeWidget     ({100, 86}, {170, 12}, WidgetType::checkbox, WindowColour::primary, STR_LAND_NOT_OWNED,              STR_SET_LAND_TO_BE_NOT_OWNED_TIP               )
     );
     // clang-format on
 
@@ -323,15 +323,15 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_INCREMENT].bottom = widgets[WIDX_INCREMENT].top + 16;
 
             // Show in-game mode widgets
-            widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::imgBtn;
-            widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].type = WidgetType::imgBtn;
+            widgets[WIDX_BUY_LAND_RIGHTS].setVisible();
+            widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].setVisible();
 
             // Hide editor/sandbox mode widgets
-            widgets[WIDX_UNOWNED_LAND_CHECKBOX].type = WidgetType::empty;
-            widgets[WIDX_LAND_OWNED_CHECKBOX].type = WidgetType::empty;
-            widgets[WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX].type = WidgetType::empty;
-            widgets[WIDX_LAND_SALE_CHECKBOX].type = WidgetType::empty;
-            widgets[WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX].type = WidgetType::empty;
+            widgets[WIDX_UNOWNED_LAND_CHECKBOX].setHidden();
+            widgets[WIDX_LAND_OWNED_CHECKBOX].setHidden();
+            widgets[WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX].setHidden();
+            widgets[WIDX_LAND_SALE_CHECKBOX].setHidden();
+            widgets[WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX].setHidden();
         }
 
         void PrepareDrawSandbox()
@@ -346,15 +346,15 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_INCREMENT].bottom = widgets[WIDX_INCREMENT].top + 16;
 
             // Hide in-game mode widgets
-            widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::empty;
-            widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].type = WidgetType::empty;
+            widgets[WIDX_BUY_LAND_RIGHTS].setHidden();
+            widgets[WIDX_BUY_CONSTRUCTION_RIGHTS].setHidden();
 
             // Show editor/sandbox mode widgets
-            widgets[WIDX_UNOWNED_LAND_CHECKBOX].type = WidgetType::checkbox;
-            widgets[WIDX_LAND_OWNED_CHECKBOX].type = WidgetType::checkbox;
-            widgets[WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX].type = WidgetType::checkbox;
-            widgets[WIDX_LAND_SALE_CHECKBOX].type = WidgetType::checkbox;
-            widgets[WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX].type = WidgetType::checkbox;
+            widgets[WIDX_UNOWNED_LAND_CHECKBOX].setVisible();
+            widgets[WIDX_LAND_OWNED_CHECKBOX].setVisible();
+            widgets[WIDX_CONSTRUCTION_RIGHTS_OWNED_CHECKBOX].setVisible();
+            widgets[WIDX_LAND_SALE_CHECKBOX].setVisible();
+            widgets[WIDX_CONSTRUCTION_RIGHTS_SALE_CHECKBOX].setVisible();
         }
 
         ScreenSize GetModeDimensions() const

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -419,7 +419,7 @@ namespace OpenRCT2::Ui::Windows
                 auto ft = Formatter();
                 ft.Add<money64>(_landRightsCost);
 
-                auto offset = widgets[WIDX_BUY_LAND_RIGHTS].type != WidgetType::empty ? 32 : 8;
+                auto offset = widgets[WIDX_BUY_LAND_RIGHTS].isVisible() ? 32 : 8;
 
                 screenCoords = { widgets[WIDX_PREVIEW].midX() + windowPos.x,
                                  widgets[WIDX_PREVIEW].bottom + windowPos.y + offset };

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -544,11 +544,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgets(window_loadsave_widgets);
 
             const auto& uiContext = GetContext()->GetUiContext();
-            if (!uiContext.HasFilePicker())
-            {
-                setWidgetDisabled(WIDX_SYSTEM_BROWSER, true);
-                widgets[WIDX_SYSTEM_BROWSER].type = WidgetType::empty;
-            }
+            widgets[WIDX_SYSTEM_BROWSER].setVisible(uiContext.HasFilePicker());
 
             const bool isSave = action == LoadSaveAction::save;
 
@@ -559,22 +555,18 @@ namespace OpenRCT2::Ui::Windows
                 Audio::StopAll();
             }
 
+            widgets[WIDX_FILENAME_TEXTBOX].setVisible(isSave);
+            widgets[WIDX_SAVE].setVisible(isSave);
+
             if (isSave)
             {
-                widgets[WIDX_FILENAME_TEXTBOX].type = WidgetType::textBox;
                 widgets[WIDX_FILENAME_TEXTBOX].string = _currentFilename;
-                widgets[WIDX_SAVE].type = WidgetType::button;
 
                 // Set current filename
                 String::set(_currentFilename, sizeof(_currentFilename), _defaultPath.c_str());
 
                 // Focus textbox
                 WindowStartTextbox(*this, WIDX_FILENAME_TEXTBOX, _currentFilename, sizeof(_currentFilename));
-            }
-            else
-            {
-                widgets[WIDX_FILENAME_TEXTBOX].type = WidgetType::empty;
-                widgets[WIDX_SAVE].type = WidgetType::empty;
             }
 
             // Populate file list
@@ -655,7 +647,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 // Date column on the right
                 Widget& dateWidget = widgets[WIDX_SORT_DATE];
-                dateWidget.type = WidgetType::tableHeader;
+                dateWidget.setVisible();
                 dateWidget.right = customiseWidget.left - 1;
                 dateWidget.left = dateWidget.right - (maxDateWidth + maxTimeWidth + (4 * kDateTimeGap) + (kScrollBarWidth + 1));
 
@@ -663,7 +655,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // File size column in the middle
                     Widget& sizeWidget = widgets[WIDX_SORT_SIZE];
-                    sizeWidget.type = WidgetType::tableHeader;
+                    sizeWidget.setVisible();
                     sizeWidget.right = dateWidget.left - 1;
                     sizeWidget.left = sizeWidget.right - 65;
 
@@ -674,7 +666,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     // Hide file size header
                     Widget& sizeWidget = widgets[WIDX_SORT_SIZE];
-                    sizeWidget.type = WidgetType::empty;
+                    sizeWidget.setHidden();
 
                     // Name column is next to date column
                     widgets[WIDX_SORT_NAME].right = dateWidget.left - 1;
@@ -684,11 +676,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 // Hide date header
                 Widget& dateWidget = widgets[WIDX_SORT_DATE];
-                dateWidget.type = WidgetType::empty;
+                dateWidget.setHidden();
 
                 // File size column on the right
                 Widget& sizeWidget = widgets[WIDX_SORT_SIZE];
-                sizeWidget.type = WidgetType::tableHeader;
+                sizeWidget.setVisible();
                 sizeWidget.right = customiseWidget.left - 1;
                 sizeWidget.left = sizeWidget.right - 65;
 
@@ -701,8 +693,8 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_SORT_NAME].right = customiseWidget.left - 1;
 
                 // Hide other columns
-                widgets[WIDX_SORT_SIZE].type = WidgetType::empty;
-                widgets[WIDX_SORT_DATE].type = WidgetType::empty;
+                widgets[WIDX_SORT_SIZE].setHidden();
+                widgets[WIDX_SORT_DATE].setHidden();
             }
 
             if (action == LoadSaveAction::save)
@@ -713,7 +705,7 @@ namespace OpenRCT2::Ui::Windows
                 auto saveLabel = LanguageGetString(STR_FILEBROWSER_SAVE_BUTTON);
                 auto saveLabelWidth = getStringWidth(saveLabel, FontStyle::medium) + 12;
 
-                widgets[WIDX_SAVE].type = WidgetType::button;
+                widgets[WIDX_SAVE].setVisible();
                 widgets[WIDX_SAVE].top = height - paddingBottom - 15;
                 widgets[WIDX_SAVE].bottom = height - paddingBottom - 3;
                 widgets[WIDX_SAVE].right = widgets[WIDX_SCROLL].right;
@@ -723,7 +715,7 @@ namespace OpenRCT2::Ui::Windows
                 auto filenameLabel = LanguageGetString(STR_FILENAME_LABEL);
                 auto filenameLabelWidth = getStringWidth(filenameLabel, FontStyle::medium);
 
-                widgets[WIDX_FILENAME_TEXTBOX].type = WidgetType::textBox;
+                widgets[WIDX_FILENAME_TEXTBOX].setVisible();
                 widgets[WIDX_FILENAME_TEXTBOX].top = height - paddingBottom - 15;
                 widgets[WIDX_FILENAME_TEXTBOX].bottom = height - paddingBottom - 3;
                 widgets[WIDX_FILENAME_TEXTBOX].left = 4 + filenameLabelWidth + 6;
@@ -731,8 +723,8 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_SAVE].type = WidgetType::empty;
-                widgets[WIDX_FILENAME_TEXTBOX].type = WidgetType::empty;
+                widgets[WIDX_SAVE].setHidden();
+                widgets[WIDX_FILENAME_TEXTBOX].setHidden();
             }
         }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -652,7 +652,7 @@ namespace OpenRCT2::Ui::Windows
             // Disable all scenario editor related widgets
             for (int32_t i = WIDX_MAP_SIZE_SPINNER_Y; i <= WIDX_MAP_GENERATOR; i++)
             {
-                widgets[i].type = WidgetType::empty;
+                widgets[i].setHidden();
             }
 
             if (isEditorOrSandbox())
@@ -1102,21 +1102,21 @@ namespace OpenRCT2::Ui::Windows
 
         void ShowDefaultScenarioEditorButtons()
         {
-            widgets[WIDX_SET_LAND_RIGHTS].type = WidgetType::flatBtn;
-            widgets[WIDX_BUILD_PARK_ENTRANCE].type = WidgetType::flatBtn;
-            widgets[WIDX_PEOPLE_STARTING_POSITION].type = WidgetType::flatBtn;
+            widgets[WIDX_SET_LAND_RIGHTS].setVisible();
+            widgets[WIDX_BUILD_PARK_ENTRANCE].setVisible();
+            widgets[WIDX_PEOPLE_STARTING_POSITION].setVisible();
 
             // only show this in the scenario editor, even when in sandbox mode.
             if (gLegacyScene == LegacyScene::scenarioEditor)
-                widgets[WIDX_MAP_GENERATOR].type = WidgetType::flatBtn;
+                widgets[WIDX_MAP_GENERATOR].setVisible();
 
-            widgets[WIDX_MAP_SIZE_SPINNER_Y].type = WidgetType::spinner;
-            widgets[WIDX_MAP_SIZE_SPINNER_Y_UP].type = WidgetType::button;
-            widgets[WIDX_MAP_SIZE_SPINNER_Y_DOWN].type = WidgetType::button;
-            widgets[WIDX_MAP_SIZE_LINK].type = WidgetType::flatBtn;
-            widgets[WIDX_MAP_SIZE_SPINNER_X].type = WidgetType::spinner;
-            widgets[WIDX_MAP_SIZE_SPINNER_X_UP].type = WidgetType::button;
-            widgets[WIDX_MAP_SIZE_SPINNER_X_DOWN].type = WidgetType::button;
+            widgets[WIDX_MAP_SIZE_SPINNER_Y].setVisible();
+            widgets[WIDX_MAP_SIZE_SPINNER_Y_UP].setVisible();
+            widgets[WIDX_MAP_SIZE_SPINNER_Y_DOWN].setVisible();
+            widgets[WIDX_MAP_SIZE_LINK].setVisible();
+            widgets[WIDX_MAP_SIZE_SPINNER_X].setVisible();
+            widgets[WIDX_MAP_SIZE_SPINNER_X_UP].setVisible();
+            widgets[WIDX_MAP_SIZE_SPINNER_X_DOWN].setVisible();
 
             // Push width (Y) and height (X) to the common formatter arguments for the map size spinners to use
             auto& gameState = getGameState();

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -512,28 +512,24 @@ namespace OpenRCT2::Ui::Windows
 
         void ToggleSimplexWidgets(bool state)
         {
-            // clang-format off
-            widgets[WIDX_SIMPLEX_GROUP].type          = state ? WidgetType::groupbox : WidgetType::empty;
-            widgets[WIDX_SIMPLEX_BASE_FREQ].type      = state ? WidgetType::spinner  : WidgetType::empty;
-            widgets[WIDX_SIMPLEX_BASE_FREQ_UP].type   = state ? WidgetType::button   : WidgetType::empty;
-            widgets[WIDX_SIMPLEX_BASE_FREQ_DOWN].type = state ? WidgetType::button   : WidgetType::empty;
-            widgets[WIDX_SIMPLEX_OCTAVES].type        = state ? WidgetType::spinner  : WidgetType::empty;
-            widgets[WIDX_SIMPLEX_OCTAVES_UP].type     = state ? WidgetType::button   : WidgetType::empty;
-            widgets[WIDX_SIMPLEX_OCTAVES_DOWN].type   = state ? WidgetType::button   : WidgetType::empty;
-            // clang-format on
+            widgets[WIDX_SIMPLEX_GROUP].setVisible(state);
+            widgets[WIDX_SIMPLEX_BASE_FREQ].setVisible(state);
+            widgets[WIDX_SIMPLEX_BASE_FREQ_UP].setVisible(state);
+            widgets[WIDX_SIMPLEX_BASE_FREQ_DOWN].setVisible(state);
+            widgets[WIDX_SIMPLEX_OCTAVES].setVisible(state);
+            widgets[WIDX_SIMPLEX_OCTAVES_UP].setVisible(state);
+            widgets[WIDX_SIMPLEX_OCTAVES_DOWN].setVisible(state);
         }
 
         void ToggleHeightmapWidgets(bool state)
         {
-            // clang-format off
-            widgets[WIDX_HEIGHTMAP_GROUP].type            = state ? WidgetType::groupbox : WidgetType::empty;
-            widgets[WIDX_HEIGHTMAP_BROWSE].type           = state ? WidgetType::button   : WidgetType::empty;
-            widgets[WIDX_HEIGHTMAP_NORMALIZE].type        = state ? WidgetType::checkbox : WidgetType::empty;
-            widgets[WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP].type = state ? WidgetType::checkbox : WidgetType::empty;
-            widgets[WIDX_HEIGHTMAP_STRENGTH].type         = state ? WidgetType::spinner  : WidgetType::empty;
-            widgets[WIDX_HEIGHTMAP_STRENGTH_UP].type      = state ? WidgetType::button   : WidgetType::empty;
-            widgets[WIDX_HEIGHTMAP_STRENGTH_DOWN].type    = state ? WidgetType::button   : WidgetType::empty;
-            // clang-format on
+            widgets[WIDX_HEIGHTMAP_GROUP].setVisible(state);
+            widgets[WIDX_HEIGHTMAP_BROWSE].setVisible(state);
+            widgets[WIDX_HEIGHTMAP_NORMALIZE].setVisible(state);
+            widgets[WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP].setVisible(state);
+            widgets[WIDX_HEIGHTMAP_STRENGTH].setVisible(state);
+            widgets[WIDX_HEIGHTMAP_STRENGTH_UP].setVisible(state);
+            widgets[WIDX_HEIGHTMAP_STRENGTH_DOWN].setVisible(state);
         }
 
         void BaseDraw(RenderTarget& rt)

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -676,10 +676,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     WindowAlignTabs(this, WIDX_TAB1, WIDX_TAB4);
 
-                    if (Network::GetMode() == Network::Mode::client)
-                    {
-                        widgets[WIDX_KNOWN_KEYS_ONLY_CHECKBOX].type = WidgetType::empty;
-                    }
+                    widgets[WIDX_KNOWN_KEYS_ONLY_CHECKBOX].setHidden(Network::GetMode() == Network::Mode::client);
 
                     setCheckboxValue(WIDX_LOG_CHAT_CHECKBOX, Config::Get().network.logChat);
                     setCheckboxValue(WIDX_LOG_SERVER_ACTIONS_CHECKBOX, Config::Get().network.logServerActions);

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -310,17 +310,17 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            widgets[WIDX_RIDE_LABEL].type = WidgetType::empty;
-            widgets[WIDX_RIDE_DROPDOWN].type = WidgetType::empty;
-            widgets[WIDX_RIDE_DROPDOWN_BUTTON].type = WidgetType::empty;
+            widgets[WIDX_RIDE_LABEL].setHidden();
+            widgets[WIDX_RIDE_DROPDOWN].setHidden();
+            widgets[WIDX_RIDE_DROPDOWN_BUTTON].setHidden();
             widgets[WIDX_RIDE_DROPDOWN].text = STR_MARKETING_NOT_SELECTED;
             switch (Campaign.campaign_type)
             {
                 case ADVERTISING_CAMPAIGN_RIDE_FREE:
                 case ADVERTISING_CAMPAIGN_RIDE:
-                    widgets[WIDX_RIDE_LABEL].type = WidgetType::label;
-                    widgets[WIDX_RIDE_DROPDOWN].type = WidgetType::dropdownMenu;
-                    widgets[WIDX_RIDE_DROPDOWN_BUTTON].type = WidgetType::button;
+                    widgets[WIDX_RIDE_LABEL].setVisible();
+                    widgets[WIDX_RIDE_DROPDOWN].setVisible();
+                    widgets[WIDX_RIDE_DROPDOWN_BUTTON].setVisible();
                     widgets[WIDX_RIDE_LABEL].text = STR_MARKETING_RIDE;
                     if (Campaign.RideId != RideId::GetNull())
                     {
@@ -333,9 +333,9 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case ADVERTISING_CAMPAIGN_FOOD_OR_DRINK_FREE:
-                    widgets[WIDX_RIDE_LABEL].type = WidgetType::label;
-                    widgets[WIDX_RIDE_DROPDOWN].type = WidgetType::dropdownMenu;
-                    widgets[WIDX_RIDE_DROPDOWN_BUTTON].type = WidgetType::button;
+                    widgets[WIDX_RIDE_LABEL].setVisible();
+                    widgets[WIDX_RIDE_DROPDOWN].setVisible();
+                    widgets[WIDX_RIDE_DROPDOWN_BUTTON].setVisible();
                     widgets[WIDX_RIDE_LABEL].text = STR_MARKETING_ITEM;
                     if (Campaign.ShopItemId != kSelectedItemUndefined)
                     {
@@ -348,9 +348,8 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_WEEKS_SPINNER].text = kStringIdNone;
 
             // Enable / disable start button based on ride dropdown
-            widgetSetDisabled(*this, WIDX_START_BUTTON, false);
-            if (widgets[WIDX_RIDE_DROPDOWN].type == WidgetType::dropdownMenu && Campaign.RideId == RideId::GetNull())
-                widgetSetDisabled(*this, WIDX_START_BUTTON, true);
+            const bool pendingRideSelection = widgets[WIDX_RIDE_DROPDOWN].isVisible() && Campaign.RideId == RideId::GetNull();
+            widgetSetDisabled(*this, WIDX_START_BUTTON, pendingRideSelection);
         }
 
         void onDraw(Drawing::RenderTarget& rt) override

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -1024,7 +1024,7 @@ namespace OpenRCT2::Ui::Windows
         {
             WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(tab);
 
-            if (widgets[widgetIndex].type != WidgetType::empty && !widgetIsDisabled(*this, widgetIndex))
+            if (widgets[widgetIndex].isVisible() && !widgetIsDisabled(*this, widgetIndex))
             {
                 int32_t frame = 0;
                 if (_currentTab == tab)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -414,11 +414,9 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_GROUP_BY_TRACK_TYPE, !Config::Get().interface.listRideVehiclesSeparately);
 
             widgets[WIDX_TITLE].text = RideTitles[_currentTab];
-            widgets[WIDX_TAB_7].type = WidgetType::tab;
             widgets[WIDX_FILTER_TEXT_BOX].string = _filter.data();
 
-            if (gLegacyScene == LegacyScene::trackDesigner)
-                widgets[WIDX_TAB_7].type = WidgetType::empty;
+            widgets[WIDX_TAB_7].setHidden(gLegacyScene == LegacyScene::trackDesigner);
 
             if (_currentTab == RESEARCH_TAB)
             {
@@ -822,45 +820,22 @@ namespace OpenRCT2::Ui::Windows
         {
             setWidgetDisabled(WIDX_GROUP_BY_TRACK_TYPE, _currentTab >= SHOP_TAB);
 
+            const bool isResearchTab = _currentTab == RESEARCH_TAB;
+            const bool moneyEnabled = !(getGameState().park.flags & PARK_FLAGS_NO_MONEY);
+
             // Show or hide unrelated widgets
+            widgets[WIDX_GROUP_BY_TRACK_TYPE].setHidden(isResearchTab);
+            widgets[WIDX_RIDE_LIST].setHidden(isResearchTab);
+            widgets[WIDX_FILTER_TEXT_BOX].setHidden(isResearchTab);
+            widgets[WIDX_FILTER_CLEAR_BUTTON].setHidden(isResearchTab);
 
-            if (_currentTab < RESEARCH_TAB)
-            {
-                widgets[WIDX_GROUP_BY_TRACK_TYPE].type = WidgetType::checkbox;
-            }
-            else
-            {
-                widgets[WIDX_GROUP_BY_TRACK_TYPE].type = WidgetType::empty;
-            }
+            widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP].setVisible(isResearchTab);
+            widgets[WIDX_LAST_DEVELOPMENT_GROUP].setVisible(isResearchTab);
+            widgets[WIDX_LAST_DEVELOPMENT_BUTTON].setVisible(isResearchTab);
+            widgets[WIDX_RESEARCH_FUNDING_BUTTON].setVisible(isResearchTab && moneyEnabled);
 
-            ScreenSize newMinSize{}, newMaxSize{};
-            if (_currentTab != RESEARCH_TAB)
-            {
-                widgets[WIDX_RIDE_LIST].type = WidgetType::scroll;
-                widgets[WIDX_FILTER_TEXT_BOX].type = WidgetType::textBox;
-                widgets[WIDX_FILTER_CLEAR_BUTTON].type = WidgetType::button;
-                widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP].type = WidgetType::empty;
-                widgets[WIDX_LAST_DEVELOPMENT_GROUP].type = WidgetType::empty;
-                widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_RESEARCH_FUNDING_BUTTON].type = WidgetType::empty;
-
-                newMinSize = kWindowSize;
-                newMaxSize = kWindowMaxSize;
-            }
-            else
-            {
-                widgets[WIDX_RIDE_LIST].type = WidgetType::empty;
-                widgets[WIDX_FILTER_TEXT_BOX].type = WidgetType::empty;
-                widgets[WIDX_FILTER_CLEAR_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP].type = WidgetType::groupbox;
-                widgets[WIDX_LAST_DEVELOPMENT_GROUP].type = WidgetType::groupbox;
-                widgets[WIDX_LAST_DEVELOPMENT_BUTTON].type = WidgetType::flatBtn;
-                if (!(getGameState().park.flags & PARK_FLAGS_NO_MONEY))
-                    widgets[WIDX_RESEARCH_FUNDING_BUTTON].type = WidgetType::flatBtn;
-
-                newMinSize = { 300, kWindowHeightResearch };
-                newMaxSize = newMinSize;
-            }
+            auto newMinSize = !isResearchTab ? kWindowSize : ScreenSize{ 300, kWindowHeightResearch };
+            auto newMaxSize = !isResearchTab ? kWindowMaxSize : newMinSize;
 
             // Handle new window size
             if (width != newMinSize.width || height != newMinSize.height)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -757,10 +757,7 @@ namespace OpenRCT2::Ui::Windows
             const bool advancedTabSelected = (WIDX_FIRST_TAB + page) == WIDX_TAB_ADVANCED;
             const bool disableAlwaysNative = !hasFilePicker && advancedTabSelected;
             setWidgetDisabled(WIDX_ALWAYS_NATIVE_LOADSAVE, disableAlwaysNative);
-            if (disableAlwaysNative)
-            {
-                widgets[WIDX_ALWAYS_NATIVE_LOADSAVE].type = WidgetType::empty;
-            }
+            widgets[WIDX_ALWAYS_NATIVE_LOADSAVE].setHidden(disableAlwaysNative);
         }
 
         void CommonPrepareDrawAfter()
@@ -2155,9 +2152,9 @@ namespace OpenRCT2::Ui::Windows
         {
             if (!Config::Get().general.rct1Path.empty())
             {
-                widgets[WIDX_PATH_TO_RCT1_PATH].type = WidgetType::label;
-                widgets[WIDX_PATH_TO_RCT1_BROWSE].type = WidgetType::empty;
-                widgets[WIDX_PATH_TO_RCT1_CLEAR].type = WidgetType::button;
+                widgets[WIDX_PATH_TO_RCT1_PATH].setVisible();
+                widgets[WIDX_PATH_TO_RCT1_BROWSE].setHidden();
+                widgets[WIDX_PATH_TO_RCT1_CLEAR].setVisible();
 
                 // Get 'Clear' button string width
                 auto clearLabel = LanguageGetString(STR_CLEAR_BUTTON);
@@ -2168,9 +2165,9 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_PATH_TO_RCT1_PATH].type = WidgetType::empty;
-                widgets[WIDX_PATH_TO_RCT1_BROWSE].type = WidgetType::button;
-                widgets[WIDX_PATH_TO_RCT1_CLEAR].type = WidgetType::empty;
+                widgets[WIDX_PATH_TO_RCT1_PATH].setHidden();
+                widgets[WIDX_PATH_TO_RCT1_BROWSE].setVisible();
+                widgets[WIDX_PATH_TO_RCT1_CLEAR].setHidden();
 
                 // Get 'Browse' button string width
                 auto browseLabel = LanguageGetString(STR_BROWSE);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -519,10 +519,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetDisabled(WIDX_OPEN_LIGHT, disableOpenClose);
 
             // only allow purchase of land when there is money
-            if (_parkData.flags & PARK_FLAGS_NO_MONEY)
-                widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::empty;
-            else
-                widgets[WIDX_BUY_LAND_RIGHTS].type = WidgetType::flatBtn;
+            widgets[WIDX_BUY_LAND_RIGHTS].setHidden(_parkData.flags & PARK_FLAGS_NO_MONEY);
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
 
@@ -536,24 +533,20 @@ namespace OpenRCT2::Ui::Windows
             auto y = 0;
             if (ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_PARK)
             {
-                widgets[WIDX_OPEN_OR_CLOSE].type = WidgetType::empty;
-                if (gameState.scenarioOptions.objective.Type == Scenario::ObjectiveType::guestsAndRating)
-                {
-                    widgets[WIDX_CLOSE_LIGHT].type = WidgetType::flatBtn;
-                    widgets[WIDX_OPEN_LIGHT].type = WidgetType::flatBtn;
-                }
-                else
-                {
-                    widgets[WIDX_CLOSE_LIGHT].type = WidgetType::imgBtn;
-                    widgets[WIDX_OPEN_LIGHT].type = WidgetType::imgBtn;
-                }
+                widgets[WIDX_OPEN_OR_CLOSE].setHidden();
+                widgets[WIDX_CLOSE_LIGHT].setVisible();
+                widgets[WIDX_OPEN_LIGHT].setVisible();
                 y = widgets[WIDX_OPEN_LIGHT].bottom + 5;
+
+                const bool forcedOpen = gameState.scenarioOptions.objective.Type == Scenario::ObjectiveType::guestsAndRating;
+                widgets[WIDX_CLOSE_LIGHT].type = forcedOpen ? WidgetType::flatBtn : WidgetType::imgBtn;
+                widgets[WIDX_OPEN_LIGHT].type = forcedOpen ? WidgetType::flatBtn : WidgetType::imgBtn;
             }
             else
             {
-                widgets[WIDX_OPEN_OR_CLOSE].type = WidgetType::flatBtn;
-                widgets[WIDX_CLOSE_LIGHT].type = WidgetType::empty;
-                widgets[WIDX_OPEN_LIGHT].type = WidgetType::empty;
+                widgets[WIDX_OPEN_OR_CLOSE].setVisible();
+                widgets[WIDX_CLOSE_LIGHT].setHidden();
+                widgets[WIDX_OPEN_LIGHT].setHidden();
                 y = widgets[WIDX_PAGE_BACKGROUND].top + 6;
             }
 
@@ -564,7 +557,7 @@ namespace OpenRCT2::Ui::Windows
             }
             for (int32_t i = WIDX_OPEN_OR_CLOSE; i <= WIDX_RENAME; i++)
             {
-                if (widgets[i].type == WidgetType::empty)
+                if (widgets[i].isHidden())
                     continue;
 
                 widgets[i].left = width - 25;
@@ -860,14 +853,14 @@ namespace OpenRCT2::Ui::Windows
             if ((park.flags & PARK_FLAGS_NO_MONEY) || !Park::EntranceFeeUnlocked(park))
             {
                 widgets[WIDX_PRICE].type = WidgetType::labelCentred;
-                widgets[WIDX_INCREASE_PRICE].type = WidgetType::empty;
-                widgets[WIDX_DECREASE_PRICE].type = WidgetType::empty;
+                widgets[WIDX_INCREASE_PRICE].setHidden();
+                widgets[WIDX_DECREASE_PRICE].setHidden();
             }
             else
             {
                 widgets[WIDX_PRICE].type = WidgetType::spinner;
-                widgets[WIDX_INCREASE_PRICE].type = WidgetType::button;
-                widgets[WIDX_DECREASE_PRICE].type = WidgetType::button;
+                widgets[WIDX_INCREASE_PRICE].setVisible();
+                widgets[WIDX_DECREASE_PRICE].setVisible();
             }
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
@@ -1050,12 +1043,12 @@ namespace OpenRCT2::Ui::Windows
             // Show name input button on scenario completion.
             if (getGameState().park.flags & PARK_FLAGS_SCENARIO_COMPLETE_NAME_INPUT)
             {
-                widgets[WIDX_ENTER_NAME].type = WidgetType::button;
+                widgets[WIDX_ENTER_NAME].setVisible();
                 widgets[WIDX_ENTER_NAME].top = height - 19;
                 widgets[WIDX_ENTER_NAME].bottom = height - 6;
             }
             else
-                widgets[WIDX_ENTER_NAME].type = WidgetType::empty;
+                widgets[WIDX_ENTER_NAME].setHidden();
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }

--- a/src/openrct2-ui/windows/ProgressWindow.cpp
+++ b/src/openrct2-ui/windows/ProgressWindow.cpp
@@ -124,10 +124,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            if (_onClose != nullptr)
-                widgets[WIDX_CLOSE].type = WidgetType::closeBox;
-            else
-                widgets[WIDX_CLOSE].type = WidgetType::empty;
+            widgets[WIDX_CLOSE].setVisible(_onClose != nullptr);
 
             PrepareCaption();
         }

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -325,16 +325,16 @@ namespace OpenRCT2::Ui::Windows
 
     void WindowResearchDevelopmentPrepareDraw(WindowBase* w, WidgetIndex baseWidgetIndex)
     {
-        const auto& gameState = getGameState();
         // Offset the widget index to allow reuse from other windows
         auto widgetOffset = GetWidgetIndexOffset(baseWidgetIndex, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
-        w->widgets[WIDX_LAST_DEVELOPMENT_BUTTON + widgetOffset].type = WidgetType::empty;
+        w->widgets[WIDX_LAST_DEVELOPMENT_BUTTON + widgetOffset].setHidden();
 
         // Display button to link to the last development, if there is one
+        const auto& gameState = getGameState();
         if (gameState.researchLastItem.has_value())
         {
             auto type = gameState.researchLastItem->type;
-            w->widgets[WIDX_LAST_DEVELOPMENT_BUTTON + widgetOffset].type = WidgetType::flatBtn;
+            w->widgets[WIDX_LAST_DEVELOPMENT_BUTTON + widgetOffset].setVisible();
             const auto image = type == Research::EntryType::ride ? SPR_NEW_RIDE : SPR_NEW_SCENERY;
             w->widgets[WIDX_LAST_DEVELOPMENT_BUTTON + widgetOffset].image = ImageId(image);
         }
@@ -533,13 +533,13 @@ namespace OpenRCT2::Ui::Windows
 
         if ((gameState.park.flags & PARK_FLAGS_NO_MONEY) || gameState.researchProgressStage == RESEARCH_STAGE_FINISHED_ALL)
         {
-            w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].type = WidgetType::empty;
-            w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].type = WidgetType::empty;
+            w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].setHidden();
+            w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].setHidden();
         }
         else
         {
-            w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].type = WidgetType::dropdownMenu;
-            w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].type = WidgetType::button;
+            w->widgets[WIDX_RESEARCH_FUNDING + widgetOffset].setVisible();
+            w->widgets[WIDX_RESEARCH_FUNDING_DROPDOWN_BUTTON + widgetOffset].setVisible();
         }
 
         // Current funding

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3511,14 +3511,17 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Sometimes, only one of the alternatives support lift hill pieces. Make sure to check both.
-            bool hasAlternativeType = rtd.flags.has(RtdFlag::hasInvertedVariant);
-            if (rtd.TrackPaintFunctions.Regular.SupportsTrackGroup(TrackGroup::liftHill)
-                || (hasAlternativeType && rtd.InvertedTrackPaintFunctions.Regular.SupportsTrackGroup(TrackGroup::liftHill)))
+            const bool hasAlternativeType = rtd.flags.has(RtdFlag::hasInvertedVariant);
+            const bool hasLiftHillControl = rtd.TrackPaintFunctions.Regular.SupportsTrackGroup(TrackGroup::liftHill)
+                || (hasAlternativeType && rtd.InvertedTrackPaintFunctions.Regular.SupportsTrackGroup(TrackGroup::liftHill));
+
+            widgets[WIDX_LIFT_HILL_SPEED_LABEL].setVisible(hasLiftHillControl);
+            widgets[WIDX_LIFT_HILL_SPEED].setVisible(hasLiftHillControl);
+            widgets[WIDX_LIFT_HILL_SPEED_INCREASE].setVisible(hasLiftHillControl);
+            widgets[WIDX_LIFT_HILL_SPEED_DECREASE].setVisible(hasLiftHillControl);
+
+            if (hasLiftHillControl)
             {
-                widgets[WIDX_LIFT_HILL_SPEED_LABEL].setVisible();
-                widgets[WIDX_LIFT_HILL_SPEED].setVisible();
-                widgets[WIDX_LIFT_HILL_SPEED_INCREASE].setVisible();
-                widgets[WIDX_LIFT_HILL_SPEED_DECREASE].setVisible();
                 _spinnerCaption1 = FormatStringID(STR_VELOCITY, static_cast<uint16_t>(ride->liftHillSpeed));
                 widgets[WIDX_LIFT_HILL_SPEED].setString(_spinnerCaption1.c_str());
 
@@ -3526,34 +3529,22 @@ namespace OpenRCT2::Ui::Windows
                 resizeSpinner(WIDX_LIFT_HILL_SPEED, { 157, startY }, { 152, 14 });
                 startY += 17;
             }
-            else
-            {
-                widgets[WIDX_LIFT_HILL_SPEED_LABEL].setHidden();
-                widgets[WIDX_LIFT_HILL_SPEED].setHidden();
-                widgets[WIDX_LIFT_HILL_SPEED_INCREASE].setHidden();
-                widgets[WIDX_LIFT_HILL_SPEED_DECREASE].setHidden();
-            }
 
             // Number of circuits
-            if (ride->canHaveMultipleCircuits())
+            const bool canHaveMultipleCircuits = ride->canHaveMultipleCircuits();
+            widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].setVisible(canHaveMultipleCircuits);
+            widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setVisible(canHaveMultipleCircuits);
+            widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].setVisible(canHaveMultipleCircuits);
+            widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].setVisible(canHaveMultipleCircuits);
+
+            if (canHaveMultipleCircuits)
             {
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].setVisible();
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setVisible();
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].setVisible();
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].setVisible();
                 _spinnerCaption2 = std::to_string(ride->numCircuits);
                 widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setString(_spinnerCaption2.c_str());
 
                 widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].moveTo({ 21, startY + 1 });
                 resizeSpinner(WIDX_OPERATE_NUMBER_OF_CIRCUITS, { 157, startY }, { 152, 14 });
                 startY += 17;
-            }
-            else
-            {
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].setHidden();
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setHidden();
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].setHidden();
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].setHidden();
             }
 
             // Mode specific functionality
@@ -3615,27 +3606,22 @@ namespace OpenRCT2::Ui::Windows
                     break;
             }
 
-            if (format != kStringIdEmpty)
+            const bool hasTweakSetting = format != kStringIdEmpty;
+            widgets[WIDX_MODE_TWEAK_LABEL].setVisible(hasTweakSetting);
+            widgets[WIDX_MODE_TWEAK].setVisible(hasTweakSetting);
+            widgets[WIDX_MODE_TWEAK_INCREASE].setVisible(hasTweakSetting);
+            widgets[WIDX_MODE_TWEAK_DECREASE].setVisible(hasTweakSetting);
+
+            if (hasTweakSetting)
             {
-                _spinnerCaption0 = FormatStringID(format, tweakValue);
-                widgets[WIDX_MODE_TWEAK_LABEL].setVisible();
                 widgets[WIDX_MODE_TWEAK_LABEL].text = caption;
                 widgets[WIDX_MODE_TWEAK_LABEL].tooltip = tooltip;
-                widgets[WIDX_MODE_TWEAK].setVisible();
-                widgets[WIDX_MODE_TWEAK].setString(_spinnerCaption0.c_str());
-                widgets[WIDX_MODE_TWEAK_INCREASE].setVisible();
-                widgets[WIDX_MODE_TWEAK_DECREASE].setVisible();
-
                 widgets[WIDX_MODE_TWEAK_LABEL].moveTo({ 21, startY + 1 });
+
+                _spinnerCaption0 = FormatStringID(format, tweakValue);
+                widgets[WIDX_MODE_TWEAK].setString(_spinnerCaption0.c_str());
                 resizeSpinner(WIDX_MODE_TWEAK, { 157, startY }, { 152, 14 });
                 startY += 17;
-            }
-            else
-            {
-                widgets[WIDX_MODE_TWEAK_LABEL].setHidden();
-                widgets[WIDX_MODE_TWEAK].setHidden();
-                widgets[WIDX_MODE_TWEAK_INCREASE].setHidden();
-                widgets[WIDX_MODE_TWEAK_DECREASE].setHidden();
             }
 
             if (ride->isBlockSectioned() && poweredLaunch)
@@ -3663,25 +3649,21 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_LOAD_GROUP].moveTo({ 3, startY });
             startY += 15;
 
+            const bool hasLoadOptions = rtd.flags.has(RtdFlag::hasLoadOptions);
+            widgets[WIDX_LOAD_CHECKBOX].setVisible(hasLoadOptions);
+            widgets[WIDX_LOAD].setVisible(hasLoadOptions);
+            widgets[WIDX_LOAD_DROPDOWN].setVisible(hasLoadOptions);
+
             // Waiting
-            if (rtd.flags.has(RtdFlag::hasLoadOptions))
+            if (hasLoadOptions)
             {
-                widgets[WIDX_LOAD_CHECKBOX].setVisible();
-                widgets[WIDX_LOAD].setVisible();
                 widgets[WIDX_LOAD].text = VehicleLoadNames[(ride->departFlags & RIDE_DEPART_WAIT_FOR_LOAD_MASK)];
-                widgets[WIDX_LOAD_DROPDOWN].setVisible();
 
                 setWidgetPressed(WIDX_LOAD_CHECKBOX, (ride->departFlags & RIDE_DEPART_WAIT_FOR_LOAD) != 0);
 
                 widgets[WIDX_LOAD_CHECKBOX].moveTo({ 7, startY + 1 });
                 resizeDropdown(WIDX_LOAD, { 87, startY }, { 222, 14 });
                 startY += 17;
-            }
-            else
-            {
-                widgets[WIDX_LOAD_CHECKBOX].setHidden();
-                widgets[WIDX_LOAD].setHidden();
-                widgets[WIDX_LOAD_DROPDOWN].setHidden();
             }
 
             // Leave if another vehicle arrives at station
@@ -3707,18 +3689,18 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Min/max waiting length
-            if (rtd.flags.has(RtdFlag::hasLoadOptions))
+            widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].setVisible(hasLoadOptions);
+            widgets[WIDX_MINIMUM_LENGTH].setVisible(hasLoadOptions);
+            widgets[WIDX_MINIMUM_LENGTH_INCREASE].setVisible(hasLoadOptions);
+            widgets[WIDX_MINIMUM_LENGTH_DECREASE].setVisible(hasLoadOptions);
+
+            widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].setVisible(hasLoadOptions);
+            widgets[WIDX_MAXIMUM_LENGTH].setVisible(hasLoadOptions);
+            widgets[WIDX_MAXIMUM_LENGTH_INCREASE].setVisible(hasLoadOptions);
+            widgets[WIDX_MAXIMUM_LENGTH_DECREASE].setVisible(hasLoadOptions);
+
+            if (hasLoadOptions)
             {
-                widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].setVisible();
-                widgets[WIDX_MINIMUM_LENGTH].setVisible();
-                widgets[WIDX_MINIMUM_LENGTH_INCREASE].setVisible();
-                widgets[WIDX_MINIMUM_LENGTH_DECREASE].setVisible();
-
-                widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].setVisible();
-                widgets[WIDX_MAXIMUM_LENGTH].setVisible();
-                widgets[WIDX_MAXIMUM_LENGTH_INCREASE].setVisible();
-                widgets[WIDX_MAXIMUM_LENGTH_DECREASE].setVisible();
-
                 _spinnerCaption3 = FormatStringID(STR_FORMAT_SECONDS, static_cast<uint16_t>(ride->minWaitingTime));
                 widgets[WIDX_MINIMUM_LENGTH].setString(_spinnerCaption3.c_str());
                 _spinnerCaption4 = FormatStringID(STR_FORMAT_SECONDS, static_cast<uint16_t>(ride->maxWaitingTime));
@@ -3734,18 +3716,6 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].moveTo({ 7, startY + 1 });
                 resizeSpinner(WIDX_MAXIMUM_LENGTH, { 157, startY }, { 152, 14 });
                 startY += 17;
-            }
-            else
-            {
-                widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].setHidden();
-                widgets[WIDX_MINIMUM_LENGTH].setHidden();
-                widgets[WIDX_MINIMUM_LENGTH_INCREASE].setHidden();
-                widgets[WIDX_MINIMUM_LENGTH_DECREASE].setHidden();
-
-                widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].setHidden();
-                widgets[WIDX_MAXIMUM_LENGTH].setHidden();
-                widgets[WIDX_MAXIMUM_LENGTH_INCREASE].setHidden();
-                widgets[WIDX_MAXIMUM_LENGTH_DECREASE].setHidden();
             }
 
             // Synchronise with adjacent stations
@@ -3781,19 +3751,15 @@ namespace OpenRCT2::Ui::Windows
 
         int32_t operatingOnPrepareDrawRideType(int32_t startY, const Ride* ride)
         {
-            if (!getGameState().cheats.allowArbitraryRideTypeChanges)
-            {
-                widgets[WIDX_RIDE_TYPE_GROUP].setHidden();
-                widgets[WIDX_RIDE_TYPE].setHidden();
-                widgets[WIDX_RIDE_TYPE_DROPDOWN].setHidden();
+            const bool showRideTypeCheat = getGameState().cheats.allowArbitraryRideTypeChanges;
+            widgets[WIDX_RIDE_TYPE_GROUP].setVisible(showRideTypeCheat);
+            widgets[WIDX_RIDE_TYPE].setVisible(showRideTypeCheat);
+            widgets[WIDX_RIDE_TYPE_DROPDOWN].setVisible(showRideTypeCheat);
 
+            if (!showRideTypeCheat)
                 return startY;
-            }
 
-            widgets[WIDX_RIDE_TYPE_GROUP].setVisible();
-            widgets[WIDX_RIDE_TYPE].setVisible();
             widgets[WIDX_RIDE_TYPE].text = ride->getRideTypeDescriptor().Naming.Name;
-            widgets[WIDX_RIDE_TYPE_DROPDOWN].setVisible();
 
             // clang-format off
             widgets[WIDX_RIDE_TYPE_GROUP].moveTo   ({  3, startY + 0});
@@ -5544,8 +5510,8 @@ namespace OpenRCT2::Ui::Windows
             auto isMusicActivated = ride->flags.has(RideFlag::music);
             bool hasPreviewImage = musicObj != nullptr && musicObj->HasPreview();
 
-            widgetSetVisible(*this, WIDX_MUSIC_DATA, isMusicActivated);
-            widgetSetVisible(*this, WIDX_MUSIC_IMAGE, isMusicActivated && hasPreviewImage);
+            widgets[WIDX_MUSIC_DATA].setVisible(isMusicActivated);
+            widgets[WIDX_MUSIC_IMAGE].setVisible(isMusicActivated && hasPreviewImage);
 
             if (isMusicActivated)
             {
@@ -5923,22 +5889,15 @@ namespace OpenRCT2::Ui::Windows
             if (ride == nullptr)
                 return;
 
-            if (gTrackDesignSaveMode && gTrackDesignSaveRideIndex == rideId)
-            {
-                widgets[WIDX_SELECT_NEARBY_SCENERY].setVisible();
-                widgets[WIDX_RESET_SELECTION].setVisible();
-                widgets[WIDX_SAVE_DESIGN].setVisible();
-                widgets[WIDX_CANCEL_DESIGN].setVisible();
-                widgets[WIDX_SAVE_TRACK_DESIGN].setHidden();
-            }
-            else
-            {
-                widgets[WIDX_SELECT_NEARBY_SCENERY].setHidden();
-                widgets[WIDX_RESET_SELECTION].setHidden();
-                widgets[WIDX_SAVE_DESIGN].setHidden();
-                widgets[WIDX_CANCEL_DESIGN].setHidden();
-                widgets[WIDX_SAVE_TRACK_DESIGN].setVisible();
+            const bool inSaveMode = gTrackDesignSaveMode && gTrackDesignSaveRideIndex == rideId;
+            widgets[WIDX_SELECT_NEARBY_SCENERY].setVisible(inSaveMode);
+            widgets[WIDX_RESET_SELECTION].setVisible(inSaveMode);
+            widgets[WIDX_SAVE_DESIGN].setVisible(inSaveMode);
+            widgets[WIDX_CANCEL_DESIGN].setVisible(inSaveMode);
+            widgets[WIDX_SAVE_TRACK_DESIGN].setHidden(inSaveMode);
 
+            if (!inSaveMode)
+            {
                 const bool canSaveTrackDesign = ride->flags.has(RideFlag::tested) && !ride->ratings.isNull();
                 setWidgetDisabled(WIDX_SAVE_TRACK_DESIGN, !canSaveTrackDesign);
                 if (canSaveTrackDesign)
@@ -6355,16 +6314,9 @@ namespace OpenRCT2::Ui::Windows
                 WIDX_GRAPH_VELOCITY + listInformationType);
 
             // Hide graph buttons that are not applicable
-            if (ride->getRideTypeDescriptor().flags.has(RtdFlag::hasGForces))
-            {
-                widgets[WIDX_GRAPH_VERTICAL].setVisible();
-                widgets[WIDX_GRAPH_LATERAL].setVisible();
-            }
-            else
-            {
-                widgets[WIDX_GRAPH_VERTICAL].setHidden();
-                widgets[WIDX_GRAPH_LATERAL].setHidden();
-            }
+            const bool hasGForces = ride->getRideTypeDescriptor().flags.has(RtdFlag::hasGForces);
+            widgets[WIDX_GRAPH_VERTICAL].setVisible(hasGForces);
+            widgets[WIDX_GRAPH_LATERAL].setVisible(hasGForces);
 
             // Anchor graph widget
             auto x = width - 4;
@@ -6913,26 +6865,17 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
-            if (secondaryItem == ShopItem::none)
-            {
-                // Hide secondary item widgets
-                widgets[WIDX_SECONDARY_PRICE_LABEL].setHidden();
-                widgets[WIDX_SECONDARY_PRICE].setHidden();
-                widgets[WIDX_SECONDARY_PRICE_INCREASE].setHidden();
-                widgets[WIDX_SECONDARY_PRICE_DECREASE].setHidden();
-                widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].setHidden();
-            }
-            else
+            const bool hasSecondaryItem = secondaryItem != ShopItem::none;
+            widgets[WIDX_SECONDARY_PRICE_LABEL].setVisible(hasSecondaryItem);
+            widgets[WIDX_SECONDARY_PRICE].setVisible(hasSecondaryItem);
+            widgets[WIDX_SECONDARY_PRICE_INCREASE].setVisible(hasSecondaryItem);
+            widgets[WIDX_SECONDARY_PRICE_DECREASE].setVisible(hasSecondaryItem);
+            widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].setVisible(hasSecondaryItem);
+
+            if (hasSecondaryItem)
             {
                 // Set same price throughout park checkbox
                 setWidgetPressed(WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK, ShopItemHasCommonPrice(secondaryItem));
-
-                // Show widgets
-                widgets[WIDX_SECONDARY_PRICE_LABEL].setVisible();
-                widgets[WIDX_SECONDARY_PRICE].setVisible();
-                widgets[WIDX_SECONDARY_PRICE_INCREASE].setVisible();
-                widgets[WIDX_SECONDARY_PRICE_DECREASE].setVisible();
-                widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].setVisible();
 
                 // Set secondary item price
                 if (ride->price[1] == 0)
@@ -7128,16 +7071,10 @@ namespace OpenRCT2::Ui::Windows
             if (ride != nullptr)
             {
                 widgets[WIDX_SHOW_GUESTS_THOUGHTS].setVisible();
-                if (ride->getRideTypeDescriptor().flags.has(RtdFlag::isShopOrFacility))
-                {
-                    widgets[WIDX_SHOW_GUESTS_ON_RIDE].setHidden();
-                    widgets[WIDX_SHOW_GUESTS_QUEUING].setHidden();
-                }
-                else
-                {
-                    widgets[WIDX_SHOW_GUESTS_ON_RIDE].setVisible();
-                    widgets[WIDX_SHOW_GUESTS_QUEUING].setVisible();
-                }
+
+                const bool isShopOrFacility = ride->getRideTypeDescriptor().flags.has(RtdFlag::isShopOrFacility);
+                widgets[WIDX_SHOW_GUESTS_ON_RIDE].setHidden(isShopOrFacility);
+                widgets[WIDX_SHOW_GUESTS_QUEUING].setHidden(isShopOrFacility);
 
                 WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
             }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2425,13 +2425,13 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_OPEN_LIGHT].type = WidgetType::imgBtn;
 
                 widgetHeight = widgets[WIDX_PAGE_BACKGROUND].top + 19;
-                if (widgets[WIDX_SIMULATE_LIGHT].type != WidgetType::empty)
+                if (widgets[WIDX_SIMULATE_LIGHT].isVisible())
                 {
                     widgets[WIDX_SIMULATE_LIGHT].top = widgetHeight;
                     widgets[WIDX_SIMULATE_LIGHT].bottom = widgetHeight + 13;
                     widgetHeight += 14;
                 }
-                if (widgets[WIDX_TEST_LIGHT].type != WidgetType::empty)
+                if (widgets[WIDX_TEST_LIGHT].isVisible())
                 {
                     widgets[WIDX_TEST_LIGHT].top = widgetHeight;
                     widgets[WIDX_TEST_LIGHT].bottom = widgetHeight + 13;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2413,16 +2413,15 @@ namespace OpenRCT2::Ui::Windows
 
             if (ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_RIDE)
             {
-                widgets[WIDX_OPEN].type = WidgetType::empty;
-                widgets[WIDX_CLOSE_LIGHT].type = WidgetType::imgBtn;
-                widgets[WIDX_SIMULATE_LIGHT].type = WidgetType::empty;
+                widgets[WIDX_OPEN].setHidden();
+                widgets[WIDX_CLOSE_LIGHT].setVisible();
+                widgets[WIDX_SIMULATE_LIGHT].setHidden();
 #ifdef __SIMULATE_IN_RIDE_WINDOW__
                 if (ride->supportsStatus(RideStatus::simulating))
-                    widgets[WIDX_SIMULATE_LIGHT].type = WidgetType::imgBtn;
+                    widgets[WIDX_SIMULATE_LIGHT].setVisible();
 #endif
-                widgets[WIDX_TEST_LIGHT].type = ride->supportsStatus(RideStatus::testing) ? WidgetType::imgBtn
-                                                                                          : WidgetType::empty;
-                widgets[WIDX_OPEN_LIGHT].type = WidgetType::imgBtn;
+                widgets[WIDX_TEST_LIGHT].setVisible(ride->supportsStatus(RideStatus::testing));
+                widgets[WIDX_OPEN_LIGHT].setVisible();
 
                 widgetHeight = widgets[WIDX_PAGE_BACKGROUND].top + 19;
                 if (widgets[WIDX_SIMULATE_LIGHT].isVisible())
@@ -2443,11 +2442,11 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_OPEN].type = WidgetType::flatBtn;
-                widgets[WIDX_CLOSE_LIGHT].type = WidgetType::empty;
-                widgets[WIDX_SIMULATE_LIGHT].type = WidgetType::empty;
-                widgets[WIDX_TEST_LIGHT].type = WidgetType::empty;
-                widgets[WIDX_OPEN_LIGHT].type = WidgetType::empty;
+                widgets[WIDX_OPEN].setVisible();
+                widgets[WIDX_CLOSE_LIGHT].setHidden();
+                widgets[WIDX_SIMULATE_LIGHT].setHidden();
+                widgets[WIDX_TEST_LIGHT].setHidden();
+                widgets[WIDX_OPEN_LIGHT].setHidden();
                 widgetHeight = widgets[WIDX_PAGE_BACKGROUND].top + 3;
             }
 
@@ -2797,45 +2796,26 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_VEHICLE_TYPE].text = rideEntry->naming.Name;
 
             const auto& gameState = getGameState();
+
             // Trains
-            if (rideEntry->cars_per_flat_ride > 1 || gameState.cheats.disableTrainLengthLimit)
-            {
-                widgets[WIDX_VEHICLE_TRAINS].type = WidgetType::spinner;
-                widgets[WIDX_VEHICLE_TRAINS_INCREASE].type = WidgetType::button;
-                widgets[WIDX_VEHICLE_TRAINS_DECREASE].type = WidgetType::button;
-            }
-            else
-            {
-                widgets[WIDX_VEHICLE_TRAINS].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_TRAINS_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_TRAINS_DECREASE].type = WidgetType::empty;
-            }
+            const bool showTrains = rideEntry->cars_per_flat_ride > 1 || gameState.cheats.disableTrainLengthLimit;
+            widgets[WIDX_VEHICLE_TRAINS].setVisible(showTrains);
+            widgets[WIDX_VEHICLE_TRAINS_INCREASE].setVisible(showTrains);
+            widgets[WIDX_VEHICLE_TRAINS_DECREASE].setVisible(showTrains);
 
             // Cars per train
-            if (rideEntry->zero_cars + 1 < rideEntry->max_cars_in_train || gameState.cheats.disableTrainLengthLimit)
-            {
-                widgets[WIDX_VEHICLE_CARS_PER_TRAIN].type = WidgetType::spinner;
-                widgets[WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE].type = WidgetType::button;
-                widgets[WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE].type = WidgetType::button;
-            }
-            else
-            {
-                widgets[WIDX_VEHICLE_CARS_PER_TRAIN].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE].type = WidgetType::empty;
-            }
+            const bool showCarsPerTrain = rideEntry->zero_cars + 1 < rideEntry->max_cars_in_train
+                || gameState.cheats.disableTrainLengthLimit;
+            widgets[WIDX_VEHICLE_CARS_PER_TRAIN].setVisible(showCarsPerTrain);
+            widgets[WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE].setVisible(showCarsPerTrain);
+            widgets[WIDX_VEHICLE_CARS_PER_TRAIN_DECREASE].setVisible(showCarsPerTrain);
 
-            if ((ride->getRideTypeDescriptor().flags.has(RtdFlag::allowReversedTrains)
-                 && !rideEntry->flags.has(RideEntryFlag::noReverseOption))
-                || (gameState.cheats.disableTrainLengthLimit && !ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide)))
-            {
-                widgets[WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX].type = WidgetType::checkbox;
-                setWidgetPressed(WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX, ride->flags.has(RideFlag::reversedTrains));
-            }
-            else
-            {
-                widgets[WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX].type = WidgetType::empty;
-            }
+            const bool showReversed = (ride->getRideTypeDescriptor().flags.has(RtdFlag::allowReversedTrains)
+                                       && !rideEntry->flags.has(RideEntryFlag::noReverseOption))
+                || (gameState.cheats.disableTrainLengthLimit && !ride->getRideTypeDescriptor().flags.has(RtdFlag::isFlatRide));
+
+            widgets[WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX].setVisible(showReversed);
+            setWidgetPressed(WIDX_VEHICLE_REVERSED_TRAINS_CHECKBOX, ride->flags.has(RideFlag::reversedTrains));
 
             RideComponentType vehicleType = ride->getRideTypeDescriptor().NameConvention.vehicle;
             auto stringId = GetRideComponentName(vehicleType).count;
@@ -3514,7 +3494,7 @@ namespace OpenRCT2::Ui::Windows
         {
             const auto initStartY = startY;
 
-            widgets[WIDX_MODE_GROUP].type = WidgetType::groupbox;
+            widgets[WIDX_MODE_GROUP].setVisible();
             widgets[WIDX_MODE_GROUP].moveTo({ 3, startY });
             startY += 15;
 
@@ -3535,10 +3515,10 @@ namespace OpenRCT2::Ui::Windows
             if (rtd.TrackPaintFunctions.Regular.SupportsTrackGroup(TrackGroup::liftHill)
                 || (hasAlternativeType && rtd.InvertedTrackPaintFunctions.Regular.SupportsTrackGroup(TrackGroup::liftHill)))
             {
-                widgets[WIDX_LIFT_HILL_SPEED_LABEL].type = WidgetType::label;
-                widgets[WIDX_LIFT_HILL_SPEED].type = WidgetType::spinner;
-                widgets[WIDX_LIFT_HILL_SPEED_INCREASE].type = WidgetType::button;
-                widgets[WIDX_LIFT_HILL_SPEED_DECREASE].type = WidgetType::button;
+                widgets[WIDX_LIFT_HILL_SPEED_LABEL].setVisible();
+                widgets[WIDX_LIFT_HILL_SPEED].setVisible();
+                widgets[WIDX_LIFT_HILL_SPEED_INCREASE].setVisible();
+                widgets[WIDX_LIFT_HILL_SPEED_DECREASE].setVisible();
                 _spinnerCaption1 = FormatStringID(STR_VELOCITY, static_cast<uint16_t>(ride->liftHillSpeed));
                 widgets[WIDX_LIFT_HILL_SPEED].setString(_spinnerCaption1.c_str());
 
@@ -3548,19 +3528,19 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_LIFT_HILL_SPEED_LABEL].type = WidgetType::empty;
-                widgets[WIDX_LIFT_HILL_SPEED].type = WidgetType::empty;
-                widgets[WIDX_LIFT_HILL_SPEED_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_LIFT_HILL_SPEED_DECREASE].type = WidgetType::empty;
+                widgets[WIDX_LIFT_HILL_SPEED_LABEL].setHidden();
+                widgets[WIDX_LIFT_HILL_SPEED].setHidden();
+                widgets[WIDX_LIFT_HILL_SPEED_INCREASE].setHidden();
+                widgets[WIDX_LIFT_HILL_SPEED_DECREASE].setHidden();
             }
 
             // Number of circuits
             if (ride->canHaveMultipleCircuits())
             {
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].type = WidgetType::label;
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].type = WidgetType::spinner;
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].type = WidgetType::button;
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].type = WidgetType::button;
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].setVisible();
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setVisible();
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].setVisible();
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].setVisible();
                 _spinnerCaption2 = std::to_string(ride->numCircuits);
                 widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setString(_spinnerCaption2.c_str());
 
@@ -3570,10 +3550,10 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].type = WidgetType::empty;
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].type = WidgetType::empty;
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].type = WidgetType::empty;
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_LABEL].setHidden();
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS].setHidden();
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_INCREASE].setHidden();
+                widgets[WIDX_OPERATE_NUMBER_OF_CIRCUITS_DECREASE].setHidden();
             }
 
             // Mode specific functionality
@@ -3638,13 +3618,13 @@ namespace OpenRCT2::Ui::Windows
             if (format != kStringIdEmpty)
             {
                 _spinnerCaption0 = FormatStringID(format, tweakValue);
-                widgets[WIDX_MODE_TWEAK_LABEL].type = WidgetType::label;
+                widgets[WIDX_MODE_TWEAK_LABEL].setVisible();
                 widgets[WIDX_MODE_TWEAK_LABEL].text = caption;
                 widgets[WIDX_MODE_TWEAK_LABEL].tooltip = tooltip;
-                widgets[WIDX_MODE_TWEAK].type = WidgetType::spinner;
+                widgets[WIDX_MODE_TWEAK].setVisible();
                 widgets[WIDX_MODE_TWEAK].setString(_spinnerCaption0.c_str());
-                widgets[WIDX_MODE_TWEAK_INCREASE].type = WidgetType::button;
-                widgets[WIDX_MODE_TWEAK_DECREASE].type = WidgetType::button;
+                widgets[WIDX_MODE_TWEAK_INCREASE].setVisible();
+                widgets[WIDX_MODE_TWEAK_DECREASE].setVisible();
 
                 widgets[WIDX_MODE_TWEAK_LABEL].moveTo({ 21, startY + 1 });
                 resizeSpinner(WIDX_MODE_TWEAK, { 157, startY }, { 152, 14 });
@@ -3652,10 +3632,10 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_MODE_TWEAK_LABEL].type = WidgetType::empty;
-                widgets[WIDX_MODE_TWEAK].type = WidgetType::empty;
-                widgets[WIDX_MODE_TWEAK_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_MODE_TWEAK_DECREASE].type = WidgetType::empty;
+                widgets[WIDX_MODE_TWEAK_LABEL].setHidden();
+                widgets[WIDX_MODE_TWEAK].setHidden();
+                widgets[WIDX_MODE_TWEAK_INCREASE].setHidden();
+                widgets[WIDX_MODE_TWEAK_DECREASE].setHidden();
             }
 
             if (ride->isBlockSectioned() && poweredLaunch)
@@ -3670,7 +3650,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_MODE_GROUP].type = WidgetType::empty;
+                widgets[WIDX_MODE_GROUP].setHidden();
                 return initStartY;
             }
         }
@@ -3679,17 +3659,17 @@ namespace OpenRCT2::Ui::Windows
         {
             const auto initStartY = startY;
 
-            widgets[WIDX_LOAD_GROUP].type = WidgetType::groupbox;
+            widgets[WIDX_LOAD_GROUP].setVisible();
             widgets[WIDX_LOAD_GROUP].moveTo({ 3, startY });
             startY += 15;
 
             // Waiting
             if (rtd.flags.has(RtdFlag::hasLoadOptions))
             {
-                widgets[WIDX_LOAD_CHECKBOX].type = WidgetType::checkbox;
-                widgets[WIDX_LOAD].type = WidgetType::dropdownMenu;
+                widgets[WIDX_LOAD_CHECKBOX].setVisible();
+                widgets[WIDX_LOAD].setVisible();
                 widgets[WIDX_LOAD].text = VehicleLoadNames[(ride->departFlags & RIDE_DEPART_WAIT_FOR_LOAD_MASK)];
-                widgets[WIDX_LOAD_DROPDOWN].type = WidgetType::button;
+                widgets[WIDX_LOAD_DROPDOWN].setVisible();
 
                 setWidgetPressed(WIDX_LOAD_CHECKBOX, (ride->departFlags & RIDE_DEPART_WAIT_FOR_LOAD) != 0);
 
@@ -3699,16 +3679,16 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_LOAD_CHECKBOX].type = WidgetType::empty;
-                widgets[WIDX_LOAD].type = WidgetType::empty;
-                widgets[WIDX_LOAD_DROPDOWN].type = WidgetType::empty;
+                widgets[WIDX_LOAD_CHECKBOX].setHidden();
+                widgets[WIDX_LOAD].setHidden();
+                widgets[WIDX_LOAD_DROPDOWN].setHidden();
             }
 
             // Leave if another vehicle arrives at station
             if (rtd.flags.has(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation) && ride->numTrains > 1
                 && !ride->isBlockSectioned())
             {
-                widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].type = WidgetType::checkbox;
+                widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].setVisible();
                 widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].tooltip = STR_LEAVE_IF_ANOTHER_VEHICLE_ARRIVES_TIP;
                 widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].text = rtd.NameConvention.vehicle == RideComponentType::Boat
                     ? STR_LEAVE_IF_ANOTHER_BOAT_ARRIVES
@@ -3723,21 +3703,21 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].type = WidgetType::empty;
+                widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].setHidden();
             }
 
             // Min/max waiting length
             if (rtd.flags.has(RtdFlag::hasLoadOptions))
             {
-                widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].type = WidgetType::checkbox;
-                widgets[WIDX_MINIMUM_LENGTH].type = WidgetType::spinner;
-                widgets[WIDX_MINIMUM_LENGTH_INCREASE].type = WidgetType::button;
-                widgets[WIDX_MINIMUM_LENGTH_DECREASE].type = WidgetType::button;
+                widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].setVisible();
+                widgets[WIDX_MINIMUM_LENGTH].setVisible();
+                widgets[WIDX_MINIMUM_LENGTH_INCREASE].setVisible();
+                widgets[WIDX_MINIMUM_LENGTH_DECREASE].setVisible();
 
-                widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].type = WidgetType::checkbox;
-                widgets[WIDX_MAXIMUM_LENGTH].type = WidgetType::spinner;
-                widgets[WIDX_MAXIMUM_LENGTH_INCREASE].type = WidgetType::button;
-                widgets[WIDX_MAXIMUM_LENGTH_DECREASE].type = WidgetType::button;
+                widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].setVisible();
+                widgets[WIDX_MAXIMUM_LENGTH].setVisible();
+                widgets[WIDX_MAXIMUM_LENGTH_INCREASE].setVisible();
+                widgets[WIDX_MAXIMUM_LENGTH_DECREASE].setVisible();
 
                 _spinnerCaption3 = FormatStringID(STR_FORMAT_SECONDS, static_cast<uint16_t>(ride->minWaitingTime));
                 widgets[WIDX_MINIMUM_LENGTH].setString(_spinnerCaption3.c_str());
@@ -3757,21 +3737,21 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].type = WidgetType::empty;
-                widgets[WIDX_MINIMUM_LENGTH].type = WidgetType::empty;
-                widgets[WIDX_MINIMUM_LENGTH_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_MINIMUM_LENGTH_DECREASE].type = WidgetType::empty;
+                widgets[WIDX_MINIMUM_LENGTH_CHECKBOX].setHidden();
+                widgets[WIDX_MINIMUM_LENGTH].setHidden();
+                widgets[WIDX_MINIMUM_LENGTH_INCREASE].setHidden();
+                widgets[WIDX_MINIMUM_LENGTH_DECREASE].setHidden();
 
-                widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].type = WidgetType::empty;
-                widgets[WIDX_MAXIMUM_LENGTH].type = WidgetType::empty;
-                widgets[WIDX_MAXIMUM_LENGTH_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_MAXIMUM_LENGTH_DECREASE].type = WidgetType::empty;
+                widgets[WIDX_MAXIMUM_LENGTH_CHECKBOX].setHidden();
+                widgets[WIDX_MAXIMUM_LENGTH].setHidden();
+                widgets[WIDX_MAXIMUM_LENGTH_INCREASE].setHidden();
+                widgets[WIDX_MAXIMUM_LENGTH_DECREASE].setHidden();
             }
 
             // Synchronise with adjacent stations
             if (rtd.flags.has(RtdFlag::canSynchroniseWithAdjacentStations))
             {
-                widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].type = WidgetType::checkbox;
+                widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].setVisible();
                 widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].text = STR_SYNCHRONISE_WITH_ADJACENT_STATIONS;
                 widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].tooltip = STR_SYNCHRONISE_WITH_ADJACENT_STATIONS_TIP;
 
@@ -3784,7 +3764,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].type = WidgetType::empty;
+                widgets[WIDX_SYNCHRONISE_WITH_ADJACENT_STATIONS_CHECKBOX].setHidden();
             }
 
             if (startY != initStartY + 15)
@@ -3794,7 +3774,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_LOAD_GROUP].type = WidgetType::empty;
+                widgets[WIDX_LOAD_GROUP].setHidden();
                 return initStartY;
             }
         }
@@ -3803,17 +3783,17 @@ namespace OpenRCT2::Ui::Windows
         {
             if (!getGameState().cheats.allowArbitraryRideTypeChanges)
             {
-                widgets[WIDX_RIDE_TYPE_GROUP].type = WidgetType::empty;
-                widgets[WIDX_RIDE_TYPE].type = WidgetType::empty;
-                widgets[WIDX_RIDE_TYPE_DROPDOWN].type = WidgetType::empty;
+                widgets[WIDX_RIDE_TYPE_GROUP].setHidden();
+                widgets[WIDX_RIDE_TYPE].setHidden();
+                widgets[WIDX_RIDE_TYPE_DROPDOWN].setHidden();
 
                 return startY;
             }
 
-            widgets[WIDX_RIDE_TYPE_GROUP].type = WidgetType::groupbox;
-            widgets[WIDX_RIDE_TYPE].type = WidgetType::dropdownMenu;
+            widgets[WIDX_RIDE_TYPE_GROUP].setVisible();
+            widgets[WIDX_RIDE_TYPE].setVisible();
             widgets[WIDX_RIDE_TYPE].text = ride->getRideTypeDescriptor().Naming.Name;
-            widgets[WIDX_RIDE_TYPE_DROPDOWN].type = WidgetType::button;
+            widgets[WIDX_RIDE_TYPE_DROPDOWN].setVisible();
 
             // clang-format off
             widgets[WIDX_RIDE_TYPE_GROUP].moveTo   ({  3, startY + 0});
@@ -4154,11 +4134,11 @@ namespace OpenRCT2::Ui::Windows
 
             if (Config::Get().general.debuggingTools && Network::GetMode() == Network::Mode::none)
             {
-                widgets[WIDX_FORCE_BREAKDOWN].type = WidgetType::flatBtn;
+                widgets[WIDX_FORCE_BREAKDOWN].setVisible();
             }
             else
             {
-                widgets[WIDX_FORCE_BREAKDOWN].type = WidgetType::empty;
+                widgets[WIDX_FORCE_BREAKDOWN].setHidden();
             }
 
             if (ride->getRideTypeDescriptor().availableBreakdowns.isEmpty() || !ride->flags.has(RideFlag::everBeenOpened))
@@ -4778,37 +4758,37 @@ namespace OpenRCT2::Ui::Windows
             if (rtd.specialType == RtdSpecialType::maze)
             {
                 widgets[WIDX_PRIMARY_PREVIEW_GROUP].text = STR_MAZE_STYLE_GROUP;
-                widgets[WIDX_MAZE_STYLE].type = WidgetType::dropdownMenu;
-                widgets[WIDX_MAZE_STYLE_DROPDOWN].type = WidgetType::button;
+                widgets[WIDX_MAZE_STYLE].setVisible();
+                widgets[WIDX_MAZE_STYLE_DROPDOWN].setVisible();
                 widgets[WIDX_MAZE_STYLE].text = MazeOptions[EnumValue(trackColour.supports)].text;
             }
             else
             {
                 bool isShop = rtd.Category == RideCategory::shop;
                 widgets[WIDX_PRIMARY_PREVIEW_GROUP].text = isShop ? STR_SHOP_STYLE_GROUP : STR_TRACK_STYLE_GROUP;
-                widgets[WIDX_MAZE_STYLE].type = WidgetType::empty;
-                widgets[WIDX_MAZE_STYLE_DROPDOWN].type = WidgetType::empty;
+                widgets[WIDX_MAZE_STYLE].setHidden();
+                widgets[WIDX_MAZE_STYLE_DROPDOWN].setHidden();
             }
 
             // Track, multiple colour schemes
             bool rideCheats = getGameState().cheats.allowArbitraryRideTypeChanges;
             if (ride->getRideTypeDescriptor().flags.has(RtdFlag::supportsMultipleColourSchemes))
             {
-                widgets[WIDX_PRIMARY_PREVIEW_GROUP].type = WidgetType::groupbox;
-                widgets[WIDX_TRACK_COLOUR_SCHEME].type = WidgetType::dropdownMenu;
-                widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].type = WidgetType::button;
-                widgets[WIDX_PAINT_INDIVIDUAL_AREA].type = WidgetType::flatBtn;
+                widgets[WIDX_PRIMARY_PREVIEW_GROUP].setVisible();
+                widgets[WIDX_TRACK_COLOUR_SCHEME].setVisible();
+                widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].setVisible();
+                widgets[WIDX_PAINT_INDIVIDUAL_AREA].setVisible();
             }
             else
             {
-                widgets[WIDX_PRIMARY_PREVIEW_GROUP].type = WidgetType::empty;
-                widgets[WIDX_TRACK_COLOUR_SCHEME].type = WidgetType::empty;
-                widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].type = WidgetType::empty;
-                widgets[WIDX_PAINT_INDIVIDUAL_AREA].type = WidgetType::empty;
+                widgets[WIDX_PRIMARY_PREVIEW_GROUP].setHidden();
+                widgets[WIDX_TRACK_COLOUR_SCHEME].setHidden();
+                widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].setHidden();
+                widgets[WIDX_PAINT_INDIVIDUAL_AREA].setHidden();
             }
 
             // Ride cheats on? Show visibility dropdown
-            widgets[WIDX_VISIBILITY_DROPDOWN].type = rideCheats ? WidgetType::flatBtn : WidgetType::empty;
+            widgets[WIDX_VISIBILITY_DROPDOWN].setVisible(rideCheats);
 
             // Set colour scheme caption
             _spinnerCaption0 = LanguageGetString(ColourSchemeNames[colourScheme]);
@@ -4817,46 +4797,46 @@ namespace OpenRCT2::Ui::Windows
             // Track main colour
             if (HasTrackColour(*ride, 0))
             {
-                widgets[WIDX_TRACK_MAIN_COLOUR].type = WidgetType::colourBtn;
+                widgets[WIDX_TRACK_MAIN_COLOUR].setVisible();
                 widgets[WIDX_TRACK_MAIN_COLOUR].image = getColourButtonImage(trackColour.main);
             }
             else
             {
-                widgets[WIDX_TRACK_MAIN_COLOUR].type = WidgetType::empty;
+                widgets[WIDX_TRACK_MAIN_COLOUR].setHidden();
             }
 
             // Track additional colour
             if (HasTrackColour(*ride, 1))
             {
-                widgets[WIDX_TRACK_ADDITIONAL_COLOUR].type = WidgetType::colourBtn;
+                widgets[WIDX_TRACK_ADDITIONAL_COLOUR].setVisible();
                 widgets[WIDX_TRACK_ADDITIONAL_COLOUR].image = getColourButtonImage(trackColour.additional);
             }
             else
             {
-                widgets[WIDX_TRACK_ADDITIONAL_COLOUR].type = WidgetType::empty;
+                widgets[WIDX_TRACK_ADDITIONAL_COLOUR].setHidden();
             }
 
             // Selling item random colour checkbox
             if (ride->hasRecolourableShopItems())
             {
                 widgets[WIDX_PRIMARY_PREVIEW_GROUP].text = STR_SHOP_STYLE_GROUP;
-                widgets[WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX].type = WidgetType::checkbox;
+                widgets[WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX].setVisible();
                 setWidgetPressed(WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX, ride->flags.has(RideFlag::randomShopColours));
             }
             else
             {
-                widgets[WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX].type = WidgetType::empty;
+                widgets[WIDX_SELL_ITEM_RANDOM_COLOUR_CHECKBOX].setHidden();
             }
 
             // Track supports colour
             if (HasTrackColour(*ride, 2) && rtd.specialType != RtdSpecialType::maze)
             {
-                widgets[WIDX_TRACK_SUPPORT_COLOUR].type = WidgetType::colourBtn;
+                widgets[WIDX_TRACK_SUPPORT_COLOUR].setVisible();
                 widgets[WIDX_TRACK_SUPPORT_COLOUR].image = getColourButtonImage(trackColour.supports);
             }
             else
             {
-                widgets[WIDX_TRACK_SUPPORT_COLOUR].type = WidgetType::empty;
+                widgets[WIDX_TRACK_SUPPORT_COLOUR].setHidden();
             }
 
             // Track preview
@@ -4864,12 +4844,12 @@ namespace OpenRCT2::Ui::Windows
                     RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourAdditional, RtdFlag::hasTrackColourSupports)
                 && !rideCheats)
             {
-                widgets[WIDX_PRIMARY_PREVIEW].type = WidgetType::empty;
+                widgets[WIDX_PRIMARY_PREVIEW].setHidden();
                 return startY;
             }
 
-            widgets[WIDX_PRIMARY_PREVIEW_GROUP].type = WidgetType::groupbox;
-            widgets[WIDX_PRIMARY_PREVIEW].type = WidgetType::spinner;
+            widgets[WIDX_PRIMARY_PREVIEW_GROUP].setVisible();
+            widgets[WIDX_PRIMARY_PREVIEW].setVisible();
 
             // clang-format off
             widgets[WIDX_PRIMARY_PREVIEW_GROUP].moveTo           ({  3, startY + 0});
@@ -4894,18 +4874,18 @@ namespace OpenRCT2::Ui::Windows
             // Entrance style
             if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::hasEntranceAndExit))
             {
-                widgets[WIDX_SECONDARY_PREVIEW_GROUP].type = WidgetType::empty;
-                widgets[WIDX_SECONDARY_PREVIEW].type = WidgetType::empty;
-                widgets[WIDX_ENTRANCE_STYLE].type = WidgetType::empty;
-                widgets[WIDX_ENTRANCE_STYLE_DROPDOWN].type = WidgetType::empty;
+                widgets[WIDX_SECONDARY_PREVIEW_GROUP].setHidden();
+                widgets[WIDX_SECONDARY_PREVIEW].setHidden();
+                widgets[WIDX_ENTRANCE_STYLE].setHidden();
+                widgets[WIDX_ENTRANCE_STYLE_DROPDOWN].setHidden();
 
                 return startY;
             }
 
-            widgets[WIDX_SECONDARY_PREVIEW_GROUP].type = WidgetType::groupbox;
-            widgets[WIDX_SECONDARY_PREVIEW].type = WidgetType::spinner;
-            widgets[WIDX_ENTRANCE_STYLE].type = WidgetType::dropdownMenu;
-            widgets[WIDX_ENTRANCE_STYLE_DROPDOWN].type = WidgetType::button;
+            widgets[WIDX_SECONDARY_PREVIEW_GROUP].setVisible();
+            widgets[WIDX_SECONDARY_PREVIEW].setVisible();
+            widgets[WIDX_ENTRANCE_STYLE].setVisible();
+            widgets[WIDX_ENTRANCE_STYLE_DROPDOWN].setVisible();
 
             // clang-format off
             widgets[WIDX_SECONDARY_PREVIEW_GROUP].moveTo({  3, startY + 0});
@@ -4924,25 +4904,25 @@ namespace OpenRCT2::Ui::Windows
                 // Main colour
                 if (HasTrackColour(*ride, 0))
                 {
-                    widgets[WIDX_TRACK_MAIN_COLOUR].type = WidgetType::colourBtn;
+                    widgets[WIDX_TRACK_MAIN_COLOUR].setVisible();
                     widgets[WIDX_TRACK_MAIN_COLOUR].image = getColourButtonImage(trackColour.main);
                     widgets[WIDX_TRACK_MAIN_COLOUR].moveTo({ 84, startY + 39 });
                 }
                 else
                 {
-                    widgets[WIDX_TRACK_MAIN_COLOUR].type = WidgetType::empty;
+                    widgets[WIDX_TRACK_MAIN_COLOUR].setHidden();
                 }
 
                 // Additional colour
                 if (HasTrackColour(*ride, 1))
                 {
-                    widgets[WIDX_TRACK_ADDITIONAL_COLOUR].type = WidgetType::colourBtn;
+                    widgets[WIDX_TRACK_ADDITIONAL_COLOUR].setVisible();
                     widgets[WIDX_TRACK_ADDITIONAL_COLOUR].image = getColourButtonImage(trackColour.additional);
                     widgets[WIDX_TRACK_ADDITIONAL_COLOUR].moveTo({ 104, startY + 39 });
                 }
                 else
                 {
-                    widgets[WIDX_TRACK_ADDITIONAL_COLOUR].type = WidgetType::empty;
+                    widgets[WIDX_TRACK_ADDITIONAL_COLOUR].setHidden();
                 }
             }
 
@@ -4954,16 +4934,16 @@ namespace OpenRCT2::Ui::Windows
             const auto& rtd = ride->getRideTypeDescriptor();
 
             auto disableVehicleRecolour = [this]() {
-                widgets[WIDX_VEHICLE_PREVIEW_GROUP].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_PREVIEW].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_COLOUR_SCHEME].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_COLOUR_INDEX].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_BODY_COLOUR].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WidgetType::empty;
-                widgets[WIDX_RANDOMISE_VEHICLE_COLOURS].type = WidgetType::empty;
+                widgets[WIDX_VEHICLE_PREVIEW_GROUP].setHidden();
+                widgets[WIDX_VEHICLE_PREVIEW].setHidden();
+                widgets[WIDX_VEHICLE_COLOUR_SCHEME].setHidden();
+                widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].setHidden();
+                widgets[WIDX_VEHICLE_COLOUR_INDEX].setHidden();
+                widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].setHidden();
+                widgets[WIDX_VEHICLE_BODY_COLOUR].setHidden();
+                widgets[WIDX_VEHICLE_TRIM_COLOUR].setHidden();
+                widgets[WIDX_VEHICLE_TERTIARY_COLOUR].setHidden();
+                widgets[WIDX_RANDOMISE_VEHICLE_COLOURS].setHidden();
             };
 
             if (rtd.flags.has(RtdFlag::noVehicles) || !rtd.flags.has(RtdFlag::hasVehicleColours))
@@ -4975,18 +4955,18 @@ namespace OpenRCT2::Ui::Windows
             if (ride->vehicleColourSettings == VehicleColourSettings::same)
             {
                 _vehicleIndex = 0;
-                widgets[WIDX_RANDOMISE_VEHICLE_COLOURS].type = WidgetType::empty;
+                widgets[WIDX_RANDOMISE_VEHICLE_COLOURS].setHidden();
             }
             else
             {
-                widgets[WIDX_RANDOMISE_VEHICLE_COLOURS].type = WidgetType::button;
+                widgets[WIDX_RANDOMISE_VEHICLE_COLOURS].setVisible();
             }
 
             VehicleColour vehicleColour = RideGetVehicleColour(*ride, _vehicleIndex);
 
-            widgets[WIDX_VEHICLE_PREVIEW_GROUP].type = WidgetType::groupbox;
-            widgets[WIDX_VEHICLE_PREVIEW].type = WidgetType::scroll;
-            widgets[WIDX_VEHICLE_BODY_COLOUR].type = WidgetType::colourBtn;
+            widgets[WIDX_VEHICLE_PREVIEW_GROUP].setVisible();
+            widgets[WIDX_VEHICLE_PREVIEW].setVisible();
+            widgets[WIDX_VEHICLE_BODY_COLOUR].setVisible();
             widgets[WIDX_VEHICLE_BODY_COLOUR].image = getColourButtonImage(vehicleColour.Body);
 
             bool allowChangingBodyColour = false;
@@ -5013,23 +4993,23 @@ namespace OpenRCT2::Ui::Windows
                 return startY;
             }
 
-            widgets[WIDX_VEHICLE_BODY_COLOUR].type = WidgetType::empty;
-            widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WidgetType::empty;
-            widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WidgetType::empty;
+            widgets[WIDX_VEHICLE_BODY_COLOUR].setHidden();
+            widgets[WIDX_VEHICLE_TRIM_COLOUR].setHidden();
+            widgets[WIDX_VEHICLE_TERTIARY_COLOUR].setHidden();
 
             if (allowChangingBodyColour)
             {
-                widgets[WIDX_VEHICLE_BODY_COLOUR].type = WidgetType::colourBtn;
+                widgets[WIDX_VEHICLE_BODY_COLOUR].setVisible();
                 widgets[WIDX_VEHICLE_BODY_COLOUR].image = getColourButtonImage(vehicleColour.Body);
             }
             if (allowChangingTrimColour)
             {
-                widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WidgetType::colourBtn;
+                widgets[WIDX_VEHICLE_TRIM_COLOUR].setVisible();
                 widgets[WIDX_VEHICLE_TRIM_COLOUR].image = getColourButtonImage(vehicleColour.Trim);
             }
             if (allowChangingTertiaryColour)
             {
-                widgets[WIDX_VEHICLE_TERTIARY_COLOUR].type = WidgetType::colourBtn;
+                widgets[WIDX_VEHICLE_TERTIARY_COLOUR].setVisible();
                 widgets[WIDX_VEHICLE_TERTIARY_COLOUR].image = getColourButtonImage(vehicleColour.Tertiary);
             }
 
@@ -5037,13 +5017,13 @@ namespace OpenRCT2::Ui::Windows
             if (!ride->getRideTypeDescriptor().flags.has(RtdFlag::vehicleIsIntegral)
                 && (ride->numCarsPerTrain | ride->numTrains) > 1)
             {
-                widgets[WIDX_VEHICLE_COLOUR_SCHEME].type = WidgetType::dropdownMenu;
-                widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WidgetType::button;
+                widgets[WIDX_VEHICLE_COLOUR_SCHEME].setVisible();
+                widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].setVisible();
             }
             else
             {
-                widgets[WIDX_VEHICLE_COLOUR_SCHEME].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WidgetType::empty;
+                widgets[WIDX_VEHICLE_COLOUR_SCHEME].setHidden();
+                widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].setHidden();
             }
 
             auto vehicleNameStandard = GetRideComponentName(ride->getRideTypeDescriptor().NameConvention.vehicle);
@@ -5054,8 +5034,8 @@ namespace OpenRCT2::Ui::Windows
             // Vehicle index
             if (ride->vehicleColourSettings != VehicleColourSettings::same)
             {
-                widgets[WIDX_VEHICLE_COLOUR_INDEX].type = WidgetType::dropdownMenu;
-                widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].type = WidgetType::button;
+                widgets[WIDX_VEHICLE_COLOUR_INDEX].setVisible();
+                widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].setVisible();
 
                 uint16_t friendlyVehicleIndex = carIndexToDropdownIndex(_vehicleIndex) + 1;
                 if (ride->vehicleColourSettings == VehicleColourSettings::perTrain)
@@ -5068,8 +5048,8 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_VEHICLE_COLOUR_INDEX].type = WidgetType::empty;
-                widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].type = WidgetType::empty;
+                widgets[WIDX_VEHICLE_COLOUR_INDEX].setHidden();
+                widgets[WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN].setHidden();
             }
 
             // clang-format off
@@ -5105,7 +5085,7 @@ namespace OpenRCT2::Ui::Windows
         {
             // Track / shop item preview
             const auto& widget = widgets[WIDX_PRIMARY_PREVIEW];
-            if (widget.type == WidgetType::empty)
+            if (widget.isHidden())
                 return;
 
             const auto clipScreenPos = windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
@@ -5238,7 +5218,7 @@ namespace OpenRCT2::Ui::Windows
         void ColourOnDrawSecondaryPreview(RenderTarget& rt, const Ride* ride)
         {
             const auto& widget = widgets[WIDX_SECONDARY_PREVIEW];
-            if (widget.type == WidgetType::empty)
+            if (widget.isHidden())
                 return;
 
             const auto clipScreenPos = windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
@@ -5943,27 +5923,28 @@ namespace OpenRCT2::Ui::Windows
             if (ride == nullptr)
                 return;
 
-            widgets[WIDX_SAVE_TRACK_DESIGN].tooltip = STR_SAVE_TRACK_DESIGN_NOT_POSSIBLE;
-            widgets[WIDX_SAVE_TRACK_DESIGN].type = WidgetType::empty;
             if (gTrackDesignSaveMode && gTrackDesignSaveRideIndex == rideId)
             {
-                widgets[WIDX_SELECT_NEARBY_SCENERY].type = WidgetType::button;
-                widgets[WIDX_RESET_SELECTION].type = WidgetType::button;
-                widgets[WIDX_SAVE_DESIGN].type = WidgetType::button;
-                widgets[WIDX_CANCEL_DESIGN].type = WidgetType::button;
+                widgets[WIDX_SELECT_NEARBY_SCENERY].setVisible();
+                widgets[WIDX_RESET_SELECTION].setVisible();
+                widgets[WIDX_SAVE_DESIGN].setVisible();
+                widgets[WIDX_CANCEL_DESIGN].setVisible();
+                widgets[WIDX_SAVE_TRACK_DESIGN].setHidden();
             }
             else
             {
-                widgets[WIDX_SELECT_NEARBY_SCENERY].type = WidgetType::empty;
-                widgets[WIDX_RESET_SELECTION].type = WidgetType::empty;
-                widgets[WIDX_SAVE_DESIGN].type = WidgetType::empty;
-                widgets[WIDX_CANCEL_DESIGN].type = WidgetType::empty;
+                widgets[WIDX_SELECT_NEARBY_SCENERY].setHidden();
+                widgets[WIDX_RESET_SELECTION].setHidden();
+                widgets[WIDX_SAVE_DESIGN].setHidden();
+                widgets[WIDX_CANCEL_DESIGN].setHidden();
+                widgets[WIDX_SAVE_TRACK_DESIGN].setVisible();
 
-                widgets[WIDX_SAVE_TRACK_DESIGN].type = WidgetType::flatBtn;
                 const bool canSaveTrackDesign = ride->flags.has(RideFlag::tested) && !ride->ratings.isNull();
                 setWidgetDisabled(WIDX_SAVE_TRACK_DESIGN, !canSaveTrackDesign);
                 if (canSaveTrackDesign)
                     widgets[WIDX_SAVE_TRACK_DESIGN].tooltip = STR_SAVE_TRACK_DESIGN;
+                else
+                    widgets[WIDX_SAVE_TRACK_DESIGN].tooltip = STR_SAVE_TRACK_DESIGN_NOT_POSSIBLE;
             }
 
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);
@@ -5974,7 +5955,7 @@ namespace OpenRCT2::Ui::Windows
             drawWidgets(rt);
             drawTabImages(rt);
 
-            if (widgets[WIDX_SAVE_DESIGN].type == WidgetType::button)
+            if (widgets[WIDX_SAVE_DESIGN].isVisible())
             {
                 Widget* widget = &widgets[WIDX_PAGE_BACKGROUND];
 
@@ -6376,13 +6357,13 @@ namespace OpenRCT2::Ui::Windows
             // Hide graph buttons that are not applicable
             if (ride->getRideTypeDescriptor().flags.has(RtdFlag::hasGForces))
             {
-                widgets[WIDX_GRAPH_VERTICAL].type = WidgetType::button;
-                widgets[WIDX_GRAPH_LATERAL].type = WidgetType::button;
+                widgets[WIDX_GRAPH_VERTICAL].setVisible();
+                widgets[WIDX_GRAPH_LATERAL].setVisible();
             }
             else
             {
-                widgets[WIDX_GRAPH_VERTICAL].type = WidgetType::empty;
-                widgets[WIDX_GRAPH_LATERAL].type = WidgetType::empty;
+                widgets[WIDX_GRAPH_VERTICAL].setHidden();
+                widgets[WIDX_GRAPH_LATERAL].setHidden();
             }
 
             // Anchor graph widget
@@ -6898,7 +6879,7 @@ namespace OpenRCT2::Ui::Windows
 
             widgets[WIDX_PRIMARY_PRICE_LABEL].text = STR_RIDE_INCOME_ADMISSION_PRICE;
             widgets[WIDX_SECONDARY_PRICE_LABEL].text = STR_SHOP_ITEM_PRICE_LABEL_ON_RIDE_PHOTO;
-            widgets[WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK].type = WidgetType::empty;
+            widgets[WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK].setHidden();
 
             auto ridePrimaryPrice = RideGetPrice(*ride);
             if (ridePrimaryPrice == 0)
@@ -6914,7 +6895,7 @@ namespace OpenRCT2::Ui::Windows
             ShopItem primaryItem = ShopItem::admission;
             if (rtd.specialType == RtdSpecialType::toilet || ((primaryItem = rideEntry->shop_item[0]) != ShopItem::none))
             {
-                widgets[WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK].type = WidgetType::checkbox;
+                widgets[WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK].setVisible();
 
                 if (ShopItemHasCommonPrice(primaryItem))
                     setWidgetPressed(WIDX_PRIMARY_PRICE_SAME_THROUGHOUT_PARK, true);
@@ -6935,11 +6916,11 @@ namespace OpenRCT2::Ui::Windows
             if (secondaryItem == ShopItem::none)
             {
                 // Hide secondary item widgets
-                widgets[WIDX_SECONDARY_PRICE_LABEL].type = WidgetType::empty;
-                widgets[WIDX_SECONDARY_PRICE].type = WidgetType::empty;
-                widgets[WIDX_SECONDARY_PRICE_INCREASE].type = WidgetType::empty;
-                widgets[WIDX_SECONDARY_PRICE_DECREASE].type = WidgetType::empty;
-                widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].type = WidgetType::empty;
+                widgets[WIDX_SECONDARY_PRICE_LABEL].setHidden();
+                widgets[WIDX_SECONDARY_PRICE].setHidden();
+                widgets[WIDX_SECONDARY_PRICE_INCREASE].setHidden();
+                widgets[WIDX_SECONDARY_PRICE_DECREASE].setHidden();
+                widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].setHidden();
             }
             else
             {
@@ -6947,11 +6928,11 @@ namespace OpenRCT2::Ui::Windows
                 setWidgetPressed(WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK, ShopItemHasCommonPrice(secondaryItem));
 
                 // Show widgets
-                widgets[WIDX_SECONDARY_PRICE_LABEL].type = WidgetType::label;
-                widgets[WIDX_SECONDARY_PRICE].type = WidgetType::spinner;
-                widgets[WIDX_SECONDARY_PRICE_INCREASE].type = WidgetType::button;
-                widgets[WIDX_SECONDARY_PRICE_DECREASE].type = WidgetType::button;
-                widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].type = WidgetType::checkbox;
+                widgets[WIDX_SECONDARY_PRICE_LABEL].setVisible();
+                widgets[WIDX_SECONDARY_PRICE].setVisible();
+                widgets[WIDX_SECONDARY_PRICE_INCREASE].setVisible();
+                widgets[WIDX_SECONDARY_PRICE_DECREASE].setVisible();
+                widgets[WIDX_SECONDARY_PRICE_SAME_THROUGHOUT_PARK].setVisible();
 
                 // Set secondary item price
                 if (ride->price[1] == 0)
@@ -7146,16 +7127,16 @@ namespace OpenRCT2::Ui::Windows
             auto ride = GetRide(rideId);
             if (ride != nullptr)
             {
-                widgets[WIDX_SHOW_GUESTS_THOUGHTS].type = WidgetType::flatBtn;
+                widgets[WIDX_SHOW_GUESTS_THOUGHTS].setVisible();
                 if (ride->getRideTypeDescriptor().flags.has(RtdFlag::isShopOrFacility))
                 {
-                    widgets[WIDX_SHOW_GUESTS_ON_RIDE].type = WidgetType::empty;
-                    widgets[WIDX_SHOW_GUESTS_QUEUING].type = WidgetType::empty;
+                    widgets[WIDX_SHOW_GUESTS_ON_RIDE].setHidden();
+                    widgets[WIDX_SHOW_GUESTS_QUEUING].setHidden();
                 }
                 else
                 {
-                    widgets[WIDX_SHOW_GUESTS_ON_RIDE].type = WidgetType::flatBtn;
-                    widgets[WIDX_SHOW_GUESTS_QUEUING].type = WidgetType::flatBtn;
+                    widgets[WIDX_SHOW_GUESTS_ON_RIDE].setVisible();
+                    widgets[WIDX_SHOW_GUESTS_QUEUING].setVisible();
                 }
 
                 WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_10);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3830,20 +3830,18 @@ namespace OpenRCT2::Ui::Windows
         switch (_currentlySelectedTrack.curve)
         {
             case TrackCurve::leftSmall:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
                 break;
             case TrackCurve::left:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -3853,18 +3851,16 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::leftLarge:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -3874,22 +3870,20 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::none:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -3899,27 +3893,24 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::rightLarge:
-                if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -3929,32 +3920,28 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::right:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -3964,37 +3951,32 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::rightSmall:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -4004,42 +3986,36 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::rightVerySmall:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL) && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_VERY_SMALL);
                 }
@@ -4068,21 +4044,18 @@ namespace OpenRCT2::Ui::Windows
         switch (_currentlySelectedTrack.curve)
         {
             case TrackCurve::rightSmall:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
                 break;
             case TrackCurve::right:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4092,19 +4065,16 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::rightLarge:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4114,24 +4084,20 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::none:
-                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4141,29 +4107,24 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::leftLarge:
-                if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4173,33 +4134,28 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::left:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4209,38 +4165,32 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::leftSmall:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4250,42 +4200,36 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackCurve::leftVerySmall:
-                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL) && w->widgets[WIDX_LEFT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_SMALL);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE) && w->widgets[WIDX_LEFT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_LEFT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_STRAIGHT);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
-                    && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE) && w->widgets[WIDX_RIGHT_CURVE_LARGE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_LARGE);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL) && w->widgets[WIDX_RIGHT_CURVE_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_SMALL);
                 }
                 else if (
-                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
-                    && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WidgetType::empty)
+                    !widgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL) && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].isVisible())
                 {
                     w->onMouseDown(WIDX_RIGHT_CURVE_VERY_SMALL);
                 }
@@ -4308,23 +4252,22 @@ namespace OpenRCT2::Ui::Windows
             return;
         }
 
-        if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WidgetType::empty)
+        if (!widgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].isVisible())
         {
             w->onMouseDown(WIDX_STRAIGHT);
         }
 
-        if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WidgetType::empty)
+        if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].isVisible())
         {
             w->onMouseDown(WIDX_LEVEL);
         }
 
-        if (!widgetIsDisabled(*w, WIDX_CHAIN_LIFT) && w->widgets[WIDX_CHAIN_LIFT].type != WidgetType::empty
-            && _currentTrackHasLiftHill)
+        if (!widgetIsDisabled(*w, WIDX_CHAIN_LIFT) && w->widgets[WIDX_CHAIN_LIFT].isVisible() && _currentTrackHasLiftHill)
         {
             w->onMouseDown(WIDX_CHAIN_LIFT);
         }
 
-        if (!widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WidgetType::empty)
+        if (!widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].isVisible())
         {
             w->onMouseDown(WIDX_BANK_STRAIGHT);
         }
@@ -4343,19 +4286,19 @@ namespace OpenRCT2::Ui::Windows
         {
             case TrackPitch::down60:
                 if (IsTrackEnabled(TrackGroup::slopeVertical) && !widgetIsDisabled(*w, WIDX_SLOPE_DOWN_VERTICAL)
-                    && w->widgets[WIDX_SLOPE_DOWN_VERTICAL].type != WidgetType::empty)
+                    && w->widgets[WIDX_SLOPE_DOWN_VERTICAL].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN_VERTICAL);
                 }
                 break;
             case TrackPitch::down25:
-                if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN_STEEP);
                 }
                 break;
             case TrackPitch::none:
-                if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN);
                 }
@@ -4363,8 +4306,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     return;
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN_STEEP);
                 }
@@ -4374,16 +4316,15 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackPitch::up25:
-                if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEVEL);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN_STEEP);
                 }
@@ -4393,15 +4334,15 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackPitch::up60:
-                if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEVEL);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN);
                 }
@@ -4409,8 +4350,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     return;
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP) && w->widgets[WIDX_SLOPE_DOWN_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN_STEEP);
                 }
@@ -4421,7 +4361,7 @@ namespace OpenRCT2::Ui::Windows
                 break;
             case TrackPitch::up90:
                 if (IsTrackEnabled(TrackGroup::slopeVertical) && !widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP)
-                    && w->widgets[WIDX_SLOPE_UP_VERTICAL].type != WidgetType::empty)
+                    && w->widgets[WIDX_SLOPE_UP_VERTICAL].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP_STEEP);
                 }
@@ -4444,19 +4384,19 @@ namespace OpenRCT2::Ui::Windows
         {
             case TrackPitch::up60:
                 if (IsTrackEnabled(TrackGroup::slopeVertical) && !widgetIsDisabled(*w, WIDX_SLOPE_UP_VERTICAL)
-                    && w->widgets[WIDX_SLOPE_UP_VERTICAL].type != WidgetType::empty)
+                    && w->widgets[WIDX_SLOPE_UP_VERTICAL].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP_VERTICAL);
                 }
                 break;
             case TrackPitch::up25:
-                if (!widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP_STEEP);
                 }
                 break;
             case TrackPitch::none:
-                if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP);
                 }
@@ -4464,8 +4404,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     return;
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP_STEEP);
                 }
@@ -4475,16 +4414,15 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackPitch::down25:
-                if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEVEL);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP);
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP_STEEP);
                 }
@@ -4494,15 +4432,15 @@ namespace OpenRCT2::Ui::Windows
                 }
                 break;
             case TrackPitch::down60:
-                if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].isVisible())
                 {
                     w->onMouseDown(WIDX_LEVEL);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP);
                 }
@@ -4510,8 +4448,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     return;
                 }
-                else if (
-                    !widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_UP_STEEP);
                 }
@@ -4522,7 +4459,7 @@ namespace OpenRCT2::Ui::Windows
                 break;
             case TrackPitch::down90:
                 if (IsTrackEnabled(TrackGroup::slopeVertical) && !widgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
-                    && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WidgetType::empty)
+                    && w->widgets[WIDX_SLOPE_DOWN_STEEP].isVisible())
                 {
                     w->onMouseDown(WIDX_SLOPE_DOWN_STEEP);
                 }
@@ -4557,17 +4494,17 @@ namespace OpenRCT2::Ui::Windows
         switch (_currentTrackRollEnd)
         {
             case TrackRoll::none:
-                if (!widgetIsDisabled(*w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].isVisible())
                 {
                     w->onMouseDown(WIDX_BANK_LEFT);
                 }
                 break;
             case TrackRoll::right:
-                if (!widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_BANK_STRAIGHT);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].isVisible())
                 {
                     w->onMouseDown(WIDX_BANK_LEFT);
                 }
@@ -4594,17 +4531,17 @@ namespace OpenRCT2::Ui::Windows
         switch (_currentTrackRollEnd)
         {
             case TrackRoll::none:
-                if (!widgetIsDisabled(*w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_BANK_RIGHT);
                 }
                 break;
             case TrackRoll::left:
-                if (!widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WidgetType::empty)
+                if (!widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_BANK_STRAIGHT);
                 }
-                else if (!widgetIsDisabled(*w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].type != WidgetType::empty)
+                else if (!widgetIsDisabled(*w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].isVisible())
                 {
                     w->onMouseDown(WIDX_BANK_RIGHT);
                 }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1496,7 +1496,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case WIDX_SPECIAL_TRACK_DROPDOWN:
-                    ShowSpecialTrackDropdown(&widgets[widgetIndex]);
+                    ShowSpecialTrackDropdown(widgets[widgetIndex]);
                     break;
                 case WIDX_U_TRACK:
                     RideConstructionInvalidateCurrentTrack();
@@ -1641,10 +1641,10 @@ namespace OpenRCT2::Ui::Windows
 
             // Simulate button
             auto& simulateWidget = widgets[WIDX_SIMULATE];
-            simulateWidget.type = WidgetType::empty;
+            simulateWidget.setHidden();
             if (currentRide->supportsStatus(RideStatus::simulating))
             {
-                simulateWidget.type = WidgetType::flatBtn;
+                simulateWidget.setVisible();
                 setWidgetPressed(WIDX_SIMULATE, currentRide->status == RideStatus::simulating);
             }
             _windowTitle = FormatStringID(STR_RIDE_CONSTRUCTION_WINDOW_TITLE, currentRide->getName().c_str());
@@ -1653,8 +1653,8 @@ namespace OpenRCT2::Ui::Windows
 
         static void onDrawUpdateCoveredPieces(const TrackDrawerDescriptor& trackDrawerDescriptor, std::span<Widget> widgets)
         {
-            widgets[WIDX_U_TRACK].type = WidgetType::empty;
-            widgets[WIDX_O_TRACK].type = WidgetType::empty;
+            widgets[WIDX_U_TRACK].setHidden();
+            widgets[WIDX_O_TRACK].setHidden();
 
             if (!trackDrawerDescriptor.HasCoveredPieces())
                 return;
@@ -1671,8 +1671,8 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             widgets[WIDX_BANKING_GROUPBOX].text = STR_RIDE_CONSTRUCTION_TRACK_STYLE;
-            widgets[WIDX_U_TRACK].type = WidgetType::flatBtn;
-            widgets[WIDX_O_TRACK].type = WidgetType::flatBtn;
+            widgets[WIDX_U_TRACK].setVisible();
+            widgets[WIDX_O_TRACK].setVisible();
 
             widgets[WIDX_U_TRACK].image = ImageId(trackDrawerDescriptor.Regular.icon);
             widgets[WIDX_O_TRACK].image = ImageId(trackDrawerDescriptor.Covered.icon);
@@ -1683,13 +1683,12 @@ namespace OpenRCT2::Ui::Windows
         void onDraw(Drawing::RenderTarget& rt) override
         {
             Drawing::RenderTarget clippedRT;
-            Widget* widget;
             int32_t widgetWidth, widgetHeight;
 
             drawWidgets(rt);
 
-            widget = &widgets[WIDX_CONSTRUCT];
-            if (widget->type == WidgetType::empty)
+            auto& widget = widgets[WIDX_CONSTRUCT];
+            if (widget.isHidden())
                 return;
 
             RideId rideIndex;
@@ -1701,9 +1700,9 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             // Draw track piece
-            auto screenCoords = ScreenCoordsXY{ windowPos.x + widget->left + 1, windowPos.y + widget->top + 1 };
-            widgetWidth = widget->width() - 2;
-            widgetHeight = widget->height() - 2;
+            auto screenCoords = ScreenCoordsXY{ windowPos.x + widget.left + 1, windowPos.y + widget.top + 1 };
+            widgetWidth = widget.width() - 2;
+            widgetHeight = widget.height() - 2;
             if (ClipRenderTarget(clippedRT, rt, screenCoords, widgetWidth, widgetHeight))
             {
                 DrawTrackPiece(
@@ -1711,7 +1710,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw cost
-            screenCoords = { windowPos.x + widget->midX(), windowPos.y + widget->bottom - 23 };
+            screenCoords = { windowPos.x + widget.midX(), windowPos.y + widget.bottom - 23 };
             if (_rideConstructionState != RideConstructionState::Place)
                 drawText(rt, screenCoords, STR_BUILD_THIS, { TextAlignment::centre });
 
@@ -1736,98 +1735,55 @@ namespace OpenRCT2::Ui::Windows
             auto trackDrawerDescriptor = getCurrentTrackDrawerDescriptor(rtd);
 
             widgetsSetHoldable(*this, { WIDX_CONSTRUCT, WIDX_DEMOLISH, WIDX_NEXT_SECTION, WIDX_PREVIOUS_SECTION });
-            if (rtd.flags.has(RtdFlag::isShopOrFacility) || !currentRide->hasStation())
-            {
-                widgets[WIDX_ENTRANCE_EXIT_GROUPBOX].type = WidgetType::empty;
-                widgets[WIDX_ENTRANCE].type = WidgetType::empty;
-                widgets[WIDX_EXIT].type = WidgetType::empty;
-            }
-            else
-            {
-                widgets[WIDX_ENTRANCE_EXIT_GROUPBOX].type = WidgetType::groupbox;
-                widgets[WIDX_ENTRANCE].type = WidgetType::button;
-                widgets[WIDX_EXIT].type = WidgetType::button;
-            }
+            const bool showEntranceExit = !rtd.flags.has(RtdFlag::isShopOrFacility) && currentRide->hasStation();
+            widgets[WIDX_ENTRANCE_EXIT_GROUPBOX].setVisible(showEntranceExit);
+            widgets[WIDX_ENTRANCE].setVisible(showEntranceExit);
+            widgets[WIDX_EXIT].setVisible(showEntranceExit);
 
-            if (_specialElementDropdownState.HasActiveElements)
-            {
-                widgets[WIDX_SPECIAL_TRACK_DROPDOWN].type = WidgetType::button;
-            }
-            else
-            {
-                widgets[WIDX_SPECIAL_TRACK_DROPDOWN].type = WidgetType::empty;
-            }
+            widgets[WIDX_SPECIAL_TRACK_DROPDOWN].setVisible(_specialElementDropdownState.HasActiveElements);
 
-            if (IsTrackEnabled(TrackGroup::straight))
-            {
-                widgets[WIDX_STRAIGHT].type = WidgetType::flatBtn;
-            }
-            else
-            {
-                widgets[WIDX_STRAIGHT].type = WidgetType::empty;
-            }
+            widgets[WIDX_STRAIGHT].setVisible(IsTrackEnabled(TrackGroup::straight));
 
-            if (IsTrackEnabled(TrackGroup::curveLarge))
-            {
-                widgets[WIDX_LEFT_CURVE_LARGE].type = WidgetType::flatBtn;
-                widgets[WIDX_RIGHT_CURVE_LARGE].type = WidgetType::flatBtn;
-            }
-            else
-            {
-                widgets[WIDX_LEFT_CURVE_LARGE].type = WidgetType::empty;
-                widgets[WIDX_RIGHT_CURVE_LARGE].type = WidgetType::empty;
-            }
+            widgets[WIDX_LEFT_CURVE_LARGE].setVisible(IsTrackEnabled(TrackGroup::curveLarge));
+            widgets[WIDX_RIGHT_CURVE_LARGE].setVisible(IsTrackEnabled(TrackGroup::curveLarge));
 
-            widgets[WIDX_LEFT_CURVE].type = WidgetType::empty;
-            widgets[WIDX_RIGHT_CURVE].type = WidgetType::empty;
-            widgets[WIDX_LEFT_CURVE_SMALL].type = WidgetType::empty;
-            widgets[WIDX_RIGHT_CURVE_SMALL].type = WidgetType::empty;
-            widgets[WIDX_LEFT_CURVE_VERY_SMALL].type = WidgetType::empty;
-            widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type = WidgetType::empty;
-            if (IsTrackEnabled(TrackGroup::curveVertical))
-            {
-                widgets[WIDX_LEFT_CURVE_SMALL].type = WidgetType::flatBtn;
-                widgets[WIDX_RIGHT_CURVE_SMALL].type = WidgetType::flatBtn;
-            }
-            if (IsTrackEnabled(TrackGroup::curve))
-            {
-                widgets[WIDX_LEFT_CURVE].type = WidgetType::flatBtn;
-                widgets[WIDX_RIGHT_CURVE].type = WidgetType::flatBtn;
-            }
-            if (IsTrackEnabled(TrackGroup::curveSmall))
-            {
-                widgets[WIDX_LEFT_CURVE_SMALL].type = WidgetType::flatBtn;
-                widgets[WIDX_RIGHT_CURVE_SMALL].type = WidgetType::flatBtn;
-            }
-            if (IsTrackEnabled(TrackGroup::curveVerySmall))
-            {
-                widgets[WIDX_LEFT_CURVE_VERY_SMALL].type = WidgetType::flatBtn;
-                widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type = WidgetType::flatBtn;
-            }
+            widgets[WIDX_LEFT_CURVE_SMALL].setVisible(IsTrackEnabled(TrackGroup::curveVertical));
+            widgets[WIDX_RIGHT_CURVE_SMALL].setVisible(IsTrackEnabled(TrackGroup::curveVertical));
 
-            widgets[WIDX_SLOPE_DOWN_STEEP].type = WidgetType::empty;
-            widgets[WIDX_SLOPE_DOWN].type = WidgetType::empty;
-            widgets[WIDX_LEVEL].type = WidgetType::empty;
-            widgets[WIDX_SLOPE_UP].type = WidgetType::empty;
-            widgets[WIDX_SLOPE_UP_STEEP].type = WidgetType::empty;
+            widgets[WIDX_LEFT_CURVE].setVisible(IsTrackEnabled(TrackGroup::curve));
+            widgets[WIDX_RIGHT_CURVE].setVisible(IsTrackEnabled(TrackGroup::curve));
+
+            widgets[WIDX_LEFT_CURVE_SMALL].setVisible(IsTrackEnabled(TrackGroup::curveSmall));
+            widgets[WIDX_RIGHT_CURVE_SMALL].setVisible(IsTrackEnabled(TrackGroup::curveSmall));
+
+            widgets[WIDX_LEFT_CURVE_VERY_SMALL].setVisible(IsTrackEnabled(TrackGroup::curveVerySmall));
+            widgets[WIDX_RIGHT_CURVE_VERY_SMALL].setVisible(IsTrackEnabled(TrackGroup::curveVerySmall));
+
+            widgets[WIDX_SLOPE_DOWN_STEEP].setHidden();
+            widgets[WIDX_SLOPE_DOWN].setHidden();
+            widgets[WIDX_LEVEL].setHidden();
+            widgets[WIDX_SLOPE_UP].setHidden();
+            widgets[WIDX_SLOPE_UP_STEEP].setHidden();
+
             widgets[WIDX_SLOPE_DOWN_STEEP].image = ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_DOWN_STEEP);
             widgets[WIDX_SLOPE_DOWN_STEEP].tooltip = STR_RIDE_CONSTRUCTION_STEEP_SLOPE_DOWN_TIP;
             widgets[WIDX_SLOPE_UP_STEEP].image = ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP_STEEP);
             widgets[WIDX_SLOPE_UP_STEEP].tooltip = STR_RIDE_CONSTRUCTION_STEEP_SLOPE_UP_TIP;
+
             if (trackDrawerDescriptor.Regular.SupportsTrackGroup(TrackGroup::reverseFreefall))
             {
-                widgets[WIDX_LEVEL].type = WidgetType::flatBtn;
-                widgets[WIDX_SLOPE_UP].type = WidgetType::flatBtn;
+                widgets[WIDX_LEVEL].setVisible();
+                widgets[WIDX_SLOPE_UP].setVisible();
             }
             if (IsTrackEnabled(TrackGroup::slope) || IsTrackEnabled(TrackGroup::slopeSteepDown)
                 || IsTrackEnabled(TrackGroup::slopeSteepUp))
             {
-                widgets[WIDX_LEVEL].type = WidgetType::flatBtn;
+                widgets[WIDX_LEVEL].setVisible();
             }
             if (IsTrackEnabled(TrackGroup::slope))
             {
-                widgets[WIDX_SLOPE_DOWN].type = WidgetType::flatBtn;
-                widgets[WIDX_SLOPE_UP].type = WidgetType::flatBtn;
+                widgets[WIDX_SLOPE_DOWN].setVisible();
+                widgets[WIDX_SLOPE_UP].setVisible();
             }
             if ((IsTrackEnabled(TrackGroup::helixDownBankedHalf) || IsTrackEnabled(TrackGroup::helixUpBankedHalf))
                 && _currentTrackRollEnd != TrackRoll::none && _currentTrackPitchEnd == TrackPitch::none)
@@ -1838,19 +1794,19 @@ namespace OpenRCT2::Ui::Windows
                 if (hasHelixEquivalent)
                 {
                     // Enable helix
-                    widgets[WIDX_SLOPE_DOWN_STEEP].type = WidgetType::flatBtn;
+                    widgets[WIDX_SLOPE_DOWN_STEEP].setVisible();
                     if (IsTrackEnabled(TrackGroup::helixUpBankedHalf))
-                        widgets[WIDX_SLOPE_UP_STEEP].type = WidgetType::flatBtn;
+                        widgets[WIDX_SLOPE_UP_STEEP].setVisible();
                 }
             }
 
             if (IsTrackEnabled(TrackGroup::slopeSteepDown) || IsTrackEnabled(TrackGroup::diagSlopeSteepDown))
             {
-                widgets[WIDX_SLOPE_DOWN_STEEP].type = WidgetType::flatBtn;
+                widgets[WIDX_SLOPE_DOWN_STEEP].setVisible();
             }
             if (IsTrackEnabled(TrackGroup::slopeSteepUp) || IsTrackEnabled(TrackGroup::diagSlopeSteepUp))
             {
-                widgets[WIDX_SLOPE_UP_STEEP].type = WidgetType::flatBtn;
+                widgets[WIDX_SLOPE_UP_STEEP].setVisible();
             }
 
             const auto& gameState = getGameState();
@@ -1861,16 +1817,10 @@ namespace OpenRCT2::Ui::Windows
                 _currentTrackHasLiftHill = true;
             }
 
-            if ((IsTrackEnabled(TrackGroup::liftHill) && !_currentlySelectedTrack.isTrackType)
+            const bool showChainLift = (IsTrackEnabled(TrackGroup::liftHill) && !_currentlySelectedTrack.isTrackType)
                 || (gameState.cheats.enableChainLiftOnAllTrack
-                    && currentRide->getRideTypeDescriptor().flags.has(RtdFlag::hasTrack)))
-            {
-                widgets[WIDX_CHAIN_LIFT].type = WidgetType::flatBtn;
-            }
-            else
-            {
-                widgets[WIDX_CHAIN_LIFT].type = WidgetType::empty;
-            }
+                    && currentRide->getRideTypeDescriptor().flags.has(RtdFlag::hasTrack));
+            widgets[WIDX_CHAIN_LIFT].setVisible(showChainLift);
 
             int32_t x = kVerticalDropButtonStart;
             for (int32_t i = WIDX_SLOPE_DOWN_VERTICAL; i <= WIDX_SLOPE_UP_VERTICAL; i++)
@@ -1879,18 +1829,18 @@ namespace OpenRCT2::Ui::Windows
                 x += 24;
             }
 
-            widgets[WIDX_SLOPE_DOWN_VERTICAL].type = WidgetType::empty;
-            widgets[WIDX_SLOPE_UP_VERTICAL].type = WidgetType::empty;
+            widgets[WIDX_SLOPE_DOWN_VERTICAL].setHidden();
+            widgets[WIDX_SLOPE_UP_VERTICAL].setHidden();
 
             if (IsTrackEnabled(TrackGroup::slopeVertical) && !TrackPieceDirectionIsDiagonal(_currentTrackPieceDirection))
             {
                 if (_previousTrackPitchEnd == TrackPitch::up60 || _previousTrackPitchEnd == TrackPitch::up90)
                 {
-                    widgets[WIDX_SLOPE_UP_VERTICAL].type = WidgetType::flatBtn;
+                    widgets[WIDX_SLOPE_UP_VERTICAL].setVisible();
                 }
                 else if (_previousTrackPitchEnd == TrackPitch::down60 || _previousTrackPitchEnd == TrackPitch::down90)
                 {
-                    widgets[WIDX_SLOPE_DOWN_VERTICAL].type = WidgetType::flatBtn;
+                    widgets[WIDX_SLOPE_DOWN_VERTICAL].setVisible();
                 }
             }
 
@@ -1898,10 +1848,10 @@ namespace OpenRCT2::Ui::Windows
                 && _currentTrackPitchEnd == TrackPitch::none && _currentTrackRollEnd == TrackRoll::none
                 && (_currentlySelectedTrack == TrackCurve::left || _currentlySelectedTrack == TrackCurve::right))
             {
-                widgets[WIDX_SLOPE_DOWN_STEEP].type = WidgetType::flatBtn;
+                widgets[WIDX_SLOPE_DOWN_STEEP].setVisible();
                 widgets[WIDX_SLOPE_DOWN_STEEP].image = ImageId(SPR_RIDE_CONSTRUCTION_HELIX_DOWN);
                 widgets[WIDX_SLOPE_DOWN_STEEP].tooltip = STR_RIDE_CONSTRUCTION_HELIX_DOWN_TIP;
-                widgets[WIDX_SLOPE_UP_STEEP].type = WidgetType::flatBtn;
+                widgets[WIDX_SLOPE_UP_STEEP].setVisible();
                 widgets[WIDX_SLOPE_UP_STEEP].image = ImageId(SPR_RIDE_CONSTRUCTION_HELIX_UP);
                 widgets[WIDX_SLOPE_UP_STEEP].tooltip = STR_RIDE_CONSTRUCTION_HELIX_UP_TIP;
 
@@ -1975,11 +1925,11 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_BANK_RIGHT].right = 140;
             widgets[WIDX_BANK_RIGHT].top = top;
             widgets[WIDX_BANK_RIGHT].bottom = bottom;
-            widgets[WIDX_BANK_LEFT].type = WidgetType::empty;
-            widgets[WIDX_BANK_STRAIGHT].type = WidgetType::empty;
-            widgets[WIDX_BANK_RIGHT].type = WidgetType::empty;
-            widgets[WIDX_U_TRACK].type = WidgetType::empty;
-            widgets[WIDX_O_TRACK].type = WidgetType::empty;
+            widgets[WIDX_BANK_LEFT].setHidden();
+            widgets[WIDX_BANK_STRAIGHT].setHidden();
+            widgets[WIDX_BANK_RIGHT].setHidden();
+            widgets[WIDX_U_TRACK].setHidden();
+            widgets[WIDX_O_TRACK].setHidden();
 
             bool trackHasSpeedSetting = trackTypeHasSpeedSetting(_selectedTrackType)
                 || trackTypeHasSpeedSetting(_currentlySelectedTrack.trackType);
@@ -1997,9 +1947,9 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (IsTrackEnabled(TrackGroup::flatRollBanking))
                 {
-                    widgets[WIDX_BANK_LEFT].type = WidgetType::flatBtn;
-                    widgets[WIDX_BANK_STRAIGHT].type = WidgetType::flatBtn;
-                    widgets[WIDX_BANK_RIGHT].type = WidgetType::flatBtn;
+                    widgets[WIDX_BANK_LEFT].setVisible();
+                    widgets[WIDX_BANK_STRAIGHT].setVisible();
+                    widgets[WIDX_BANK_RIGHT].setVisible();
                 }
                 onDrawUpdateCoveredPieces(trackDrawerDescriptor, widgets);
             }
@@ -2022,10 +1972,10 @@ namespace OpenRCT2::Ui::Windows
 
                 _currentlyShowingBrakeOrBoosterSpeed = true;
 
-                widgets[WIDX_SPEED_SETTING_SPINNER].type = WidgetType::spinner;
-                widgets[WIDX_SPEED_SETTING_SPINNER_UP].type = WidgetType::button;
+                widgets[WIDX_SPEED_SETTING_SPINNER].setVisible();
+                widgets[WIDX_SPEED_SETTING_SPINNER_UP].setVisible();
                 widgets[WIDX_SPEED_SETTING_SPINNER_UP].text = STR_NUMERIC_UP;
-                widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].type = WidgetType::button;
+                widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].setVisible();
                 widgets[WIDX_SPEED_SETTING_SPINNER_DOWN].text = STR_NUMERIC_DOWN;
 
                 auto spinnerStart = 124 + widgets[WIDX_TITLE].bottom;
@@ -2038,19 +1988,19 @@ namespace OpenRCT2::Ui::Windows
             static constexpr int16_t bankingGroupboxRightWithSeatRotation = 114;
 
             widgets[WIDX_BANKING_GROUPBOX].right = bankingGroupboxRightNoSeatRotation;
-            widgets[WIDX_SEAT_ROTATION_GROUPBOX].type = WidgetType::empty;
-            widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER].type = WidgetType::empty;
-            widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_UP].type = WidgetType::empty;
-            widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_DOWN].type = WidgetType::empty;
+            widgets[WIDX_SEAT_ROTATION_GROUPBOX].setHidden();
+            widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER].setHidden();
+            widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_UP].setHidden();
+            widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_DOWN].setHidden();
 
             // Simplify this condition to "rideHasSeatRotation" for new track design format
             if ((rideHasSeatRotation && !trackHasSpeedSetting)
                 || (rideHasSeatRotation && trackHasSpeedSetting && trackHasSpeedAndSeatRotation))
             {
-                widgets[WIDX_SEAT_ROTATION_GROUPBOX].type = WidgetType::groupbox;
-                widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER].type = WidgetType::spinner;
-                widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_UP].type = WidgetType::button;
-                widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_DOWN].type = WidgetType::button;
+                widgets[WIDX_SEAT_ROTATION_GROUPBOX].setVisible();
+                widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER].setVisible();
+                widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_UP].setVisible();
+                widgets[WIDX_SEAT_ROTATION_ANGLE_SPINNER_DOWN].setVisible();
                 widgets[WIDX_BANKING_GROUPBOX].right = bankingGroupboxRightWithSeatRotation;
 
                 // squishes the track speed spinner slightly to make room for the seat rotation widgets
@@ -2083,41 +2033,41 @@ namespace OpenRCT2::Ui::Windows
                     newPressedWidgets |= (1uLL << preservedIndex);
             }
 
-            widgets[WIDX_CONSTRUCT].type = WidgetType::empty;
-            widgets[WIDX_DEMOLISH].type = WidgetType::flatBtn;
-            widgets[WIDX_ROTATE].type = WidgetType::empty;
+            widgets[WIDX_CONSTRUCT].setHidden();
+            widgets[WIDX_DEMOLISH].setVisible();
+            widgets[WIDX_ROTATE].setHidden();
             if (rtd.flags.has(RtdFlag::cannotHaveGaps))
             {
-                widgets[WIDX_PREVIOUS_SECTION].type = WidgetType::empty;
-                widgets[WIDX_NEXT_SECTION].type = WidgetType::empty;
+                widgets[WIDX_PREVIOUS_SECTION].setHidden();
+                widgets[WIDX_NEXT_SECTION].setHidden();
             }
             else
             {
-                widgets[WIDX_PREVIOUS_SECTION].type = WidgetType::flatBtn;
-                widgets[WIDX_NEXT_SECTION].type = WidgetType::flatBtn;
+                widgets[WIDX_PREVIOUS_SECTION].setVisible();
+                widgets[WIDX_NEXT_SECTION].setVisible();
             }
 
             switch (_rideConstructionState)
             {
                 case RideConstructionState::Front:
-                    widgets[WIDX_CONSTRUCT].type = WidgetType::imgBtn;
-                    widgets[WIDX_NEXT_SECTION].type = WidgetType::empty;
+                    widgets[WIDX_CONSTRUCT].setVisible();
+                    widgets[WIDX_NEXT_SECTION].setHidden();
                     break;
                 case RideConstructionState::Back:
-                    widgets[WIDX_CONSTRUCT].type = WidgetType::imgBtn;
-                    widgets[WIDX_PREVIOUS_SECTION].type = WidgetType::empty;
+                    widgets[WIDX_CONSTRUCT].setVisible();
+                    widgets[WIDX_PREVIOUS_SECTION].setHidden();
                     break;
                 case RideConstructionState::Place:
-                    widgets[WIDX_CONSTRUCT].type = WidgetType::imgBtn;
-                    widgets[WIDX_DEMOLISH].type = WidgetType::empty;
-                    widgets[WIDX_NEXT_SECTION].type = WidgetType::empty;
-                    widgets[WIDX_PREVIOUS_SECTION].type = WidgetType::empty;
-                    widgets[WIDX_ROTATE].type = WidgetType::flatBtn;
+                    widgets[WIDX_CONSTRUCT].setVisible();
+                    widgets[WIDX_DEMOLISH].setHidden();
+                    widgets[WIDX_NEXT_SECTION].setHidden();
+                    widgets[WIDX_PREVIOUS_SECTION].setHidden();
+                    widgets[WIDX_ROTATE].setVisible();
                     break;
                 case RideConstructionState::EntranceExit:
-                    widgets[WIDX_DEMOLISH].type = WidgetType::empty;
-                    widgets[WIDX_NEXT_SECTION].type = WidgetType::empty;
-                    widgets[WIDX_PREVIOUS_SECTION].type = WidgetType::empty;
+                    widgets[WIDX_DEMOLISH].setHidden();
+                    widgets[WIDX_NEXT_SECTION].setHidden();
+                    widgets[WIDX_PREVIOUS_SECTION].setHidden();
                     break;
                 default:
                     applyPressedBits(newPressedWidgets);
@@ -2591,7 +2541,7 @@ namespace OpenRCT2::Ui::Windows
             WindowRideConstructionUpdateActiveElements();
         }
 
-        void ShowSpecialTrackDropdown(Widget* widget)
+        void ShowSpecialTrackDropdown(Widget& widget)
         {
             auto& elements = _specialElementDropdownState.Elements;
 
@@ -2631,13 +2581,13 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Tune dropdown to the elements it contains
-            auto ddWidth = widget->width() - 1;
+            auto ddWidth = widget.width() - 1;
             auto targetColumnSize = _specialElementDropdownState.PreferredNumRows;
             if (targetColumnSize < _specialElementDropdownState.Elements.size())
                 ddWidth -= 30;
 
             WindowDropdownShowTextCustomWidth(
-                { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height(), colours[1], 0,
+                { windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(), colours[1], 0,
                 Dropdown::Flag::StayOpen, elements.size(), ddWidth, targetColumnSize);
 
             for (size_t j = 0; j < elements.size(); j++)
@@ -3819,7 +3769,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4033,7 +3983,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4247,7 +4197,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4277,7 +4227,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4375,7 +4325,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4473,7 +4423,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_CHAIN_LIFT) || w->widgets[WIDX_CHAIN_LIFT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_CHAIN_LIFT) || w->widgets[WIDX_CHAIN_LIFT].isHidden())
         {
             return;
         }
@@ -4485,8 +4435,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_BANK_STRAIGHT)
-            || w->widgets[WIDX_BANK_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) || w->widgets[WIDX_BANK_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4522,8 +4471,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_BANK_STRAIGHT)
-            || w->widgets[WIDX_BANK_STRAIGHT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_BANK_STRAIGHT) || w->widgets[WIDX_BANK_STRAIGHT].isHidden())
         {
             return;
         }
@@ -4559,8 +4507,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_PREVIOUS_SECTION)
-            || w->widgets[WIDX_PREVIOUS_SECTION].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_PREVIOUS_SECTION) || w->widgets[WIDX_PREVIOUS_SECTION].isHidden())
         {
             return;
         }
@@ -4572,7 +4519,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_NEXT_SECTION) || w->widgets[WIDX_NEXT_SECTION].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_NEXT_SECTION) || w->widgets[WIDX_NEXT_SECTION].isHidden())
         {
             return;
         }
@@ -4584,7 +4531,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_CONSTRUCT) || w->widgets[WIDX_CONSTRUCT].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_CONSTRUCT) || w->widgets[WIDX_CONSTRUCT].isHidden())
         {
             return;
         }
@@ -4596,7 +4543,7 @@ namespace OpenRCT2::Ui::Windows
     {
         auto* windowMgr = GetWindowManager();
         WindowBase* w = windowMgr->FindByClass(WindowClass::rideConstruction);
-        if (w == nullptr || widgetIsDisabled(*w, WIDX_DEMOLISH) || w->widgets[WIDX_DEMOLISH].type == WidgetType::empty)
+        if (w == nullptr || widgetIsDisabled(*w, WIDX_DEMOLISH) || w->widgets[WIDX_DEMOLISH].isHidden())
         {
             return;
         }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -541,9 +541,9 @@ namespace OpenRCT2::Ui::Windows
 
             if (ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_RIDE)
             {
-                widgets[WIDX_OPEN_CLOSE_ALL].type = WidgetType::empty;
-                widgets[WIDX_CLOSE_LIGHT].type = WidgetType::imgBtn;
-                widgets[WIDX_OPEN_LIGHT].type = WidgetType::imgBtn;
+                widgets[WIDX_OPEN_CLOSE_ALL].setHidden();
+                widgets[WIDX_CLOSE_LIGHT].setVisible();
+                widgets[WIDX_OPEN_LIGHT].setVisible();
 
                 const auto& gameState = getGameState();
                 const auto& rideManager = RideManager(gameState);
@@ -570,14 +570,13 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                widgets[WIDX_OPEN_CLOSE_ALL].type = WidgetType::flatBtn;
-                widgets[WIDX_CLOSE_LIGHT].type = WidgetType::empty;
-                widgets[WIDX_OPEN_LIGHT].type = WidgetType::empty;
+                widgets[WIDX_OPEN_CLOSE_ALL].setVisible();
+                widgets[WIDX_CLOSE_LIGHT].setHidden();
+                widgets[WIDX_OPEN_LIGHT].setHidden();
                 widgets[WIDX_QUICK_DEMOLISH].top = widgets[WIDX_OPEN_CLOSE_ALL].bottom + 3;
             }
             widgets[WIDX_QUICK_DEMOLISH].bottom = widgets[WIDX_QUICK_DEMOLISH].top + 23;
-            widgets[WIDX_QUICK_DEMOLISH].type = Network::GetMode() != Network::Mode::client ? WidgetType::flatBtn
-                                                                                            : WidgetType::empty;
+            widgets[WIDX_QUICK_DEMOLISH].setVisible(Network::GetMode() != Network::Mode::client);
         }
 
         /**

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -325,7 +325,7 @@ namespace OpenRCT2::Ui::Windows
             for (uint32_t i = 0; i < std::size(kScenarioOriginStringIds); i++)
             {
                 const Widget& widget = widgets[WIDX_TAB1 + i];
-                if (widget.type == WidgetType::empty)
+                if (widget.isHidden())
                     continue;
 
                 auto ft = Formatter();
@@ -833,7 +833,7 @@ namespace OpenRCT2::Ui::Windows
                 auto& widget = widgets[i + WIDX_TAB1];
                 if (!(showPages & (1 << i)))
                 {
-                    widget.type = WidgetType::empty;
+                    widget.setHidden();
                     continue;
                 }
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -724,31 +724,31 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_SCENERY_EYEDROPPER_BUTTON, gWindowSceneryEyedropperEnabled);
             setWidgetPressed(WIDX_SCENERY_BUILD_CLUSTER_BUTTON, gWindowSceneryScatterEnabled);
 
-            widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WidgetType::empty;
-            widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = WidgetType::empty;
-            widgets[WIDX_RESTRICT_SCENERY].type = WidgetType::empty;
+            widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].setHidden();
+            widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].setHidden();
+            widgets[WIDX_RESTRICT_SCENERY].setHidden();
 
             const auto tabSelectedScenery = GetSelectedScenery(tabIndex);
             if (!tabSelectedScenery.IsUndefined())
             {
                 if (tabSelectedScenery.SceneryType == SCENERY_TYPE_SMALL)
                 {
-                    widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = WidgetType::flatBtn;
+                    widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].setVisible();
 
                     auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (sceneryEntry != nullptr && sceneryEntry->flags.has(SmallSceneryFlag::isRotatable))
                     {
-                        widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WidgetType::flatBtn;
+                        widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].setVisible();
                     }
                 }
                 else if (tabSelectedScenery.SceneryType >= SCENERY_TYPE_LARGE)
                 {
-                    widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type = WidgetType::flatBtn;
+                    widgets[WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].setVisible();
                 }
 
                 if (gLegacyScene == LegacyScene::scenarioEditor || getGameState().cheats.sandboxMode)
                 {
-                    widgets[WIDX_RESTRICT_SCENERY].type = WidgetType::button;
+                    widgets[WIDX_RESTRICT_SCENERY].setVisible();
                     setWidgetPressed(WIDX_RESTRICT_SCENERY, IsSceneryItemRestricted(tabSelectedScenery));
                 }
             }
@@ -757,15 +757,15 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].image = getColourButtonImage(_scenerySecondaryColour);
             widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].image = getColourButtonImage(_sceneryTertiaryColour);
 
-            widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::empty;
-            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WidgetType::empty;
-            widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WidgetType::empty;
+            widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setHidden();
+            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].setHidden();
+            widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].setHidden();
 
             if (_sceneryPaintEnabled)
             { // repaint coloured scenery tool is on
-                widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
-                widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
-                widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setVisible();
+                widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].setVisible();
+                widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].setVisible();
             }
             else if (!tabSelectedScenery.IsUndefined())
             {
@@ -774,7 +774,7 @@ namespace OpenRCT2::Ui::Windows
                     auto* bannerEntry = ObjectEntryManager::GetObjectEntry<BannerSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (bannerEntry != nullptr && bannerEntry->flags & BANNER_ENTRY_FLAG_HAS_PRIMARY_COLOUR)
                     {
-                        widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                        widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setVisible();
                     }
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_LARGE)
@@ -785,16 +785,16 @@ namespace OpenRCT2::Ui::Windows
                         if (sceneryEntry->flags.has(LargeSceneryFlag::hasPrimaryColour)
                             && !sceneryEntry->flags.has(LargeSceneryFlag::hidePrimaryRemapButton))
                         {
-                            widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                            widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setVisible();
                         }
                         if (sceneryEntry->flags.has(LargeSceneryFlag::hasSecondaryColour)
                             && !sceneryEntry->flags.has(LargeSceneryFlag::hideSecondaryRemapButton))
                         {
-                            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].setVisible();
                         }
                         if (sceneryEntry->flags.has(LargeSceneryFlag::hasTertiaryColour))
                         {
-                            widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                            widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].setVisible();
                         }
                     }
                 }
@@ -803,16 +803,16 @@ namespace OpenRCT2::Ui::Windows
                     auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(tabSelectedScenery.EntryIndex);
                     if (wallEntry != nullptr && wallEntry->flags & (WALL_SCENERY_HAS_PRIMARY_COLOUR | WALL_SCENERY_HAS_GLASS))
                     {
-                        widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                        widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setVisible();
 
                         if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
                         {
-                            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].setVisible();
 
                             if (wallEntry->flags2 & WALL_SCENERY_2_NO_SELECT_PRIMARY_COLOUR)
-                                widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::empty;
+                                widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setHidden();
                             if (wallEntry->flags & WALL_SCENERY_HAS_TERTIARY_COLOUR)
-                                widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                                widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].setVisible();
                         }
                     }
                 }
@@ -823,12 +823,12 @@ namespace OpenRCT2::Ui::Windows
                     if (sceneryEntry != nullptr
                         && sceneryEntry->flags.hasAny(SmallSceneryFlag::hasPrimaryColour, SmallSceneryFlag::hasGlass))
                     {
-                        widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                        widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].setVisible();
 
                         if (sceneryEntry->flags.has(SmallSceneryFlag::hasSecondaryColour))
-                            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                            widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].setVisible();
                         if (sceneryEntry->flags.has(SmallSceneryFlag::hasTertiaryColour))
-                            widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WidgetType::colourBtn;
+                            widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].setVisible();
                     }
                 }
             }
@@ -882,8 +882,8 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].right = windowWidth - 8;
 
             const bool canFit = widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].top < height;
-            widgets[WIDX_SCENERY_EYEDROPPER_BUTTON].type = canFit ? WidgetType::flatBtn : WidgetType::empty;
-            widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].type = canFit ? WidgetType::flatBtn : WidgetType::empty;
+            widgets[WIDX_SCENERY_EYEDROPPER_BUTTON].setVisible(canFit);
+            widgets[WIDX_SCENERY_BUILD_CLUSTER_BUTTON].setVisible(canFit);
         }
 
         void onDraw(RenderTarget& rt) override

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -247,50 +247,50 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            Widget* main_colour_btn = &widgets[WIDX_MAIN_COLOUR];
-            Widget* text_colour_btn = &widgets[WIDX_TEXT_COLOUR];
+            auto& mainColourButton = widgets[WIDX_MAIN_COLOUR];
+            auto& textColourButotn = widgets[WIDX_TEXT_COLOUR];
 
             if (_isSmall)
             {
-                auto* wallEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(_sceneryEntry);
+                auto* wallEntry = ObjectEntryManager::GetObjectEntry<WallSceneryEntry>(_sceneryEntry);
 
-                main_colour_btn->type = WidgetType::empty;
-                text_colour_btn->type = WidgetType::empty;
+                mainColourButton.setHidden();
+                textColourButotn.setHidden();
                 if (wallEntry == nullptr)
                 {
                     return;
                 }
                 if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
                 {
-                    main_colour_btn->type = WidgetType::colourBtn;
+                    mainColourButton.setVisible();
                 }
                 if (wallEntry->flags & WALL_SCENERY_HAS_SECONDARY_COLOUR)
                 {
-                    text_colour_btn->type = WidgetType::colourBtn;
+                    textColourButotn.setVisible();
                 }
             }
             else
             {
-                auto* sceneryEntry = OpenRCT2::ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(_sceneryEntry);
+                auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<LargeSceneryEntry>(_sceneryEntry);
 
-                main_colour_btn->type = WidgetType::empty;
-                text_colour_btn->type = WidgetType::empty;
+                mainColourButton.setHidden();
+                textColourButotn.setHidden();
                 if (sceneryEntry == nullptr)
                 {
                     return;
                 }
                 if (sceneryEntry->flags.has(LargeSceneryFlag::hasPrimaryColour))
                 {
-                    main_colour_btn->type = WidgetType::colourBtn;
+                    mainColourButton.setVisible();
                 }
                 if (sceneryEntry->flags.has(LargeSceneryFlag::hasSecondaryColour))
                 {
-                    text_colour_btn->type = WidgetType::colourBtn;
+                    textColourButotn.setVisible();
                 }
             }
 
-            main_colour_btn->image = getColourButtonImage(_mainColour);
-            text_colour_btn->image = getColourButtonImage(_textColour);
+            mainColourButton.image = getColourButtonImage(_mainColour);
+            textColourButotn.image = getColourButtonImage(_textColour);
         }
 
         void onDraw(Drawing::RenderTarget& rt) override

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -843,12 +843,12 @@ namespace OpenRCT2::Ui::Windows
             {
                 case StaffType::entertainer:
                 {
-                    widgets[WIDX_CHECKBOX_1].type = WidgetType::empty;
-                    widgets[WIDX_CHECKBOX_2].type = WidgetType::empty;
-                    widgets[WIDX_CHECKBOX_3].type = WidgetType::empty;
-                    widgets[WIDX_CHECKBOX_4].type = WidgetType::empty;
-                    widgets[WIDX_COSTUME_BOX].type = WidgetType::dropdownMenu;
-                    widgets[WIDX_COSTUME_BTN].type = WidgetType::button;
+                    widgets[WIDX_CHECKBOX_1].setHidden();
+                    widgets[WIDX_CHECKBOX_2].setHidden();
+                    widgets[WIDX_CHECKBOX_3].setHidden();
+                    widgets[WIDX_CHECKBOX_4].setHidden();
+                    widgets[WIDX_COSTUME_BOX].setVisible();
+                    widgets[WIDX_COSTUME_BTN].setVisible();
 
                     auto pos = std::find_if(_availableCostumes.begin(), _availableCostumes.end(), [staff](auto costume) {
                         return costume.index == staff->AnimationObjectIndex;
@@ -868,28 +868,28 @@ namespace OpenRCT2::Ui::Windows
                     break;
                 }
                 case StaffType::handyman:
-                    widgets[WIDX_CHECKBOX_1].type = WidgetType::checkbox;
+                    widgets[WIDX_CHECKBOX_1].setVisible();
                     widgets[WIDX_CHECKBOX_1].text = STR_STAFF_OPTION_SWEEP_FOOTPATHS;
-                    widgets[WIDX_CHECKBOX_2].type = WidgetType::checkbox;
+                    widgets[WIDX_CHECKBOX_2].setVisible();
                     widgets[WIDX_CHECKBOX_2].text = STR_STAFF_OPTION_WATER_GARDENS;
-                    widgets[WIDX_CHECKBOX_3].type = WidgetType::checkbox;
+                    widgets[WIDX_CHECKBOX_3].setVisible();
                     widgets[WIDX_CHECKBOX_3].text = STR_STAFF_OPTION_EMPTY_LITTER;
-                    widgets[WIDX_CHECKBOX_4].type = WidgetType::checkbox;
+                    widgets[WIDX_CHECKBOX_4].setVisible();
                     widgets[WIDX_CHECKBOX_4].text = STR_STAFF_OPTION_MOW_GRASS;
-                    widgets[WIDX_COSTUME_BOX].type = WidgetType::empty;
-                    widgets[WIDX_COSTUME_BTN].type = WidgetType::empty;
+                    widgets[WIDX_COSTUME_BOX].setHidden();
+                    widgets[WIDX_COSTUME_BTN].setHidden();
                     OptionsSetCheckboxValues();
                     break;
                 case StaffType::mechanic:
-                    widgets[WIDX_CHECKBOX_1].type = WidgetType::checkbox;
+                    widgets[WIDX_CHECKBOX_1].setVisible();
                     widgets[WIDX_CHECKBOX_1].text = STR_INSPECT_RIDES;
-                    widgets[WIDX_CHECKBOX_2].type = WidgetType::checkbox;
+                    widgets[WIDX_CHECKBOX_2].setVisible();
                     widgets[WIDX_CHECKBOX_2].text = STR_FIX_RIDES;
-                    widgets[WIDX_CHECKBOX_3].type = WidgetType::empty;
-                    widgets[WIDX_CHECKBOX_4].type = WidgetType::empty;
-                    widgets[WIDX_COSTUME_BOX].type = WidgetType::empty;
-                    widgets[WIDX_COSTUME_BTN].type = WidgetType::empty;
-                    widgets[WIDX_COSTUME_BTN].type = WidgetType::empty;
+                    widgets[WIDX_CHECKBOX_3].setHidden();
+                    widgets[WIDX_CHECKBOX_4].setHidden();
+                    widgets[WIDX_COSTUME_BOX].setHidden();
+                    widgets[WIDX_COSTUME_BTN].setHidden();
+                    widgets[WIDX_COSTUME_BTN].setHidden();
                     OptionsSetCheckboxValues();
                     break;
                 case StaffType::security:

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -130,7 +130,7 @@ namespace OpenRCT2::Ui::Windows
             WindowInitScrollWidgets(*this);
             WindowSetResize(*this, kWindowSize, { kMaximumWindowWidth, kMaximumWindowHeight });
 
-            widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WidgetType::empty;
+            widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].setHidden();
 
             RefreshList();
         }
@@ -255,11 +255,11 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(_selectedTab + WIDX_STAFF_LIST_HANDYMEN_TAB, true);
 
             widgets[WIDX_STAFF_LIST_HIRE_BUTTON].text = GetStaffNamingConvention(GetSelectedStaffType()).ActionHire;
-            widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WidgetType::empty;
+            widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].setHidden();
 
             if (GetSelectedStaffType() != StaffType::entertainer)
             {
-                widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WidgetType::colourBtn;
+                widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].setVisible();
                 widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].image = getColourButtonImage(
                     StaffGetColour(GetSelectedStaffType()));
             }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -332,66 +332,37 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_THEMES_LIST].right = width - 4;
             widgets[WIDX_THEMES_LIST].bottom = height - 0x0F;
 
-            if (_selectedTab == WINDOW_THEMES_TAB_SETTINGS)
-            {
-                widgets[WIDX_THEMES_HEADER_WINDOW].type = WidgetType::empty;
-                widgets[WIDX_THEMES_HEADER_PALETTE].type = WidgetType::empty;
-                widgets[WIDX_THEMES_HEADER_TRANSPARENCY].type = WidgetType::empty;
-                widgets[WIDX_THEMES_LIST].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WidgetType::empty;
-                widgets[WIDX_THEMES_USE_3D_IMAGE_BUTTONS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WidgetType::button;
-                widgets[WIDX_THEMES_DELETE_BUTTON].type = WidgetType::button;
-                widgets[WIDX_THEMES_RENAME_BUTTON].type = WidgetType::button;
-                widgets[WIDX_THEMES_PRESETS].type = WidgetType::dropdownMenu;
-                widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WidgetType::button;
-                widgets[WIDX_THEMES_COLOURBTN_MASK].type = WidgetType::empty;
-            }
-            else if (_selectedTab == WINDOW_THEMES_TAB_FEATURES)
-            {
-                widgets[WIDX_THEMES_HEADER_WINDOW].type = WidgetType::empty;
-                widgets[WIDX_THEMES_HEADER_PALETTE].type = WidgetType::empty;
-                widgets[WIDX_THEMES_HEADER_TRANSPARENCY].type = WidgetType::empty;
-                widgets[WIDX_THEMES_LIST].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WidgetType::checkbox;
-                widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WidgetType::checkbox;
-                widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WidgetType::checkbox;
-                widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WidgetType::checkbox;
-                widgets[WIDX_THEMES_USE_3D_IMAGE_BUTTONS].type = WidgetType::checkbox;
-                widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_THEMES_DELETE_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RENAME_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_THEMES_PRESETS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WidgetType::empty;
-                widgets[WIDX_THEMES_COLOURBTN_MASK].type = WidgetType::empty;
+            const bool isSettings = _selectedTab == WINDOW_THEMES_TAB_SETTINGS;
+            const bool isFeatures = _selectedTab == WINDOW_THEMES_TAB_FEATURES;
+            const bool isOther = !(isSettings || isFeatures);
 
+            widgets[WIDX_THEMES_HEADER_WINDOW].setVisible(isOther);
+            widgets[WIDX_THEMES_HEADER_PALETTE].setVisible(isOther);
+            widgets[WIDX_THEMES_HEADER_TRANSPARENCY].setVisible(isOther);
+            widgets[WIDX_THEMES_LIST].setVisible(isOther);
+
+            widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].setVisible(isFeatures);
+            widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].setVisible(isFeatures);
+            widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].setVisible(isFeatures);
+            widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].setVisible(isFeatures);
+            widgets[WIDX_THEMES_USE_3D_IMAGE_BUTTONS].setVisible(isFeatures);
+
+            widgets[WIDX_THEMES_DUPLICATE_BUTTON].setVisible(isSettings);
+            widgets[WIDX_THEMES_DELETE_BUTTON].setVisible(isSettings);
+            widgets[WIDX_THEMES_RENAME_BUTTON].setVisible(isSettings);
+            widgets[WIDX_THEMES_PRESETS].setVisible(isSettings);
+            widgets[WIDX_THEMES_PRESETS_DROPDOWN].setVisible(isSettings);
+
+            widgets[WIDX_THEMES_COLOURBTN_MASK].setHidden();
+
+            if (isFeatures)
+            {
                 setCheckboxValue(WIDX_THEMES_RCT1_RIDE_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_RIDE);
                 setCheckboxValue(WIDX_THEMES_RCT1_PARK_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_PARK);
                 setCheckboxValue(
                     WIDX_THEMES_RCT1_SCENARIO_FONT, ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT);
                 setCheckboxValue(WIDX_THEMES_RCT1_BOTTOM_TOOLBAR, ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
                 setCheckboxValue(WIDX_THEMES_USE_3D_IMAGE_BUTTONS, ThemeGetFlags() & UITHEME_FLAG_USE_3D_IMAGE_BUTTONS);
-            }
-            else
-            {
-                widgets[WIDX_THEMES_HEADER_WINDOW].type = WidgetType::tableHeader;
-                widgets[WIDX_THEMES_HEADER_PALETTE].type = WidgetType::tableHeader;
-                widgets[WIDX_THEMES_HEADER_TRANSPARENCY].type = WidgetType::tableHeader;
-                widgets[WIDX_THEMES_LIST].type = WidgetType::scroll;
-                widgets[WIDX_THEMES_RCT1_RIDE_LIGHTS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_PARK_LIGHTS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_SCENARIO_FONT].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RCT1_BOTTOM_TOOLBAR].type = WidgetType::empty;
-                widgets[WIDX_THEMES_USE_3D_IMAGE_BUTTONS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_DUPLICATE_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_THEMES_DELETE_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_THEMES_RENAME_BUTTON].type = WidgetType::empty;
-                widgets[WIDX_THEMES_PRESETS].type = WidgetType::empty;
-                widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WidgetType::empty;
-                widgets[WIDX_THEMES_COLOURBTN_MASK].type = WidgetType::empty;
             }
         }
 
@@ -683,14 +654,13 @@ namespace OpenRCT2::Ui::Windows
                         }
                         else
                         {
-                            widgets[WIDX_THEMES_COLOURBTN_MASK].type = WidgetType::colourBtn;
-                            widgets[WIDX_THEMES_COLOURBTN_MASK].left = _button_offset_x + widgets[WIDX_THEMES_LIST].left
-                                + _button_size;
-                            widgets[WIDX_THEMES_COLOURBTN_MASK].top = GetTotalColoursUpTo(_classIndex) * (_button_size + 2)
-                                - _button_offset_y - 4 + _button_size * _buttonIndex - scrolls[0].contentOffsetY
-                                + widgets[WIDX_THEMES_LIST].top;
-                            widgets[WIDX_THEMES_COLOURBTN_MASK].right = widgets[WIDX_THEMES_COLOURBTN_MASK].left + 12;
-                            widgets[WIDX_THEMES_COLOURBTN_MASK].bottom = widgets[WIDX_THEMES_COLOURBTN_MASK].top + 12;
+                            auto& colourButton = widgets[WIDX_THEMES_COLOURBTN_MASK];
+                            colourButton.setVisible();
+                            colourButton.left = _button_offset_x + widgets[WIDX_THEMES_LIST].left + _button_size;
+                            colourButton.top = GetTotalColoursUpTo(_classIndex) * (_button_size + 2) - _button_offset_y - 4
+                                + _button_size * _buttonIndex - scrolls[0].contentOffsetY + widgets[WIDX_THEMES_LIST].top;
+                            colourButton.right = colourButton.left + 12;
+                            colourButton.bottom = colourButton.top + 12;
 
                             auto colour = ThemeGetColour(wc, _buttonIndex);
                             WindowDropdownShowColour(

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -2165,14 +2165,14 @@ namespace OpenRCT2::Ui::Windows
 
             if (tileInspectorPage == TileInspectorPage::Default)
             {
-                widgets[WIDX_GROUPBOX_DETAILS].type = WidgetType::empty;
-                widgets[WIDX_GROUPBOX_PROPERTIES].type = WidgetType::empty;
+                widgets[WIDX_GROUPBOX_DETAILS].setHidden();
+                widgets[WIDX_GROUPBOX_PROPERTIES].setHidden();
                 widgets[WIDX_LIST].bottom = height - kBottomPadding;
             }
             else
             {
-                widgets[WIDX_GROUPBOX_DETAILS].type = WidgetType::groupbox;
-                widgets[WIDX_GROUPBOX_PROPERTIES].type = WidgetType::groupbox;
+                widgets[WIDX_GROUPBOX_DETAILS].setVisible();
+                widgets[WIDX_GROUPBOX_PROPERTIES].setVisible();
 
                 auto pageIndex = EnumValue(tileInspectorPage) - 1;
                 auto& settings = kPageGroupBoxSettings[pageIndex];

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -107,7 +107,7 @@ namespace OpenRCT2::Ui::Windows
             int32_t x = 0;
             for (Widget* widget = widgets.data(); widget != &widgets[WIDX_NEW_VERSION]; widget++)
             {
-                if (widget->type != WidgetType::empty)
+                if (widget->isVisible())
                 {
                     widget->left = x;
                     widget->right = x + MenuButtonDims.width - 1;

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -49,16 +49,16 @@ namespace OpenRCT2::Ui::Windows
         DDIDX_CUSTOM_BEGIN = 6,
     };
 
-    static constexpr ScreenSize MenuButtonDims = { 82, 82 };
-    static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
+    static constexpr ScreenSize kMenuButtonDims = { 82, 82 };
+    static constexpr ScreenSize kUpdateButtonDims = { kMenuButtonDims.width * 4, 28 };
 
     // clang-format off
     static constexpr auto _titleMenuWidgets = makeWidgets(
-        makeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_MENU_NEW_GAME),       STR_START_NEW_GAME_TIP),
-        makeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_MENU_LOAD_GAME),      STR_CONTINUE_SAVED_GAME_TIP),
-        makeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_G2_MENU_MULTIPLAYER), STR_SHOW_MULTIPLAYER_TIP),
-        makeWidget({0, UpdateButtonDims.height}, MenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_MENU_TOOLBOX),        STR_GAME_TOOLS_TIP),
-        makeWidget({0,                       0}, UpdateButtonDims, WidgetType::empty,  WindowColour::secondary, STR_UPDATE_AVAILABLE)
+        makeWidget({0, kUpdateButtonDims.height}, kMenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_MENU_NEW_GAME),       STR_START_NEW_GAME_TIP),
+        makeWidget({0, kUpdateButtonDims.height}, kMenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_MENU_LOAD_GAME),      STR_CONTINUE_SAVED_GAME_TIP),
+        makeWidget({0, kUpdateButtonDims.height}, kMenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_G2_MENU_MULTIPLAYER), STR_SHOW_MULTIPLAYER_TIP),
+        makeWidget({0, kUpdateButtonDims.height}, kMenuButtonDims,   WidgetType::imgBtn, WindowColour::tertiary,  ImageId(SPR_MENU_TOOLBOX),        STR_GAME_TOOLS_TIP),
+        makeWidget({0, kUpdateButtonDims.height}, kUpdateButtonDims, WidgetType::button, WindowColour::secondary, STR_UPDATE_AVAILABLE)
     );
     // clang-format on
 
@@ -101,7 +101,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgets(_titleMenuWidgets);
 
 #ifdef DISABLE_NETWORK
-            widgets[WIDX_MULTIPLAYER].type = WidgetType::empty;
+            widgets[WIDX_MULTIPLAYER].setHidden();
 #endif
 
             int32_t x = 0;
@@ -110,9 +110,9 @@ namespace OpenRCT2::Ui::Windows
                 if (widget->isVisible())
                 {
                     widget->left = x;
-                    widget->right = x + MenuButtonDims.width - 1;
+                    widget->right = x + kMenuButtonDims.width - 1;
 
-                    x += MenuButtonDims.width;
+                    x += kMenuButtonDims.width;
                 }
             }
             width = x;
@@ -272,13 +272,14 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            _filterRect = { windowPos + ScreenCoordsXY{ 0, UpdateButtonDims.height },
-                            windowPos + ScreenCoordsXY{ width - 1, MenuButtonDims.height + UpdateButtonDims.height - 1 } };
-            if (GetContext()->HasNewVersionInfo())
-            {
-                widgets[WIDX_NEW_VERSION].type = WidgetType::button;
+            _filterRect = { windowPos + ScreenCoordsXY{ 0, kUpdateButtonDims.height },
+                            windowPos + ScreenCoordsXY{ width - 1, kMenuButtonDims.height + kUpdateButtonDims.height - 1 } };
+
+            const bool newVersionAvailable = GetContext()->HasNewVersionInfo();
+            widgets[WIDX_NEW_VERSION].setVisible(newVersionAvailable);
+
+            if (newVersionAvailable)
                 _filterRect.Point1.y = windowPos.y;
-            }
         }
 
         void onDraw(RenderTarget& rt) override
@@ -293,7 +294,7 @@ namespace OpenRCT2::Ui::Windows
      */
     WindowBase* TitleMenuOpen()
     {
-        const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
+        const uint16_t windowHeight = kMenuButtonDims.height + kUpdateButtonDims.height;
 
         auto* windowMgr = GetWindowManager();
         return windowMgr->Create<TitleMenuWindow>(

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1238,7 +1238,7 @@ namespace OpenRCT2::Ui::Windows
         void ApplyMapRotation()
         {
             // Set map button to the right image.
-            if (widgets[WIDX_MAP].type != WidgetType::empty)
+            if (widgets[WIDX_MAP].isVisible())
             {
                 static constexpr uint32_t _imageIdByRotation[] = {
                     SPR_G2_MAP_NORTH,
@@ -1364,7 +1364,7 @@ namespace OpenRCT2::Ui::Windows
 
             ScreenCoordsXY screenPos{};
             // Draw staff button image (setting masks to the staff colours)
-            if (widgets[WIDX_STAFF].type != WidgetType::empty)
+            if (widgets[WIDX_STAFF].isVisible())
             {
                 screenPos = { windowPos.x + widgets[WIDX_STAFF].left, windowPos.y + widgets[WIDX_STAFF].top };
                 imgId = SPR_TOOLBAR_STAFF;
@@ -1375,7 +1375,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw fast forward button
-            if (widgets[WIDX_FASTFORWARD].type != WidgetType::empty)
+            if (widgets[WIDX_FASTFORWARD].isVisible())
             {
                 screenPos = { windowPos.x + widgets[WIDX_FASTFORWARD].left + 0,
                               windowPos.y + widgets[WIDX_FASTFORWARD].top + 0 };
@@ -1394,7 +1394,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw cheats button
-            if (widgets[WIDX_CHEATS].type != WidgetType::empty)
+            if (widgets[WIDX_CHEATS].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHEATS].left - 1, widgets[WIDX_CHEATS].top - 1 };
                 if (widgetIsPressed(*this, WIDX_CHEATS))
@@ -1412,7 +1412,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw chat button
-            if (widgets[WIDX_CHAT].type != WidgetType::empty)
+            if (widgets[WIDX_CHAT].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHAT].left, widgets[WIDX_CHAT].top - 2 };
                 if (widgetIsPressed(*this, WIDX_CHAT))
@@ -1421,7 +1421,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw debug button
-            if (widgets[WIDX_DEBUG].type != WidgetType::empty)
+            if (widgets[WIDX_DEBUG].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_DEBUG].left, widgets[WIDX_DEBUG].top - 1 };
                 if (widgetIsPressed(*this, WIDX_DEBUG))
@@ -1430,7 +1430,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw research button
-            if (widgets[WIDX_RESEARCH].type != WidgetType::empty)
+            if (widgets[WIDX_RESEARCH].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_RESEARCH].left - 1, widgets[WIDX_RESEARCH].top };
                 if (widgetIsPressed(*this, WIDX_RESEARCH))
@@ -1439,7 +1439,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw finances button
-            if (widgets[WIDX_FINANCES].type != WidgetType::empty)
+            if (widgets[WIDX_FINANCES].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_FINANCES].left + 3, widgets[WIDX_FINANCES].top + 1 };
                 if (widgetIsPressed(*this, WIDX_FINANCES))
@@ -1448,7 +1448,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw news button
-            if (widgets[WIDX_NEWS].type != WidgetType::empty)
+            if (widgets[WIDX_NEWS].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_NEWS].left + 3, widgets[WIDX_NEWS].top + 0 };
                 if (widgetIsPressed(*this, WIDX_NEWS))
@@ -1457,7 +1457,7 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Draw network button
-            if (widgets[WIDX_NETWORK].type != WidgetType::empty)
+            if (widgets[WIDX_NETWORK].isVisible())
             {
                 screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_NETWORK].left + 3, widgets[WIDX_NETWORK].top + 0 };
                 if (widgetIsPressed(*this, WIDX_NETWORK))
@@ -1474,7 +1474,7 @@ namespace OpenRCT2::Ui::Windows
                 drawText(rt, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft, { colour, TextAlignment::right });
             }
 
-            if (widgets[WIDX_ROTATE_ANTI_CLOCKWISE].type != WidgetType::empty)
+            if (widgets[WIDX_ROTATE_ANTI_CLOCKWISE].isVisible())
             {
                 screenPos = windowPos
                     + ScreenCoordsXY{ widgets[WIDX_ROTATE_ANTI_CLOCKWISE].left + 2,

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1084,133 +1084,83 @@ namespace OpenRCT2::Ui::Windows
         }
 #endif
 
-        void ResetWidgetToDefaultState()
+        void ResetWidgetsToDefaultState()
         {
-            // Enable / disable buttons
-            widgets[WIDX_PAUSE].type = WidgetType::trnBtn;
-            widgets[WIDX_FILE_MENU].type = WidgetType::trnBtn;
-            widgets[WIDX_ZOOM_OUT].type = WidgetType::trnBtn;
-            widgets[WIDX_ZOOM_IN].type = WidgetType::trnBtn;
-            widgets[WIDX_ROTATE_CLOCKWISE].type = WidgetType::trnBtn;
-            widgets[WIDX_ROTATE_ANTI_CLOCKWISE].type = WidgetType::trnBtn;
-            widgets[WIDX_VIEW_MENU].type = WidgetType::trnBtn;
-            widgets[WIDX_MAP].type = WidgetType::trnBtn;
-            widgets[WIDX_MUTE].type = WidgetType::trnBtn;
-            widgets[WIDX_CHAT].type = WidgetType::trnBtn;
-            widgets[WIDX_LAND].type = WidgetType::trnBtn;
-            widgets[WIDX_WATER].type = WidgetType::trnBtn;
-            widgets[WIDX_SCENERY].type = WidgetType::trnBtn;
-            widgets[WIDX_PATH].type = WidgetType::trnBtn;
-            widgets[WIDX_CONSTRUCT_RIDE].type = WidgetType::trnBtn;
-            widgets[WIDX_RIDES].type = WidgetType::trnBtn;
-            widgets[WIDX_PARK].type = WidgetType::trnBtn;
-            widgets[WIDX_STAFF].type = WidgetType::trnBtn;
-            widgets[WIDX_GUESTS].type = WidgetType::trnBtn;
-            widgets[WIDX_CLEAR_SCENERY].type = WidgetType::trnBtn;
-            widgets[WIDX_FINANCES].type = WidgetType::trnBtn;
-            widgets[WIDX_RESEARCH].type = WidgetType::trnBtn;
-            widgets[WIDX_FASTFORWARD].type = WidgetType::trnBtn;
-            widgets[WIDX_CHEATS].type = WidgetType::trnBtn;
-            widgets[WIDX_DEBUG].type = Config::Get().general.debuggingTools ? WidgetType::trnBtn : WidgetType::empty;
-            widgets[WIDX_NEWS].type = WidgetType::trnBtn;
-            widgets[WIDX_NETWORK].type = WidgetType::trnBtn;
+            for (auto& widget : widgets)
+                widget.setVisible();
         }
 
         void HideDisabledButtons()
         {
-            if (!Config::Get().interface.toolbarShowMute)
-                widgets[WIDX_MUTE].type = WidgetType::empty;
+            auto& config = Config::Get().interface;
 
-            if (!Config::Get().interface.toolbarShowChat)
-                widgets[WIDX_CHAT].type = WidgetType::empty;
+            widgets[WIDX_MUTE].setVisible(config.toolbarShowMute);
+            widgets[WIDX_CHAT].setVisible(config.toolbarShowChat);
+            widgets[WIDX_RESEARCH].setVisible(config.toolbarShowResearch);
+            widgets[WIDX_CHEATS].setVisible(config.toolbarShowCheats);
+            widgets[WIDX_NEWS].setVisible(config.toolbarShowNews);
+            widgets[WIDX_ZOOM_IN].setVisible(config.toolbarShowZoom);
+            widgets[WIDX_ZOOM_OUT].setVisible(config.toolbarShowZoom);
+            widgets[WIDX_ROTATE_ANTI_CLOCKWISE].setVisible(config.toolbarShowRotateAnticlockwise);
 
-            if (!Config::Get().interface.toolbarShowResearch)
-                widgets[WIDX_RESEARCH].type = WidgetType::empty;
+            const bool hasPauseButton = !(
+                gLegacyScene == LegacyScene::scenarioEditor || gLegacyScene == LegacyScene::trackDesignsManager);
+            widgets[WIDX_PAUSE].setVisible(hasPauseButton);
 
-            if (!Config::Get().interface.toolbarShowCheats)
-                widgets[WIDX_CHEATS].type = WidgetType::empty;
-
-            if (!Config::Get().interface.toolbarShowNews)
-                widgets[WIDX_NEWS].type = WidgetType::empty;
-
-            if (!Config::Get().interface.toolbarShowZoom)
-            {
-                widgets[WIDX_ZOOM_IN].type = WidgetType::empty;
-                widgets[WIDX_ZOOM_OUT].type = WidgetType::empty;
-            }
-
-            if (!Config::Get().interface.toolbarShowRotateAnticlockwise)
-                widgets[WIDX_ROTATE_ANTI_CLOCKWISE].type = WidgetType::empty;
-
-            if (gLegacyScene == LegacyScene::scenarioEditor || gLegacyScene == LegacyScene::trackDesignsManager)
-            {
-                widgets[WIDX_PAUSE].type = WidgetType::empty;
-            }
-
-            if ((getGameState().park.flags & PARK_FLAGS_NO_MONEY) || !Config::Get().interface.toolbarShowFinances)
-                widgets[WIDX_FINANCES].type = WidgetType::empty;
+            const bool hasFinanceButton = !((getGameState().park.flags & PARK_FLAGS_NO_MONEY) || !config.toolbarShowFinances);
+            widgets[WIDX_FINANCES].setVisible(hasFinanceButton);
         }
 
         void ApplyEditorMode()
         {
-            if (isInEditorMode() == 0)
-            {
+            if (!isInEditorMode())
                 return;
-            }
 
-            widgets[WIDX_PARK].type = WidgetType::empty;
-            widgets[WIDX_STAFF].type = WidgetType::empty;
-            widgets[WIDX_GUESTS].type = WidgetType::empty;
-            widgets[WIDX_FINANCES].type = WidgetType::empty;
-            widgets[WIDX_RESEARCH].type = WidgetType::empty;
-            widgets[WIDX_NEWS].type = WidgetType::empty;
-            widgets[WIDX_NETWORK].type = WidgetType::empty;
+            widgets[WIDX_PARK].setHidden();
+            widgets[WIDX_STAFF].setHidden();
+            widgets[WIDX_GUESTS].setHidden();
+            widgets[WIDX_FINANCES].setHidden();
+            widgets[WIDX_RESEARCH].setHidden();
+            widgets[WIDX_NEWS].setHidden();
+            widgets[WIDX_NETWORK].setHidden();
 
             auto& gameState = getGameState();
             if (gameState.editorStep != Editor::Step::landscapeEditor)
             {
-                widgets[WIDX_LAND].type = WidgetType::empty;
-                widgets[WIDX_WATER].type = WidgetType::empty;
+                widgets[WIDX_LAND].setHidden();
+                widgets[WIDX_WATER].setHidden();
             }
 
             if (gameState.editorStep != Editor::Step::rollerCoasterDesigner)
             {
-                widgets[WIDX_RIDES].type = WidgetType::empty;
-                widgets[WIDX_CONSTRUCT_RIDE].type = WidgetType::empty;
-                widgets[WIDX_FASTFORWARD].type = WidgetType::empty;
+                widgets[WIDX_RIDES].setHidden();
+                widgets[WIDX_CONSTRUCT_RIDE].setHidden();
+                widgets[WIDX_FASTFORWARD].setHidden();
             }
 
             if (gameState.editorStep != Editor::Step::landscapeEditor
                 && gameState.editorStep != Editor::Step::rollerCoasterDesigner)
             {
-                widgets[WIDX_MAP].type = WidgetType::empty;
-                widgets[WIDX_SCENERY].type = WidgetType::empty;
-                widgets[WIDX_PATH].type = WidgetType::empty;
-                widgets[WIDX_CLEAR_SCENERY].type = WidgetType::empty;
+                widgets[WIDX_MAP].setHidden();
+                widgets[WIDX_SCENERY].setHidden();
+                widgets[WIDX_PATH].setHidden();
+                widgets[WIDX_CLEAR_SCENERY].setHidden();
 
-                widgets[WIDX_ZOOM_OUT].type = WidgetType::empty;
-                widgets[WIDX_ZOOM_IN].type = WidgetType::empty;
-                widgets[WIDX_ROTATE_ANTI_CLOCKWISE].type = WidgetType::empty;
-                widgets[WIDX_ROTATE_CLOCKWISE].type = WidgetType::empty;
-                widgets[WIDX_VIEW_MENU].type = WidgetType::empty;
+                widgets[WIDX_ZOOM_OUT].setHidden();
+                widgets[WIDX_ZOOM_IN].setHidden();
+                widgets[WIDX_ROTATE_ANTI_CLOCKWISE].setHidden();
+                widgets[WIDX_ROTATE_CLOCKWISE].setHidden();
+                widgets[WIDX_VIEW_MENU].setHidden();
             }
         }
 
         void ApplyNetworkMode()
         {
-            switch (Network::GetMode())
-            {
-                case Network::Mode::none:
-                    widgets[WIDX_NETWORK].type = WidgetType::empty;
-                    widgets[WIDX_CHAT].type = WidgetType::empty;
-                    break;
-                case Network::Mode::client:
-                    widgets[WIDX_PAUSE].type = WidgetType::empty;
-                    [[fallthrough]];
-                case Network::Mode::server:
-                    widgets[WIDX_FASTFORWARD].type = WidgetType::empty;
-                    break;
-            }
+            const auto mode = Network::GetMode();
+            widgets[WIDX_NETWORK].setHidden(mode == Network::Mode::none);
+            widgets[WIDX_CHAT].setHidden(mode == Network::Mode::none);
+            widgets[WIDX_PAUSE].setHidden(mode == Network::Mode::client);
+            widgets[WIDX_FASTFORWARD].setHidden(mode == Network::Mode::server);
         }
 
         void ApplyZoomState()
@@ -1275,14 +1225,14 @@ namespace OpenRCT2::Ui::Windows
             auto totalWidth = 0;
             for (auto widgetIndex : toolbarItems)
             {
-                auto* widget = &widgets[widgetIndex];
-                if (widget->type == WidgetType::empty && widgetIndex != WIDX_SEPARATOR)
+                auto& widget = widgets[widgetIndex];
+                if (!widget.isVisible())
                     continue;
 
                 if (firstItem && widgetIndex == WIDX_SEPARATOR)
                     continue;
 
-                totalWidth += widget->width();
+                totalWidth += widget.width();
                 firstItem = false;
             }
             return totalWidth;
@@ -1295,17 +1245,17 @@ namespace OpenRCT2::Ui::Windows
             bool firstItem = true;
             for (auto widgetIndex : toolbarItems)
             {
-                auto* widget = &widgets[widgetIndex];
-                if (widget->type == WidgetType::empty && widgetIndex != WIDX_SEPARATOR)
+                auto& widget = widgets[widgetIndex];
+                if (!widget.isVisible())
                     continue;
 
                 if (firstItem && widgetIndex == WIDX_SEPARATOR)
                     continue;
 
-                auto widgetWidth = widget->width() - 1;
-                widget->left = xPos;
+                auto widgetWidth = widget.width() - 1;
+                widget.left = xPos;
                 xPos += widgetWidth;
-                widget->right = xPos;
+                widget.right = xPos;
                 xPos += 1;
 
                 firstItem = false;
@@ -1337,7 +1287,7 @@ namespace OpenRCT2::Ui::Windows
 
         void onPrepareDraw() override
         {
-            ResetWidgetToDefaultState();
+            ResetWidgetsToDefaultState();
             HideDisabledButtons();
             ApplyEditorMode();
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -416,17 +416,11 @@ namespace OpenRCT2::Ui::Windows
             const bool showPreview = (gLegacyScene == LegacyScene::trackDesignsManager) || selectedListItem != 0;
             setWidgetPressed(WIDX_TRACK_PREVIEW, showPreview);
             setWidgetDisabled(WIDX_TRACK_PREVIEW, !showPreview);
+
+            widgets[WIDX_ROTATE].setVisible(showPreview);
+            widgets[WIDX_TOGGLE_SCENERY].setVisible(showPreview);
             if (showPreview)
-            {
-                widgets[WIDX_ROTATE].type = WidgetType::flatBtn;
-                widgets[WIDX_TOGGLE_SCENERY].type = WidgetType::flatBtn;
                 setWidgetPressed(WIDX_TOGGLE_SCENERY, !gTrackDesignSceneryToggle);
-            }
-            else
-            {
-                widgets[WIDX_ROTATE].type = WidgetType::empty;
-                widgets[WIDX_TOGGLE_SCENERY].type = WidgetType::empty;
-            }
 
             // When debugging tools are on, shift everything up a bit to make room for displaying the path.
             const int32_t bottomMargin = Config::Get().general.debuggingTools ? (kWindowPadding + kDebugPathHeight)

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -166,9 +166,24 @@ namespace OpenRCT2
             moveDown(y - top);
         }
 
+        bool isHidden() const
+        {
+            return flags.has(WidgetFlag::isHidden);
+        }
+
         bool isVisible() const
         {
-            return !flags.has(WidgetFlag::isHidden);
+            return !isHidden();
+        }
+
+        void setHidden(bool state = true)
+        {
+            flags.set(WidgetFlag::isHidden, state);
+        }
+
+        void setVisible(bool state = true)
+        {
+            setHidden(!state);
         }
 
         void setString(StringId newStringId)


### PR DESCRIPTION
This is a refactor I've been meaning to do for a while. Windows now uses the 'hidden' flag for widget visibility, instead of changing the widget type itself in `prepareDraw` event functions. This simplifies some of the window code quite a bit, and will allow us to simplify widget code further down the line.

I've been careful not to change functionality, but it's still manual work. This means some testing is still in order. The windows affected are listed below, in my former to-do list.

No behavioural change is intended for this PR, so if you find anything, please report it.

- [x] Banner.cpp
- [x] EditorBottomToolbar.cpp
- [x] EditorInventionsList.cpp
- [x] EditorObjectSelection.cpp
- [x] EditorScenarioOptions.cpp
- [x] Finances.cpp
- [x] Footpath.cpp
- [x] GameBottomToolbar.cpp
- [x] GuestList.cpp
- [x] LandRights.cpp
- [x] LoadSave.cpp
- [x] Map.cpp
- [x] MapGen.cpp
- [ ] MazeConstruction.cpp -> these should stay for now
- [x] Multiplayer.cpp
- [x] NewCampaign.cpp
- [x] NewRide.cpp
- [x] Options.cpp
- [x] Park.cpp
- [x] ProgressWindow.cpp
- [x] Research.cpp
- [x] Ride.cpp
- [x] RideConstruction.cpp
- [x] RideList.cpp
- [x] ScenarioSelect.cpp
- [x] Scenery.cpp
- [x] Sign.cpp
- [x] Staff.cpp
- [x] StaffList.cpp
- [x] Themes.cpp
- [x] TileInspector.cpp
- [x] TitleMenu.cpp
- [x] TopToolbar.cpp
- [x] TrackDesignPlace.cpp
- [x] TrackList.cpp