### PR TITLE
Improve terraforming to support column/row selection for water and paint

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Improved: [#26837] Selecting columns or rows of tiles by holding down Ctrl is now also supported by land paint and water tools.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -80,6 +80,8 @@ namespace OpenRCT2::Ui::Windows
         bool _landToolBlocked = false;
         bool _landToolMountainMode = false;
         bool _landToolPaintMode = false;
+        bool _landToolPaintDragging{};
+        uint8_t _landToolPaintSide{};
 
         money64 _landToolRaiseCost = kMoney64Undefined;
         money64 _landToolLowerCost = kMoney64Undefined;
@@ -454,11 +456,24 @@ namespace OpenRCT2::Ui::Windows
 
         int8_t ToolUpdateLandPaint(const ScreenCoordsXY& screenPos)
         {
+            const bool mapCtrlPressed = GetInputManager().isModifierKeyPressed(ModifierKey::ctrl);
+            uint8_t side{};
+
             uint8_t state_changed = 0;
 
             gMapSelectFlags.unset(MapSelectFlag::enable);
 
-            auto mapTile = ScreenGetMapXY(screenPos, nullptr);
+            auto mapTile = ScreenGetMapXYSide(screenPos, &side);
+
+            // Retain paint side while dragging
+            if (_landToolPaintDragging)
+            {
+                side = _landToolPaintSide;
+            }
+            else
+            {
+                _landToolPaintSide = side;
+            }
 
             if (!mapTile.has_value())
             {
@@ -477,13 +492,38 @@ namespace OpenRCT2::Ui::Windows
                 state_changed++;
             }
 
+            MapSelectType selectedSide = getMapSelectEdge(side & 0xFF);
+            if (gMapSelectType != selectedSide && mapCtrlPressed)
+            {
+                gMapSelectType = selectedSide;
+                state_changed++;
+            }
+
             int16_t tool_size = std::max<uint16_t>(1, gLandToolSize);
             int16_t tool_length = (tool_size - 1) * 32;
 
-            // Move to tool bottom left
-            mapTile->x -= (tool_size - 1) * 16;
-            mapTile->y -= (tool_size - 1) * 16;
-            mapTile = mapTile->ToTileStart();
+            // Decide on shape of the brush for bigger selection size
+            switch (gMapSelectType)
+            {
+                case MapSelectType::edge0:
+                case MapSelectType::edge2:
+                    // Line
+                    mapTile->y -= (tool_size - 1) * 16;
+                    mapTile->y = mapTile->ToTileStart().y;
+                    break;
+                case MapSelectType::edge1:
+                case MapSelectType::edge3:
+                    // Line
+                    mapTile->x -= (tool_size - 1) * 16;
+                    mapTile->x = mapTile->ToTileStart().x;
+                    break;
+                default:
+                    // Move to tool bottom left
+                    mapTile->x -= (tool_size - 1) * 16;
+                    mapTile->y -= (tool_size - 1) * 16;
+                    mapTile = mapTile->ToTileStart();
+                    break;
+            }
 
             if (gMapSelectPositionA.x != mapTile->x)
             {
@@ -497,8 +537,26 @@ namespace OpenRCT2::Ui::Windows
                 state_changed++;
             }
 
-            mapTile->x += tool_length;
-            mapTile->y += tool_length;
+            // Go to other side
+            switch (gMapSelectType)
+            {
+                case MapSelectType::edge0:
+                case MapSelectType::edge2:
+                    // Line
+                    mapTile->y += tool_length;
+                    gMapSelectType = MapSelectType::full;
+                    break;
+                case MapSelectType::edge1:
+                case MapSelectType::edge3:
+                    // Line
+                    mapTile->x += tool_length;
+                    gMapSelectType = MapSelectType::full;
+                    break;
+                default:
+                    mapTile->x += tool_length;
+                    mapTile->y += tool_length;
+                    break;
+            }
 
             if (gMapSelectPositionB.x != mapTile->x)
             {
@@ -561,6 +619,7 @@ namespace OpenRCT2::Ui::Windows
                     // Custom setting to only change land style instead of raising or lowering land
                     if (_landToolPaintMode)
                     {
+                        _landToolPaintDragging = true;
                         if (gMapSelectFlags.has(MapSelectFlag::enable))
                         {
                             auto surfaceSetStyleAction = GameActions::SurfaceSetStyleAction(
@@ -594,6 +653,7 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_BACKGROUND:
                     gMapSelectFlags.unset(MapSelectFlag::enable);
                     gCurrentToolId = Tool::digDown;
+                    _landToolPaintDragging = false;
                     break;
             }
         }

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -7,6 +7,8 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <openrct2-ui/UiContext.h>
+#include <openrct2-ui/input/InputManager.h>
 #include <openrct2-ui/input/MouseInput.h>
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>
@@ -294,8 +296,11 @@ namespace OpenRCT2::Ui::Windows
          */
         void ToolUpdateWater(const ScreenCoordsXY& screenPos)
         {
+            const bool mapCtrlPressed = GetInputManager().isModifierKeyPressed(ModifierKey::ctrl);
             auto* windowMgr = GetWindowManager();
+
             auto& gameState = getGameState();
+            uint8_t side{};
 
             if (gCurrentToolId == Tool::upDownArrow)
             {
@@ -344,6 +349,8 @@ namespace OpenRCT2::Ui::Windows
 
             uint8_t state_changed = 0;
 
+            ScreenGetMapXYSide(screenPos, &side);
+
             if (!gMapSelectFlags.has(MapSelectFlag::enable))
             {
                 gMapSelectFlags.set(MapSelectFlag::enable);
@@ -356,13 +363,38 @@ namespace OpenRCT2::Ui::Windows
                 state_changed++;
             }
 
+            MapSelectType selectedSide = getMapSelectEdge(side & 0xFF);
+            if (gMapSelectType != selectedSide && mapCtrlPressed)
+            {
+                gMapSelectType = selectedSide;
+                state_changed++;
+            }
+
             uint16_t tool_size = std::max<uint16_t>(1, gLandToolSize);
             uint16_t tool_length = (tool_size - 1) * kCoordsXYStep;
 
-            // Move to tool bottom left
-            mapTile.x -= tool_length / 2;
-            mapTile.y -= tool_length / 2;
-            mapTile = mapTile.ToTileStart();
+            // Decide on shape of the brush for bigger selection size
+            switch (gMapSelectType)
+            {
+                case MapSelectType::edge0:
+                case MapSelectType::edge2:
+                    // Line
+                    mapTile.y -= tool_length / 2;
+                    mapTile.y = mapTile.ToTileStart().y;
+                    break;
+                case MapSelectType::edge1:
+                case MapSelectType::edge3:
+                    // Line
+                    mapTile.x -= tool_length / 2;
+                    mapTile.x = mapTile.ToTileStart().x;
+                    break;
+                default:
+                    // Move to tool bottom left
+                    mapTile.x -= tool_length / 2;
+                    mapTile.y -= tool_length / 2;
+                    mapTile = mapTile.ToTileStart();
+                    break;
+            }
 
             if (gMapSelectPositionA.x != mapTile.x)
             {
@@ -376,8 +408,26 @@ namespace OpenRCT2::Ui::Windows
                 state_changed++;
             }
 
-            mapTile.x += tool_length;
-            mapTile.y += tool_length;
+            // Go to other side
+            switch (gMapSelectType)
+            {
+                case MapSelectType::edge0:
+                case MapSelectType::edge2:
+                    // Line
+                    mapTile.y += tool_length;
+                    gMapSelectType = MapSelectType::fullWater;
+                    break;
+                case MapSelectType::edge1:
+                case MapSelectType::edge3:
+                    // Line
+                    mapTile.x += tool_length;
+                    gMapSelectType = MapSelectType::fullWater;
+                    break;
+                default:
+                    mapTile.x += tool_length;
+                    mapTile.y += tool_length;
+                    break;
+            }
 
             if (gMapSelectPositionB.x != mapTile.x)
             {


### PR DESCRIPTION
- Improved: Selecting columns or rows of tiles by holding down Ctrl is now also supported by land paint and water tools.

Note: The price calculation of land paint is overly simplistic and may need to be improved in the future (not part of this PR):
- it incorrectly adds tiles already painted in the requested styles
- it incorrectly adds out of bounds tiles when the selection is over the edge of the map
- it incorrectly adds unowned land tiles

https://github.com/user-attachments/assets/63c38520-99ad-457c-962c-8fbc8991e18f

_(My cursor is offset in the recording above due to a recording issue; it is centered on tiles appropriately on screen.)_