### PR TITLE
feat: Migrate to SDL3

### DIFF
--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -14,9 +14,9 @@ if (EMSCRIPTEN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${USE_FLAGS} ${SHARED_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EMSCRIPTEN_LDFLAGS} --bind ${SHARED_FLAGS} -sEXPORTED_FUNCTIONS=${EMSCRIPTEN_EXPORTED_FUNCTIONS} --js-library ${ROOT_DIR}/emscripten/deps.js")
 elseif (MSVC)
-    find_package(SDL2 REQUIRED)
+    find_package(SDL3 REQUIRED CONFIG)
 else ()
-    PKG_CHECK_MODULES(SDL2 REQUIRED IMPORTED_TARGET sdl2)
+    PKG_CHECK_MODULES(SDL3 REQUIRED IMPORTED_TARGET sdl3)
     if (NOT DISABLE_FLAC)
         PKG_CHECK_MODULES(FLAC REQUIRED IMPORTED_TARGET flac)
     endif ()
@@ -61,10 +61,10 @@ if (EMSCRIPTEN)
                                     ${ICU_DT_LIBRARY_RELEASE})
 elseif (NOT MSVC AND NOT WIN32)
     target_link_libraries(openrct2 "libopenrct2"
-                                    PkgConfig::SDL2)
+                                    PkgConfig::SDL3)
 else ()
     target_link_libraries(openrct2 "libopenrct2"
-                                    ${SDL2_LDFLAGS})
+                                    ${SDL3_LDFLAGS})
 endif ()
 target_link_platform_libraries(openrct2)
 
@@ -99,7 +99,7 @@ target_include_directories(openrct2 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/.."
                                               ${OGG_INCLUDE_DIRS}
                                               ${VORBIS_INCLUDE_DIRS}
                                               ${FLAC_INCLUDE_DIRS})
-target_include_directories(openrct2 SYSTEM PRIVATE ${SDL2_INCLUDE_DIRS}
+target_include_directories(openrct2 SYSTEM PRIVATE ${SDL3_INCLUDE_DIRS}
                                                      "${CMAKE_CURRENT_LIST_DIR}/../thirdparty")
 
 # Compiler flags
@@ -109,15 +109,15 @@ if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_MINGW_ANSI_STDIO=1")
     target_link_libraries(openrct2 comdlg32)
     if (MSVC)
-        target_link_libraries(openrct2 SDL2::SDL2-static)
-        target_include_directories(openrct2 SYSTEM PRIVATE SDL2::SDL2-static)
+        target_link_libraries(openrct2 SDL3::SDL3-static)
+        target_include_directories(openrct2 SYSTEM PRIVATE SDL3::SDL3-static)
     else ()
         # mingw does not provide proper CMake information like other configurations
-        find_path(SDL2_INCLUDE_DIRS SDL2/SDL.h)
+        find_path(SDL3_INCLUDE_DIRS SDL3/SDL.h)
         if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-            find_library(SDL2_LDFLAGS sdl2d)
+            find_library(SDL3_LDFLAGS SDL3d)
         else ()
-            find_library(SDL2_LDFLAGS sdl2)
+            find_library(SDL3_LDFLAGS SDL3)
         endif ()
         # Hardcode some of the libraries used by mingw builds
         target_link_libraries(openrct2 imm32 winmm setupapi version)

--- a/src/openrct2-ui/CursorRepository.cpp
+++ b/src/openrct2-ui/CursorRepository.cpp
@@ -123,9 +123,9 @@ void CursorRepository::GenerateScaledCursorSetHolder(uint8_t scale)
             {
                 // We can't scale the system cursors, but they should be appropriately scaled anyway
                 case CursorID::arrow:
-                    return SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
+                    return SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_DEFAULT);
                 case CursorID::handPoint:
-                    return SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+                    return SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_POINTER);
                 default:
                     return this->Create(getCursorData(cursorId), scale);
             }

--- a/src/openrct2-ui/CursorRepository.h
+++ b/src/openrct2-ui/CursorRepository.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <SDL_mouse.h>
+#include <SDL3/SDL.h>
 #include <functional>
 #include <map>
 #include <openrct2/core/EnumUtils.hpp>
@@ -40,7 +40,7 @@ namespace OpenRCT2::Ui
             {
                 for (size_t i = 0; i < EnumValue(CursorID::count); i++)
                 {
-                    SDL_FreeCursor(_cursors[i]);
+                    SDL_DestroyCursor(_cursors[i]);
                 }
             }
 

--- a/src/openrct2-ui/SDLException.cpp
+++ b/src/openrct2-ui/SDLException.cpp
@@ -9,7 +9,7 @@
 
 #include "SDLException.h"
 
-#include <SDL_error.h>
+#include <SDL3/SDL.h>
 
 using namespace OpenRCT2::Ui;
 

--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -14,17 +14,17 @@
 #include "interface/InGameConsole.h"
 #include "interface/Window.h"
 
-#include <SDL_clipboard.h>
-#include <SDL_events.h>
+#include <SDL3/SDL.h>
+#include <openrct2-ui/windows/Windows.h>
 #include <openrct2/core/String.hpp>
 #include <openrct2/core/UTF8.h>
 #include <openrct2/ui/UiContext.h>
 
 #ifdef __MACOSX__
     // macOS uses COMMAND rather than CTRL for many keyboard shortcuts
-    #define KB_PRIMARY_MODIFIER KMOD_GUI
+    #define KB_PRIMARY_MODIFIER SDL_KMOD_GUI
 #else
-    #define KB_PRIMARY_MODIFIER KMOD_CTRL
+    #define KB_PRIMARY_MODIFIER SDL_KMOD_CTRL
 #endif
 
 using namespace OpenRCT2;
