### PR TITLE
Fix #26811: Crash when a ride points to a non-existing station object

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
+- Fix: [#26811] Crash when a ride points to a non-existing station object.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5211,6 +5211,9 @@ namespace OpenRCT2::Ui::Windows
 
             // Draw entrance label
             auto* stationObj = ride->getStationObject();
+            if (stationObj == nullptr)
+                return;
+
             Formatter ft;
             ft.Add<StringId>(stationObj->NameStringId);
             drawTextEllipsised(clippedRT, { 19, 1 }, widget.width() - 12 - 19, STR_WINDOW_COLOUR_2_STRINGID, ft);


### PR DESCRIPTION
Spun off from #26812.