### PR TITLE
Magnify picked-up peeps when viewport is in double or quadruple zoom

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#26747] Exporting a sprite file now also outputs a JSON file, allowing for round-trip conversions.
 - Improved: [#26763] The ride colour/appearance tab now visually separates fields using group boxes.
 - Improved: [#26765] The ride operations tab now visually separates fields using group boxes.
+- Improved: [#26839] Magnify picked-up peeps when viewport is in double or quadruple zoom.
 - Fix: [#26610] Player list is not updated automatically when a player joins or leaves.
 - Fix: [#26639] Handymen could begin a task while another handyman was already doing the exact same task.
 - Fix: [#26752] The Cut-away View window doesn’t display negative height values correctly on some platforms.

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -155,11 +155,6 @@ namespace OpenRCT2::Ui
             Windows::WindowZoomIn(w, true);
         else if (wheel > 0)
             Windows::WindowZoomOut(w, true);
-
-        if (w.classification == WindowClass::mainWindow && gPickupPeepImage.HasValue())
-        {
-            gPickupPeepZoom = std::min(w.viewport->zoom, ZoomLevel{ 0 });
-        }
     }
 
     static bool isSpinnerGroup(WindowBase& w, WidgetIndex index, WidgetType buttonType)

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -155,6 +155,11 @@ namespace OpenRCT2::Ui
             Windows::WindowZoomIn(w, true);
         else if (wheel > 0)
             Windows::WindowZoomOut(w, true);
+
+        if (w.classification == WindowClass::mainWindow && gPickupPeepImage.HasValue())
+        {
+            gPickupPeepZoom = std::min(w.viewport->zoom, ZoomLevel{ 0 });
+        }
     }
 
     static bool isSpinnerGroup(WindowBase& w, WidgetIndex index, WidgetType buttonType)

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -995,6 +995,12 @@ namespace OpenRCT2::Ui::Windows
             gPickupPeepX = screenCoords.x - 1;
             gPickupPeepY = screenCoords.y + 16;
 
+            auto* mainWindow = WindowGetMain();
+            if (mainWindow != nullptr)
+            {
+                gPickupPeepZoom = std::min(mainWindow->viewport->zoom, ZoomLevel{ 0 });
+            }
+
             const auto peep = GetGuest();
             if (peep == nullptr)
             {

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -690,6 +690,12 @@ namespace OpenRCT2::Ui::Windows
             gPickupPeepX = screenCoords.x - 1;
             gPickupPeepY = screenCoords.y + 16;
 
+            auto* mainWindow = WindowGetMain();
+            if (mainWindow != nullptr)
+            {
+                gPickupPeepZoom = std::min(mainWindow->viewport->zoom, ZoomLevel{ 0 });
+            }
+
             auto staff = GetStaff();
             if (staff == nullptr)
             {

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -624,23 +624,23 @@ constexpr std::array<int8_t, 3> kPickedUpPeepYOffsets = { 0, 16, 48 };
 
 void GfxInvalidatePickedUpPeep()
 {
-    auto imageId = gPickupPeepImage;
-    if (imageId.HasValue())
-    {
-        auto* g1 = GfxGetG1Element(imageId);
-        if (g1 != nullptr)
-        {
-            auto zoom = gPickupPeepZoom;
-            auto xOffset = -int8_t(gPickupPeepZoom);
-            auto yOffset = kPickedUpPeepYOffsets[xOffset];
+    if (!gPickupPeepImage.HasValue())
+        return;
 
-            int32_t left = zoom.ApplyTo(gPickupPeepX + g1->xOffset + xOffset);
-            int32_t top = zoom.ApplyTo(gPickupPeepY + g1->yOffset + yOffset);
-            int32_t right = left + zoom.ApplyTo(g1->width);
-            int32_t bottom = top + zoom.ApplyTo(g1->height);
-            GfxSetDirtyBlocks({ { left, top }, { right, bottom } });
-        }
-    }
+    auto* g1 = GfxGetG1Element(gPickupPeepImage);
+    if (g1 == nullptr)
+        return;
+
+    auto zoom = gPickupPeepZoom;
+    auto xOffset = -int8_t(gPickupPeepZoom);
+    auto yOffset = kPickedUpPeepYOffsets[xOffset];
+
+    int32_t left = gPickupPeepX + zoom.ApplyInversedTo(g1->xOffset) + xOffset;
+    int32_t top = gPickupPeepY + zoom.ApplyInversedTo(g1->yOffset) + yOffset;
+    int32_t right = left + zoom.ApplyInversedTo(g1->width);
+    int32_t bottom = top + zoom.ApplyInversedTo(g1->height);
+
+    GfxSetDirtyBlocks({ { left, top }, { right, bottom } });
 }
 
 void GfxDrawPickedUpPeep(RenderTarget& rt)

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -620,6 +620,8 @@ bool ClipRenderTarget(RenderTarget& dst, RenderTarget& src, const ScreenCoordsXY
     return false;
 }
 
+constexpr std::array<int8_t, 3> kPickedUpPeepYOffsets = { 0, 16, 48 };
+
 void GfxInvalidatePickedUpPeep()
 {
     auto imageId = gPickupPeepImage;
@@ -628,10 +630,14 @@ void GfxInvalidatePickedUpPeep()
         auto* g1 = GfxGetG1Element(imageId);
         if (g1 != nullptr)
         {
-            int32_t left = gPickupPeepX + g1->xOffset;
-            int32_t top = gPickupPeepY + g1->yOffset;
-            int32_t right = left + g1->width;
-            int32_t bottom = top + g1->height;
+            auto zoom = gPickupPeepZoom;
+            auto xOffset = -int8_t(gPickupPeepZoom);
+            auto yOffset = kPickedUpPeepYOffsets[xOffset];
+
+            int32_t left = zoom.ApplyTo(gPickupPeepX + g1->xOffset + xOffset);
+            int32_t top = zoom.ApplyTo(gPickupPeepY + g1->yOffset + yOffset);
+            int32_t right = left + zoom.ApplyTo(g1->width);
+            int32_t bottom = top + zoom.ApplyTo(g1->height);
             GfxSetDirtyBlocks({ { left, top }, { right, bottom } });
         }
     }
@@ -644,11 +650,9 @@ void GfxDrawPickedUpPeep(RenderTarget& rt)
 
     assert(rt.zoom_level == ZoomLevel{ 0 });
 
-    constexpr std::array<int8_t, 3> kYOffset = { 0, 16, 48 };
-
     auto zoom = gPickupPeepZoom;
     auto xOffset = -int8_t(gPickupPeepZoom);
-    auto yOffset = kYOffset[xOffset];
+    auto yOffset = kPickedUpPeepYOffsets[xOffset];
 
     auto pos = ScreenCoordsXY{ zoom.ApplyTo(gPickupPeepX + xOffset), zoom.ApplyTo(gPickupPeepY + yOffset) };
 

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -102,6 +102,7 @@ uint32_t gPaletteEffectFrame;
 ImageId gPickupPeepImage;
 int32_t gPickupPeepX;
 int32_t gPickupPeepY;
+ZoomLevel gPickupPeepZoom;
 
 bool gPaintForceRedraw{ false };
 
@@ -638,10 +639,26 @@ void GfxInvalidatePickedUpPeep()
 
 void GfxDrawPickedUpPeep(RenderTarget& rt)
 {
-    if (gPickupPeepImage.HasValue())
-    {
-        GfxDrawSprite(rt, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
-    }
+    if (!gPickupPeepImage.HasValue())
+        return;
+
+    assert(rt.zoom_level == ZoomLevel{ 0 });
+
+    constexpr std::array<int8_t, 3> kYOffset = { 0, 16, 48 };
+
+    auto zoom = gPickupPeepZoom;
+    auto xOffset = -int8_t(gPickupPeepZoom);
+    auto yOffset = kYOffset[xOffset];
+
+    auto pos = ScreenCoordsXY{ zoom.ApplyTo(gPickupPeepX + xOffset), zoom.ApplyTo(gPickupPeepY + yOffset) };
+
+    rt.zoom_level = zoom;
+    rt.pitch = zoom.ApplyTo(rt.pitch);
+
+    GfxDrawSprite(rt, gPickupPeepImage, pos);
+
+    rt.pitch = zoom.ApplyInversedTo(rt.pitch);
+    rt.zoom_level = ZoomLevel{ 0 };
 }
 
 std::optional<uint32_t> GetPaletteG1Index(FilterPaletteID paletteId)

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -21,6 +21,7 @@
 struct ScreenCoordsXY;
 struct ScreenLine;
 struct ScreenRect;
+struct ZoomLevel;
 
 namespace OpenRCT2::Drawing
 {
@@ -51,6 +52,8 @@ extern const OpenRCT2::Drawing::TranslucentWindowPalette kTranslucentWindowPalet
 extern ImageId gPickupPeepImage;
 extern int32_t gPickupPeepX;
 extern int32_t gPickupPeepY;
+extern ZoomLevel gPickupPeepZoom;
+
 extern bool gPaintForceRedraw;
 
 bool ClipRenderTarget(


### PR DESCRIPTION
Bit of an oddball due to how render targets are set up, but I thought this was too ridiculous _not_ to address.

Before:

https://github.com/user-attachments/assets/c7122ab6-71cc-44e0-8654-b8ed78d9c9db

After:

https://github.com/user-attachments/assets/165b88ee-de1f-46ce-8a79-9b8a081289d2


