### PR TITLE
Fix: water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
+- Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
 
 0.5.4 (2026-08-02)

--- a/src/openrct2/actions/terraform/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/LandSetHeightAction.cpp
@@ -116,16 +116,16 @@ namespace OpenRCT2::GameActions
             return Result(Status::disallowed, STR_REMOVE_LEVEL_CROSSING_FIRST, kStringIdNone);
         }
 
-        TileElement* tileElement = CheckFloatingStructures(reinterpret_cast<TileElement*>(surfaceElement), _height);
-        if (tileElement != nullptr)
-        {
-            auto res = Result(Status::disallowed, kStringIdNone, kStringIdNone);
-            MapGetObstructionErrorText(tileElement, res);
-            return res;
-        }
-
         if (!gameState.cheats.disableClearanceChecks)
         {
+            TileElement* tileElement = CheckFloatingStructures(reinterpret_cast<TileElement*>(surfaceElement), _height);
+            if (tileElement != nullptr)
+            {
+                auto res = Result(Status::disallowed, kStringIdNone, kStringIdNone);
+                MapGetObstructionErrorText(tileElement, res);
+                return res;
+            }
+
             uint8_t zCorner = _height;
             if (_style & kTileSlopeRaisedCornersMask)
             {

--- a/src/openrct2/actions/terraform/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/WaterSetHeightAction.cpp
@@ -101,7 +101,7 @@ namespace OpenRCT2::GameActions
         {
             return res2;
         }
-        if (surfaceElement->HasTrackThatNeedsWater())
+        if (surfaceElement->HasTrackThatNeedsWater() && !gameState.cheats.disableClearanceChecks)
         {
             return Result(Status::disallowed, STR_ERR_INVALID_PARAMETER, STR_ERR_TRACK_ON_THIS_TILE_NEEDS_WATER);
         }

--- a/src/openrct2/actions/track/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/track/TrackPlaceAction.cpp
@@ -326,28 +326,33 @@ namespace OpenRCT2::GameActions
                         Status::unknown, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_ERR_SURFACE_ELEMENT_NOT_FOUND);
                 }
 
-                auto waterHeight = surfaceElement->GetWaterHeight();
-                if (waterHeight == 0)
+                if (!gameState.cheats.disableClearanceChecks)
                 {
-                    return Result(
-                        Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_CAN_ONLY_BUILD_THIS_ON_WATER);
-                }
-
-                if (waterHeight != baseZ)
-                {
-                    return Result(
-                        Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_CAN_ONLY_BUILD_THIS_ON_WATER);
-                }
-                waterHeight -= kLandHeightStep;
-                if (waterHeight == surfaceElement->getBaseZ())
-                {
-                    uint8_t slope = surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask;
-                    if (slope == kTileSlopeWCornerDown || slope == kTileSlopeSCornerDown || slope == kTileSlopeECornerDown
-                        || slope == kTileSlopeNCornerDown)
+                    auto waterHeight = surfaceElement->GetWaterHeight();
+                    if (waterHeight == 0)
                     {
                         return Result(
                             Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
                             STR_CAN_ONLY_BUILD_THIS_ON_WATER);
+                    }
+
+                    if (waterHeight != baseZ)
+                    {
+                        return Result(
+                            Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
+                            STR_CAN_ONLY_BUILD_THIS_ON_WATER);
+                    }
+                    waterHeight -= kLandHeightStep;
+                    if (waterHeight == surfaceElement->getBaseZ())
+                    {
+                        uint8_t slope = surfaceElement->GetSlope() & kTileSlopeRaisedCornersMask;
+                        if (slope == kTileSlopeWCornerDown || slope == kTileSlopeSCornerDown || slope == kTileSlopeECornerDown
+                            || slope == kTileSlopeNCornerDown)
+                        {
+                            return Result(
+                                Status::disallowed, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE,
+                                STR_CAN_ONLY_BUILD_THIS_ON_WATER);
+                        }
                     }
                 }
             }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 2;
+constexpr uint8_t kStreamVersion = 3;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Even with clearance checks disabled, it was not yet possible to build water elements (like Boat Hire track elements) on land or mid-air. This PR skips those validations if clearance checks are disabled.

The 2nd commit in this PR also allows no-CC to raise/lower terrain through water-based tracks just as with other tracks, by skipping `CheckFloatingStructures` checks that only checked for `HasTrackThatNeedsWater`.