### PR TITLE
Prevent setting invalid / out-of-bounds (not unknown) ride types

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#26758] [Plugin] IPv6 addresses are reported incorrectly.
 - Fix: [#26775] Maze gets wrong intensity boost from size (0.02 per tile instead of 0.01 per 2 tiles).
 - Fix: [#26805] Park entrance path is sometimes invisible when placed.
+- Fix: [#26826] Invalid ride types can be set when the “Allow arbitrary ride type changes” cheat is enabled.
 
 0.5.3 (2026-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/actions/ride/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/ride/RideSetSettingAction.cpp
@@ -146,6 +146,11 @@ namespace OpenRCT2::GameActions
                     LOG_ERROR("Arbitrary ride type changes not allowed.");
                     return Result(Status::disallowed, STR_CANT_CHANGE_OPERATING_MODE, kStringIdNone);
                 }
+                if (_value >= RIDE_TYPE_COUNT)
+                {
+                    LOG_ERROR("Invalid ride type: %u", _value);
+                    return Result(Status::disallowed, STR_CANT_CHANGE_OPERATING_MODE, kStringIdNone);
+                }
                 break;
             default:
                 LOG_ERROR("Invalid ride setting %u", static_cast<uint8_t>(_setting));


### PR DESCRIPTION
The in-game console can currently set rides to absolutely _any_ type:

- ✅Valid types, which obviously work as expected.
- ⚠️Unknown types, which simply don't show a track but otherwise "behave".
- ⚠️Invalid / out-of-bounds types `>= RIDE_TYPE_COUNT` (103), which prevent opening the ride window when clicking their entrances/exits.
- ❌`kRideTypeNull` (255), which causes the ride to be virtually removed from all listings. *This command cannot be undone as the ride is no longer found*. This is especially annoying online as it breaks parks for seemingly no visible reason. It can prevent constructing new rides as that only desyncs builders. It spams the console with error messages about paint failures, slowing down clients noticeably if a larger track was set to this "type". Also, a client still having a window open on that ride will crash trying to click "Delete".

  https://github.com/user-attachments/assets/395262dc-9228-4546-9a0c-b59f9dfb76ab

This PR adds a "sanity" check to prevent setting types `>= RIDE_TYPE_COUNT`.

Please let me know if this requires a network version bump (I do not know which changes exactly require a bump, but I suppose any changes to `GameAction` related logic do).

