### PR TITLE
Fix crash for rides with missing station objects

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -267,6 +267,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Michael Hlas (mhlas7)
 * (byteraidhost)
 * Ray (RayKoopa)
+* James Cranston (jcranston)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/object/DefaultObjects.cpp
+++ b/src/openrct2/object/DefaultObjects.cpp
@@ -9,6 +9,12 @@
 
 #include "DefaultObjects.h"
 
+#include "ObjectLimits.h"
+#include "ObjectManager.h"
+#include "StationObject.h"
+
+using ObjectEntryIndex = uint16_t;
+
 namespace OpenRCT2
 {
     constexpr std::array<std::string_view, 3> kMinimumRequiredObjects = {
@@ -163,4 +169,23 @@ namespace OpenRCT2
         "rct2.terrain_edge.wood_black",
         "rct2.terrain_edge.ice",
     };
+
+    ObjectEntryIndex GetDefaultStationObject(IObjectManager& objectManager)
+    {
+        auto stationObjectIndex = objectManager.GetLoadedObjectEntryIndex("rct2.station.plain");
+        if (stationObjectIndex != kObjectEntryIndexNull)
+        {
+            return stationObjectIndex;
+        }
+
+        for (ObjectEntryIndex i = 0; i < kMaxStationObjects; i++)
+        {
+            if (objectManager.GetLoadedObject<StationObject>(i) != nullptr)
+            {
+                return i;
+            }
+        }
+
+        return kObjectEntryIndexNull;
+    }
 } // namespace OpenRCT2

--- a/src/openrct2/object/DefaultObjects.h
+++ b/src/openrct2/object/DefaultObjects.h
@@ -10,10 +10,15 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <string_view>
+
+using ObjectEntryIndex = uint16_t;
 
 namespace OpenRCT2
 {
+    struct IObjectManager;
+
     /**
      * Used by all editor modes: Scenario Editor, Track Designer and Track Designs Manager.
      */
@@ -28,4 +33,6 @@ namespace OpenRCT2
      * Used only by the Scenario Editor.
      */
     extern const std::array<std::string_view, 37> kDefaultScenarioObjects;
+
+    ObjectEntryIndex GetDefaultStationObject(IObjectManager& objectManager);
 } // namespace OpenRCT2

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -31,6 +31,7 @@
 #include "../management/NewsItem.h"
 #include "../management/Research.h"
 #include "../network/Network.h"
+#include "../object/DefaultObjects.h"
 #include "../object/ObjectEntryManager.h"
 #include "../object/ObjectManager.h"
 #include "../object/ScenarioMetaObject.h"
@@ -126,12 +127,7 @@ void ScenarioReset(GameState_t& gameState)
     MapCountRemainingLandRights();
     Staff::resetStats();
 
-    gameState.lastEntranceStyle = objManager.GetLoadedObjectEntryIndex("rct2.station.plain");
-    if (gameState.lastEntranceStyle == kObjectEntryIndexNull)
-    {
-        // Fall back to first entrance object
-        gameState.lastEntranceStyle = 0;
-    }
+    gameState.lastEntranceStyle = GetDefaultStationObject(objManager);
 
     park.marketingCampaigns.clear();
     park.ratingCasualtyPenalty = 0;

--- a/src/openrct2/scenes/editor/EditorController.cpp
+++ b/src/openrct2/scenes/editor/EditorController.cpp
@@ -713,11 +713,7 @@ namespace OpenRCT2::Editor
             SetEveryRideEntryInvented();
 
             auto& objManager = GetContext()->GetObjectManager();
-            gameState.lastEntranceStyle = objManager.GetLoadedObjectEntryIndex("rct2.station.plain");
-            if (gameState.lastEntranceStyle == kObjectEntryIndexNull)
-            {
-                gameState.lastEntranceStyle = 0;
-            }
+            gameState.lastEntranceStyle = GetDefaultStationObject(objManager);
 
             gameState.editorStep = Editor::Step::rollerCoasterDesigner;
             GfxInvalidateScreen();

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/CircularBuffer.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/CLITests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/CryptTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/DefaultObjectsTests.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/Endianness.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/EnumMapTest.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/FormattingTests.cpp"

