### PR TITLE
Add land style picker / eyedropper tool

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3838,3 +3838,4 @@ STR_7040    :Footpath additions
 STR_7041    :Park info panel
 STR_7042    :Date info panel
 STR_7043    :Can’t change land height here…
+STR_7044    :Land style picker. Click any tile on the map to select the same style for terraforming.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Feature: [#26845] Land ground and wall styles can be picked from existing map tiles.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 

--- a/src/openrct2-ui/UiStringIds.h
+++ b/src/openrct2-ui/UiStringIds.h
@@ -825,6 +825,7 @@ namespace OpenRCT2
         STR_LAND_TOOL_SIZE_VALUE = 5486,
         STR_LOWER_COST_AMOUNT = 985,
         STR_RAISE_COST_AMOUNT = 984,
+        STR_STYLE_EYEDROPPER_TIP = 7044,
 
         // Window: LandRights
         STR_ADJUST_LARGER_LAND_RIGHTS_TIP = 5134,

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -32,7 +32,9 @@
 #include <openrct2/object/TerrainEdgeObject.h>
 #include <openrct2/object/TerrainSurfaceObject.h>
 #include <openrct2/ui/WindowManager.h>
+#include <openrct2/world/Map.h>
 #include <openrct2/world/MapSelection.h>
+#include <openrct2/world/tile_element/SurfaceElement.h>
 
 using OpenRCT2::GameActions::CommandFlag;
 
@@ -48,6 +50,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_CLOSE,
         WIDX_MOUNTAINMODE,
         WIDX_PAINTMODE,
+        WIDX_PICKMODE,
         WIDX_PREVIEW,
         WIDX_DECREMENT,
         WIDX_INCREMENT,
@@ -64,8 +67,9 @@ namespace OpenRCT2::Ui::Windows
     // clang-format off
     static constexpr auto window_land_widgets = makeWidgets(
         makeWindowShim(kWindowTitle, kWindowSize),
-        makeWidget     ({19,  19}, {24, 24}, WidgetType::flatBtn, WindowColour::secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP), STR_ENABLE_MOUNTAIN_TOOL_TIP), // mountain mode
-        makeWidget     ({55,  19}, {24, 24}, WidgetType::flatBtn, WindowColour::secondary, ImageId(SPR_PAINTBRUSH),                 STR_DISABLE_ELEVATION),        // paint mode
+        makeWidget     ({ 7,  19}, {24, 24}, WidgetType::flatBtn, WindowColour::secondary, ImageId(SPR_RIDE_CONSTRUCTION_SLOPE_UP), STR_ENABLE_MOUNTAIN_TOOL_TIP), // mountain mode
+        makeWidget     ({37,  19}, {24, 24}, WidgetType::flatBtn, WindowColour::secondary, ImageId(SPR_PAINTBRUSH),                 STR_DISABLE_ELEVATION),        // paint mode
+        makeWidget     ({67,  19}, {24, 24}, WidgetType::flatBtn, WindowColour::secondary, ImageId(SPR_G2_EYEDROPPER),              STR_STYLE_EYEDROPPER_TIP),     // picker
         makeWidget     ({27,  48}, {44, 32}, WidgetType::imgBtn,  WindowColour::primary  , ImageId(SPR_LAND_TOOL_SIZE_0),           kStringIdNone),                // preview box
         makeRemapWidget({28,  49}, {16, 16}, WidgetType::trnBtn,  WindowColour::secondary, SPR_LAND_TOOL_DECREASE,                  STR_ADJUST_SMALLER_LAND_TIP),  // decrement size
         makeRemapWidget({54,  63}, {16, 16}, WidgetType::trnBtn,  WindowColour::secondary, SPR_LAND_TOOL_INCREASE,                  STR_ADJUST_LARGER_LAND_TIP),   // increment size
@@ -80,6 +84,7 @@ namespace OpenRCT2::Ui::Windows
         bool _landToolBlocked = false;
         bool _landToolMountainMode = false;
         bool _landToolPaintMode = false;
+        bool _landToolPickMode = false;
 
         money64 _landToolRaiseCost = kMoney64Undefined;
         money64 _landToolLowerCost = kMoney64Undefined;
@@ -131,16 +136,30 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_MOUNTAINMODE:
                     _landToolMountainMode ^= 1;
                     _landToolPaintMode = false;
+                    _landToolPickMode = false;
                     invalidate();
                     break;
                 case WIDX_PAINTMODE:
                     _landToolMountainMode = false;
                     _landToolPaintMode ^= 1;
+                    _landToolPickMode = false;
+                    invalidate();
+                    break;
+                case WIDX_PICKMODE:
+                    _landToolPickMode ^= 1;
+                    gCurrentToolId = _landToolPickMode ? Tool::crosshair : Tool::digDown;
                     invalidate();
                     break;
                 case WIDX_PREVIEW:
                     InputSize();
                     break;
+            }
+
+            // Disable picking when interacting with any other terraforming widget
+            if (widgetIndex != WIDX_PICKMODE)
+            {
+                _landToolPickMode = false;
+                gCurrentToolId = Tool::digDown;
             }
         }
 
