### PR TITLE
Fix #16409: scatter tool cannot be used in multiplayer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Fix: [#16409] The scatter tool cannot be used in multiplayer, even when the group permission is enabled.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -46,6 +46,7 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/management/Research.h>
 #include <openrct2/network/Network.h>
+#include <openrct2/network/NetworkAction.h>
 #include <openrct2/object/BannerSceneryEntry.h>
 #include <openrct2/object/LargeSceneryEntry.h>
 #include <openrct2/object/ObjectEntryManager.h>
@@ -337,7 +338,8 @@ namespace OpenRCT2::Ui::Windows
                         windowMgr->CloseByClass(WindowClass::sceneryScatter);
                     else if (
                         Network::GetMode() != Network::Mode::client
-                        || Network::CanPerformCommand(Network::GetCurrentPlayerGroupIndex(), -2))
+                        || Network::CanPerformAction(
+                            Network::GetCurrentPlayerGroupIndex(), Network::Permission::toggleSceneryCluster))
                     {
                         SceneryScatterOpen();
                     }
@@ -2908,7 +2910,8 @@ namespace OpenRCT2::Ui::Windows
             int32_t quantity = 1;
             bool isCluster = gWindowSceneryScatterEnabled
                 && (Network::GetMode() != Network::Mode::client
-                    || Network::CanPerformCommand(Network::GetCurrentPlayerGroupIndex(), -2));
+                    || Network::CanPerformAction(
+                        Network::GetCurrentPlayerGroupIndex(), Network::Permission::toggleSceneryCluster));
 
             if (isCluster)
             {


### PR DESCRIPTION
Fixes #16409.

The scatter tool has no game action of its own: it just fires many regular scenery placements, so `PERMISSION_TOGGLE_SCENERY_CLUSTER` is checked in the UI rather than mapped to a command. Both call sites did that by passing a magic -2, a leftover from when `MISC_COMMAND_TOGGLE_SCENERY_CLUSTER` was listed in the permission's command list.

#13103 merged `MISC_COMMAND` into GameCommand and emptied those lists, but did not update these two call sites, so `findCommand()` could never match and `canPerformCommand()` returned false for every group. Ticking the permission had no effect at all.

Now checked directly, the same way `PERMISSION_DRAG_PATH_AREA` is checked in Footpath.cpp.

https://github.com/OpenRCT2/OpenRCT2/blob/bdbe9013ccbcfb36be7c3948f296da8dcd9a61c2/src/openrct2-ui/windows/Footpath.cpp#L537-L543
----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._