### PR TITLE
Fix #26288: Land bordering map edges does not blend at certain angles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#26763] The ride colour/appearance tab now visually separates fields using group boxes.
 - Improved: [#26765] The ride operations tab now visually separates fields using group boxes.
 - Improved: [#26839] Magnify picked-up peeps when viewport is in double or quadruple zoom.
+- Fix: [#26288] Land bordering map edges does not blend at certain angles.
 - Fix: [#26610] Player list is not updated automatically when a player joins or leaves.
 - Fix: [#26639] Handymen could begin a task while another handyman was already doing the exact same task.
 - Fix: [#26752] The Cut-away View window doesn’t display negative height values correctly on some platforms.

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -53,27 +53,27 @@ static constexpr uint8_t Byte97B444[] = {
 static constexpr CoordsXY viewport_surface_paint_data[][4] = {
     {
         { 32, 0 },
-        { -32, 32 },
-        { -64, -32 },
-        { 0, -64 },
+        { 0, 32 },
+        { -32, 0 },
+        { 0, -32 },
     },
     {
         { 0, 32 },
-        { -64, 0 },
-        { -32, -64 },
-        { 32, -32 },
+        { -32, 0 },
+        { 0, -32 },
+        { 32, 0 },
     },
     {
         { 0, -32 },
-        { 0, 0 },
+        { 32, 0 },
+        { 0, 32 },
         { -32, 0 },
-        { -32, -32 },
     },
     {
         { -32, 0 },
-        { -32, -32 },
         { 0, -32 },
-        { 0, 0 },
+        { 32, 0 },
+        { 0, 32 },
     },
 };
 
@@ -937,7 +937,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
     const auto zoomLevel = session.rt.zoom_level;
     const uint8_t rotation = session.CurrentRotation;
     const uint8_t surfaceShape = ViewportSurfacePaintSetupGetRelativeSlope(tileElement, rotation);
-    const CoordsXY& base = session.SpritePosition;
+    const CoordsXY& base = session.MapPosition;
     const auto cornerHeights = GetSlopeRelativeCornerHeights(surfaceShape);
     const TileElement* elementPtr = &reinterpret_cast<const TileElement&>(tileElement);
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -50,7 +50,7 @@ static constexpr uint8_t Byte97B444[] = {
 };
 
 // rct2: 0x97B464, 0x97B474, 0x97B484, 0x97B494
-static constexpr CoordsXY viewport_surface_paint_data[][4] = {
+static constexpr CoordsXY kNeighbouringTileCoordOffsets[4][kNumOrthogonalDirections] = {
     {
         { 32, 0 },
         { 0, 32 },
@@ -959,9 +959,9 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
 
     TileDescriptor tileDescriptors[4];
 
-    for (std::size_t i = 0; i < std::size(viewport_surface_paint_data); i++)
+    for (std::size_t i = 0; i < std::size(kNeighbouringTileCoordOffsets); i++)
     {
-        const CoordsXY& offset = viewport_surface_paint_data[i][rotation];
+        const CoordsXY& offset = kNeighbouringTileCoordOffsets[i][rotation];
         const CoordsXY position = base + offset;
 
         TileDescriptor& descriptor = tileDescriptors[i];


### PR DESCRIPTION
This fixes #26288.

<img width="500" height="274" alt="landbug" src="https://github.com/user-attachments/assets/25e0c239-5b4c-41ad-84f7-a487fd703670" />
<img width="500" height="274" alt="landfix" src="https://github.com/user-attachments/assets/121e3579-1ceb-40a8-9001-b71a5880b62e" />

[Mini test file](https://github.com/user-attachments/files/30481297/landblendbug.zip).

The current surface tiles position was being set to `session.SpritePosition`, which changed depending on the camera angle, rather than `session.MapPosition`. Depending on the camera angle, this puts the current tile position out of bounds at the edges of the map, skipping the blend.

This fixes that, and then adjusts the neighbouring tile coordinates so that they work for the correct starting position. These now make a lot more sense, the previous coordinates were quite strange in order to compensate for the original offset position.

This also renames that array of coordinates to a better name. As far as I know this array doesn't already exist elsewhere.

The current surfaces position is only being used to check when blending, so this should not affect anything else.

I've checked by diffing giant screenshots of a couple of parks at all rotations and found no other differences, but this could probably do with a double check.