### PR TITLE
Fix #23872: Set load/save folder for parks loaded outside the game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#26827] [Plugin] Add map resize hook to scripting api.
 - Feature: [#26877] Clear Scenery can remove footpath additions or walls separately.
+- Improved: [#23872] Loading a park outside the game now sets the folder of the load/save window, as loading one in-game does.
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1001,7 +1001,7 @@ namespace OpenRCT2
             return true;
         }
 
-        void RememberStartUpParkDirectory()
+        void rememberStartUpParkDirectory()
         {
             const bool isContinuedSaveGame = gScenarioSavePath == gOpenRCT2StartupActionPath;
             if (!isContinuedSaveGame || gScenarioSavePath.empty())
@@ -1086,7 +1086,7 @@ namespace OpenRCT2
                             break;
                         }
 
-                        RememberStartUpParkDirectory();
+                        rememberStartUpParkDirectory();
                     }
 
                     // Successfully loaded a file

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1001,6 +1001,16 @@ namespace OpenRCT2
             return true;
         }
 
+        void RememberStartUpParkDirectory()
+        {
+            const bool isContinuedSaveGame = gScenarioSavePath == gOpenRCT2StartupActionPath;
+            if (!isContinuedSaveGame || gScenarioSavePath.empty())
+                return;
+
+            Config::Get().general.lastSaveGameDirectory = Path::GetDirectory(Path::GetAbsolute(gScenarioSavePath));
+            Config::Save();
+        }
+
         void SwitchToStartUpScene()
         {
             if (gOpenRCT2Headless)
@@ -1075,6 +1085,8 @@ namespace OpenRCT2
                             nextScene = _sceneManager->getTitleScene();
                             break;
                         }
+
+                        RememberStartUpParkDirectory();
                     }
 
                     // Successfully loaded a file


### PR DESCRIPTION
Fixes #23872.

The last used folder is only stored by the file browser itself, so a park loaded on start up through a file association or the command line never updated it. `Context::SwitchToStartUpScene` now stores the folder of the park it just loaded.

Scenarios are skipped, as ScenarioBegin points gScenarioSavePath at the user save folder, and aiming the browser at the folder of the scenario would suggest saving into the game installation. Downloads over http are skipped too, as there is no local folder to remember. Did not hook into ``Context::LoadParkFromStream``, since the title sequence player loads parks through it and would overwrite the folder on every title screen.

Tested headless against a separate user folder: a park sets last_game_directory to its own folder, while a scenario from that same folder leaves it untouched.

----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._