### PR TITLE
Move WindowFlags into their own header

### DIFF
--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -14,6 +14,7 @@
 #include <openrct2-ui/UiStringIds.h>
 #include <openrct2/Limits.h>
 #include <openrct2/core/EnumUtils.hpp>
+#include <openrct2/core/FlagHolder.hpp>
 #include <openrct2/core/StringTypes.h>
 #include <openrct2/drawing/Colour.h>
 #include <openrct2/drawing/ImageId.hpp>

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "../interface/ZoomLevel.h"
 #include "../world/Location.hpp"
 #include "Window.h"
 

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -11,16 +11,15 @@
 
 #include "../Identifiers.h"
 #include "../core/EnumUtils.hpp"
-#include "../core/FlagHolder.hpp"
-#include "WindowClasses.h"
-#include "ZoomLevel.h"
 
 #include <functional>
 #include <memory>
 
 enum class CloseWindowModifier : uint8_t;
+enum class WindowClass : uint8_t;
 
 struct CoordsXYZ;
+struct ZoomLevel;
 
 namespace OpenRCT2::Drawing
 {
@@ -56,40 +55,6 @@ namespace OpenRCT2
     };
 
     struct Viewport;
-
-    enum class WindowFlag : uint8_t
-    {
-        stickToBack,
-        stickToFront,
-        /**
-         * User is unable to scroll this viewport
-         */
-        noScrolling,
-        scrollingToLocation,
-        transparent,
-        /**
-         * Instead of half transparency, completely remove the window background
-         */
-        noBackground,
-        /**
-         * Window is closed and will be deleted in the next update.
-         */
-        dead,
-        resizable,
-        /**
-         * Don't auto close this window if too many windows are open
-         */
-        noAutoClose,
-        // TODO: investigate why exactly this is used.
-        higherContrastOnPress,
-        noTitleBar,
-        noSnapping,
-
-        // *ONLY* create only flags below
-        autoPosition,
-        centreScreen,
-    };
-    using WindowFlags = FlagHolder<uint16_t, WindowFlag>;
 
     enum class WindowView : uint8_t
     {

--- a/src/openrct2/interface/WindowBase.h
+++ b/src/openrct2/interface/WindowBase.h
@@ -9,6 +9,9 @@
 
 #pragma once
 
+#include "../interface/WindowClasses.h"
+#include "../interface/WindowFlags.h"
+#include "../interface/ZoomLevel.h"
 #include "../localisation/StringWithArgs.h"
 #include "ColourWithFlags.h"
 #include "Cursors.h"

--- a/src/openrct2/interface/WindowFlags.h
+++ b/src/openrct2/interface/WindowFlags.h
@@ -1,0 +1,49 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../core/FlagHolder.hpp"
+
+namespace OpenRCT2
+{
+    enum class WindowFlag : uint8_t
+    {
+        stickToBack,
+        stickToFront,
+        /**
+         * User is unable to scroll this viewport
+         */
+        noScrolling,
+        scrollingToLocation,
+        transparent,
+        /**
+         * Instead of half transparency, completely remove the window background
+         */
+        noBackground,
+        /**
+         * Window is closed and will be deleted in the next update.
+         */
+        dead,
+        resizable,
+        /**
+         * Don't auto close this window if too many windows are open
+         */
+        noAutoClose,
+        // TODO: investigate why exactly this is used.
+        higherContrastOnPress,
+        noTitleBar,
+        noSnapping,
+
+        // *ONLY* create only flags below
+        autoPosition,
+        centreScreen,
+    };
+    using WindowFlags = FlagHolder<uint16_t, WindowFlag>;
+} // namespace OpenRCT2

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -305,9 +305,11 @@
     <ClInclude Include="interface\ScrollArea.h" />
     <ClInclude Include="interface\Viewport.h" />
     <ClInclude Include="interface\Widget.h" />
+    <ClInclude Include="interface\WidgetIndexGlobals.h" />
     <ClInclude Include="interface\Window.h" />
     <ClInclude Include="interface\WindowBase.h" />
     <ClInclude Include="interface\WindowClasses.h" />
+    <ClInclude Include="interface\WindowFlags.h" />
     <ClInclude Include="interface\ZoomLevel.h" />
     <ClInclude Include="Limits.h" />
     <ClInclude Include="localisation\Currency.h" />

--- a/src/openrct2/ui/DummyWindowManager.cpp
+++ b/src/openrct2/ui/DummyWindowManager.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include "../interface/Widget.h"
+#include "../interface/ZoomLevel.h"
 #include "WindowManager.h"
 
 namespace OpenRCT2::Ui

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../interface/Window.h"
+#include "../interface/WindowFlags.h"
 #include "../localisation/StringIdType.h"
 #include "../windows/Intent.h"
 #include "../world/Location.hpp"

--- a/src/openrct2/windows/Intent.h
+++ b/src/openrct2/windows/Intent.h
@@ -11,6 +11,8 @@
 
 #include "../core/Identifier.hpp"
 #include "../interface/Window.h"
+#include "../interface/WindowClasses.h"
+#include "../interface/WindowFlags.h"
 
 #include <map>
 #include <sfl/static_vector.hpp>


### PR DESCRIPTION
This PR moves `WindowFlags` into their own header, and uses a forward declaration for `WindowClass` and `ZoomLevel` in the library `Window.h` header.

More to come!