--- a/test/tests/DefaultObjectsTests.cpp
+++ b/test/tests/DefaultObjectsTests.cpp
@@ -1,0 +1,156 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include <array>
+#include <gtest/gtest.h>
+#include <openrct2/object/DefaultObjects.h>
+#include <openrct2/object/ObjectLimits.h>
+#include <openrct2/object/ObjectList.h>
+#include <openrct2/object/ObjectManager.h>
+#include <openrct2/object/StationObject.h>
+
+using namespace OpenRCT2;
+
+class DefaultObjectsObjectManager final : public IObjectManager
+{
+public:
+    ObjectEntryIndex PlainStationIndex = kObjectEntryIndexNull;
+    std::array<StationObject*, kMaxStationObjects> StationObjects{};
+
+    Object* GetLoadedObject(ObjectType objectType, size_t index) override
+    {
+        if (objectType != ObjectType::station || index >= StationObjects.size())
+        {
+            return nullptr;
+        }
+
+        return StationObjects[index];
+    }
+
+    Object* GetLoadedObject(const ObjectEntryDescriptor& entry) override
+    {
+        return nullptr;
+    }
+
+    ObjectEntryIndex GetLoadedObjectEntryIndex(std::string_view identifier) override
+    {
+        if (identifier == "rct2.station.plain")
+        {
+            return PlainStationIndex;
+        }
+
+        return kObjectEntryIndexNull;
+    }
+
+    ObjectEntryIndex GetLoadedObjectEntryIndex(const ObjectEntryDescriptor& descriptor) override
+    {
+        return kObjectEntryIndexNull;
+    }
+
+    ObjectEntryIndex GetLoadedObjectEntryIndex(const Object* object) override
+    {
+        return kObjectEntryIndexNull;
+    }
+
+    ObjectList GetLoadedObjects() override
+    {
+        return {};
+    }
+
+    std::unique_ptr<Object> LoadTempObject(std::string_view identifier, bool loadImages) override
+    {
+        return nullptr;
+    }
+
+    Object* LoadObject(std::string_view identifier) override
+    {
+        return nullptr;
+    }
+
+    Object* LoadObject(const RCTObjectEntry* entry) override
+    {
+        return nullptr;
+    }
+
+    Object* LoadObject(const ObjectEntryDescriptor& descriptor) override
+    {
+        return nullptr;
+    }
+
+    Object* LoadObject(const ObjectEntryDescriptor& descriptor, ObjectEntryIndex slot) override
+    {
+        return nullptr;
+    }
+
+    Object* LoadRepositoryItem(const ObjectRepositoryItem& ori) override
+    {
+        return nullptr;
+    }
+
+    void LoadObjects(const ObjectList& entries, bool reportProgress = false) override
+    {
+    }
+
+    void UnloadObjects(const std::vector<ObjectEntryDescriptor>& entries) override
+    {
+    }
+
+    void UnloadAllTransient() override
+    {
+    }
+
+    void UnloadAll() override
+    {
+    }
+
+    void ResetObjects() override
+    {
+    }
+
+    std::vector<const ObjectRepositoryItem*> GetPackableObjects() override
+    {
+        return {};
+    }
+
+    const std::vector<ObjectEntryIndex>& GetAllRideEntries(ride_type_t rideType) override
+    {
+        return _rideEntries;
+    }
+
+private:
+    std::vector<ObjectEntryIndex> _rideEntries;
+};
+
+TEST(DefaultObjectsTests, DefaultStationObjectPrefersPlainStation)
+{
+    DefaultObjectsObjectManager objectManager;
+    objectManager.PlainStationIndex = 4;
+
+    StationObject stationObject;
+    objectManager.StationObjects[1] = &stationObject;
+
+    ASSERT_EQ(GetDefaultStationObject(objectManager), 4);
+}
+
+TEST(DefaultObjectsTests, DefaultStationObjectFallsBackToFirstLoadedStation)
+{
+    DefaultObjectsObjectManager objectManager;
+
+    StationObject stationObject;
+    objectManager.StationObjects[3] = &stationObject;
+
+    ASSERT_EQ(GetDefaultStationObject(objectManager), 3);
+}
+
+TEST(DefaultObjectsTests, DefaultStationObjectReturnsNullWhenNoStationIsLoaded)
+{
+    DefaultObjectsObjectManager objectManager;
+
+    ASSERT_EQ(GetDefaultStationObject(objectManager), kObjectEntryIndexNull);
+}


### PR DESCRIPTION
## Summary

- avoid dereferencing a missing station object in the ride colour-tab caption
- choose the first loaded station object when the preferred default is unavailable
- add regression tests for named, fallback, and missing station-object defaults

## Root cause

Legacy/RCT Classic object selections can have an empty station-object slot 0. The fallback selected slot 0 by number, and manually created rides inherited it. Opening the colour tab then dereferenced the missing station object while drawing its caption.

## Testing

- `cmake --build build-codex --parallel 8`
- `build-codex/OpenRCT2Tests '--gtest_filter=DefaultObjectsTests.*'` (3/3 passed)
- `bash -lc '. scripts/setenv -q; run-tests'` (270/270 passed)
- `git diff --check`
- loaded the affected save from #26811 and verified the custom Corkscrew Roller Coaster's Paint tab opens without crashing on macOS ARM64

Fixes #26811