### PR TITLE
Add footpath picker / eyedropper tool

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3838,3 +3838,4 @@ STR_7040    :Footpath additions
 STR_7041    :Park info panel
 STR_7042    :Date info panel
 STR_7043    :Can’t change land height here…
+STR_7044    :Footpath picker. Click any footpath on the map to select the same surface and railings for construction.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Feature: [#26846] Footpath styles and railings can be picked from existing footpaths on the map.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 

--- a/src/openrct2-ui/UiStringIds.h
+++ b/src/openrct2-ui/UiStringIds.h
@@ -707,6 +707,7 @@ namespace OpenRCT2
         STR_SLOPE_DOWN_TIP = 1186,
         STR_SLOPE_UP_TIP = 1188,
         STR_TYPE = 1182,
+        STR_FOOTPATH_EYEDROPPER_TIP = 7044,
 
         // Window: GameBottomToolbar
         STR_BOTTOM_TOOLBAR_CASH = 1390,

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -166,6 +166,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_FOOTPATH_TYPE,
         WIDX_QUEUELINE_TYPE,
         WIDX_RAILINGS_TYPE,
+        WIDX_EYEDROPPER,
 
         WIDX_DIRECTION_GROUP,
         WIDX_DIRECTION_NW,
@@ -195,6 +196,7 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({ 6,  30}, { 47, 36}, WidgetType::flatBtn,  WindowColour::secondary, 0xFFFFFFFF,                             STR_FOOTPATH_TIP                                   ),
         makeWidget({53,  30}, { 47, 36}, WidgetType::flatBtn,  WindowColour::secondary, 0xFFFFFFFF,                             STR_QUEUE_LINE_PATH_TIP                            ),
         makeWidget({29,  69}, { 47, 36}, WidgetType::flatBtn,  WindowColour::secondary, 0xFFFFFFFF,                             STR_OBJECT_SELECTION_FOOTPATH_RAILINGS             ),
+        makeWidget({76,  81}, { 24, 24}, WidgetType::flatBtn,  WindowColour::secondary, ImageId(SPR_G2_EYEDROPPER),             STR_FOOTPATH_EYEDROPPER_TIP                        ),
 
         // Direction group
         makeWidget({ 3, 115}, {100, 77}, WidgetType::groupbox, WindowColour::primary  , STR_DIRECTION                                                                              ),
@@ -255,6 +257,9 @@ namespace OpenRCT2::Ui::Windows
 
         CoordsXY _dragStartPos;
 
+        bool _eyedropperEnabled = false;
+        bool _eyedropperBlocked = false;
+
     public:
 #pragma region Window Override Events
 
@@ -267,12 +272,7 @@ namespace OpenRCT2::Ui::Windows
             WindowPushOthersRight(*this);
             ShowGridlines();
 
-            ToolCancel();
-            _footpathConstructionMode = PathConstructionMode::onLand;
-            ToolSet(*this, WIDX_CONSTRUCT_ON_LAND, Tool::pathDown);
-            gInputFlags.set(InputFlag::allowRightMouseRemoval);
-            _footpathErrorOccured = false;
-            WindowFootpathSetEnabledAndPressedWidgets();
+            enableOnLandMode();
 
             _footpathPlaceCtrlState = false;
             _footpathPlaceShiftState = false;
@@ -302,25 +302,28 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Check tool
-            switch (_footpathConstructionMode)
+            if (!_eyedropperEnabled)
             {
-                case PathConstructionMode::onLand:
-                    if (!isToolActive(WindowClass::footpath, WIDX_CONSTRUCT_ON_LAND))
-                        close();
-                    break;
-                case PathConstructionMode::dragArea:
-                    // If another window has enabled a tool, close ours.
-                    // If the user merely pressed Escape, we cancel the tool but don’t close the window.
-                    if (gInputFlags.has(InputFlag::toolActive)
-                        && gCurrentToolWidget.windowClassification != WindowClass::footpath)
-                        close();
-                    break;
-                case PathConstructionMode::bridgeOrTunnelPick:
-                    if (!isToolActive(WindowClass::footpath, WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL))
-                        close();
-                    break;
-                case PathConstructionMode::bridgeOrTunnel:
-                    break;
+                switch (_footpathConstructionMode)
+                {
+                    case PathConstructionMode::onLand:
+                        if (!isToolActive(WindowClass::footpath, WIDX_CONSTRUCT_ON_LAND))
+                            close();
+                        break;
+                    case PathConstructionMode::dragArea:
+                        // If another window has enabled a tool, close ours.
+                        // If the user merely pressed Escape, we cancel the tool but don’t close the window.
+                        if (gInputFlags.has(InputFlag::toolActive)
+                            && gCurrentToolWidget.windowClassification != WindowClass::footpath)
+                            close();
+                        break;
+                    case PathConstructionMode::bridgeOrTunnelPick:
+                        if (!isToolActive(WindowClass::footpath, WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL))
+                            close();
+                        break;
+                    case PathConstructionMode::bridgeOrTunnel:
+                        break;
+                }
             }
         }
 
