### PR TITLE
Fix title windows not flashing when already open

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#26903] Making a ride visible or invisible is always denied in multiplayer.
 - Fix: [#26917] Tile Inspector does not show indestructible track status correctly when ‘Make all track pieces destructible’ cheat is enabled.
 - Fix: [#26921] The bottom panel buttons for finances, park rating, date, etc. are not invalidating properly.
+- Fix: [#26935] Windows opened on the title screen do not ‘flash’ around the edges when bringing them back into focus.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -125,19 +125,12 @@ namespace OpenRCT2::Ui::Windows
 
         void onMouseUp(WidgetIndex widgetIndex) override
         {
-            WindowBase* windowToOpen = nullptr;
-
             auto* windowMgr = GetWindowManager();
 
             switch (widgetIndex)
             {
                 case WIDX_START_NEW_GAME:
-                    windowToOpen = windowMgr->FindByClass(WindowClass::scenarioSelect);
-                    if (windowToOpen != nullptr)
-                    {
-                        windowMgr->BringToFront(*windowToOpen);
-                    }
-                    else
+                    if (auto* window = windowMgr->BringToFrontByClass(WindowClass::scenarioSelect); window == nullptr)
                     {
                         windowMgr->CloseByClass(WindowClass::loadsave);
                         windowMgr->CloseByClass(WindowClass::serverList);
@@ -145,12 +138,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case WIDX_CONTINUE_SAVED_GAME:
-                    windowToOpen = windowMgr->FindByClass(WindowClass::loadsave);
-                    if (windowToOpen != nullptr)
-                    {
-                        windowMgr->BringToFront(*windowToOpen);
-                    }
-                    else
+                    if (auto* window = windowMgr->BringToFrontByClass(WindowClass::loadsave); window == nullptr)
                     {
                         windowMgr->CloseByClass(WindowClass::scenarioSelect);
                         windowMgr->CloseByClass(WindowClass::serverList);
@@ -159,12 +147,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case WIDX_MULTIPLAYER:
-                    windowToOpen = windowMgr->FindByClass(WindowClass::serverList);
-                    if (windowToOpen != nullptr)
-                    {
-                        windowMgr->BringToFront(*windowToOpen);
-                    }
-                    else
+                    if (auto* window = windowMgr->BringToFrontByClass(WindowClass::serverList); window == nullptr)
                     {
                         windowMgr->CloseByClass(WindowClass::scenarioSelect);
                         windowMgr->CloseByClass(WindowClass::loadsave);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -130,7 +130,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_START_NEW_GAME:
-                    if (auto* window = windowMgr->BringToFrontByClass(WindowClass::scenarioSelect); window == nullptr)
+                    if (windowMgr->BringToFrontByClass(WindowClass::scenarioSelect) == nullptr)
                     {
                         windowMgr->CloseByClass(WindowClass::loadsave);
                         windowMgr->CloseByClass(WindowClass::serverList);
@@ -138,7 +138,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case WIDX_CONTINUE_SAVED_GAME:
-                    if (auto* window = windowMgr->BringToFrontByClass(WindowClass::loadsave); window == nullptr)
+                    if (windowMgr->BringToFrontByClass(WindowClass::loadsave) == nullptr)
                     {
                         windowMgr->CloseByClass(WindowClass::scenarioSelect);
                         windowMgr->CloseByClass(WindowClass::serverList);
@@ -147,7 +147,7 @@ namespace OpenRCT2::Ui::Windows
                     }
                     break;
                 case WIDX_MULTIPLAYER:
-                    if (auto* window = windowMgr->BringToFrontByClass(WindowClass::serverList); window == nullptr)
+                    if (windowMgr->BringToFrontByClass(WindowClass::serverList) == nullptr)
                     {
                         windowMgr->CloseByClass(WindowClass::scenarioSelect);
                         windowMgr->CloseByClass(WindowClass::loadsave);


### PR DESCRIPTION
When attempting to reopen a window while it's already open, we expect to see it 'flash' using a white border for a few frames. While debugging something else, I noticed this wasn't working for windows opened on the title scene (e.g. scenario select, load/save, multiplayer). This PR addresses this by using the relevant helper function, cleaning up some code in the process.