@@ -251,6 +270,7 @@ namespace OpenRCT2::Ui::Windows
             setWidgetPressed(WIDX_WALL, gLandToolTerrainEdge != kObjectEntryIndexNull);
             setWidgetPressed(WIDX_MOUNTAINMODE, _landToolMountainMode);
             setWidgetPressed(WIDX_PAINTMODE, _landToolPaintMode);
+            setWidgetPressed(WIDX_PICKMODE, _landToolPickMode);
 
             // Update the preview image (for tool sizes up to 7)
             widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
@@ -521,7 +541,9 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_BACKGROUND:
-                    if (_landToolPaintMode)
+                    if (_landToolPickMode)
+                        ToolUpdateLandPick(screenCoords);
+                    else if (_landToolPaintMode)
                         ToolUpdateLandPaint(screenCoords);
                     else
                         ToolUpdateLand(screenCoords);
@@ -534,7 +556,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_BACKGROUND:
-                    if (gMapSelectFlags.has(MapSelectFlag::enable))
+                    if (!_landToolPickMode && gMapSelectFlags.has(MapSelectFlag::enable))
                     {
                         auto surfaceSetStyleAction = GameActions::SurfaceSetStyleAction(
                             { gMapSelectPositionA.x, gMapSelectPositionA.y, gMapSelectPositionB.x, gMapSelectPositionB.y },
@@ -558,8 +580,24 @@ namespace OpenRCT2::Ui::Windows
             {
                 case WIDX_BACKGROUND:
                 {
+                    if (_landToolPickMode)
+                    {
+                        if (_landToolBlocked)
+                        {
+                            // While holding down mouse and dragging over terrain, continuously pick styles under pointer
+                            const auto surfaceElement = MapGetSurfaceElementAt(gMapSelectPositionA);
+                            if (surfaceElement)
+                            {
+                                gLandToolTerrainSurface = surfaceElement->getSurfaceObjectIndex();
+                                gLandToolTerrainEdge = surfaceElement->getEdgeObjectIndex();
+                                _selectedFloorTexture = gLandToolTerrainSurface;
+                                _selectedWallTexture = gLandToolTerrainEdge;
+                                invalidate();
+                            }
+                        }
+                    }
                     // Custom setting to only change land style instead of raising or lowering land
-                    if (_landToolPaintMode)
+                    else if (_landToolPaintMode)
                     {
                         if (gMapSelectFlags.has(MapSelectFlag::enable))
                         {
@@ -592,6 +630,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_BACKGROUND:
+                    _landToolPickMode = false;
                     gMapSelectFlags.unset(MapSelectFlag::enable);
                     gCurrentToolId = Tool::digDown;
                     break;
@@ -844,6 +883,22 @@ namespace OpenRCT2::Ui::Windows
                 _landToolRaiseCost = raise_cost;
                 _landToolLowerCost = lower_cost;
                 windowMgr->InvalidateByClass(WindowClass::land);
+            }
+        }
+
+        void ToolUpdateLandPick(const ScreenCoordsXY& screenPos)
+        {
+            // Get map coordinates from mouse x,y position
+            std::optional<CoordsXY> mapPos = ScreenPosToMapPos(screenPos, nullptr);
+
+            // Update selection
+            gMapSelectFlags.unset(MapSelectFlag::enable);
+            if (mapPos.has_value())
+            {
+                gMapSelectFlags.set(MapSelectFlag::enable);
+                gMapSelectPositionA = mapPos.value();
+                gMapSelectPositionB = mapPos.value();
+                gMapSelectType = MapSelectType::full;
             }
         }
 


### PR DESCRIPTION
This adds a picking tool to the Land window to allow copying existing land ground and wall styles from the map:

- Holding down LMB continuously reveals the styles under the current pointer.
- Releasing LMB picks and sets the styles under the mouse pointer.
- Picking is cancelled when interacting with any other widget on the Land window (similar to Scenery).

<img width="714" height="412" alt="animation" src="https://github.com/user-attachments/assets/5e5fc26e-7f16-4b90-9ddb-4f566969dcba" />
