### PR TITLE
Fix forced portrait orientation on Android app launch

### DIFF
--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         <activity
             android:name=".MainActivity"
             android:theme="@style/AppTheme.Splash"
+            android:screenOrientation="sensorLandscape"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -33,7 +34,7 @@
         <activity
             android:name=".GameActivity"
             android:configChanges="orientation|screenSize|keyboard|keyboardHidden"
-            android:screenOrientation="landscape"
+            android:screenOrientation="sensorLandscape"
             android:preferMinimalPostProcessing="true"
             >
 

--- a/src/openrct2-android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/src/openrct2-android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1026,7 +1026,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         }
 
         Log.v(TAG, "setOrientation() requestedOrientation=" + req + " width=" + w +" height="+ h +" resizable=" + resizable + " hint=" + hint);
-        mSingleton.setRequestedOrientation(req);
+        // mSingleton.setRequestedOrientation(req); // Removed: was overriding manifest sensorLandscape and fighting device rotation lock
     }
 
     /**

--- a/src/openrct2-android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/src/openrct2-android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -968,65 +968,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
      */
     public void setOrientationBis(int w, int h, boolean resizable, String hint)
     {
-        int orientation_landscape = -1;
-        int orientation_portrait = -1;
-
-        /* If set, hint "explicitly controls which UI orientations are allowed". */
-        if (hint.contains("LandscapeRight") && hint.contains("LandscapeLeft")) {
-            orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
-        } else if (hint.contains("LandscapeLeft")) {
-            orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
-        } else if (hint.contains("LandscapeRight")) {
-            orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
-        }
-
-        /* exact match to 'Portrait' to distinguish with PortraitUpsideDown */
-        boolean contains_Portrait = hint.contains("Portrait ") || hint.endsWith("Portrait");
-
-        if (contains_Portrait && hint.contains("PortraitUpsideDown")) {
-            orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
-        } else if (contains_Portrait) {
-            orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
-        } else if (hint.contains("PortraitUpsideDown")) {
-            orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
-        }
-
-        boolean is_landscape_allowed = (orientation_landscape != -1);
-        boolean is_portrait_allowed = (orientation_portrait != -1);
-        int req; /* Requested orientation */
-
-        /* No valid hint, nothing is explicitly allowed */
-        if (!is_portrait_allowed && !is_landscape_allowed) {
-            if (resizable) {
-                /* All orientations are allowed, respecting user orientation lock setting */
-                req = ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
-            } else {
-                /* Fixed window and nothing specified. Get orientation from w/h of created window */
-                req = (w > h ? ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE : ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
-            }
-        } else {
-            /* At least one orientation is allowed */
-            if (resizable) {
-                if (is_portrait_allowed && is_landscape_allowed) {
-                    /* hint allows both landscape and portrait, promote to full user */
-                    req = ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
-                } else {
-                    /* Use the only one allowed "orientation" */
-                    req = (is_landscape_allowed ? orientation_landscape : orientation_portrait);
-                }
-            } else {
-                /* Fixed window and both orientations are allowed. Choose one. */
-                if (is_portrait_allowed && is_landscape_allowed) {
-                    req = (w > h ? orientation_landscape : orientation_portrait);
-                } else {
-                    /* Use the only one allowed "orientation" */
-                    req = (is_landscape_allowed ? orientation_landscape : orientation_portrait);
-                }
-            }
-        }
-
-        Log.v(TAG, "setOrientation() requestedOrientation=" + req + " width=" + w +" height="+ h +" resizable=" + resizable + " hint=" + hint);
-        // mSingleton.setRequestedOrientation(req); // Removed: was overriding manifest sensorLandscape and fighting device rotation lock
     }
 
     /**


### PR DESCRIPTION
## Problem
On Android, the app launched into portrait orientation regardless of
the device's actual orientation or the AndroidManifest's intended
landscape setup. OpenRCT2 was never designed for portrait mode. `MainActivity`
had no `android:screenOrientation` set, so it fell back to the system default
(portrait), while `GameActivity` was set to `landscape`, causing a jarring transition.

Additionally, `SDLActivity.setOrientation()` calculated runtime orientation
overrides that conflicted with the manifest, broke edge-scrolling (#10684),
and fought system rotation lock.

## Fix
- Set `android:screenOrientation="sensorLandscape"` on both `MainActivity`
  and `GameActivity` in AndroidManifest.xml.
- Removed unused portrait fallback logic and runtime `setRequestedOrientation()`
  calls in `SDLActivity.java` since the game is landscape-only.
- Fixes #10684

## Testing
Manually tested and confirmed working on Android 17 (CP31.260623.005). Not yet tested
on lower API levels (minSdkVersion is API 24). The `sensorLandscape`
attribute has been supported since API 9, and this behavior should
be consistent, but I don't currently have access to an older device
to verify directly.