### PR TITLE
Fixed bug where ride.previousVerticalG was reset to 0 instead of 100

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,6 @@
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
 
-
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------
 - Improved: [#26560] [Plugin] Scripts can now be used to trigger saving a game (limited to the user save folder).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,8 @@
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
+- Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
+
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 1;
+constexpr uint8_t kStreamVersion = 2;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -968,7 +968,7 @@ namespace OpenRCT2
         ride.maxPositiveVerticalG = MakeFixed16_2dp(1, 0);
         ride.maxNegativeVerticalG = MakeFixed16_2dp(1, 0);
         ride.maxLateralG = 0;
-        ride.previousVerticalG = 0;
+        ride.previousVerticalG = MakeFixed16_2dp(1, 0);
         ride.previousLateralG = 0;
         ride.testingFlags.clearAll();
         ride.curTestTrackLocation.SetNull();


### PR DESCRIPTION
Fixes: https://github.com/OpenRCT2/OpenRCT2/issues/26880 Fixed a bug where ride.previousVerticalG was erroneously reset to 0 in test_reset function in Vehicle.cpp instead of 100. This would make the stats readout from a flat coaster track read max negative Gs as 0.49g instead 0.99g as it did in vanilla RCT2.

I verified by finding the variable which would be ride.previousVerticalG in the original RCT2 assembly as the offset [edi+13629FA]. It is reset to the value 0x64 at address 0x006D6C9B within what would be the test_reset function first located at 0x006D6BE7.

To verify it was previousVerticalG I made a test coaster that had a max negative G readout of 0.57g. I put a conditional breakpoint on it first as less than 0x39 (< 57) as a boundary test. When running my test coaster the breakpoint didn't hit. I deleted a turn track and rebuilt it, and then I changed the breakpoint condition to < 0x3A (< 58). I ran another test on the coaster, and sure enough the breakpoint was hit when the coaster went down the 2nd hill.