@@ -367,19 +370,6 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void enableDragAreaMode()
-        {
-            _windowFootpathCost = kMoney64Undefined;
-            ToolCancel();
-            FootpathUpdateProvisional();
-            gMapSelectFlags.unset(MapSelectFlag::enableConstruct);
-            _footpathConstructionMode = PathConstructionMode::dragArea;
-            ToolSet(*this, WIDX_CONSTRUCT_DRAG_AREA, Tool::pathDown);
-            gInputFlags.set(InputFlag::allowRightMouseRemoval);
-            _footpathErrorOccured = false;
-            WindowFootpathSetEnabledAndPressedWidgets();
-        }
-
         void onMouseUp(WidgetIndex widgetIndex) override
         {
             switch (widgetIndex)
@@ -387,47 +377,26 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_CLOSE:
                     close();
                     break;
+                case WIDX_EYEDROPPER:
+                    toggleEyedropper(!_eyedropperEnabled);
+                    break;
                 case WIDX_CONSTRUCT_ON_LAND:
-                    if (_footpathConstructionMode == PathConstructionMode::onLand)
-                    {
-                        break;
-                    }
-
-                    _windowFootpathCost = kMoney64Undefined;
-                    ToolCancel();
-                    FootpathUpdateProvisional();
-                    gMapSelectFlags.unset(MapSelectFlag::enableConstruct);
-                    _footpathConstructionMode = PathConstructionMode::onLand;
-                    ToolSet(*this, WIDX_CONSTRUCT_ON_LAND, Tool::pathDown);
-                    gInputFlags.set(InputFlag::allowRightMouseRemoval);
-                    _footpathErrorOccured = false;
-                    WindowFootpathSetEnabledAndPressedWidgets();
+                    if (_footpathConstructionMode != PathConstructionMode::onLand)
+                        enableOnLandMode();
                     break;
                 case WIDX_CONSTRUCT_DRAG_AREA:
-                    if (_footpathConstructionMode == PathConstructionMode::dragArea)
-                    {
-                        break;
-                    }
-
-                    enableDragAreaMode();
+                    if (_footpathConstructionMode != PathConstructionMode::dragArea)
+                        enableDragAreaMode();
                     break;
                 case WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL:
-                    if (_footpathConstructionMode == PathConstructionMode::bridgeOrTunnelPick)
-                    {
-                        break;
-                    }
-
-                    _windowFootpathCost = kMoney64Undefined;
-                    ToolCancel();
-                    FootpathUpdateProvisional();
-                    gMapSelectFlags.unset(MapSelectFlag::enableConstruct);
-                    _footpathConstructionMode = PathConstructionMode::bridgeOrTunnelPick;
-                    ToolSet(*this, WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL, Tool::crosshair);
-                    gInputFlags.set(InputFlag::allowRightMouseRemoval);
-                    _footpathErrorOccured = false;
-                    WindowFootpathSetEnabledAndPressedWidgets();
+                    if (_footpathConstructionMode != PathConstructionMode::bridgeOrTunnelPick)
+                        enableBridgeOrTunnelMode();
                     break;
             }
+
+            // Disable picking when interacting with any other widget
+            if (widgetIndex != WIDX_EYEDROPPER)
+                toggleEyedropper(false);
         }
 
         void onDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
