### PR TITLE
Fix #25169: convert command strips packed objects

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -265,6 +265,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Alex Harvey (loonyduck1)
 * Daniel Rödl (danielroedl)
 * Michael Hlas (mhlas7)
+* (byteraidhost)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
+- Fix: [#25169] The convert command strips custom objects from the resulting park.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -28,11 +28,13 @@ using namespace OpenRCT2::CommandLine;
 namespace OpenRCT2
 {
     static int32_t _compressLevel = kParkFileSaveCompressionLevel;
+    static bool _stripObjects = false;
 
     // clang-format off
     static constexpr CommandLineOptionDefinition kConvertOptions[]
     {
         { CMDLINE_TYPE_INTEGER, &_compressLevel, 'l', "compress-level", "The compression level to use when writing the converted file" },
+        { CMDLINE_TYPE_SWITCH, &_stripObjects, kNAC, "strip-objects", "do not pack custom objects into the converted file" },
         kOptionTableEnd
     };
 
@@ -140,7 +142,7 @@ namespace OpenRCT2
         try
         {
             auto exporter = std::make_unique<ParkFileExporter>();
-            if (Config::Get().general.savePluginData)
+            if (!_stripObjects)
             {
                 exporter->ExportObjectsList = objManager.GetPackableObjects();
             }

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -140,6 +140,10 @@ namespace OpenRCT2
         try
         {
             auto exporter = std::make_unique<ParkFileExporter>();
+            if (Config::Get().general.savePluginData)
+            {
+                exporter->ExportObjectsList = objManager.GetPackableObjects();
+            }
 
             // HACK remove the main window so it saves the park with the
             //      correct initial view

--- a/src/openrct2/command_line/ConvertCommand.cpp
+++ b/src/openrct2/command_line/ConvertCommand.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2
     static constexpr CommandLineOptionDefinition kConvertOptions[]
     {
         { CMDLINE_TYPE_INTEGER, &_compressLevel, 'l', "compress-level", "The compression level to use when writing the converted file" },
-        { CMDLINE_TYPE_SWITCH, &_stripObjects, kNAC, "strip-objects", "do not pack custom objects into the converted file" },
+        { CMDLINE_TYPE_SWITCH, &_stripObjects, kNAC, "strip-objects", "Do not pack custom objects into the converted file" },
         kOptionTableEnd
     };
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2715,6 +2715,7 @@ namespace OpenRCT2
     void ParkFileExporter::Export(GameState_t& gameState, std::string_view path, int16_t compressionLevel)
     {
         auto parkFile = std::make_unique<ParkFile>();
+        parkFile->ExportObjectsList = ExportObjectsList;
         parkFile->Save(gameState, path, compressionLevel);
     }
 


### PR DESCRIPTION
Fixes #25169.

The `convert` command produced a `.park` with no packed objects: a ~40 MB workbench `.sv6` converts to an ~11 kB file that is missing all custom content on any machine that doesn't already have those objects installed locally.

Two causes:
- `ConvertCommand.cpp` never populated the exporter's `ExportObjectsList`, unlike `ScenarioSave`, which fills it via `ObjectManager::GetPackableObjects()` when `save_plugin_data` is enabled.
- The path-based `ParkFileExporter::Export()` overload did not forward `ExportObjectsList` to the underlying `ParkFile` (the stream-based overload already does), so `ReadWritePackedObjectsChunk` saw an empty list and skipped the `packedObjects` chunk.

This populates the list in the convert command (gated on `savePluginData`, matching the in-game save) and forwards it in the path-based export.

**Testing:** Pending CI build. Once CI produces a binary I will confirm the converted `.park` contains the packed objects and loads correctly on a machine without the objects installed, then mark this ready for review.

Note: authored with AI assistance; I am verifying the build and behaviour myself before requesting review.