### PR TITLE
Fix #26842: Best staff award doesn't need one of each staff type

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#26775] Maze gets wrong intensity boost from size (0.02 per tile instead of 0.01 per 2 tiles).
 - Fix: [#26805] Park entrance path is sometimes invisible when placed.
 - Fix: [#26826] Invalid ride types can be set when the “Allow arbitrary ride type changes” cheat is enabled.
+- Fix: [#26842] Best staff award doesn’t need one of each staff type.
 
 0.5.3 (2026-07-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -14,6 +14,7 @@
 #include "../config/Config.h"
 #include "../entity/EntityList.h"
 #include "../entity/Guest.h"
+#include "../entity/Staff.h"
 #include "../localisation/Formatter.h"
 #include "../profiling/Profiling.h"
 #include "../ride/Ride.h"
@@ -281,8 +282,16 @@ static bool AwardIsDeservedBestStaff(GameState_t& gameState, Park::ParkData& par
 
     auto staffCount = gameState.entities.GetEntityListCount(EntityType::staff);
     auto peepCount = gameState.entities.GetEntityListCount(EntityType::guest);
+    FlagHolder<uint8_t, StaffType> foundStaffTypes{};
 
-    return ((staffCount != 0) && staffCount >= 20 && staffCount >= peepCount / 32);
+    for (auto* staff : EntityList<Staff>())
+    {
+        foundStaffTypes.set(staff->assignedStaffType);
+    }
+
+    return (
+        foundStaffTypes.hasAll(StaffType::handyman, StaffType::mechanic, StaffType::security, StaffType::entertainer)
+        && staffCount >= 20 && staffCount >= peepCount / 32);
 }
 
 /** At least 7 shops, 4 unique, one shop per 128 guests and no more than 12 hungry guests. */

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 3;
+constexpr uint8_t kStreamVersion = 4;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 


### PR DESCRIPTION
Fixes #26842