### PR TITLE
Fix bottom toolbar button invalidation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
 - Fix: [#26917] Tile Inspector does not show indestructible track status correctly when ‘Make all track pieces destructible’ cheat is enabled.
+- Fix: [#26921] The bottom panel buttons for finances, park rating, date, etc. are not invalidating properly.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1020,7 +1020,8 @@ namespace OpenRCT2
         if (w != nullptr)
         {
             w->onPrepareDraw();
-            if (w->widgets[gHoverWidget.widgetIndex].type == WidgetType::flatBtn)
+            if (w->widgets[gHoverWidget.widgetIndex].type == WidgetType::flatBtn
+                || w->widgets[gHoverWidget.widgetIndex].type == WidgetType::hiddenButton)
             {
                 windowMgr->InvalidateWidgetByNumber(
                     gHoverWidget.windowClassification, gHoverWidget.windowNumber, gHoverWidget.widgetIndex);


### PR DESCRIPTION
The buttons in the bottom toolbar are drawn using custom (non-widget) rectangles. However, the window is not invalidated properly, leading to the hover state for these widgets glitching. This PR fixes that issue.

This appears to have been broken since `WidgetType::hiddenButton` was introduced in October 2025 (2eb34e205934042fbd4a398341512b62645adfdd)

Backported from #26919