### PR TITLE
Fix park entrance path sometimes being invisible when placed

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#26756] Guests cannot puke or litter on sloped path.
 - Fix: [#26758] [Plugin] IPv6 addresses are reported incorrectly.
 - Fix: [#26775] Maze gets wrong intensity boost from size (0.02 per tile instead of 0.01 per 2 tiles).
+- Fix: [#26805] Park entrance path is sometimes invisible when placed.
 
 0.5.3 (2026-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/park/ParkEntrancePlaceAction.cpp
+++ b/src/openrct2/actions/park/ParkEntrancePlaceAction.cpp
@@ -32,6 +32,7 @@ namespace OpenRCT2::GameActions
         : _loc(location)
         , _pathType(pathType)
         , _entranceType(entranceType)
+        , _pathTypeIsLegacy(pathTypeIsLegacy)
     {
     }
 


### PR DESCRIPTION
This fixes park entrance paths sometimes being invisible by initialising _pathTypeIsLegacy in the ParkEntrancePlaceAction constructor.


https://github.com/user-attachments/assets/57766122-2b26-45d8-9918-ec83a62184fe


https://github.com/user-attachments/assets/0b2beea5-2e44-406d-ad66-8b2a0cd3762d