@@ -32,12 +32,12 @@ using namespace OpenRCT2::Ui;
 
 bool TextComposition::IsActive()
 {
-    return SDL_IsTextInputActive() && _session.Buffer != nullptr;
+    return SDL_TextInputActive(SDL_GetKeyboardFocus()) && _session.Buffer != nullptr;
 }
 
 TextInputSession* TextComposition::Start(u8string& buffer, size_t maxLength)
 {
-    SDL_StartTextInput();
+    SDL_StartTextInput(SDL_GetKeyboardFocus());
     _session.Buffer = &buffer;
     _session.MaxLength = maxLength;
     _session.SelectionStart = buffer.size();
@@ -49,7 +49,7 @@ TextInputSession* TextComposition::Start(u8string& buffer, size_t maxLength)
 
 void TextComposition::Stop()
 {
-    SDL_StopTextInput();
+    SDL_StopTextInput(SDL_GetKeyboardFocus());
     _session.Buffer = nullptr;
     _session.ImeBuffer = nullptr;
     _imeActive = false;
@@ -66,7 +66,7 @@ static std::pair<SDL_Keycode, SDL_Scancode> ProcessKeyPress(SDL_Keycode key, SDL
         key = SDLK_RETURN;
         scancode = SDL_SCANCODE_RETURN;
     }
-    else if (!(SDL_GetModState() & KMOD_NUM))
+    else if (!(SDL_GetModState() & SDL_KMOD_NUM))
     {
         switch (key)
         {
@@ -111,14 +111,14 @@ void TextComposition::HandleMessage(const SDL_Event* e)
 
     switch (e->type)
     {
-        case SDL_TEXTEDITING:
+        case SDL_EVENT_TEXT_EDITING:
             // When inputting Korean characters, `edit.length` is always zero
             String::set(_imeBuffer, sizeof(_imeBuffer), e->edit.text);
             _imeStart = e->edit.start;
             _imeLength = e->edit.length;
             _imeActive = ((e->edit.length != 0 || String::sizeOf(e->edit.text) != 0) && _imeBuffer[0] != '\0');
             break;
-        case SDL_TEXTINPUT:
+        case SDL_EVENT_TEXT_INPUT:
             // will receive an `SDL_TEXTINPUT` event when a composition is committed
             _imeActive = false;
             _imeBuffer[0] = '\0';
@@ -136,16 +136,16 @@ void TextComposition::HandleMessage(const SDL_Event* e)
                 Windows::WindowUpdateTextbox();
             }
             break;
-        case SDL_KEYDOWN:
+        case SDL_EVENT_KEY_DOWN:
         {
             if (_imeActive)
             {
                 break;
             }
 
-            uint16_t modifier = e->key.keysym.mod;
-            SDL_Keycode rawKey = e->key.keysym.sym;
-            SDL_Scancode rawScancode = e->key.keysym.scancode;
+            uint16_t modifier = e->key.mod;
+            SDL_Keycode rawKey = e->key.key;
+            SDL_Scancode rawScancode = e->key.scancode;
 
             auto [key, scancode] = ProcessKeyPress(rawKey, rawScancode);
 
@@ -214,14 +214,14 @@ void TextComposition::HandleMessage(const SDL_Event* e)
                         CaretMoveRight();
                     console.RefreshCaret(_session.SelectionStart);
                     break;
-                case SDLK_c:
+                case SDLK_C:
                     if ((modifier & KB_PRIMARY_MODIFIER) && _session.Length)
                     {
                         GetContext()->GetUiContext().SetClipboardText(_session.Buffer->c_str());
                         ContextShowError(STR_COPY_INPUT_TO_CLIPBOARD, kStringIdNone, {});
                     }
                     break;
-                case SDLK_v:
+                case SDLK_V:
                     if ((modifier & KB_PRIMARY_MODIFIER) && SDL_HasClipboardText())
                     {
                         utf8* text = SDL_GetClipboardText();
@@ -231,7 +231,7 @@ void TextComposition::HandleMessage(const SDL_Event* e)
                         Windows::WindowUpdateTextbox();
                     }
                     break;
-                case SDLK_x:
+                case SDLK_X:
                     if ((modifier & KB_PRIMARY_MODIFIER) && _session.Length)
                     {
                         GetContext()->GetUiContext().SetClipboardText(_session.Buffer->c_str());

--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -11,7 +11,7 @@
 
     #include "UiContext.h"
 
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <dlfcn.h>
     #include <jni.h>
     #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -13,7 +13,7 @@
 
     #include "UiStringIds.h"
 
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <algorithm>
     #include <dlfcn.h>
     #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -22,8 +22,7 @@
     // Then the rest
     #include "UiContext.h"
 
-    #include <SDL.h>
-    #include <SDL_syswm.h>
+    #include <SDL3/SDL.h>
     #include <openrct2/Diagnostic.h>
     #include <openrct2/core/Path.hpp>
     #include <openrct2/core/String.hpp>
@@ -219,15 +218,8 @@ namespace OpenRCT2::Ui
             HWND result = nullptr;
             if (window != nullptr)
             {
-                SDL_SysWMinfo wmInfo;
-                SDL_VERSION(&wmInfo.version);
-                if (SDL_GetWindowWMInfo(window, &wmInfo) != SDL_TRUE)
-                {
-                    LOG_ERROR("SDL_GetWindowWMInfo failed %s", SDL_GetError());
-                    exit(-1);
-                }
-
-                result = wmInfo.info.win.window;
+                result = static_cast<HWND>(
+                    SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr));
             }
             return result;
         }

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -20,7 +20,8 @@
 #include "scripting/UiExtensions.h"
 #include "title/TitleSequencePlayer.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
@@ -58,9 +59,9 @@ using namespace OpenRCT2::Ui;
 
 #ifdef __MACOSX__
     // macOS uses COMMAND rather than CTRL for many keyboard shortcuts
-    #define KB_PRIMARY_MODIFIER KMOD_GUI
+    #define KB_PRIMARY_MODIFIER SDL_KMOD_GUI
 #else
-    #define KB_PRIMARY_MODIFIER KMOD_CTRL
+    #define KB_PRIMARY_MODIFIER SDL_KMOD_CTRL
 #endif
 
 class UiContext final : public IUiContext
@@ -90,8 +91,6 @@ private:
     uint32_t _lastKeyPressed = 0;
     const uint8_t* _keysState = nullptr;
     uint8_t _keysPressed[256] = {};
-    uint32_t _lastGestureTimestamp = 0;
-    float _gestureRadius = 0;
 
     InGameConsole _inGameConsole;
     std::unique_ptr<ITitleSequencePlayer> _titleSequencePlayer;
@@ -118,7 +117,7 @@ public:
         , _shortcutManager(env)
     {
         LogSDLVersion();
-        if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0)
+        if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK))
         {
             SDLException::Throw("SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)");
         }
@@ -180,30 +179,38 @@ public:
     void SetFullscreenMode(FullscreenMode mode) override
     {
 #ifndef __EMSCRIPTEN__
-        static constexpr int32_t kSDLFullscreenFlags[] = {
-            0,
-            SDL_WINDOW_FULLSCREEN,
-            SDL_WINDOW_FULLSCREEN_DESKTOP,
-        };
-        uint32_t windowFlags = kSDLFullscreenFlags[EnumValue(mode)];
-
         // HACK Changing window size when in fullscreen usually has no effect
         if (mode == FullscreenMode::fullscreen)
         {
-            SDL_SetWindowFullscreen(_window, 0);
+            SDL_SetWindowFullscreen(_window, false);
 
             // Set window size
             UpdateFullscreenResolutions();
             Resolution resolution = GetClosestResolution(
                 Config::Get().general.fullscreenWidth, Config::Get().general.fullscreenHeight);
             SDL_SetWindowSize(_window, resolution.Width, resolution.Height);
+
+            // Exclusive fullscreen needs an explicit display mode to switch to
+            SDL_DisplayMode closest{};
+            if (SDL_GetClosestFullscreenDisplayMode(
+                    SDL_GetDisplayForWindow(_window), resolution.Width, resolution.Height, 0, false, &closest))
+            {
+                SDL_SetWindowFullscreenMode(_window, &closest);
+            }
         }
         else if (mode == FullscreenMode::windowed)
         {
+            SDL_SetWindowFullscreenMode(_window, nullptr);
             SDL_SetWindowSize(_window, Config::Get().general.windowWidth, Config::Get().general.windowHeight);
         }
+        else
+        {
+            // Borderless "fullscreen desktop": a NULL mode means match the desktop resolution
+            SDL_SetWindowFullscreenMode(_window, nullptr);
+        }
 
-        if (SDL_SetWindowFullscreen(_window, windowFlags))
+        bool wantsFullscreen = mode == FullscreenMode::fullscreen || mode == FullscreenMode::fullscreenDesktop;
+        if (!SDL_SetWindowFullscreen(_window, wantsFullscreen))
         {
             LOG_FATAL("SDL_SetWindowFullscreen %s", SDL_GetError());
             exit(1);
@@ -278,14 +285,21 @@ public:
 
     void SetCursorVisible(bool value) override
     {
-        SDL_ShowCursor(value ? SDL_ENABLE : SDL_DISABLE);
+        if (value)
+        {
+            SDL_ShowCursor();
+        }
+        else
+        {
+            SDL_HideCursor();
+        }
     }
 
     ScreenCoordsXY GetCursorPosition() override
     {
-        ScreenCoordsXY cursorPosition;
-        SDL_GetMouseState(&cursorPosition.x, &cursorPosition.y);
-        return cursorPosition;
+        float x{}, y{};
+        SDL_GetMouseState(&x, &y);
+        return { static_cast<int32_t>(x), static_cast<int32_t>(y) };
     }
 
     void SetCursorPosition(const ScreenCoordsXY& cursorPosition) override
@@ -295,7 +309,7 @@ public:
 
     void SetCursorTrap(bool value) override
     {
-        SDL_SetWindowGrab(_window, value ? SDL_TRUE : SDL_FALSE);
+        SDL_SetWindowMouseGrab(_window, value);
     }
 
     void SetKeysPressed(uint32_t keysym, uint8_t scancode) override
@@ -352,51 +366,43 @@ public:
         {
             switch (e.type)
             {
-                case SDL_QUIT:
+                case SDL_EVENT_QUIT:
                     ContextQuit();
                     break;
-                case SDL_WINDOWEVENT:
-                    if (e.window.event == SDL_WINDOWEVENT_RESIZED)
+                case SDL_EVENT_WINDOW_RESIZED:
+                    LOG_VERBOSE("New Window size: %ux%u\n", e.window.data1, e.window.data2);
+                    OnResize(e.window.data1, e.window.data2);
+                    [[fallthrough]];
+                case SDL_EVENT_WINDOW_MOVED:
+                case SDL_EVENT_WINDOW_MAXIMIZED:
+                case SDL_EVENT_WINDOW_RESTORED:
+                {
+                    // Update default display index
+                    int32_t displayIndex = static_cast<int32_t>(SDL_GetDisplayForWindow(_window));
+                    if (displayIndex != Config::Get().general.defaultDisplay)
                     {
-                        LOG_VERBOSE("New Window size: %ux%u\n", e.window.data1, e.window.data2);
-                        OnResize(e.window.data1, e.window.data2);
-                    }
-
-                    switch (e.window.event)
-                    {
-                        case SDL_WINDOWEVENT_RESIZED:
-                        case SDL_WINDOWEVENT_MOVED:
-                        case SDL_WINDOWEVENT_MAXIMIZED:
-                        case SDL_WINDOWEVENT_RESTORED:
-                        {
-                            // Update default display index
-                            int32_t displayIndex = SDL_GetWindowDisplayIndex(_window);
-                            if (displayIndex != Config::Get().general.defaultDisplay)
-                            {
-                                Config::Get().general.defaultDisplay = displayIndex;
-                                Config::Save();
-                            }
-                            break;
-                        }
-                    }
-
-                    if (Config::Get().sound.audioFocus)
-                    {
-                        if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
-                        {
-                            SetAudioVolume(1);
-                        }
-                        if (e.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
-                        {
-                            SetAudioVolume(0);
-                        }
+                        Config::Get().general.defaultDisplay = displayIndex;
+                        Config::Save();
                     }
                     break;
-                case SDL_MOUSEMOTION:
+                }
+                case SDL_EVENT_WINDOW_FOCUS_GAINED:
+                    if (Config::Get().sound.audioFocus)
+                    {
+                        SetAudioVolume(1);
+                    }
+                    break;
+                case SDL_EVENT_WINDOW_FOCUS_LOST:
+                    if (Config::Get().sound.audioFocus)
+                    {
+                        SetAudioVolume(0);
+                    }
+                    break;
+                case SDL_EVENT_MOUSE_MOTION:
                     _cursorState.position = { static_cast<int32_t>(e.motion.x / Config::Get().general.windowScale),
                                               static_cast<int32_t>(e.motion.y / Config::Get().general.windowScale) };
                     break;
-                case SDL_MOUSEWHEEL:
+                case SDL_EVENT_MOUSE_WHEEL:
                     if (_inGameConsole.IsOpen())
                     {
                         _inGameConsole.Scroll(e.wheel.y * 3); // Scroll 3 lines at a time
@@ -404,7 +410,7 @@ public:
                     }
                     _cursorState.wheel -= e.wheel.y;
                     break;
-                case SDL_MOUSEBUTTONDOWN:
+                case SDL_EVENT_MOUSE_BUTTON_DOWN:
                 {
                     if (e.button.which == SDL_TOUCH_MOUSEID)
                     {
@@ -440,7 +446,7 @@ public:
                     }
                     break;
                 }
-                case SDL_MOUSEBUTTONUP:
+                case SDL_EVENT_MOUSE_BUTTON_UP:
                 {
                     if (e.button.which == SDL_TOUCH_MOUSEID)
                     {
@@ -478,18 +484,18 @@ public:
                 }
                 // Apple sends touchscreen events for trackpads, so ignore these events on macOS
 #ifndef __MACOSX__
-                case SDL_FINGERMOTION:
+                case SDL_EVENT_FINGER_MOTION:
                     _cursorState.position = { static_cast<int32_t>(e.tfinger.x * _width),
                                               static_cast<int32_t>(e.tfinger.y * _height) };
                     break;
-                case SDL_FINGERDOWN:
+                case SDL_EVENT_FINGER_DOWN:
                 {
                     ScreenCoordsXY fingerPos = { static_cast<int32_t>(e.tfinger.x * _width),
                                                  static_cast<int32_t>(e.tfinger.y * _height) };
 
                     _cursorState.touchIsDouble
                         = (!_cursorState.touchIsDouble
-                           && e.tfinger.timestamp - _cursorState.touchDownTimestamp < kTouchDoubleTimeout);
+                           && e.tfinger.timestamp / 1'000'000 - _cursorState.touchDownTimestamp < kTouchDoubleTimeout);
 
                     if (_cursorState.touchIsDouble)
                     {
@@ -504,10 +510,10 @@ public:
                         _cursorState.old = 1;
                     }
                     _cursorState.touch = true;
-                    _cursorState.touchDownTimestamp = e.tfinger.timestamp;
+                    _cursorState.touchDownTimestamp = static_cast<uint32_t>(e.tfinger.timestamp / 1'000'000);
                     break;
                 }
-                case SDL_FINGERUP:
+                case SDL_EVENT_FINGER_UP:
                 {
                     ScreenCoordsXY fingerPos = { static_cast<int32_t>(e.tfinger.x * _width),
                                                  static_cast<int32_t>(e.tfinger.y * _height) };
@@ -528,13 +534,13 @@ public:
                     break;
                 }
 #endif
-                case SDL_KEYDOWN:
+                case SDL_EVENT_KEY_DOWN:
                 {
 #ifndef __MACOSX__
                     // Ignore winkey keydowns. Handles edge case where tiling
                     // window managers don't eat the keypresses when changing
                     // workspaces.
-                    if (SDL_GetModState() & KMOD_GUI)
+                    if (SDL_GetModState() & SDL_KMOD_GUI)
                     {
                         break;
                     }
@@ -545,37 +551,20 @@ public:
                     _inputManager.queueInputEvent(std::move(ie));
                     break;
                 }
-                case SDL_KEYUP:
+                case SDL_EVENT_KEY_UP:
                 {
                     auto ie = GetInputEventFromSDLEvent(e);
                     ie.state = InputEventState::release;
                     _inputManager.queueInputEvent(std::move(ie));
                     break;
                 }
-                case SDL_MULTIGESTURE:
-                    if (e.mgesture.numFingers == 2)
-                    {
-                        if (e.mgesture.timestamp > _lastGestureTimestamp + 1000)
-                        {
-                            _gestureRadius = 0;
-                        }
-                        _lastGestureTimestamp = e.mgesture.timestamp;
-                        _gestureRadius += e.mgesture.dDist;
-
-                        // Zoom gesture
-                        constexpr int32_t tolerance = 128;
-                        int32_t gesturePixels = static_cast<int32_t>(_gestureRadius * _width);
-                        if (abs(gesturePixels) > tolerance)
-                        {
-                            _gestureRadius = 0;
-                            Windows::MainWindowZoom(gesturePixels > 0, true);
-                        }
-                    }
-                    break;
-                case SDL_TEXTEDITING:
+                // NOTE: SDL3 dropped the multi-finger pinch gesture API (SDL_MULTIGESTURE / SDL_GestureEvent).
+                // Trackpad pinch-to-zoom is unsupported until this is reimplemented on top of raw
+                // SDL_EVENT_FINGER_MOTION tracking.
+                case SDL_EVENT_TEXT_EDITING:
                     _textComposition.HandleMessage(&e);
                     break;
-                case SDL_TEXTINPUT:
+                case SDL_EVENT_TEXT_INPUT:
                     _textComposition.HandleMessage(&e);
                     break;
                 default:
@@ -590,7 +579,8 @@ public:
 
         // Updates the state of the keys
         int32_t numKeys = 256;
-        _keysState = SDL_GetKeyboardState(&numKeys);
+        // SDL3 returns bool*; false/true are guaranteed to be stored as 0/1, so this is safe to treat as a byte array.
+        _keysState = reinterpret_cast<const uint8_t*>(SDL_GetKeyboardState(&numKeys));
     }
 
     /**
@@ -599,21 +589,13 @@ public:
      */
     void TriggerResize() override
     {
-        char scaleQualityBuffer[4];
         _scaleQuality = ScaleQuality::smoothNearestNeighbour;
         if (Config::Get().general.windowScale == std::floor(Config::Get().general.windowScale))
         {
             _scaleQuality = ScaleQuality::nearestNeighbour;
         }
 
-        ScaleQuality scaleQuality = _scaleQuality;
-        if (_scaleQuality == ScaleQuality::smoothNearestNeighbour)
-        {
-            scaleQuality = ScaleQuality::linear;
-        }
-        snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%d", static_cast<int32_t>(scaleQuality));
-        SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQualityBuffer);
-
+        // Actual scale mode (SDL_ScaleMode) is applied per-texture by the drawing engine via GetScaleQuality().
         int32_t width, height;
         SDL_GetWindowSize(_window, &width, &height);
         OnResize(width, height);
@@ -666,7 +648,7 @@ public:
         auto message_box_button_data = std::make_unique<SDL_MessageBoxButtonData[]>(options.size());
         for (size_t i = 0; i < options.size(); i++)
         {
-            message_box_button_data[i].buttonid = static_cast<int>(i);
+            message_box_button_data[i].buttonID = static_cast<int>(i);
             message_box_button_data[i].text = options[i].c_str();
         }
 
@@ -727,7 +709,7 @@ public:
     bool SetClipboardText(const utf8* target) override
     {
 #ifndef __EMSCRIPTEN__
-        return (SDL_SetClipboardText(target) == 0);
+        return SDL_SetClipboardText(target);
 #else
         return (
             MAIN_THREAD_EM_ASM_INT(
@@ -759,9 +741,10 @@ public:
 private:
     void LogSDLVersion()
     {
-        SDL_version version{};
-        SDL_GetVersion(&version);
-        LOG_VERBOSE("SDL2 version: %d.%d.%d", version.major, version.minor, version.patch);
+        int32_t version = SDL_GetVersion();
+        LOG_VERBOSE(
+            "SDL3 version: %d.%d.%d", SDL_VERSIONNUM_MAJOR(version), SDL_VERSIONNUM_MINOR(version),
+            SDL_VERSIONNUM_MICRO(version));
     }
 
     void InferDisplayDPI()
@@ -775,7 +758,7 @@ private:
 
         auto renderer = SDL_GetRenderer(_window);
         int rWidth, rHeight;
-        if (SDL_GetRendererOutputSize(renderer, &rWidth, &rHeight) == 0)
+        if (SDL_GetCurrentRenderOutputSize(renderer, &rWidth, &rHeight))
             config.windowScale = rWidth / wWidth;
 
         config.inferDisplayDPI = false;
@@ -805,21 +788,21 @@ private:
             height = 720;
 
         // Create window in window first rather than fullscreen so we have the display the window is on first
-        uint32_t flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
+        SDL_WindowFlags flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
         if (Config::Get().general.drawingEngine == DrawingEngine::openGL)
         {
             flags |= SDL_WINDOW_OPENGL;
         }
 
-        _window = SDL_CreateWindow(OPENRCT2_NAME, windowPos.x, windowPos.y, width, height, flags);
+        _window = SDL_CreateWindow(OPENRCT2_NAME, width, height, flags);
         if (_window == nullptr)
         {
             const char* error = SDL_GetError();
             std::string errorMessage = String::stdFormat(
-                "SDL_CreateWindow(" OPENRCT2_NAME ", %d, %d, %d, %d, %d) failed: %s", windowPos.x, windowPos.y, width, height,
-                flags, error);
+                "SDL_CreateWindow(" OPENRCT2_NAME ", %d, %d, %d) failed: %s", width, height, flags, error);
             SDLException::Throw(errorMessage.c_str());
         }
+        SDL_SetWindowPosition(_window, windowPos.x, windowPos.y);
 
         ApplyScreenSaverLockSetting();
 
@@ -860,7 +843,7 @@ private:
 #ifndef __MACOSX__
             SDL_WINDOW_MAXIMIZED |
 #endif
-            SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP;
+            SDL_WINDOW_MINIMIZED | SDL_WINDOW_FULLSCREEN;
 
         if (!(flags & nonWindowFlags))
         {
@@ -876,19 +859,20 @@ private:
     void UpdateFullscreenResolutions()
     {
         // Query number of display modes
-        int32_t displayIndex = SDL_GetWindowDisplayIndex(_window);
-        int32_t numDisplayModes = SDL_GetNumDisplayModes(displayIndex);
+        SDL_DisplayID displayId = SDL_GetDisplayForWindow(_window);
+        int32_t numDisplayModes = 0;
+        SDL_DisplayMode** displayModes = SDL_GetFullscreenDisplayModes(displayId, &numDisplayModes);
 
         // Get desktop aspect ratio
-        SDL_DisplayMode mode;
-        SDL_GetDesktopDisplayMode(displayIndex, &mode);
+        const SDL_DisplayMode* desktopMode = SDL_GetDesktopDisplayMode(displayId);
+        SDL_DisplayMode mode = desktopMode != nullptr ? *desktopMode : SDL_DisplayMode{};
 
         // Get resolutions
         auto resolutions = std::vector<Resolution>();
         float desktopAspectRatio = static_cast<float>(mode.w) / mode.h;
         for (int32_t i = 0; i < numDisplayModes; i++)
         {
-            SDL_GetDisplayMode(displayIndex, i, &mode);
+            mode = *displayModes[i];
             if (mode.w > 0 && mode.h > 0)
             {
                 float aspectRatio = static_cast<float>(mode.w) / mode.h;
@@ -898,6 +882,7 @@ private:
                 }
             }
         }
+        SDL_free(displayModes);
 
         // Sort by area
         std::sort(resolutions.begin(), resolutions.end(), [](const Resolution& a, const Resolution& b) -> bool {
@@ -1044,13 +1029,13 @@ private:
     {
         InputEvent ie;
         ie.deviceKind = InputDeviceKind::keyboard;
-        ie.modifiers = e.key.keysym.mod;
-        ie.button = e.key.keysym.sym;
+        ie.modifiers = e.key.mod;
+        ie.button = e.key.key;
 
         // Handle dead keys
         if (ie.button == (SDLK_SCANCODE_MASK | 0))
         {
-            switch (e.key.keysym.scancode)
+            switch (e.key.scancode)
             {
                 case SDL_SCANCODE_APOSTROPHE:
                     ie.button = '\'';

--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -22,7 +22,7 @@
     #include <ApplicationServices/ApplicationServices.h>
     #include <Cocoa/Cocoa.h>
     #include <CoreFoundation/CFBundle.h>
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <mach-o/dyld.h>
     #pragma clang diagnostic pop
     #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/audio/AudioContext.cpp
+++ b/src/openrct2-ui/audio/AudioContext.cpp
@@ -13,7 +13,7 @@
 #include "AudioMixer.h"
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <memory>
 #include <openrct2/Diagnostic.h>
 #include <openrct2/audio/AudioContext.h>
@@ -32,7 +32,7 @@ namespace OpenRCT2::Audio
     public:
         AudioContext()
         {
-            if (SDL_Init(SDL_INIT_AUDIO) < 0)
+            if (!SDL_Init(SDL_INIT_AUDIO))
             {
                 Ui::SDLException::Throw("SDL_Init(SDL_INIT_AUDIO)");
             }
@@ -41,6 +41,9 @@ namespace OpenRCT2::Audio
 
         ~AudioContext() override
         {
+            // Must close the mixer (which destroys its SDL_AudioStream) before quitting the audio
+            // subsystem - otherwise the implicit ~AudioMixer() runs after SDL has torn it down.
+            _audioMixer->Close();
             SDL_QuitSubSystem(SDL_INIT_AUDIO);
         }
 
@@ -52,10 +55,15 @@ namespace OpenRCT2::Audio
         std::vector<std::string> GetOutputDevices() override
         {
             std::vector<std::string> devices;
-            int32_t numDevices = SDL_GetNumAudioDevices(SDL_FALSE);
-            for (int32_t i = 0; i < numDevices; i++)
+            int numDevices = 0;
+            auto* deviceIds = SDL_GetAudioPlaybackDevices(&numDevices);
+            if (deviceIds != nullptr)
             {
-                devices.emplace_back(String::toStd(SDL_GetAudioDeviceName(i, SDL_FALSE)));
+                for (int32_t i = 0; i < numDevices; i++)
+                {
+                    devices.emplace_back(String::toStd(SDL_GetAudioDeviceName(deviceIds[i])));
+                }
+                SDL_free(deviceIds);
             }
             return devices;
         }
@@ -88,7 +96,7 @@ namespace OpenRCT2::Audio
                 LOG_VERBOSE("Unable to create audio source: %s", e.what());
             }
 
-            SDL_RWclose(rw);
+            SDL_CloseIO(rw);
 
             if (source == nullptr)
             {
@@ -126,7 +134,7 @@ namespace OpenRCT2::Audio
             }
             catch (const std::exception& e)
             {
-                SDL_RWclose(rw);
+                SDL_CloseIO(rw);
                 LOG_VERBOSE("Unable to create audio source: %s", e.what());
                 return nullptr;
             }
@@ -168,36 +176,29 @@ namespace OpenRCT2::Audio
             return _audioMixer->AddSource(std::move(source));
         }
 
-        static SDL_RWops* StreamToSDL2(std::unique_ptr<IStream> stream)
+        static SDL_IOStream* StreamToSDL2(std::unique_ptr<IStream> stream)
         {
-            auto* rw = SDL_AllocRW();
-            if (rw == nullptr)
-                return nullptr;
-            *rw = {};
-
-            rw->type = SDL_RWOPS_UNKNOWN;
-            rw->hidden.unknown.data1 = stream.release();
-            rw->seek = [](SDL_RWops* ctx, Sint64 offset, int whence) {
-                auto ptr = static_cast<IStream*>(ctx->hidden.unknown.data1);
-                ptr->Seek(offset, whence);
+            SDL_IOStreamInterface iface{};
+            SDL_INIT_INTERFACE(&iface);
+            iface.seek = [](void* userdata, Sint64 offset, SDL_IOWhence whence) {
+                auto ptr = static_cast<IStream*>(userdata);
+                ptr->Seek(offset, static_cast<int>(whence));
                 return static_cast<Sint64>(ptr->GetPosition());
             };
-            rw->read = [](SDL_RWops* ctx, void* buf, size_t size, size_t maxnum) {
-                auto ptr = static_cast<IStream*>(ctx->hidden.unknown.data1);
-                return static_cast<size_t>(ptr->TryRead(buf, size * maxnum) / size);
+            iface.read = [](void* userdata, void* buf, size_t size, SDL_IOStatus*) {
+                auto ptr = static_cast<IStream*>(userdata);
+                return static_cast<size_t>(ptr->TryRead(buf, size));
             };
-            rw->size = [](SDL_RWops* ctx) {
-                auto ptr = static_cast<IStream*>(ctx->hidden.unknown.data1);
+            iface.size = [](void* userdata) {
+                auto ptr = static_cast<IStream*>(userdata);
                 return static_cast<Sint64>(ptr->GetLength());
             };
-            rw->close = [](SDL_RWops* ctx) {
-                auto* ptr = static_cast<IStream*>(ctx->hidden.unknown.data1);
+            iface.close = [](void* userdata) {
+                auto* ptr = static_cast<IStream*>(userdata);
                 delete ptr;
-                ctx->hidden.unknown.data1 = nullptr;
-                SDL_free(ctx);
-                return 0;
+                return true;
             };
-            return rw;
+            return SDL_OpenIO(&iface, stream.release());
         }
     };
 

--- a/src/openrct2-ui/audio/AudioContext.h
+++ b/src/openrct2-ui/audio/AudioContext.h
@@ -14,7 +14,7 @@
 #include <openrct2/audio/AudioSource.h>
 #include <string>
 
-struct SDL_RWops;
+struct SDL_IOStream;
 
 namespace OpenRCT2::Audio
 {

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <cstdint>
 
 namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/AudioMixer.cpp
+++ b/src/openrct2-ui/audio/AudioMixer.cpp
@@ -13,6 +13,8 @@
 #include <iterator>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/core/String.hpp>
+#include <utility>
 
 using namespace OpenRCT2::Audio;
 
@@ -27,33 +29,56 @@ void AudioMixer::Init(const char* device)
 
     SDL_AudioSpec want = {};
     want.freq = 22050;
-    want.format = AUDIO_S16SYS;
+    want.format = SDL_AUDIO_S16;
     want.channels = 2;
-    want.samples = 2048;
-    want.callback = [](void* arg, uint8_t* dst, int32_t length) -> void {
-        auto* mixer = static_cast<AudioMixer*>(arg);
-        mixer->GetNextAudioChunk(dst, static_cast<size_t>(length));
-        mixer->RemoveReleasedSources();
-    };
-    want.userdata = this;
 
-    SDL_AudioSpec have;
-    _deviceId = SDL_OpenAudioDevice(device, 0, &want, &have, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_SAMPLES_CHANGE);
-    _outputFormat.format = have.format;
-    _outputFormat.channels = have.channels;
-    _outputFormat.freq = have.freq;
+    SDL_AudioDeviceID devId = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;
+    if (device != nullptr)
+    {
+        int numDevices = 0;
+        auto* deviceIds = SDL_GetAudioPlaybackDevices(&numDevices);
+        if (deviceIds != nullptr)
+        {
+            for (int i = 0; i < numDevices; i++)
+            {
+                if (String::equals(SDL_GetAudioDeviceName(deviceIds[i]), device))
+                {
+                    devId = deviceIds[i];
+                    break;
+                }
+            }
+            SDL_free(deviceIds);
+        }
+    }
 
-    SDL_PauseAudioDevice(_deviceId, 0);
+    _deviceStream = SDL_OpenAudioDeviceStream(devId, &want, AudioStreamCallback, this);
+
+    // PutAudioStreamData is always fed in `want` format; SDL resamples to the device's native format internally.
+    _outputFormat.format = want.format;
+    _outputFormat.channels = want.channels;
+    _outputFormat.freq = want.freq;
+    _deviceId = _deviceStream != nullptr ? SDL_GetAudioStreamDevice(_deviceStream) : 0;
+
+    if (_deviceStream != nullptr)
+    {
+        SDL_ResumeAudioStreamDevice(_deviceStream);
+    }
 }
 
 void AudioMixer::Close()
 {
-    // Free channels
-    Lock();
-    _channels.clear();
-    Unlock();
+    // Destroy the stream first: SDL_DestroyAudioStream synchronously stops the device thread,
+    // so once it returns the audio callback can no longer be running and it's safe to touch
+    // mixer state below without locking against it.
+    SDL_AudioStream* stream = std::exchange(_deviceStream, nullptr);
+    if (stream != nullptr)
+    {
+        SDL_DestroyAudioStream(stream);
+    }
+    _deviceId = 0;
 
-    SDL_CloseAudioDevice(_deviceId);
+    // Free channels
+    _channels.clear();
 
     // Free buffers
     _channelBuffer.clear();
@@ -66,12 +91,27 @@ void AudioMixer::Close()
 
 void AudioMixer::Lock()
 {
-    SDL_LockAudioDevice(_deviceId);
+    if (_deviceStream != nullptr)
+    {
+        SDL_LockAudioStream(_deviceStream);
+    }
 }
 
 void AudioMixer::Unlock()
 {
-    SDL_UnlockAudioDevice(_deviceId);
+    if (_deviceStream != nullptr)
+    {
+        SDL_UnlockAudioStream(_deviceStream);
+    }
+}
+
+void AudioMixer::AudioStreamCallback(void* userdata, SDL_AudioStream* stream, int additionalAmount, int totalAmount)
+{
+    auto* mixer = static_cast<AudioMixer*>(userdata);
+    std::vector<uint8_t> buffer(static_cast<size_t>(additionalAmount));
+    mixer->GetNextAudioChunk(buffer.data(), buffer.size());
+    mixer->RemoveReleasedSources();
+    SDL_PutAudioStreamData(stream, buffer.data(), additionalAmount);
 }
 
 std::shared_ptr<IAudioChannel> AudioMixer::Play(IAudioSource* source, int32_t loop, bool deleteondone)
@@ -178,31 +218,25 @@ void AudioMixer::MixChannel(ISDLAudioChannel* channel, uint8_t* data, size_t len
     int32_t outputByteRate = _outputFormat.GetByteRate();
     auto numSamples = static_cast<int32_t>(length / outputByteRate);
     double rate = 1;
-    if (_outputFormat.format == AUDIO_S16SYS)
+    if (_outputFormat.format == SDL_AUDIO_S16)
     {
         rate = channel->GetRate();
     }
 
     bool mustConvert = false;
-    SDL_AudioCVT cvt;
-    cvt.len_ratio = 1;
+    double lenRatio = 1;
     AudioFormat streamformat = channel->GetFormat();
     if (streamformat != _outputFormat)
     {
-        if (SDL_BuildAudioCVT(
-                &cvt, streamformat.format, streamformat.channels, streamformat.freq, _outputFormat.format,
-                _outputFormat.channels, _outputFormat.freq)
-            == -1)
-        {
-            // Unable to convert channel data
-            return;
-        }
+        lenRatio = (static_cast<double>(_outputFormat.freq) / streamformat.freq)
+            * (static_cast<double>(_outputFormat.channels) / streamformat.channels)
+            * (static_cast<double>(SDL_AUDIO_BYTESIZE(_outputFormat.format)) / SDL_AUDIO_BYTESIZE(streamformat.format));
         mustConvert = true;
     }
 
     // Read raw PCM from channel
     int32_t readSamples = numSamples * rate;
-    auto readLength = static_cast<size_t>(ceil(readSamples / cvt.len_ratio)) * outputByteRate;
+    auto readLength = static_cast<size_t>(ceil(readSamples / lenRatio)) * outputByteRate;
     _channelBuffer.resize(readLength);
     size_t bytesRead = channel->Read(_channelBuffer.data(), readLength);
 
@@ -211,12 +245,7 @@ void AudioMixer::MixChannel(ISDLAudioChannel* channel, uint8_t* data, size_t len
     size_t bufferLen = 0;
     if (mustConvert)
     {
-        if (Convert(&cvt, _channelBuffer.data(), bytesRead))
-        {
-            buffer = cvt.buf;
-            bufferLen = cvt.len_cvt;
-        }
-        else
+        if (!Convert(streamformat, _channelBuffer.data(), bytesRead, &buffer, &bufferLen))
         {
             return;
         }
@@ -248,8 +277,9 @@ void AudioMixer::MixChannel(ISDLAudioChannel* channel, uint8_t* data, size_t len
 
     // Finally mix on to destination buffer
     size_t dstLength = std::min(length, bufferLen);
-    SDL_MixAudioFormat(
-        data, static_cast<const uint8_t*>(buffer), _outputFormat.format, static_cast<uint32_t>(dstLength), mixVolume);
+    SDL_MixAudio(
+        data, static_cast<const uint8_t*>(buffer), _outputFormat.format, static_cast<uint32_t>(dstLength),
+        static_cast<float>(mixVolume) / kMixerVolumeMax);
 
     channel->UpdateOldVolume();
 }
@@ -317,11 +347,13 @@ void AudioMixer::ApplyPan(const IAudioChannel* channel, void* buffer, size_t len
     {
         switch (_outputFormat.format)
         {
-            case AUDIO_S16SYS:
+            case SDL_AUDIO_S16:
                 EffectPanS16(channel, static_cast<int16_t*>(buffer), static_cast<int32_t>(len / sampleSize));
                 break;
-            case AUDIO_U8:
+            case SDL_AUDIO_U8:
                 EffectPanU8(channel, static_cast<uint8_t*>(buffer), static_cast<int32_t>(len / sampleSize));
+                break;
+            default:
                 break;
         }
     }
@@ -368,11 +400,13 @@ int32_t AudioMixer::ApplyVolume(const IAudioChannel* channel, void* buffer, size
         int32_t fadeLength = static_cast<int32_t>(len) / _outputFormat.BytesPerSample();
         switch (_outputFormat.format)
         {
-            case AUDIO_S16SYS:
+            case SDL_AUDIO_S16:
                 EffectFadeS16(static_cast<int16_t*>(buffer), fadeLength, startVolume, endVolume);
                 break;
-            case AUDIO_U8:
+            case SDL_AUDIO_U8:
                 EffectFadeU8(static_cast<uint8_t*>(buffer), fadeLength, startVolume, endVolume);
+                break;
+            default:
                 break;
         }
     }
@@ -416,10 +450,8 @@ void AudioMixer::EffectPanU8(const IAudioChannel* channel, uint8_t* data, int32_
 // TODO: investigate replacing this with OpenAL (#26035)
 void AudioMixer::EffectFadeS16(int16_t* data, int32_t length, int32_t startvolume, int32_t endvolume)
 {
-    static_assert(SDL_MIX_MAXVOLUME == kMixerVolumeMax, "Max volume differs between OpenRCT2 and SDL2");
-
-    float startvolume_f = static_cast<float>(startvolume) / SDL_MIX_MAXVOLUME;
-    float endvolume_f = static_cast<float>(endvolume) / SDL_MIX_MAXVOLUME;
+    float startvolume_f = static_cast<float>(startvolume) / kMixerVolumeMax;
+    float endvolume_f = static_cast<float>(endvolume) / kMixerVolumeMax;
     for (int32_t i = 0; i < length; i++)
     {
         float t = static_cast<float>(i) / length;
@@ -430,10 +462,8 @@ void AudioMixer::EffectFadeS16(int16_t* data, int32_t length, int32_t startvolum
 // TODO: investigate replacing this with OpenAL (#26035)
 void AudioMixer::EffectFadeU8(uint8_t* data, int32_t length, int32_t startvolume, int32_t endvolume)
 {
-    static_assert(SDL_MIX_MAXVOLUME == kMixerVolumeMax, "Max volume differs between OpenRCT2 and SDL2");
-
-    float startvolume_f = static_cast<float>(startvolume) / SDL_MIX_MAXVOLUME;
-    float endvolume_f = static_cast<float>(endvolume) / SDL_MIX_MAXVOLUME;
+    float startvolume_f = static_cast<float>(startvolume) / kMixerVolumeMax;
+    float endvolume_f = static_cast<float>(endvolume) / kMixerVolumeMax;
     for (int32_t i = 0; i < length; i++)
     {
         float t = static_cast<float>(i) / length;
@@ -441,23 +471,29 @@ void AudioMixer::EffectFadeU8(uint8_t* data, int32_t length, int32_t startvolume
     }
 }
 
-bool AudioMixer::Convert(SDL_AudioCVT* cvt, const void* src, size_t len)
+bool AudioMixer::Convert(const AudioFormat& srcFormat, const void* src, size_t len, void** outBuf, size_t* outLen)
 {
-    // tofix: there seems to be an issue with converting audio using SDL_ConvertAudio in the callback vs preconverted,
-    // can cause pops and static depending on sample rate and channels
-    bool result = false;
-    if (len != 0 && cvt->len_mult != 0)
+    // tofix: there seems to be an issue with converting audio using SDL_ConvertAudioSamples in the callback vs
+    // preconverted, can cause pops and static depending on sample rate and channels
+    if (len == 0)
     {
-        size_t reqConvertBufferCapacity = len * cvt->len_mult;
-        _convertBuffer.resize(reqConvertBufferCapacity);
-        std::copy_n(static_cast<const uint8_t*>(src), len, _convertBuffer.data());
-
-        cvt->len = static_cast<int32_t>(len);
-        cvt->buf = static_cast<uint8_t*>(_convertBuffer.data());
-        if (SDL_ConvertAudio(cvt) >= 0)
-        {
-            result = true;
-        }
+        return false;
     }
-    return result;
+
+    SDL_AudioSpec srcSpec{ srcFormat.format, srcFormat.channels, srcFormat.freq };
+    SDL_AudioSpec dstSpec{ _outputFormat.format, _outputFormat.channels, _outputFormat.freq };
+
+    Uint8* dstData = nullptr;
+    int dstLen = 0;
+    if (!SDL_ConvertAudioSamples(&srcSpec, static_cast<const Uint8*>(src), static_cast<int>(len), &dstSpec, &dstData, &dstLen))
+    {
+        return false;
+    }
+
+    _convertBuffer.assign(dstData, dstData + dstLen);
+    SDL_free(dstData);
+
+    *outBuf = _convertBuffer.data();
+    *outLen = _convertBuffer.size();
+    return true;
 }

--- a/src/openrct2-ui/audio/AudioMixer.h
+++ b/src/openrct2-ui/audio/AudioMixer.h
@@ -13,7 +13,7 @@
 #include "AudioFormat.h"
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <cstdint>
 #include <list>
 #include <memory>
@@ -33,6 +33,7 @@ namespace OpenRCT2::Audio
         std::vector<std::unique_ptr<SDLAudioSource>> _sources;
 
         SDL_AudioDeviceID _deviceId = 0;
+        SDL_AudioStream* _deviceStream = nullptr;
         AudioFormat _outputFormat = {};
         std::list<std::shared_ptr<ISDLAudioChannel>> _channels;
         float _volume = 1.0f;
@@ -76,6 +77,7 @@ namespace OpenRCT2::Audio
         static void EffectPanU8(const IAudioChannel* channel, uint8_t* data, int32_t length);
         static void EffectFadeS16(int16_t* data, int32_t length, int32_t startvolume, int32_t endvolume);
         static void EffectFadeU8(uint8_t* data, int32_t length, int32_t startvolume, int32_t endvolume);
-        bool Convert(SDL_AudioCVT* cvt, const void* src, size_t len);
+        static void AudioStreamCallback(void* userdata, SDL_AudioStream* stream, int additionalAmount, int totalAmount);
+        bool Convert(const AudioFormat& srcFormat, const void* src, size_t len, void** outBuf, size_t* outLen);
     };
 } // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/FlacAudioSource.cpp
+++ b/src/openrct2-ui/audio/FlacAudioSource.cpp
@@ -14,7 +14,7 @@
 
 #ifndef DISABLE_FLAC
     #include <FLAC/all.h>
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <cstring>
     #include <vector>
 #endif
@@ -29,7 +29,7 @@ namespace OpenRCT2::Audio
     {
     private:
         AudioFormat _format = {};
-        SDL_RWops* _rw = nullptr;
+        SDL_IOStream* _rw = nullptr;
 
         FLAC__StreamDecoder* _decoder{};
         uint32_t _bitsPerSample{};
@@ -55,7 +55,7 @@ namespace OpenRCT2::Audio
             return _format;
         }
 
-        bool LoadFlac(SDL_RWops* rw)
+        bool LoadFlac(SDL_IOStream* rw)
         {
             _rw = rw;
             _decoder = FLAC__stream_decoder_new();
@@ -119,7 +119,7 @@ namespace OpenRCT2::Audio
             }
             if (_rw != nullptr)
             {
-                SDL_RWclose(_rw);
+                SDL_CloseIO(_rw);
                 _rw = nullptr;
             }
         }
@@ -174,7 +174,7 @@ namespace OpenRCT2::Audio
             auto* self = static_cast<FlacAudioSource*>(clientData);
             if (*bytes > 0)
             {
-                *bytes = SDL_RWread(self->_rw, buffer, sizeof(FLAC__byte), *bytes);
+                *bytes = SDL_ReadIO(self->_rw, buffer, *bytes);
                 if (*bytes == 0)
                 {
                     return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
@@ -194,7 +194,7 @@ namespace OpenRCT2::Audio
             const FLAC__StreamDecoder* decoder, FLAC__uint64 absoluteByteOffset, void* clientData)
         {
             auto* self = static_cast<FlacAudioSource*>(clientData);
-            if (SDL_RWseek(self->_rw, absoluteByteOffset, RW_SEEK_SET) < 0)
+            if (SDL_SeekIO(self->_rw, absoluteByteOffset, SDL_IO_SEEK_SET) < 0)
             {
                 return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
             }
@@ -208,7 +208,7 @@ namespace OpenRCT2::Audio
             const FLAC__StreamDecoder* decoder, FLAC__uint64* absoluteByteOffset, void* clientData)
         {
             auto* self = static_cast<FlacAudioSource*>(clientData);
-            auto pos = SDL_RWtell(self->_rw);
+            auto pos = SDL_TellIO(self->_rw);
             if (pos < 0)
             {
                 return FLAC__STREAM_DECODER_TELL_STATUS_ERROR;
@@ -224,9 +224,9 @@ namespace OpenRCT2::Audio
             const FLAC__StreamDecoder* decoder, FLAC__uint64* streamLength, void* clientData)
         {
             auto* self = static_cast<FlacAudioSource*>(clientData);
-            auto pos = SDL_RWtell(self->_rw);
-            auto length = SDL_RWseek(self->_rw, 0, RW_SEEK_END);
-            if (SDL_RWseek(self->_rw, pos, RW_SEEK_SET) != pos || length < 0)
+            auto pos = SDL_TellIO(self->_rw);
+            auto length = SDL_SeekIO(self->_rw, 0, SDL_IO_SEEK_END);
+            if (SDL_SeekIO(self->_rw, pos, SDL_IO_SEEK_SET) != pos || length < 0)
             {
                 return FLAC__STREAM_DECODER_LENGTH_STATUS_ERROR;
             }
@@ -240,15 +240,15 @@ namespace OpenRCT2::Audio
         static FLAC__bool FlacCallbackEof(const FLAC__StreamDecoder* decoder, void* clientData)
         {
             auto* self = static_cast<FlacAudioSource*>(clientData);
-            auto pos = SDL_RWtell(self->_rw);
-            auto end = SDL_RWseek(self->_rw, 0, RW_SEEK_END);
+            auto pos = SDL_TellIO(self->_rw);
+            auto end = SDL_SeekIO(self->_rw, 0, SDL_IO_SEEK_END);
             if (pos == end)
             {
                 return true;
             }
             else
             {
-                SDL_RWseek(self->_rw, pos, RW_SEEK_SET);
+                SDL_SeekIO(self->_rw, pos, SDL_IO_SEEK_SET);
                 return false;
             }
         }
@@ -307,7 +307,7 @@ namespace OpenRCT2::Audio
                 self->_bitsPerSample = metadata->data.stream_info.bits_per_sample;
                 self->_totalSamples = metadata->data.stream_info.total_samples;
                 self->_format.freq = metadata->data.stream_info.sample_rate;
-                self->_format.format = AUDIO_S16LSB;
+                self->_format.format = SDL_AUDIO_S16LE;
                 self->_format.channels = metadata->data.stream_info.channels;
                 self->_dataLength = self->_totalSamples * self->_format.channels * sizeof(int16_t);
             }
@@ -320,7 +320,7 @@ namespace OpenRCT2::Audio
     };
 #endif
 
-    std::unique_ptr<SDLAudioSource> CreateFlacAudioSource(SDL_RWops* rw)
+    std::unique_ptr<SDLAudioSource> CreateFlacAudioSource(SDL_IOStream* rw)
     {
 #ifndef DISABLE_FLAC
         auto source = std::make_unique<FlacAudioSource>();

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -11,7 +11,7 @@
 #include "AudioFormat.h"
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <algorithm>
 #include <openrct2/audio/AudioSource.h>
 #include <stdexcept>
@@ -73,22 +73,17 @@ namespace OpenRCT2::Audio
     {
         if (target != src)
         {
-            SDL_AudioCVT cvt;
-            if (SDL_BuildAudioCVT(&cvt, src.format, src.channels, src.freq, target.format, target.channels, target.freq) >= 0)
+            SDL_AudioSpec srcSpec{ src.format, src.channels, src.freq };
+            SDL_AudioSpec dstSpec{ target.format, target.channels, target.freq };
+
+            Uint8* dstData = nullptr;
+            int dstLen = 0;
+            if (SDL_ConvertAudioSamples(
+                    &srcSpec, pcmData.data(), static_cast<int>(pcmData.size()), &dstSpec, &dstData, &dstLen))
             {
-                auto srcData = pcmData.data();
-                auto srcLen = pcmData.size();
-                auto cvtBuffer = std::vector<uint8_t>(srcLen * cvt.len_mult);
-                std::copy_n(srcData, srcLen, cvtBuffer.data());
-                cvt.len = static_cast<int32_t>(srcLen);
-                cvt.buf = cvtBuffer.data();
-                if (SDL_ConvertAudio(&cvt) >= 0)
-                {
-                    cvtBuffer.resize(cvt.len_cvt);
-                    cvtBuffer.shrink_to_fit();
-                    pcmData = std::move(cvtBuffer);
-                    return true;
-                }
+                pcmData.assign(dstData, dstData + dstLen);
+                SDL_free(dstData);
+                return true;
             }
         }
         return true;

--- a/src/openrct2-ui/audio/OggAudioSource.cpp
+++ b/src/openrct2-ui/audio/OggAudioSource.cpp
@@ -14,7 +14,7 @@
 #include <stdexcept>
 
 #ifndef DISABLE_VORBIS
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <optional>
     #include <vector>
     #include <vorbis/vorbisfile.h>
@@ -30,7 +30,7 @@ namespace OpenRCT2::Audio
     {
     private:
         AudioFormat _format = {};
-        SDL_RWops* _rw = nullptr;
+        SDL_IOStream* _rw = nullptr;
 
         std::optional<OggVorbis_File> _file;
         uint64_t _dataLength{};
@@ -54,7 +54,7 @@ namespace OpenRCT2::Audio
             return _format;
         }
 
-        bool LoadOgg(SDL_RWops* rw)
+        bool LoadOgg(SDL_IOStream* rw)
         {
             _rw = rw;
 
@@ -76,7 +76,7 @@ namespace OpenRCT2::Audio
                 return false;
             }
 
-            _format.format = AUDIO_S16LSB;
+            _format.format = SDL_AUDIO_S16LE;
             _format.channels = vi->channels;
             _format.freq = vi->rate;
             _totalSamples = ov_pcm_total(&*_file, -1);
@@ -131,7 +131,7 @@ namespace OpenRCT2::Audio
             }
             if (_rw != nullptr)
             {
-                SDL_RWclose(_rw);
+                SDL_CloseIO(_rw);
                 _rw = nullptr;
             }
         }
@@ -139,22 +139,26 @@ namespace OpenRCT2::Audio
     private:
         static size_t VorbisCallbackRead(void* ptr, size_t size, size_t nmemb, void* datasource)
         {
-            return SDL_RWread(static_cast<SDL_RWops*>(datasource), ptr, size, nmemb);
+            if (size == 0)
+                return 0;
+            auto bytesRead = SDL_ReadIO(static_cast<SDL_IOStream*>(datasource), ptr, size * nmemb);
+            return bytesRead / size;
         }
 
         static int VorbisCallbackSeek(void* datasource, ogg_int64_t offset, int whence)
         {
-            return (SDL_RWseek(static_cast<SDL_RWops*>(datasource), offset, whence) < 0) ? -1 : 0;
+            return (SDL_SeekIO(static_cast<SDL_IOStream*>(datasource), offset, static_cast<SDL_IOWhence>(whence)) < 0) ? -1
+                                                                                                                        : 0;
         }
 
         static long VorbisCallbackTell(void* datasource)
         {
-            return static_cast<long>(SDL_RWtell(static_cast<SDL_RWops*>(datasource)));
+            return static_cast<long>(SDL_TellIO(static_cast<SDL_IOStream*>(datasource)));
         }
     };
 #endif
 
-    std::unique_ptr<SDLAudioSource> CreateOggAudioSource(SDL_RWops* rw)
+    std::unique_ptr<SDLAudioSource> CreateOggAudioSource(SDL_IOStream* rw)
     {
 #ifndef DISABLE_VORBIS
         auto source = std::make_unique<OggAudioSource>();

--- a/src/openrct2-ui/audio/SDLAudioSource.cpp
+++ b/src/openrct2-ui/audio/SDLAudioSource.cpp
@@ -15,6 +15,20 @@
 
 using namespace OpenRCT2::Audio;
 
+static uint32_t ReadU32LE(SDL_IOStream* rw)
+{
+    Uint32 value{};
+    SDL_ReadU32LE(rw, &value);
+    return value;
+}
+
+static uint16_t ReadU16LE(SDL_IOStream* rw)
+{
+    Uint16 value{};
+    SDL_ReadU16LE(rw, &value);
+    return value;
+}
+
 enum class AudioCodecKind
 {
     unknown,
@@ -75,15 +89,15 @@ std::unique_ptr<SDLAudioSource> SDLAudioSource::ToMemory(const AudioFormat& targ
     return CreateMemoryAudioSource(target, srcFormat, std::move(pcmData));
 }
 
-static AudioCodecKind GetAudioCodec(SDL_RWops* rw)
+static AudioCodecKind GetAudioCodec(SDL_IOStream* rw)
 {
     constexpr uint32_t kMagicFLAC = 0x43614C66;
     constexpr uint32_t kMagicOGG = 0x5367674F;
     constexpr uint32_t kMagicRIFF = 0x46464952;
 
-    auto originalPosition = SDL_RWtell(rw);
-    auto magic = SDL_ReadLE32(rw);
-    SDL_RWseek(rw, originalPosition, RW_SEEK_SET);
+    auto originalPosition = SDL_TellIO(rw);
+    auto magic = ReadU32LE(rw);
+    SDL_SeekIO(rw, originalPosition, SDL_IO_SEEK_SET);
     switch (magic)
     {
         case kMagicFLAC:
@@ -97,7 +111,7 @@ static AudioCodecKind GetAudioCodec(SDL_RWops* rw)
     }
 }
 
-std::unique_ptr<SDLAudioSource> OpenRCT2::Audio::CreateAudioSource(SDL_RWops* rw)
+std::unique_ptr<SDLAudioSource> OpenRCT2::Audio::CreateAudioSource(SDL_IOStream* rw)
 {
     auto codec = GetAudioCodec(rw);
     switch (codec)
@@ -113,48 +127,48 @@ std::unique_ptr<SDLAudioSource> OpenRCT2::Audio::CreateAudioSource(SDL_RWops* rw
     }
 }
 
-std::unique_ptr<SDLAudioSource> OpenRCT2::Audio::CreateAudioSource(SDL_RWops* rw, uint32_t cssIndex)
+std::unique_ptr<SDLAudioSource> OpenRCT2::Audio::CreateAudioSource(SDL_IOStream* rw, uint32_t cssIndex)
 {
-    auto numSounds = SDL_ReadLE32(rw);
+    auto numSounds = ReadU32LE(rw);
     if (cssIndex >= numSounds)
     {
         // Not enough sounds, caller is responsible for freeing rw
         return nullptr;
     }
 
-    SDL_RWseek(rw, cssIndex * 4, RW_SEEK_CUR);
+    SDL_SeekIO(rw, cssIndex * 4, SDL_IO_SEEK_CUR);
 
-    auto pcmOffset = SDL_ReadLE32(rw);
-    SDL_RWseek(rw, pcmOffset, RW_SEEK_SET);
+    auto pcmOffset = ReadU32LE(rw);
+    SDL_SeekIO(rw, pcmOffset, SDL_IO_SEEK_SET);
 
-    auto pcmLength = SDL_ReadLE32(rw);
+    auto pcmLength = ReadU32LE(rw);
 
     AudioFormat format;
     // encoding, 16 bits
-    rw->seek(rw, 2, RW_SEEK_CUR);
-    format.channels = SDL_ReadLE16(rw);
-    format.freq = SDL_ReadLE32(rw);
+    SDL_SeekIO(rw, 2, SDL_IO_SEEK_CUR);
+    format.channels = ReadU16LE(rw);
+    format.freq = ReadU32LE(rw);
     // byterate, 32 bits
     // blockalign, 16 bits
-    rw->seek(rw, 6, RW_SEEK_CUR);
-    auto bitspersample = SDL_ReadLE16(rw);
+    SDL_SeekIO(rw, 6, SDL_IO_SEEK_CUR);
+    auto bitspersample = ReadU16LE(rw);
     switch (bitspersample)
     {
         case 8:
-            format.format = AUDIO_U8;
+            format.format = SDL_AUDIO_U8;
             break;
         case 16:
-            format.format = AUDIO_S16LSB;
+            format.format = SDL_AUDIO_S16LE;
             break;
         default:
             throw std::runtime_error("Unsupported bits per sample");
     }
     // extrasize, 16 bits
-    rw->seek(rw, 2, RW_SEEK_CUR);
+    SDL_SeekIO(rw, 2, SDL_IO_SEEK_CUR);
 
     std::vector<uint8_t> pcmData;
     pcmData.resize(pcmLength);
-    SDL_RWread(rw, pcmData.data(), pcmLength, 1);
+    SDL_ReadIO(rw, pcmData.data(), pcmLength);
 
     return CreateMemoryAudioSource(format, format, std::move(pcmData));
 }

--- a/src/openrct2-ui/audio/SDLAudioSource.h
+++ b/src/openrct2-ui/audio/SDLAudioSource.h
@@ -11,7 +11,7 @@
 
 #include "AudioFormat.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <atomic>
 #include <memory>
 #include <openrct2/audio/AudioSource.h>
@@ -49,11 +49,11 @@ namespace OpenRCT2::Audio
     #pragma GCC diagnostic pop
 #endif
 
-    std::unique_ptr<SDLAudioSource> CreateAudioSource(SDL_RWops* rw);
-    std::unique_ptr<SDLAudioSource> CreateAudioSource(SDL_RWops* rw, uint32_t cssIndex);
+    std::unique_ptr<SDLAudioSource> CreateAudioSource(SDL_IOStream* rw);
+    std::unique_ptr<SDLAudioSource> CreateAudioSource(SDL_IOStream* rw, uint32_t cssIndex);
     std::unique_ptr<SDLAudioSource> CreateMemoryAudioSource(
         const AudioFormat& target, const AudioFormat& src, std::vector<uint8_t>&& pcmData);
-    std::unique_ptr<SDLAudioSource> CreateFlacAudioSource(SDL_RWops* rw);
-    std::unique_ptr<SDLAudioSource> CreateOggAudioSource(SDL_RWops* rw);
-    std::unique_ptr<SDLAudioSource> CreateWavAudioSource(SDL_RWops* rw);
+    std::unique_ptr<SDLAudioSource> CreateFlacAudioSource(SDL_IOStream* rw);
+    std::unique_ptr<SDLAudioSource> CreateOggAudioSource(SDL_IOStream* rw);
+    std::unique_ptr<SDLAudioSource> CreateWavAudioSource(SDL_IOStream* rw);
 } // namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/WavAudioSource.cpp
+++ b/src/openrct2-ui/audio/WavAudioSource.cpp
@@ -9,11 +9,25 @@
 
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <stdexcept>
 
 namespace OpenRCT2::Audio
 {
+    static uint32_t ReadU32LE(SDL_IOStream* rw)
+    {
+        Uint32 value{};
+        SDL_ReadU32LE(rw, &value);
+        return value;
+    }
+
+    static uint16_t ReadU16LE(SDL_IOStream* rw)
+    {
+        Uint16 value{};
+        SDL_ReadU16LE(rw, &value);
+        return value;
+    }
+
     /**
      * An audio source where raw PCM data is stored in RAM.
      */
@@ -26,76 +40,76 @@ namespace OpenRCT2::Audio
         static constexpr uint32_t kChunkIdWAVE = 0x45564157;
         static constexpr uint16_t kPCMFormat = 0x0001;
 
-        SDL_RWops* _rw{};
+        SDL_IOStream* _rw{};
         AudioFormat _format = {};
         uint64_t _dataBegin{};
         uint64_t _dataLength{};
 
     public:
-        WavAudioSource(SDL_RWops* rw)
+        WavAudioSource(SDL_IOStream* rw)
             : _rw(rw)
         {
-            auto chunkId = SDL_ReadLE32(rw);
+            auto chunkId = ReadU32LE(rw);
             if (chunkId != kChunkIdRIFF)
             {
-                SDL_RWclose(rw);
+                SDL_CloseIO(rw);
                 throw std::runtime_error("Not a WAV file");
             }
 
             // Read and discard chunk size
-            SDL_ReadLE32(rw);
-            auto chunkFormat = SDL_ReadLE32(rw);
+            ReadU32LE(rw);
+            auto chunkFormat = ReadU32LE(rw);
             if (chunkFormat != kChunkIdWAVE)
             {
-                SDL_RWclose(rw);
+                SDL_CloseIO(rw);
                 throw std::runtime_error("Not in WAVE format");
             }
 
             auto fmtChunkSize = FindChunk(rw, kChunkIdFMT);
             if (!fmtChunkSize)
             {
-                SDL_RWclose(rw);
+                SDL_CloseIO(rw);
                 throw std::runtime_error("Could not find FMT chunk");
             }
 
-            auto chunkStart = SDL_RWtell(rw);
+            auto chunkStart = SDL_TellIO(rw);
 
-            auto encoding = SDL_ReadLE16(rw);
+            auto encoding = ReadU16LE(rw);
             if (encoding != kPCMFormat)
             {
-                SDL_RWclose(rw);
+                SDL_CloseIO(rw);
                 throw std::runtime_error("Not in PCM format");
             }
 
-            _format.channels = SDL_ReadLE16(rw);
-            _format.freq = SDL_ReadLE32(rw);
-            [[maybe_unused]] auto byterate = SDL_ReadLE32(rw);
-            [[maybe_unused]] auto blockalign = SDL_ReadLE16(rw);
-            [[maybe_unused]] auto bitspersample = SDL_ReadLE16(rw);
+            _format.channels = ReadU16LE(rw);
+            _format.freq = ReadU32LE(rw);
+            [[maybe_unused]] auto byterate = ReadU32LE(rw);
+            [[maybe_unused]] auto blockalign = ReadU16LE(rw);
+            [[maybe_unused]] auto bitspersample = ReadU16LE(rw);
             switch (bitspersample)
             {
                 case 8:
-                    _format.format = AUDIO_U8;
+                    _format.format = SDL_AUDIO_U8;
                     break;
                 case 16:
-                    _format.format = AUDIO_S16LSB;
+                    _format.format = SDL_AUDIO_S16LE;
                     break;
                 default:
-                    SDL_RWclose(rw);
+                    SDL_CloseIO(rw);
                     throw std::runtime_error("Unsupported bits per sample");
             }
 
-            SDL_RWseek(rw, chunkStart + fmtChunkSize, RW_SEEK_SET);
+            SDL_SeekIO(rw, chunkStart + fmtChunkSize, SDL_IO_SEEK_SET);
 
             auto dataChunkSize = FindChunk(rw, kChunkIdDATA);
             if (dataChunkSize == 0)
             {
-                SDL_RWclose(rw);
+                SDL_CloseIO(rw);
                 throw std::runtime_error("Could not find DATA chunk");
             }
 
             _dataLength = dataChunkSize;
-            _dataBegin = static_cast<uint64_t>(SDL_RWtell(rw));
+            _dataBegin = static_cast<uint64_t>(SDL_TellIO(rw));
         }
 
         ~WavAudioSource() override
@@ -116,20 +130,20 @@ namespace OpenRCT2::Audio
         size_t Read(void* dst, uint64_t offset, size_t len) override
         {
             size_t bytesRead = 0;
-            int64_t currentPosition = SDL_RWtell(_rw);
+            int64_t currentPosition = SDL_TellIO(_rw);
             if (currentPosition != -1)
             {
                 size_t bytesToRead = static_cast<size_t>(std::min<uint64_t>(len, _dataLength - offset));
                 int64_t dataOffset = _dataBegin + offset;
                 if (currentPosition != dataOffset)
                 {
-                    int64_t newPosition = SDL_RWseek(_rw, dataOffset, SEEK_SET);
+                    int64_t newPosition = SDL_SeekIO(_rw, dataOffset, SDL_IO_SEEK_SET);
                     if (newPosition == -1)
                     {
                         return 0;
                     }
                 }
-                bytesRead = SDL_RWread(_rw, dst, 1, bytesToRead);
+                bytesRead = SDL_ReadIO(_rw, dst, bytesToRead);
             }
             return bytesRead;
         }
@@ -139,7 +153,7 @@ namespace OpenRCT2::Audio
         {
             if (_rw != nullptr)
             {
-                SDL_RWclose(_rw);
+                SDL_CloseIO(_rw);
                 _rw = nullptr;
             }
             _dataBegin = 0;
@@ -147,10 +161,10 @@ namespace OpenRCT2::Audio
         }
 
     private:
-        static uint32_t FindChunk(SDL_RWops* rw, uint32_t wantedId)
+        static uint32_t FindChunk(SDL_IOStream* rw, uint32_t wantedId)
         {
-            uint32_t subchunkId = SDL_ReadLE32(rw);
-            uint32_t subchunkSize = SDL_ReadLE32(rw);
+            uint32_t subchunkId = ReadU32LE(rw);
+            uint32_t subchunkSize = ReadU32LE(rw);
             if (subchunkId == wantedId)
             {
                 return subchunkSize;
@@ -162,9 +176,9 @@ namespace OpenRCT2::Audio
             while (subchunkId == kChunkIdFACT || subchunkId == kChunkIdLIST || subchunkId == kChunkIdBEXT
                    || subchunkId == kChunkIdJUNK)
             {
-                SDL_RWseek(rw, subchunkSize, RW_SEEK_CUR);
-                subchunkId = SDL_ReadLE32(rw);
-                subchunkSize = SDL_ReadLE32(rw);
+                SDL_SeekIO(rw, subchunkSize, SDL_IO_SEEK_CUR);
+                subchunkId = ReadU32LE(rw);
+                subchunkSize = ReadU32LE(rw);
                 if (subchunkId == wantedId)
                 {
                     return subchunkSize;
@@ -174,7 +188,7 @@ namespace OpenRCT2::Audio
         }
     };
 
-    std::unique_ptr<SDLAudioSource> CreateWavAudioSource(SDL_RWops* rw)
+    std::unique_ptr<SDLAudioSource> CreateWavAudioSource(SDL_IOStream* rw)
     {
         return std::make_unique<WavAudioSource>(rw);
     }

--- a/src/openrct2-ui/drawing/BitmapReader.cpp
+++ b/src/openrct2-ui/drawing/BitmapReader.cpp
@@ -9,7 +9,7 @@
 
 #include "BitmapReader.h"
 
-#include <SDL_surface.h>
+#include <SDL3/SDL.h>
 #include <cstring>
 #include <openrct2/core/Imaging.h>
 #include <stdexcept>
@@ -35,19 +35,20 @@ namespace OpenRCT2::Ui
     static Image ReadBitmap(std::istream& istream, ImageFormat format)
     {
         auto buffer = ReadToVector(istream);
-        auto sdlStream = SDL_RWFromConstMem(buffer.data(), static_cast<int>(buffer.size()));
-        auto bitmap = SDL_LoadBMP_RW(sdlStream, 1);
+        auto sdlStream = SDL_IOFromConstMem(buffer.data(), buffer.size());
+        auto bitmap = SDL_LoadBMP_IO(sdlStream, true);
         if (bitmap != nullptr)
         {
-            auto numChannels = bitmap->format->BytesPerPixel;
-            if (numChannels < 3 || bitmap->format->BitsPerPixel < 24)
+            auto formatDetails = SDL_GetPixelFormatDetails(bitmap->format);
+            auto numChannels = formatDetails->bytes_per_pixel;
+            if (numChannels < 3 || formatDetails->bits_per_pixel < 24)
             {
-                SDL_FreeSurface(bitmap);
+                SDL_DestroySurface(bitmap);
                 throw std::runtime_error("Only 24-bit bitmaps are supported.");
             }
 
             // Copy pixels over, then discard the surface
-            if (SDL_LockSurface(bitmap) == 0)
+            if (SDL_LockSurface(bitmap))
             {
                 Image image;
                 image.Width = bitmap->w;
@@ -85,12 +86,12 @@ namespace OpenRCT2::Ui
                     }
                 }
                 SDL_UnlockSurface(bitmap);
-                SDL_FreeSurface(bitmap);
+                SDL_DestroySurface(bitmap);
 
                 return image;
             }
 
-            SDL_FreeSurface(bitmap);
+            SDL_DestroySurface(bitmap);
             throw std::runtime_error("Unable to lock surface.");
         }
         else

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -9,7 +9,7 @@
 
 #include "DrawingEngineFactory.hpp"
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include <cmath>
 #include <memory>
 #include <openrct2/Diagnostic.h>
@@ -39,7 +39,7 @@ private:
     SDL_Renderer* _sdlRenderer = nullptr;
     SDL_Texture* _screenTexture = nullptr;
     SDL_Texture* _scaledScreenTexture = nullptr;
-    SDL_PixelFormat* _screenTextureFormat = nullptr;
+    const SDL_PixelFormatDetails* _screenTextureFormat = nullptr;
     uint32_t _paletteHWMapped[256] = { 0 };
     uint32_t _lightPaletteHWMapped[256] = { 0 };
 
@@ -67,13 +67,13 @@ public:
         {
             SDL_DestroyTexture(_scaledScreenTexture);
         }
-        SDL_FreeFormat(_screenTextureFormat);
         SDL_DestroyRenderer(_sdlRenderer);
     }
 
     void Initialise() override
     {
-        _sdlRenderer = SDL_CreateRenderer(_window, -1, SDL_RENDERER_ACCELERATED | (_useVsync ? SDL_RENDERER_PRESENTVSYNC : 0));
+        _sdlRenderer = SDL_CreateRenderer(_window, nullptr);
+        SDL_SetRenderVSync(_sdlRenderer, _useVsync ? 1 : 0);
     }
 
     void SetVSync(bool vsync) override
@@ -81,15 +81,7 @@ public:
         if (_useVsync != vsync)
         {
             _useVsync = vsync;
-#if SDL_VERSION_ATLEAST(2, 0, 18)
-            SDL_RenderSetVSync(_sdlRenderer, vsync ? 1 : 0);
-#else
-            SDL_DestroyRenderer(_sdlRenderer);
-            _screenTexture = nullptr;
-            _scaledScreenTexture = nullptr;
-            Initialise();
-            Resize(_uiContext->GetWidth(), _uiContext->GetHeight());
-#endif
+            SDL_SetRenderVSync(_sdlRenderer, vsync ? 1 : 0);
         }
     }
 
@@ -104,20 +96,22 @@ public:
         {
             SDL_DestroyTexture(_screenTexture);
         }
-        SDL_FreeFormat(_screenTextureFormat);
 
-        SDL_RendererInfo rendererInfo = {};
-        int32_t result = SDL_GetRendererInfo(_sdlRenderer, &rendererInfo);
-        if (result < 0)
+        auto rendererProps = SDL_GetRendererProperties(_sdlRenderer);
+        auto* textureFormats = static_cast<const SDL_PixelFormat*>(
+            SDL_GetPointerProperty(rendererProps, SDL_PROP_RENDERER_TEXTURE_FORMATS_POINTER, nullptr));
+        if (textureFormats == nullptr)
         {
             LOG_WARNING("HWDisplayDrawingEngine::Resize error: %s", SDL_GetError());
             return;
         }
-        uint32_t pixelFormat = SDL_PIXELFORMAT_UNKNOWN;
-        for (uint32_t i = 0; i < rendererInfo.num_texture_formats; i++)
+        SDL_PixelFormat pixelFormat = SDL_PIXELFORMAT_UNKNOWN;
+        for (size_t i = 0; textureFormats[i] != SDL_PIXELFORMAT_UNKNOWN; i++)
         {
-            uint32_t format = rendererInfo.texture_formats[i];
-            if (!SDL_ISPIXELFORMAT_FOURCC(format) && !SDL_ISPIXELFORMAT_INDEXED(format)
+            SDL_PixelFormat format = textureFormats[i];
+            // CopyBitsToTexture only has a correct implementation for 4-byte-per-pixel formats; narrower
+            // formats (e.g. RGB565) hit dead/broken packing code, so never select below 4 bytes per pixel.
+            if (!SDL_ISPIXELFORMAT_FOURCC(format) && !SDL_ISPIXELFORMAT_INDEXED(format) && SDL_BYTESPERPIXEL(format) == 4
                 && (pixelFormat == SDL_PIXELFORMAT_UNKNOWN || SDL_BYTESPERPIXEL(format) < SDL_BYTESPERPIXEL(pixelFormat)))
             {
                 pixelFormat = format;
@@ -135,6 +129,8 @@ public:
             smoothNN = false;
         }
 
+        SDL_ScaleMode sdlScaleMode = scaleQuality == ScaleQuality::linear ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST;
+
         if (smoothNN)
         {
             if (_scaledScreenTexture != nullptr)
@@ -142,16 +138,11 @@ public:
                 SDL_DestroyTexture(_scaledScreenTexture);
             }
 
-            char scaleQualityBuffer[4];
-            snprintf(scaleQualityBuffer, sizeof(scaleQualityBuffer), "%d", static_cast<int32_t>(scaleQuality));
-            SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
-
             _screenTexture = SDL_CreateTexture(_sdlRenderer, pixelFormat, SDL_TEXTUREACCESS_STREAMING, width, height);
             Guard::Assert(
                 _screenTexture != nullptr, "Failed to create unscaled screen texture (%ux%u, pixelFormat = %u): %s", width,
                 height, pixelFormat, SDL_GetError());
-
-            SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, scaleQualityBuffer);
+            SDL_SetTextureScaleMode(_screenTexture, SDL_SCALEMODE_NEAREST);
 
             uint32_t scale = std::ceil(Config::Get().general.windowScale);
             _scaledScreenTexture = SDL_CreateTexture(
@@ -161,6 +152,7 @@ public:
                 _scaledScreenTexture != nullptr,
                 "Failed to create scaled screen texture (%ux%u, scale = %u, pixelFormat = %u): %s", width, height, scale,
                 pixelFormat, SDL_GetError());
+            SDL_SetTextureScaleMode(_scaledScreenTexture, sdlScaleMode);
         }
         else
         {
@@ -168,11 +160,10 @@ public:
             Guard::Assert(
                 _screenTexture != nullptr, "Failed to create screen texture (%ux%u, pixelFormat = %u): %s", width, height,
                 pixelFormat, SDL_GetError());
+            SDL_SetTextureScaleMode(_screenTexture, sdlScaleMode);
         }
 
-        uint32_t format;
-        SDL_QueryTexture(_screenTexture, &format, nullptr, nullptr, nullptr);
-        _screenTextureFormat = SDL_AllocFormat(format);
+        _screenTextureFormat = SDL_GetPixelFormatDetails(pixelFormat);
 
         X8DrawingEngine::Resize(width, height);
     }
@@ -183,7 +174,8 @@ public:
         {
             for (int32_t i = 0; i < 256; i++)
             {
-                _paletteHWMapped[i] = SDL_MapRGB(_screenTextureFormat, palette[i].red, palette[i].green, palette[i].blue);
+                _paletteHWMapped[i] = SDL_MapRGB(
+                    _screenTextureFormat, nullptr, palette[i].red, palette[i].green, palette[i].blue);
             }
 
             if (Config::Get().general.enableLightFx)
@@ -192,7 +184,8 @@ public:
                 for (int32_t i = 0; i < 256; i++)
                 {
                     const auto& src = lightPalette[i];
-                    _lightPaletteHWMapped[i] = SDL_MapRGBA(_screenTextureFormat, src.red, src.green, src.blue, src.alpha);
+                    _lightPaletteHWMapped[i] = SDL_MapRGBA(
+                        _screenTextureFormat, nullptr, src.red, src.green, src.blue, src.alpha);
                 }
             }
         }
@@ -239,7 +232,7 @@ private:
         {
             void* pixels;
             int32_t pitch;
-            if (SDL_LockTexture(_screenTexture, nullptr, &pixels, &pitch) == 0)
+            if (SDL_LockTexture(_screenTexture, nullptr, &pixels, &pitch))
             {
                 LightFx::RenderToTexture(
                     *viewport, pixels, pitch, _bits, _width, _height, _paletteHWMapped, _lightPaletteHWMapped);
@@ -254,14 +247,14 @@ private:
         if (smoothNN)
         {
             SDL_SetRenderTarget(_sdlRenderer, _scaledScreenTexture);
-            SDL_RenderCopy(_sdlRenderer, _screenTexture, nullptr, nullptr);
+            SDL_RenderTexture(_sdlRenderer, _screenTexture, nullptr, nullptr);
 
             SDL_SetRenderTarget(_sdlRenderer, nullptr);
-            SDL_RenderCopy(_sdlRenderer, _scaledScreenTexture, nullptr, nullptr);
+            SDL_RenderTexture(_sdlRenderer, _scaledScreenTexture, nullptr, nullptr);
         }
         else
         {
-            SDL_RenderCopy(_sdlRenderer, _screenTexture, nullptr, nullptr);
+            SDL_RenderTexture(_sdlRenderer, _screenTexture, nullptr, nullptr);
         }
 
         if (gShowDirtyVisuals)
@@ -276,7 +269,7 @@ private:
     {
         void* pixels;
         int32_t pitch;
-        if (SDL_LockTexture(texture, nullptr, &pixels, &pitch) == 0)
+        if (SDL_LockTexture(texture, nullptr, &pixels, &pitch))
         {
             int32_t padding = pitch - (width * 4);
             if (pitch == width * 4)
@@ -349,7 +342,7 @@ private:
     {
         int windowX, windowY, renderX, renderY;
         SDL_GetWindowSize(_window, &windowX, &windowY);
-        SDL_GetRendererOutputSize(_sdlRenderer, &renderX, &renderY);
+        SDL_GetCurrentRenderOutputSize(_sdlRenderer, &renderX, &renderY);
 
         float scaleX = Config::Get().general.windowScale * renderX / static_cast<float>(windowX);
         float scaleY = Config::Get().general.windowScale * renderY / static_cast<float>(windowY);
@@ -364,11 +357,11 @@ private:
                 if (timeLeft > 0)
                 {
                     uint8_t alpha = timeLeft * kDirtyRegionAlpha / kDirtyVisualTime;
-                    SDL_Rect ddRect;
-                    ddRect.x = static_cast<int32_t>(x * _invalidationGrid.getBlockWidth() * scaleX);
-                    ddRect.y = static_cast<int32_t>(y * _invalidationGrid.getBlockHeight() * scaleY);
-                    ddRect.w = static_cast<int32_t>(_invalidationGrid.getBlockWidth() * scaleX);
-                    ddRect.h = static_cast<int32_t>(_invalidationGrid.getBlockHeight() * scaleY);
+                    SDL_FRect ddRect;
+                    ddRect.x = static_cast<float>(x * _invalidationGrid.getBlockWidth() * scaleX);
+                    ddRect.y = static_cast<float>(y * _invalidationGrid.getBlockHeight() * scaleY);
+                    ddRect.w = static_cast<float>(_invalidationGrid.getBlockWidth() * scaleX);
+                    ddRect.h = static_cast<float>(_invalidationGrid.getBlockHeight() * scaleY);
 
                     SDL_SetRenderDrawColor(_sdlRenderer, 255, 255, 255, alpha);
                     SDL_RenderFillRect(_sdlRenderer, &ddRect);

--- a/src/openrct2-ui/drawing/engines/opengl/DrawRectShader.h
+++ b/src/openrct2-ui/drawing/engines/opengl/DrawRectShader.h
@@ -12,6 +12,8 @@
 #include "DrawCommands.h"
 #include "OpenGLShaderProgram.h"
 
+#include <SDL3/SDL_pixels.h>
+
 namespace OpenRCT2::Ui
 {
     class DrawRectShader final : public OpenGLShaderProgram

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.cpp
@@ -17,7 +17,7 @@
         #include "OpenGLAPIProc.h"
         #undef OPENGL_PROC
 
-        #include <SDL_video.h>
+        #include <SDL3/SDL_video.h>
         #include <openrct2/core/Console.hpp>
 
 static const char* TryLoadAllProcAddresses()

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLAPI.h
@@ -54,7 +54,7 @@
 
 #endif
 
-#include <SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 // OpenRCT2: SDL_opengl.h includes windows.h, which defines some macros that can cause conflicts
 #undef CreateWindow
 #undef CreateDirectory

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -23,7 +23,7 @@
     #include "TextureCache.h"
     #include "TransparencyDepth.h"
 
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <algorithm>
     #include <cassert>
     #include <cmath>
@@ -240,7 +240,7 @@ public:
 
     ~OpenGLDrawingEngine() override
     {
-        SDL_GL_DeleteContext(_context);
+        SDL_GL_DestroyContext(_context);
     }
 
     void Initialise() override

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
@@ -11,7 +11,7 @@
 
     #include "OpenGLFramebuffer.h"
 
-    #include <SDL_video.h>
+    #include <SDL3/SDL_video.h>
     #include <algorithm>
     #include <cassert>
     #include <memory>
@@ -26,7 +26,7 @@ OpenGLFramebuffer::OpenGLFramebuffer(SDL_Window* window)
     _id = kBackBufferID;
     _texture = 0;
     _depth = 0;
-    SDL_GL_GetDrawableSize(window, &_width, &_height);
+    SDL_GetWindowSizeInPixels(window, &_width, &_height);
 }
 
 OpenGLFramebuffer::OpenGLFramebuffer(int32_t width, int32_t height, bool depth, bool integer, bool word)

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -11,6 +11,7 @@
 
 #include "GLSLTypes.h"
 
+#include <SDL3/SDL_pixels.h>
 #include <array>
 #include <cassert>
 #include <cmath>

--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -11,8 +11,8 @@
 
 #include "ShortcutIds.h"
 
-#include <SDL_events.h>
-#include <SDL_timer.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_gamepad.h>
 #include <cmath>
 #include <openrct2-ui/UiContext.h>
 #include <openrct2-ui/input/MouseInput.h>
@@ -40,23 +40,23 @@ void InputManager::queueInputEvent(const SDL_Event& e)
 {
     switch (e.type)
     {
-        case SDL_CONTROLLERAXISMOTION:
+        case SDL_EVENT_GAMEPAD_AXIS_MOTION:
         {
             // Process only the stick axes for scrolling (ignore triggers)
-            if (e.caxis.axis == SDL_CONTROLLER_AXIS_LEFTX || e.caxis.axis == SDL_CONTROLLER_AXIS_LEFTY
-                || e.caxis.axis == SDL_CONTROLLER_AXIS_RIGHTX || e.caxis.axis == SDL_CONTROLLER_AXIS_RIGHTY)
+            if (e.gaxis.axis == SDL_GAMEPAD_AXIS_LEFTX || e.gaxis.axis == SDL_GAMEPAD_AXIS_LEFTY
+                || e.gaxis.axis == SDL_GAMEPAD_AXIS_RIGHTX || e.gaxis.axis == SDL_GAMEPAD_AXIS_RIGHTY)
             {
                 InputEvent ie;
                 ie.deviceKind = InputDeviceKind::joyAxis;
                 ie.modifiers = SDL_GetModState();
-                ie.button = e.caxis.axis;
+                ie.button = e.gaxis.axis;
                 ie.state = InputEventState::down;
-                ie.axisValue = e.caxis.value;
+                ie.axisValue = e.gaxis.value;
                 queueInputEvent(std::move(ie));
             }
             break;
         }
-        case SDL_JOYHATMOTION:
+        case SDL_EVENT_JOYSTICK_HAT_MOTION:
         {
             if (e.jhat.value != SDL_HAT_CENTERED)
             {
@@ -70,34 +70,34 @@ void InputManager::queueInputEvent(const SDL_Event& e)
             }
             break;
         }
-        case SDL_CONTROLLERBUTTONDOWN:
-        case SDL_JOYBUTTONDOWN:
+        case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+        case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
         {
             InputEvent ie;
             ie.deviceKind = InputDeviceKind::joyButton;
             ie.modifiers = SDL_GetModState();
-            ie.button = e.cbutton.button;
+            ie.button = e.gbutton.button;
             ie.state = InputEventState::down;
             ie.axisValue = 0;
             queueInputEvent(std::move(ie));
             break;
         }
-        case SDL_CONTROLLERBUTTONUP:
-        case SDL_JOYBUTTONUP:
+        case SDL_EVENT_GAMEPAD_BUTTON_UP:
+        case SDL_EVENT_JOYSTICK_BUTTON_UP:
         {
             InputEvent ie;
             ie.deviceKind = InputDeviceKind::joyButton;
             ie.modifiers = SDL_GetModState();
-            ie.button = e.cbutton.button;
+            ie.button = e.gbutton.button;
             ie.state = InputEventState::release;
             ie.axisValue = 0;
             queueInputEvent(std::move(ie));
             break;
         }
-        case SDL_CONTROLLERDEVICEADDED:
-        case SDL_CONTROLLERDEVICEREMOVED:
-        case SDL_JOYDEVICEADDED:
-        case SDL_JOYDEVICEREMOVED:
+        case SDL_EVENT_GAMEPAD_ADDED:
+        case SDL_EVENT_GAMEPAD_REMOVED:
+        case SDL_EVENT_JOYSTICK_ADDED:
+        case SDL_EVENT_JOYSTICK_REMOVED:
         {
             // Force joystick refresh on next check
             _lastJoystickCheck = 0;
@@ -121,17 +121,22 @@ void InputManager::checkJoysticks()
         _lastJoystickCheck = tick;
 
         _gameControllers.clear();
-        auto numJoysticks = SDL_NumJoysticks();
-        for (auto i = 0; i < numJoysticks; i++)
+        int numJoysticks = 0;
+        auto* joystickIds = SDL_GetJoysticks(&numJoysticks);
+        if (joystickIds != nullptr)
         {
-            if (SDL_IsGameController(i))
+            for (int i = 0; i < numJoysticks; i++)
             {
-                auto gameController = SDL_GameControllerOpen(i);
-                if (gameController != nullptr)
+                if (SDL_IsGamepad(joystickIds[i]))
                 {
-                    _gameControllers.push_back(gameController);
+                    auto gameController = SDL_OpenGamepad(joystickIds[i]);
+                    if (gameController != nullptr)
+                    {
+                        _gameControllers.push_back(gameController);
+                    }
                 }
             }
+            SDL_free(joystickIds);
         }
     }
 }
@@ -148,8 +153,8 @@ void InputManager::processAnalogueInput()
     {
         if (gameController != nullptr)
         {
-            int32_t stickX = SDL_GameControllerGetAxis(gameController, SDL_CONTROLLER_AXIS_LEFTX);
-            int32_t stickY = SDL_GameControllerGetAxis(gameController, SDL_CONTROLLER_AXIS_LEFTY);
+            int32_t stickX = SDL_GetGamepadAxis(gameController, SDL_GAMEPAD_AXIS_LEFTX);
+            int32_t stickY = SDL_GetGamepadAxis(gameController, SDL_GAMEPAD_AXIS_LEFTY);
 
             // Calculate the magnitude of the stick input vector
             float magnitude = std::sqrt(static_cast<float>(stickX * stickX + stickY * stickY));
@@ -279,20 +284,20 @@ void InputManager::handleModifiers()
     _modifierKeyState = EnumValue(ModifierKey::none);
 
     auto modifiers = SDL_GetModState();
-    if (modifiers & KMOD_SHIFT)
+    if (modifiers & SDL_KMOD_SHIFT)
     {
         _modifierKeyState |= EnumValue(ModifierKey::shift);
     }
-    if (modifiers & KMOD_CTRL)
+    if (modifiers & SDL_KMOD_CTRL)
     {
         _modifierKeyState |= EnumValue(ModifierKey::ctrl);
     }
-    if (modifiers & KMOD_ALT)
+    if (modifiers & SDL_KMOD_ALT)
     {
         _modifierKeyState |= EnumValue(ModifierKey::alt);
     }
 #ifdef __MACOSX__
-    if (modifiers & KMOD_GUI)
+    if (modifiers & SDL_KMOD_GUI)
     {
         _modifierKeyState |= EnumValue(ModifierKey::cmd);
     }
@@ -501,7 +506,7 @@ bool InputManager::getState(const RegisteredShortcut& shortcut) const
 
 bool InputManager::getState(const ShortcutInput& shortcut) const
 {
-    constexpr uint32_t kUsefulModifiers = KMOD_SHIFT | KMOD_CTRL | KMOD_ALT | KMOD_GUI;
+    constexpr uint32_t kUsefulModifiers = SDL_KMOD_SHIFT | SDL_KMOD_CTRL | SDL_KMOD_ALT | SDL_KMOD_GUI;
     auto modifiers = SDL_GetModState() & kUsefulModifiers;
     if ((shortcut.modifiers & kUsefulModifiers) == modifiers)
     {
@@ -517,7 +522,7 @@ bool InputManager::getState(const ShortcutInput& shortcut) const
             }
             case InputDeviceKind::keyboard:
             {
-                auto scanCode = static_cast<size_t>(SDL_GetScancodeFromKey(shortcut.button));
+                auto scanCode = static_cast<size_t>(SDL_GetScancodeFromKey(shortcut.button, nullptr));
                 if (scanCode < _keyboardState.size() && _keyboardState[scanCode])
                 {
                     return true;
@@ -529,8 +534,8 @@ bool InputManager::getState(const ShortcutInput& shortcut) const
                 for (auto* gameController : _gameControllers)
                 {
                     // Get the underlying joystick to maintain compatibility with raw button numbers
-                    auto* joystick = SDL_GameControllerGetJoystick(gameController);
-                    if (joystick && SDL_JoystickGetButton(joystick, shortcut.button))
+                    auto* joystick = SDL_GetGamepadJoystick(gameController);
+                    if (joystick && SDL_GetJoystickButton(joystick, shortcut.button))
                     {
                         return true;
                     }
@@ -542,13 +547,13 @@ bool InputManager::getState(const ShortcutInput& shortcut) const
                 for (auto* gameController : _gameControllers)
                 {
                     // Get the underlying joystick to maintain compatibility with hat functionality
-                    auto* joystick = SDL_GameControllerGetJoystick(gameController);
+                    auto* joystick = SDL_GetGamepadJoystick(gameController);
                     if (joystick)
                     {
-                        auto numHats = SDL_JoystickNumHats(joystick);
+                        auto numHats = SDL_GetNumJoystickHats(joystick);
                         for (int i = 0; i < numHats; i++)
                         {
-                            auto hat = SDL_JoystickGetHat(joystick, i);
+                            auto hat = SDL_GetJoystickHat(joystick, i);
                             if (hat & shortcut.button)
                             {
                                 return true;

--- a/src/openrct2-ui/input/InputManager.h
+++ b/src/openrct2-ui/input/InputManager.h
@@ -13,7 +13,7 @@
 #include <queue>
 #include <string_view>
 
-typedef struct _SDL_GameController SDL_GameController;
+typedef struct SDL_Gamepad SDL_Gamepad;
 typedef union SDL_Event SDL_Event;
 
 namespace OpenRCT2::Ui
@@ -58,7 +58,7 @@ namespace OpenRCT2::Ui
     {
     private:
         uint32_t _lastJoystickCheck{};
-        std::vector<SDL_GameController*> _gameControllers;
+        std::vector<SDL_Gamepad*> _gameControllers;
         std::queue<InputEvent> _events;
         ScreenCoordsXY _viewScroll;
         ScreenCoordsXY _analogueScroll;     // analogue stick scroll values

--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -10,8 +10,7 @@
 #include "../UiStringIds.h"
 #include "ShortcutManager.h"
 
-#include <SDL_joystick.h>
-#include <SDL_keyboard.h>
+#include <SDL3/SDL.h>
 #include <cstring>
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Formatting.h>
@@ -21,57 +20,57 @@
 using namespace OpenRCT2;
 using namespace OpenRCT2::Ui;
 
-constexpr uint32_t kUsefulModifiers = KMOD_SHIFT | KMOD_CTRL | KMOD_ALT | KMOD_GUI;
+constexpr uint32_t kUsefulModifiers = SDL_KMOD_SHIFT | SDL_KMOD_CTRL | SDL_KMOD_ALT | SDL_KMOD_GUI;
 
 static uint32_t ParseModifier(std::string_view text)
 {
     if (String::iequals(text, "CTRL"))
     {
-        return KMOD_CTRL;
+        return SDL_KMOD_CTRL;
     }
     if (String::iequals(text, "LCTRL"))
     {
-        return KMOD_LCTRL;
+        return SDL_KMOD_LCTRL;
     }
     if (String::iequals(text, "RCTRL"))
     {
-        return KMOD_RCTRL;
+        return SDL_KMOD_RCTRL;
     }
     if (String::iequals(text, "SHIFT"))
     {
-        return KMOD_SHIFT;
+        return SDL_KMOD_SHIFT;
     }
     if (String::iequals(text, "LSHIFT"))
     {
-        return KMOD_LSHIFT;
+        return SDL_KMOD_LSHIFT;
     }
     if (String::iequals(text, "RSHIFT"))
     {
-        return KMOD_RSHIFT;
+        return SDL_KMOD_RSHIFT;
     }
     if (String::iequals(text, "ALT"))
     {
-        return KMOD_ALT;
+        return SDL_KMOD_ALT;
     }
     if (String::iequals(text, "LALT"))
     {
-        return KMOD_LALT;
+        return SDL_KMOD_LALT;
     }
     if (String::iequals(text, "RALT"))
     {
-        return KMOD_RALT;
+        return SDL_KMOD_RALT;
     }
     if (String::iequals(text, "GUI"))
     {
-        return KMOD_GUI;
+        return SDL_KMOD_GUI;
     }
     if (String::iequals(text, "LCTRL"))
     {
-        return KMOD_LGUI;
+        return SDL_KMOD_LGUI;
     }
     if (String::iequals(text, "RGUI"))
     {
-        return KMOD_RGUI;
+        return SDL_KMOD_RGUI;
     }
 
     return 0;
@@ -192,12 +191,12 @@ ShortcutInput::ShortcutInput(std::string_view value)
 std::string_view ShortcutInput::getModifierName(uint32_t key, bool localised)
 {
     static std::unordered_map<uint32_t, std::pair<const char*, StringId>> _keys{
-        { KMOD_SHIFT, { "SHIFT", STR_SHORTCUT_MOD_SHIFT } },    { KMOD_LSHIFT, { "LSHIFT", STR_SHORTCUT_MOD_LSHIFT } },
-        { KMOD_RSHIFT, { "RSHIFT", STR_SHORTCUT_MOD_RSHIFT } }, { KMOD_CTRL, { "CTRL", STR_SHORTCUT_MOD_CTRL } },
-        { KMOD_LCTRL, { "LCTRL", STR_SHORTCUT_MOD_LCTRL } },    { KMOD_RCTRL, { "RCTRL", STR_SHORTCUT_MOD_RCTRL } },
-        { KMOD_ALT, { "ALT", STR_SHORTCUT_MOD_ALT } },          { KMOD_LALT, { "LALT", STR_SHORTCUT_MOD_LALT } },
-        { KMOD_RALT, { "RALT", STR_SHORTCUT_MOD_RALT } },       { KMOD_GUI, { "GUI", STR_SHORTCUT_MOD_GUI } },
-        { KMOD_LGUI, { "LGUI", STR_SHORTCUT_MOD_LGUI } },       { KMOD_RGUI, { "RGUI", STR_SHORTCUT_MOD_RGUI } },
+        { SDL_KMOD_SHIFT, { "SHIFT", STR_SHORTCUT_MOD_SHIFT } },    { SDL_KMOD_LSHIFT, { "LSHIFT", STR_SHORTCUT_MOD_LSHIFT } },
+        { SDL_KMOD_RSHIFT, { "RSHIFT", STR_SHORTCUT_MOD_RSHIFT } }, { SDL_KMOD_CTRL, { "CTRL", STR_SHORTCUT_MOD_CTRL } },
+        { SDL_KMOD_LCTRL, { "LCTRL", STR_SHORTCUT_MOD_LCTRL } },    { SDL_KMOD_RCTRL, { "RCTRL", STR_SHORTCUT_MOD_RCTRL } },
+        { SDL_KMOD_ALT, { "ALT", STR_SHORTCUT_MOD_ALT } },          { SDL_KMOD_LALT, { "LALT", STR_SHORTCUT_MOD_LALT } },
+        { SDL_KMOD_RALT, { "RALT", STR_SHORTCUT_MOD_RALT } },       { SDL_KMOD_GUI, { "GUI", STR_SHORTCUT_MOD_GUI } },
+        { SDL_KMOD_LGUI, { "LGUI", STR_SHORTCUT_MOD_LGUI } },       { SDL_KMOD_RGUI, { "RGUI", STR_SHORTCUT_MOD_RGUI } },
     };
 
     auto r = _keys.find(key);
@@ -283,10 +282,10 @@ std::string ShortcutInput::toLocalisedString() const
 std::string ShortcutInput::toString(bool localised) const
 {
     std::string result;
-    appendModifier(result, KMOD_LSHIFT, KMOD_RSHIFT, localised);
-    appendModifier(result, KMOD_LCTRL, KMOD_RCTRL, localised);
-    appendModifier(result, KMOD_LALT, KMOD_RALT, localised);
-    appendModifier(result, KMOD_LGUI, KMOD_RGUI, localised);
+    appendModifier(result, SDL_KMOD_LSHIFT, SDL_KMOD_RSHIFT, localised);
+    appendModifier(result, SDL_KMOD_LCTRL, SDL_KMOD_RCTRL, localised);
+    appendModifier(result, SDL_KMOD_LALT, SDL_KMOD_RALT, localised);
+    appendModifier(result, SDL_KMOD_LGUI, SDL_KMOD_RGUI, localised);
 
     if (kind == InputDeviceKind::keyboard)
     {
@@ -393,8 +392,8 @@ static bool HasModifier(uint32_t shortcut, uint32_t actual, uint32_t left, uint3
 static bool CompareModifiers(uint32_t shortcut, uint32_t actual)
 {
     shortcut &= kUsefulModifiers;
-    return HasModifier(shortcut, actual, KMOD_LCTRL, KMOD_RCTRL) && HasModifier(shortcut, actual, KMOD_LSHIFT, KMOD_RSHIFT)
-        && HasModifier(shortcut, actual, KMOD_LALT, KMOD_RALT) && HasModifier(shortcut, actual, KMOD_LGUI, KMOD_RGUI);
+    return HasModifier(shortcut, actual, SDL_KMOD_LCTRL, SDL_KMOD_RCTRL) && HasModifier(shortcut, actual, SDL_KMOD_LSHIFT, SDL_KMOD_RSHIFT)
+        && HasModifier(shortcut, actual, SDL_KMOD_LALT, SDL_KMOD_RALT) && HasModifier(shortcut, actual, SDL_KMOD_LGUI, SDL_KMOD_RGUI);
 }
 
 bool ShortcutInput::matches(const InputEvent& e) const
@@ -413,7 +412,7 @@ std::optional<ShortcutInput> ShortcutInput::fromInputEvent(const InputEvent& e)
 {
     // Assume any side modifier (more specific configurations can be done by manually editing config file)
     auto modifiers = e.modifiers & kUsefulModifiers;
-    for (auto mod : { KMOD_CTRL, KMOD_SHIFT, KMOD_ALT, KMOD_GUI })
+    for (auto mod : { SDL_KMOD_CTRL, SDL_KMOD_SHIFT, SDL_KMOD_ALT, SDL_KMOD_GUI })
     {
         if (modifiers & mod)
         {

--- a/src/openrct2-ui/input/ShortcutManager.cpp
+++ b/src/openrct2-ui/input/ShortcutManager.cpp
@@ -11,7 +11,7 @@
 
 #include "ShortcutIds.h"
 
-#include <SDL_keyboard.h>
+#include <SDL3/SDL.h>
 #include <openrct2-ui/UiStringIds.h>
 #include <openrct2/PlatformEnvironment.h>
 #include <openrct2/core/Console.hpp>
@@ -242,14 +242,14 @@ std::optional<ShortcutInput> ShortcutManager::convertLegacyBinding(uint16_t bind
     ShortcutInput result;
     result.kind = InputDeviceKind::keyboard;
     if (binding & kShift)
-        result.modifiers |= KMOD_SHIFT;
+        result.modifiers |= SDL_KMOD_SHIFT;
     if (binding & kCtrl)
-        result.modifiers |= KMOD_CTRL;
+        result.modifiers |= SDL_KMOD_CTRL;
     if (binding & kAlt)
-        result.modifiers |= KMOD_ALT;
+        result.modifiers |= SDL_KMOD_ALT;
     if (binding & kCmd)
-        result.modifiers |= KMOD_GUI;
-    result.button = SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(binding & 0xFF));
+        result.modifiers |= SDL_KMOD_GUI;
+    result.button = SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(binding & 0xFF), SDL_KMOD_NONE, false);
     return result;
 }
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -12,7 +12,7 @@
 #include "../UiStringIds.h"
 #include "Widget.h"
 
-#include <SDL_video.h>
+#include <SDL3/SDL.h>
 #include <algorithm>
 #include <openrct2-ui/windows/Windows.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -9,6 +9,7 @@
 
 #include "../UiStringIds.h"
 
+#include <SDL3/SDL_clipboard.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/windows/Windows.h>

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <SDL_keycode.h>
+#include <SDL3/SDL_keycode.h>
 #include <ctime>
 #include <iterator>
 #include <memory>

--- a/src/openrct2-ui/windows/OverwritePrompt.cpp
+++ b/src/openrct2-ui/windows/OverwritePrompt.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <SDL_keycode.h>
+#include <SDL3/SDL_keycode.h>
 #include <openrct2-ui/interface/FileBrowser.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -7,7 +7,9 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <SDL_keyboard.h>
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_keycode.h>
+#include <iterator>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
 #include <openrct2-ui/windows/Windows.h>
@@ -322,7 +324,7 @@ namespace OpenRCT2::Ui::Windows
         static void IMEComposition(int32_t cursorX, int32_t cursorY)
         {
             SDL_Rect rect = { cursorX, cursorY, 100, 100 };
-            SDL_SetTextInputRect(&rect);
+            SDL_SetTextInputArea(SDL_GetKeyboardFocus(), &rect, 0);
         }
 
         void ExecuteCallback(bool hasValue)

--- a/src/openrct2/core/Http.Android.cpp
+++ b/src/openrct2/core/Http.Android.cpp
@@ -14,7 +14,7 @@
     #include "../Version.h"
     #include "../platform/Platform.h"
 
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <android/log.h>
     #include <jni.h>
 

--- a/src/openrct2/core/ZipAndroid.cpp
+++ b/src/openrct2/core/ZipAndroid.cpp
@@ -15,7 +15,7 @@
     #include "MemoryStream.h"
     #include "Zip.h"
 
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <jni.h>
     #include <string>
 

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -19,7 +19,7 @@
     #include "../drawing/Font.h"
     #include "../localisation/Language.h"
 
-    #include <SDL.h>
+    #include <SDL3/SDL.h>
     #include <algorithm>
     #include <android/asset_manager.h>
     #include <android/asset_manager_jni.h>


### PR DESCRIPTION
I've seen [some attempts](https://github.com/OpenRCT2/OpenRCT2/issues?q=is%3Aissue%20state%3Aopen%20sdl3%20compat) in the past. This PR would be a "full" migration to the new APIs and Symbols SDL3 provides.

I've tested it on a current macOS and Windows 11 Pro and haven't found any major (new) glitches. (e.g. the current OpenRCT2 title sequence looks nearly identical - by eye. i haven't recorded it and diff-ed)

Because in itself the project is rather complex (to build) it isn't as simple as creating this MR.

Open TODOs i see:
- [ ] Providing SDL3 via [Dependencies-repo](https://github.com/OpenRCT2/Dependencies)
- [ ] Add `SDL_SetAppMetaData()` ([request](https://github.com/OpenRCT2/OpenRCT2/issues/23682#issuecomment-2636894374))
- [ ] Test it with Linux


This could open up the way for a SDL drawing engine which uses current and supported graphics APIs and provide various quality-of-life features (e.g. Discord detects a running game) in the future.
 
Since the replacement is a rather "mechanical" task i used a 🤖 which created some scripts (for batch-renaming) and summarized what changed in what commit.

fixes #23682 