### PR TITLE
Fix colour buttons showing up for uncolourable shops with cheats active

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4720,41 +4720,31 @@ namespace OpenRCT2::Ui::Windows
             auto& trackColour = ride->trackColours[colourScheme];
 
             const auto& rtd = ride->getRideTypeDescriptor();
+            const bool isMaze = rtd.specialType == RtdSpecialType::maze;
+            const bool isShop = rtd.Category == RideCategory::shop;
 
             // Maze style
-            if (rtd.specialType == RtdSpecialType::maze)
+            widgets[WIDX_MAZE_STYLE].setVisible(isMaze);
+            widgets[WIDX_MAZE_STYLE_DROPDOWN].setVisible(isMaze);
+            if (isMaze)
             {
                 widgets[WIDX_PRIMARY_PREVIEW_GROUP].text = STR_MAZE_STYLE_GROUP;
-                widgets[WIDX_MAZE_STYLE].setVisible();
-                widgets[WIDX_MAZE_STYLE_DROPDOWN].setVisible();
                 widgets[WIDX_MAZE_STYLE].text = MazeOptions[EnumValue(trackColour.supports)].text;
             }
             else
             {
-                bool isShop = rtd.Category == RideCategory::shop;
                 widgets[WIDX_PRIMARY_PREVIEW_GROUP].text = isShop ? STR_SHOP_STYLE_GROUP : STR_TRACK_STYLE_GROUP;
-                widgets[WIDX_MAZE_STYLE].setHidden();
-                widgets[WIDX_MAZE_STYLE_DROPDOWN].setHidden();
             }
 
             // Track, multiple colour schemes
-            bool rideCheats = getGameState().cheats.allowArbitraryRideTypeChanges;
-            if (ride->getRideTypeDescriptor().flags.has(RtdFlag::supportsMultipleColourSchemes))
-            {
-                widgets[WIDX_PRIMARY_PREVIEW_GROUP].setVisible();
-                widgets[WIDX_TRACK_COLOUR_SCHEME].setVisible();
-                widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].setVisible();
-                widgets[WIDX_PAINT_INDIVIDUAL_AREA].setVisible();
-            }
-            else
-            {
-                widgets[WIDX_PRIMARY_PREVIEW_GROUP].setHidden();
-                widgets[WIDX_TRACK_COLOUR_SCHEME].setHidden();
-                widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].setHidden();
-                widgets[WIDX_PAINT_INDIVIDUAL_AREA].setHidden();
-            }
+            const bool supportsMultipleColourSchemes = rtd.flags.has(RtdFlag::supportsMultipleColourSchemes);
+            widgets[WIDX_PRIMARY_PREVIEW_GROUP].setVisible(supportsMultipleColourSchemes);
+            widgets[WIDX_TRACK_COLOUR_SCHEME].setVisible(supportsMultipleColourSchemes);
+            widgets[WIDX_TRACK_COLOUR_SCHEME_DROPDOWN].setVisible(supportsMultipleColourSchemes);
+            widgets[WIDX_PAINT_INDIVIDUAL_AREA].setVisible(supportsMultipleColourSchemes);
 
             // Ride cheats on? Show visibility dropdown
+            bool rideCheats = getGameState().cheats.allowArbitraryRideTypeChanges;
             widgets[WIDX_VISIBILITY_DROPDOWN].setVisible(rideCheats);
 
             // Set colour scheme caption

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4254,6 +4254,9 @@ namespace OpenRCT2::Ui::Windows
                 }
             }
 
+            if (stationObjFlags == 0 && ride.getRideEntry()->flags.has(RideEntryFlag::disableColourTab))
+                return 0;
+
             switch (trackColour)
             {
                 case 0:

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4881,6 +4881,12 @@ namespace OpenRCT2::Ui::Windows
                 {
                     widgets[WIDX_TRACK_ADDITIONAL_COLOUR].setHidden();
                 }
+
+                // Move visiblity button as well, if ride type cheats are on
+                bool rideCheats = getGameState().cheats.allowArbitraryRideTypeChanges;
+                widgets[WIDX_VISIBILITY_DROPDOWN].setVisible(rideCheats);
+                widgets[WIDX_VISIBILITY_DROPDOWN].moveTo(
+                    { widgets[WIDX_SECONDARY_PREVIEW].left - 28, widgets[WIDX_SECONDARY_PREVIEW].bottom - 28 });
             }
 
             return startY + 74;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4799,7 +4799,7 @@ namespace OpenRCT2::Ui::Windows
             // Track preview
             if (!rtd.flags.hasAny(
                     RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourAdditional, RtdFlag::hasTrackColourSupports)
-                && !rideCheats)
+                && !(rideCheats && isShop))
             {
                 widgets[WIDX_PRIMARY_PREVIEW].setHidden();
                 return startY;


### PR DESCRIPTION
Fixes #26857. Regression from #26099. (First commit)

Refactored a little bit while investigating, owing to #26801. (Second commit)

Also noticed the Merry-go-round showing the track style group. Fixed as well. (Third commit)

All of the rides/stalls below look good to me now.

<img width="949" height="600" alt="Forest Frontiers 2026-08-02 22-58-59" src="https://github.com/user-attachments/assets/4e1feed2-2700-4fd2-8314-b2f651053dad" />