### PR TITLE
Fix #25496: guest pickup button does not grey out when guest state changes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
+- Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -473,6 +473,8 @@ namespace OpenRCT2::Ui::Windows
             _windowTitle = peep->GetName();
             widgets[WIDX_TITLE].setString(_windowTitle.c_str());
 
+            DisableWidgets();
+
             WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_7);
         }
 
@@ -606,7 +608,6 @@ namespace OpenRCT2::Ui::Windows
 
         void onResizeOverview()
         {
-            DisableWidgets();
             onPrepareDraw();
             invalidateWidget(WIDX_MARQUEE);
             onResizeCommon();


### PR DESCRIPTION
Fixes #25496.

The "pick up guest" button is greyed out whenever the guest can't be picked up. That was only checked when the window was opened, a tab was switched or the window was resized, so if the guest's situation changed while you were watching them, the button kept its old look: still pressable after they'd left the park (doing nothing when clicked), or still greyed out after they'd come back in. Same for boarding and leaving rides, as noted in the comments.

The staff window already re-checks its buttons every time it's drawn:

https://github.com/OpenRCT2/OpenRCT2/blob/27a9d4b3d5e8488601e9d78daea56b64a3070221/src/openrct2-ui/windows/Staff.cpp#L345-L349

The guest window now does the same, and picks up the state-change notifications it was already being sent. The finance and debug tabs had the same staleness and are covered too.

----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._