### PR TITLE
Fix #21632: Crash when loading custom image larger than 300 by 300 pixels.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
+- Fix: [#21632] [Plugin] Crash when loading custom image larger than 300 by 300 pixels.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.

--- a/src/openrct2-ui/scripting/ScImageManager.hpp
+++ b/src/openrct2-ui/scripting/ScImageManager.hpp
@@ -156,7 +156,7 @@ namespace OpenRCT2::Scripting
             {
                 JSSetPixelData(ctx, id, pixelData);
             }
-            catch (const std::runtime_error& e)
+            catch (const std::exception& e)
             {
                 JS_ThrowInternalError(ctx, "%s", e.what());
                 return JS_EXCEPTION;

--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -115,7 +115,10 @@ namespace OpenRCT2::Imaging
             if (colourType == PNG_COLOR_TYPE_RGB)
             {
                 // 24-bit PNG (no alpha)
-                Guard::Assert(rowBytes == pngWidth * 3, GUARD_LINE);
+                if (rowBytes != pngWidth * 3)
+                {
+                    throw std::runtime_error("PNG must have 24-bit colours in RGB mode. ");
+                }
                 for (png_uint_32 i = 0; i < pngHeight; i++)
                 {
                     auto src = rowPointers[i];
@@ -131,7 +134,10 @@ namespace OpenRCT2::Imaging
             else if (bitDepth == 8 && !expandTo32)
             {
                 // 8-bit paletted or greyscale
-                Guard::Assert(rowBytes == pngWidth, GUARD_LINE);
+                if (rowBytes != pngWidth)
+                {
+                    throw std::runtime_error("PNG must be 8-bit paletted when using \"keep\" palette. ");
+                }
                 for (png_uint_32 i = 0; i < pngHeight; i++)
                 {
                     std::copy_n(rowPointers[i], rowBytes, dst);
@@ -141,7 +147,10 @@ namespace OpenRCT2::Imaging
             else
             {
                 // 32-bit PNG (with alpha)
-                Guard::Assert(rowBytes == pngWidth * 4, GUARD_LINE);
+                if (rowBytes != pngWidth * 4)
+                {
+                    throw std::runtime_error("PNG must either have 8-bit paletted, or 24-bit/32-bit full colour data. ");
+                }
                 for (png_uint_32 i = 0; i < pngHeight; i++)
                 {
                     std::copy_n(rowPointers[i], rowBytes, dst);


### PR DESCRIPTION
Fixes #21632: a few crashes that can occur when loading a custom image via plugins.

- Catch `std::exception` instead of `std::runtime_error` because the 300x300 check throws a [`std::invalid_argument`](https://github.com/OpenRCT2/OpenRCT2/blob/11da390704950cd30f1275c392140480908183a0/src/openrct2/drawing/ImageImporter.cpp#L34) exception and `std::exception` is the base class of both (`std::runtime_error` is not).
- Replaced a few asserts with `std::runtime_error`s as well, because the test script supplied in the issue was tripping over those as well.

Now instead of crashing the game or throwing an assert, they log nice readable errors to the console for plugin developers:
<img width="726" height="249" alt="image" src="https://github.com/user-attachments/assets/ffddcda2-6b6f-41c3-9ef8-34c3a7580415" />

cc: @Crazycolbster can you check whether this fix also solves the crashes for you?