@@ -492,9 +461,13 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void onToolUp(WidgetIndex widgetIndex, const ScreenCoordsXY&) override
+        void onToolUp(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
+            if (widgetIndex == WIDX_EYEDROPPER)
+            {
+                toggleEyedropper(false);
+            }
+            else if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
             {
                 _footpathErrorOccured = false;
             }
@@ -507,7 +480,12 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
+            if (widgetIndex == WIDX_EYEDROPPER)
+            {
+                _eyedropperBlocked = true;
+                FootpathPickAt(screenCoords);
+            }
+            else if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
             {
                 WindowFootpathPlacePathAtPoint(screenCoords);
             }
@@ -523,7 +501,12 @@ namespace OpenRCT2::Ui::Windows
 
         void onToolDrag(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
         {
-            if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
+            if (widgetIndex == WIDX_EYEDROPPER)
+            {
+                if (_eyedropperBlocked)
+                    FootpathPickAt(screenCoords);
+            }
+            else if (widgetIndex == WIDX_CONSTRUCT_ON_LAND)
             {
                 WindowFootpathPlacePathAtPoint(screenCoords);
             }
@@ -637,6 +620,75 @@ namespace OpenRCT2::Ui::Windows
 #pragma endregion
 
     private:
+        void enableMode(const PathConstructionMode mode, const WindowFootpathWidgetIdx widget, const Tool tool)
+        {
+            ToolCancel();
+            FootpathUpdateProvisional();
+            gMapSelectFlags.unset(MapSelectFlag::enableConstruct);
+
+            _footpathConstructionMode = mode;
+            ToolSet(*this, widget, tool);
+            gInputFlags.set(InputFlag::allowRightMouseRemoval);
+            _footpathErrorOccured = false;
+            WindowFootpathSetEnabledAndPressedWidgets();
+        }
+
+        void enableOnLandMode()
+        {
+            enableMode(PathConstructionMode::onLand, WIDX_CONSTRUCT_ON_LAND, Tool::pathDown);
+        }
+
+        void enableBridgeOrTunnelMode()
+        {
+            _windowFootpathCost = kMoney64Undefined;
+            enableMode(PathConstructionMode::bridgeOrTunnelPick, WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL, Tool::crosshair);
+        }
+
+        void enableDragAreaMode()
+        {
+            _windowFootpathCost = kMoney64Undefined;
+            enableMode(PathConstructionMode::dragArea, WIDX_CONSTRUCT_DRAG_AREA, Tool::pathDown);
+        }
+
+        void toggleEyedropper(const bool enabled)
+        {
+            if (_eyedropperEnabled == enabled)
+                return;
+
+            if (enabled)
+            {
+                _eyedropperEnabled = true;
+                ToolSet(*this, WIDX_EYEDROPPER, Tool::crosshair);
+            }
+            else
+            {
+                _eyedropperEnabled = false;
+                switch (_footpathConstructionMode)
+                {
+                    case PathConstructionMode::onLand:
+                        ToolCancel();
+                        enableOnLandMode();
+                        break;
+                    case PathConstructionMode::dragArea:
+                        ToolCancel();
+                        enableDragAreaMode();
+                        break;
+                    case PathConstructionMode::bridgeOrTunnel:
+                    {
+                        // Retain map selection after cancelling picker tool
+                        const MapSelectFlags prevMapSelectFlags = gMapSelectFlags;
+                        ToolCancel();
+                        gMapSelectFlags = prevMapSelectFlags;
+                        break;
+                    }
+                    case PathConstructionMode::bridgeOrTunnelPick:
+                        ToolCancel();
+                        enableBridgeOrTunnelMode();
+                        break;
+                }
+            }
+        }
+
         /**
          *
          *  rct2: 0x006A7760
@@ -1825,6 +1877,51 @@ namespace OpenRCT2::Ui::Windows
                 type = gFootpathSelection.legacyPath;
             }
             return pathConstructFlags;
+        }
+
+        void FootpathPickAt(const ScreenCoordsXY& screenCoords)
+        {
+            auto mapPos = FootpathGetPlacePositionFromScreenPosition(screenCoords);
+            if (!mapPos)
+                return;
+
+            auto placement = WindowFootpathGetPlacementFromScreenCoords(screenCoords);
+            auto tileElement = MapGetFootpathElementWithSlope({ *mapPos, placement.baseZ }, placement.slope);
+            if (!tileElement)
+                return;
+
+            // Update only if necessary (allows new style to appear during bridge/tunnel construction)
+            bool changed;
+            FootpathSelection picked = gFootpathSelection;
+            picked.legacyPath = tileElement->getLegacyPathEntryIndex();
+            picked.isQueueSelected = tileElement->isQueue();
+            if (picked.legacyPath == kObjectEntryIndexNull)
+            {
+                if (picked.isQueueSelected)
+                    picked.queueSurface = tileElement->getSurfaceEntryIndex();
+                else
+                    picked.normalSurface = tileElement->getSurfaceEntryIndex();
+                picked.railings = tileElement->getRailingsEntryIndex();
+
+                changed = gFootpathSelection.legacyPath != picked.legacyPath
+                    || gFootpathSelection.isQueueSelected != picked.isQueueSelected
+                    || gFootpathSelection.getSelectedSurface() != picked.getSelectedSurface()
+                    || gFootpathSelection.railings != picked.railings;
+            }
+            else
+            {
+                changed = gFootpathSelection.legacyPath != picked.legacyPath
+                    || gFootpathSelection.isQueueSelected != picked.isQueueSelected;
+            }
+
+            if (changed)
+            {
+                gFootpathSelection = picked;
+
+                FootpathUpdateProvisional();
+                _windowFootpathCost = kMoney64Undefined;
+                invalidate();
+            }
         }
 
 #pragma region Keyboard Shortcuts Events

--- a/src/openrct2/actions/footpath/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathPlaceAction.cpp
@@ -519,22 +519,4 @@ namespace OpenRCT2::GameActions
         FootpathUpdateQueueChains();
         MapInvalidateTileFull(_loc);
     }
-
-    PathElement* FootpathPlaceAction::MapGetFootpathElementWithSlope(const CoordsXYZ& footpathPos, FootpathSlope slope) const
-    {
-        const bool isSloped = slope.type == FootpathSlopeType::sloped;
-
-        for (auto* pathElement : TileElementsView<PathElement>(footpathPos))
-        {
-            if (pathElement->getBaseZ() != footpathPos.z)
-                continue;
-            if (pathElement->isSloped() != isSloped)
-                continue;
-            if (isSloped && pathElement->getSlopeDirection() != slope.direction)
-                continue;
-            return pathElement;
-        }
-
-        return nullptr;
-    }
 } // namespace OpenRCT2::GameActions

--- a/src/openrct2/actions/footpath/FootpathPlaceAction.h
+++ b/src/openrct2/actions/footpath/FootpathPlaceAction.h
@@ -44,7 +44,6 @@ namespace OpenRCT2::GameActions
         Result ElementInsertExecute(GameState_t& gameState, Result res) const;
         void AutomaticallySetPeepSpawn(GameState_t& gameState) const;
         void RemoveIntersectingWalls(PathElement* pathElement) const;
-        PathElement* MapGetFootpathElementWithSlope(const CoordsXYZ& footpathPos, FootpathSlope slope) const;
         bool IsSameAsPathElement(const PathElement* pathElement) const;
         bool IsSameAsEntranceElement(const EntranceElement& entranceElement) const;
     };

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -28,6 +28,7 @@
 #include "Map.h"
 #include "MapAnimation.h"
 #include "MapOwnership.h"
+#include "TileElementsView.h"
 #include "Wall.h"
 #include "tile_element/BannerElement.h"
 #include "tile_element/EntranceElement.h"
@@ -122,6 +123,24 @@ namespace OpenRCT2
             if (pathElement != nullptr && pathElement->getBaseZ() == coords.z)
                 return pathElement;
         } while (!(tileElement++)->isLastForTile());
+
+        return nullptr;
+    }
+
+    PathElement* MapGetFootpathElementWithSlope(const CoordsXYZ& footpathPos, FootpathSlope slope)
+    {
+        const bool isSloped = slope.type == FootpathSlopeType::sloped;
+
+        for (auto* pathElement : TileElementsView<PathElement>(footpathPos))
+        {
+            if (pathElement->getBaseZ() != footpathPos.z)
+                continue;
+            if (pathElement->isSloped() != isSloped)
+                continue;
+            if (isSloped && pathElement->getSlopeDirection() != slope.direction)
+                continue;
+            return pathElement;
+        }
 
         return nullptr;
     }

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -177,6 +177,7 @@ namespace OpenRCT2
     extern const std::array<CoordsXY, kNumOrthogonalDirections * 2> BenchUseOffsets;
 
     PathElement* MapGetFootpathElement(const CoordsXYZ& coords);
+    PathElement* MapGetFootpathElementWithSlope(const CoordsXYZ& footpathPos, FootpathSlope slope);
     void FootpathInterruptPeeps(const CoordsXYZ& footpathPos);
     void FootpathRemoveLitter(const CoordsXYZ& footpathPos);
     void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, GameActions::CommandFlags flags);


### PR DESCRIPTION
This adds a picking tool to the Footpath window to allow copying existing footpath styles and railings from the map:

- Holding down LMB continuously reveals the styles under the current pointer.*
- Picking is cancelled when interacting with any other widget on the Footpath window (similar to Scenery).
- Ensures to not cancel ongoing bridge/tunnel construction while picking a new style.

*The flicker observed during this is the same as when manually choosing new styles (seemingly due to the preview footpath being removed in the selection frame and only being added back in the next), something I did not change.

<img width="640" height="460" alt="animation" src="https://github.com/user-attachments/assets/13a27e4b-8ed2-4d4e-a55d-e1c8bda052a7" />
<img width="640" height="460" alt="animation" src="https://github.com/user-attachments/assets/4bdda437-7613-49c3-81e1-f5d468c13d05" />

