### PR TITLE
Fix #24610: graph tabs grow by a pixel every time you switch between them

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
+- Fix: [#24610] Graph tabs get a little bit longer every time you switch between them.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -190,8 +190,8 @@ namespace OpenRCT2::Ui
         // clang-format off
         std::array<Widget, 3> out = {
             makeWidget({ 0, 0 }, { size.width, size.height }, WidgetType::frame, WindowColour::primary),
-            makeWidget({ 1, 1 }, { size.width - 1, kTitleHeightNormal }, WidgetType::caption, WindowColour::primary, title, STR_WINDOW_TITLE_TIP),
-            makeWidget({ size.width - 12, 2 }, { 11, 11 }, WidgetType::closeBox, WindowColour::primary, kWidgetContentEmpty, STR_CLOSE_WINDOW_TIP),
+            makeWidget({ 1, 1 }, { size.width - 2, kTitleHeightNormal }, WidgetType::caption, WindowColour::primary, title, STR_WINDOW_TITLE_TIP),
+            makeWidget({ size.width - 13, 2 }, { 11, 12 }, WidgetType::closeBox, WindowColour::primary, kWidgetContentEmpty, STR_CLOSE_WINDOW_TIP),
         };
         // clang-format on
 

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -211,8 +211,8 @@ namespace OpenRCT2
         }
     };
 
-    constexpr uint8_t kTitleHeightNormal = 13;
-    constexpr uint8_t kTitleHeightLarge = 24;
+    constexpr uint8_t kTitleHeightNormal = 14;
+    constexpr uint8_t kTitleHeightLarge = 25;
 
     constexpr uint8_t kCloseButtonSize = 10;
     constexpr uint8_t kCloseButtonSizeTouch = 20;

--- a/src/openrct2/interface/WindowBase.cpp
+++ b/src/openrct2/interface/WindowBase.cpp
@@ -109,7 +109,7 @@ namespace OpenRCT2
 
         // Figure out if we need to push the other widgets down to accommodate a resized title/caption
         auto preferredHeight = getTitleBarTargetHeight();
-        auto currentHeight = titleWidget.height() - 1;
+        auto currentHeight = titleWidget.height();
         auto heightDifference = preferredHeight - currentHeight;
 
         if (!hasTitleWidget || heightDifference == 0)
@@ -151,7 +151,7 @@ namespace OpenRCT2
     int16_t WindowBase::getTitleBarCurrentHeight() const
     {
         if (!flags.has(WindowFlag::noTitleBar) && widgets.size() > 2)
-            return widgets[1].height() - 1;
+            return widgets[1].height();
         else
             return 0;
     }


### PR DESCRIPTION
Fixes #24610.

The window shim has declared the caption one row short since #24566: the macro it replaced ran from y 1 to 14, the constexpr version only to 13. `resizeFrame()` stretched it back on every `setWidgets()` call and added the same pixel to the window height, and as `setWidgets()` resets the widget but not the height, that piled up on every tab switch. Tabs with a fixed height clamp it away; tabs that keep their height have nothing to reset it. The resizable tabs of the park and ride windows and the file browser's remembered size drifted the same way, and are fixed here too.

The underlying confusion is that `kTitleHeightNormal` and `kTitleHeightLarge` described `bottom - top` rather than the widget's height, which was consistent when they were introduced in #23590 but stopped being so once #25486 made `Widget::height()` inclusive. They now hold the actual heights, the compensating `- 1` is gone from `resizeFrame()` and `getTitleBarCurrentHeight()`, and the shim derives the caption from the constant.

The caption and close box end up on the exact coordinates the old macro used, so the title bar and close button are drawn as before. Tested in-game in both normal and enlarged UI mode.

Related: #23590 added the enlarged UI, #24566 replaced the shim, #25486 adjusted the measurements.

----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._
