### PR TITLE
Fix Mini Golf vehicles on non-Mini Golf rides freezing the game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
+- Fix: [#26831] Mini Golf vehicles on initially non-Mini Golf rides freeze the game when the ride is opened.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
 
 0.5.4 (2026-08-02)

--- a/src/openrct2/ride/Vehicle.MiniGolf.cpp
+++ b/src/openrct2/ride/Vehicle.MiniGolf.cpp
@@ -427,6 +427,7 @@ void OpenRCT2::RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const 
 
 [[nodiscard]] Vehicle::UpdateMiniGolfSubroutineStatus Vehicle::Loc6DCA9A(const Ride& curRide)
 {
+    bool stuck = false;
     while (true)
     {
         if (track_progress == 0)
@@ -440,8 +441,12 @@ void OpenRCT2::RideUpdateMeasurementsSpecialElements_MiniGolf(Ride& ride, const 
                 remaining_distance = -1;
                 acceleration += Geometry::getAccelerationFromPitch(pitch);
                 _vehicleUnkF64E10++;
+                if (stuck)
+                    return UpdateMiniGolfSubroutineStatus::stop;
+                stuck = true;
                 continue;
             }
+            stuck = false;
             CoordsXYZ trackPos = { trackBeginEnd.begin_x, trackBeginEnd.begin_y, trackBeginEnd.begin_z };
             auto direction = trackBeginEnd.begin_direction;
             tileElement = trackBeginEnd.begin_element;


### PR DESCRIPTION
Attempted fix for https://github.com/OpenRCT2/OpenRCT2/issues/26830

Added a simplistic stuck detection to workaround an infinite loop.

Tested behavior with purposefully broken and valid rides, seems fine.
There may be better solutions by actually fixing `Loc6DCA9A`'s logic, but I do not understand it enough for that.