### PR TITLE
Fix #25558: plugin buttons ignore an explicitly set border

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#21632] [Plugin] Crash when loading custom image larger than 300 by 300 pixels.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.
+- Fix: [#25558] [Plugin] Image buttons ignore their explicit border setting when a theme draws borders around them.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -74,7 +74,7 @@ namespace OpenRCT2::Ui::Windows
         bool IsDisabled{};
         bool IsVisible{};
         bool IsPressed{};
-        bool HasBorder{};
+        std::optional<bool> HasBorder;
         bool ShowColumnHeaders{};
         bool IsStriped{};
         bool CanSelect{};
@@ -105,12 +105,10 @@ namespace OpenRCT2::Ui::Windows
                 if (JS_IsString(jsImage) || JS_IsNumber(jsImage))
                 {
                     result.Image = ImageId(ImageFromJSValue(ctx, jsImage));
-                    result.HasBorder = false;
                 }
                 else
                 {
                     result.Text = AsOrDefault(ctx, desc, "text", "");
-                    result.HasBorder = true;
                 }
                 JS_FreeValue(ctx, jsImage);
                 result.IsPressed = AsOrDefault(ctx, desc, "isPressed", false);
@@ -191,7 +189,12 @@ namespace OpenRCT2::Ui::Windows
                 result.MaxLength = AsOrDefault(ctx, desc, "maxLength", 32);
                 result.OnChange = JSToCallback(ctx, desc, "onChange");
             }
-            result.HasBorder = AsOrDefault(ctx, desc, "border", result.HasBorder);
+            JSValue jsBorder = JS_GetPropertyStr(ctx, desc, "border");
+            if (JS_IsBool(jsBorder))
+            {
+                result.HasBorder = JS_ToBool(ctx, jsBorder) > 0;
+            }
+            JS_FreeValue(ctx, jsBorder);
             return result;
         }
     };
@@ -963,7 +966,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (desc.Image.HasValue())
                 {
-                    widget.type = desc.HasBorder ? WidgetType::imgBtn : WidgetType::flatBtn;
+                    // When the border is not specified, flatBtn lets the theme decide whether to draw one.
+                    if (!desc.HasBorder.has_value())
+                        widget.type = WidgetType::flatBtn;
+                    else
+                        widget.type = *desc.HasBorder ? WidgetType::imgBtn : WidgetType::hiddenButton;
                     widget.image = desc.Image;
                 }
                 else

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -557,6 +557,11 @@ namespace OpenRCT2::Scripting
         }
 
     private:
+        static bool isImageButton(WidgetType type)
+        {
+            return type == WidgetType::flatBtn || type == WidgetType::imgBtn || type == WidgetType::hiddenButton;
+        }
+
         static JSValue border_get(JSContext* ctx, JSValue thisVal)
         {
             auto widget = GetWidget(thisVal);
@@ -571,12 +576,10 @@ namespace OpenRCT2::Scripting
             JS_UNPACK_BOOL(valueBool, ctx, value);
 
             auto widget = GetWidget(thisVal);
-            if (widget != nullptr && (widget->type == WidgetType::flatBtn || widget->type == WidgetType::imgBtn))
+            if (widget != nullptr && isImageButton(widget->type))
             {
-                if (valueBool)
-                    widget->type = WidgetType::imgBtn;
-                else
-                    widget->type = WidgetType::flatBtn;
+                // hiddenButton rather than flatBtn, so that themes do not draw a border anyway.
+                widget->type = valueBool ? WidgetType::imgBtn : WidgetType::hiddenButton;
                 Invalidate(thisVal);
             }
             return JS_UNDEFINED;
@@ -610,7 +613,7 @@ namespace OpenRCT2::Scripting
         static JSValue image_get(JSContext* ctx, JSValue thisVal)
         {
             auto widget = GetWidget(thisVal);
-            if (widget != nullptr && (widget->type == WidgetType::flatBtn || widget->type == WidgetType::imgBtn))
+            if (widget != nullptr && isImageButton(widget->type))
             {
                 if (GetTargetAPIVersion() <= kApiVersionG2Reorder)
                 {
@@ -624,7 +627,7 @@ namespace OpenRCT2::Scripting
         static JSValue image_set(JSContext* ctx, JSValue thisVal, JSValue value)
         {
             auto widget = GetWidget(thisVal);
-            if (widget != nullptr && (widget->type == WidgetType::flatBtn || widget->type == WidgetType::imgBtn))
+            if (widget != nullptr && isImageButton(widget->type))
             {
                 widget->image = ImageId(ImageFromJSValue(ctx, value));
                 Invalidate(thisVal);
@@ -1145,6 +1148,7 @@ namespace OpenRCT2::Scripting
             case WidgetType::button:
             case WidgetType::flatBtn:
             case WidgetType::imgBtn:
+            case WidgetType::hiddenButton:
                 ScButtonWidget::AddFuncs(ctx, newObj);
                 break;
             case WidgetType::checkbox:


### PR DESCRIPTION
Fixes #25558.

Since #25392, themes that draw borders around image buttons also drew one around plugin buttons that had explicitly set `border: false`.

The three border states now map onto three widget types:

| `border` | Widget type | Result |
|---|---|---|
| `true` | `imgBtn` | always bordered |
| `false` | `hiddenButton` | never bordered |
| not set | `flatBtn` | follows the theme |

`hiddenButton` already draws like `flatBtn` without the theme's 3D border, so no drawing code changed — `CustomWidgetDesc::HasBorder` just became a `std::optional<bool>` to tell "not set" apart from "set to false".

Using the example plugin from the issue:

<img width="553" height="171" alt="Test window" src="https://github.com/user-attachments/assets/06cf2512-5b6f-405f-8ffd-09a166729ff8" />

----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._