### PR TITLE
Improve save field alignment in file browser window

### DIFF
--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -688,8 +688,8 @@ namespace OpenRCT2::Ui::Windows
                 {
                     campaignButton.setVisible();
                     campaignButton.top = y;
-                    campaignButton.bottom = y + kButtonFaceHeight + 1;
-                    y += kButtonFaceHeight + 2;
+                    campaignButton.bottom = y + kButtonFaceHeight;
+                    y += kButtonFaceHeight + 1;
                 }
                 else
                 {

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -700,15 +700,15 @@ namespace OpenRCT2::Ui::Windows
 
             if (action == LoadSaveAction::save)
             {
-                widgets[WIDX_SCROLL].bottom -= 18;
+                widgets[WIDX_SCROLL].bottom -= kButtonFaceHeight + 7;
 
                 // Get 'Save' button string width
                 auto saveLabel = LanguageGetString(STR_FILEBROWSER_SAVE_BUTTON);
                 auto saveLabelWidth = getStringWidth(saveLabel, FontStyle::medium) + 12;
 
                 widgets[WIDX_SAVE].setVisible();
-                widgets[WIDX_SAVE].top = height - paddingBottom - 15;
-                widgets[WIDX_SAVE].bottom = height - paddingBottom - 3;
+                widgets[WIDX_SAVE].bottom = height - paddingBottom - 2;
+                widgets[WIDX_SAVE].top = widgets[WIDX_SAVE].bottom - kButtonFaceHeight;
                 widgets[WIDX_SAVE].right = widgets[WIDX_SCROLL].right;
                 widgets[WIDX_SAVE].left = widgets[WIDX_SAVE].right - saveLabelWidth;
 
@@ -717,8 +717,8 @@ namespace OpenRCT2::Ui::Windows
                 auto filenameLabelWidth = getStringWidth(filenameLabel, FontStyle::medium);
 
                 widgets[WIDX_FILENAME_TEXTBOX].setVisible();
-                widgets[WIDX_FILENAME_TEXTBOX].top = height - paddingBottom - 15;
-                widgets[WIDX_FILENAME_TEXTBOX].bottom = height - paddingBottom - 3;
+                widgets[WIDX_FILENAME_TEXTBOX].bottom = height - paddingBottom - 2;
+                widgets[WIDX_FILENAME_TEXTBOX].top = widgets[WIDX_FILENAME_TEXTBOX].bottom - kButtonFaceHeight;
                 widgets[WIDX_FILENAME_TEXTBOX].left = 4 + filenameLabelWidth + 6;
                 widgets[WIDX_FILENAME_TEXTBOX].right = widgets[WIDX_SAVE].left - 5;
             }
@@ -786,7 +786,7 @@ namespace OpenRCT2::Ui::Windows
             if (action == LoadSaveAction::save)
             {
                 auto& widget = widgets[WIDX_FILENAME_TEXTBOX];
-                drawText(rt, windowPos + ScreenCoordsXY{ 5, widget.top + 2 }, STR_FILENAME_LABEL, { Drawing::Colour::grey });
+                drawText(rt, windowPos + ScreenCoordsXY{ 5, widget.top + 1 }, STR_FILENAME_LABEL, { Drawing::Colour::grey });
             }
         }
 

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -220,7 +220,7 @@ namespace OpenRCT2
     constexpr int32_t kScrollableRowHeight = 12;
     constexpr uint8_t kListRowHeight = 12;
     constexpr uint8_t kTableCellHeight = 12;
-    constexpr uint8_t kButtonFaceHeight = 12;
+    constexpr uint8_t kButtonFaceHeight = 14;
     constexpr uint8_t kSpinnerHeight = 14;
     constexpr uint8_t kDropdownHeight = 14;
 


### PR DESCRIPTION
This PR adjusts the `kButtonFaceHeight` constant to match actual usage, and fixes the only issue with button/label alignment I could find. Ironically, the window in question wasn't even using the constant.

Before:

<img width="608" height="406" alt="Electric Fields 2026-08-12 14-49-48" src="https://github.com/user-attachments/assets/21afc5e4-efd4-4051-b672-6084afb98460" />

After:

<img width="608" height="406" alt="Electric Fields 2026-08-12 14-49-20" src="https://github.com/user-attachments/assets/1c1c82f9-0368-4db4-933a-80e319aa348c" />

