### PR TITLE
Shrink and reposition top toolbar

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
+- Improved: [#26936] Rain is now drawn next to the top toolbar, but only when it is centred.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1257,12 +1257,20 @@ namespace OpenRCT2::Ui::Windows
 
         void AlignButtonsLeftRight()
         {
+            if (windowPos.x != 0)
+            {
+                invalidate();
+                windowPos.x = 0;
+                width = ContextGetWidth();
+                invalidate();
+            }
+
             // Align left hand side toolbar buttons
             AlignButtons(kWidgetOrderLeftGroup, 0);
 
             // Align right hand side toolbar buttons
             auto totalWidth = GetToolbarWidth(kWidgetOrderRightGroup);
-            auto xPos = ContextGetWidth() - totalWidth;
+            auto xPos = width - totalWidth;
             AlignButtons(kWidgetOrderRightGroup, xPos);
         }
 
@@ -1274,8 +1282,16 @@ namespace OpenRCT2::Ui::Windows
             // We'll start from the centre of the UI...
             auto xPos = (ContextGetWidth() - totalWidth) / 2;
 
+            if (windowPos.x != xPos)
+            {
+                invalidate();
+                windowPos.x = xPos;
+                width = totalWidth;
+                invalidate();
+            }
+
             // And finally, align the buttons in the centre
-            AlignButtons(kWidgetOrderCombined, xPos);
+            AlignButtons(kWidgetOrderCombined, 0);
         }
 
         void onPrepareDraw() override


### PR DESCRIPTION
This shrinks the top toolbar window to just the size required when using centred mode. As an added bonus, this means rain is now drawn in the top corners in this mode :wink:

(Note that the bottom toolbar is one wide window, too. That will be split into smaller shunks by #26919.)

Before (with debug rectangles):
<img width="994" height="597" alt="Electric Fields 2026-08-15 16-49-30" src="https://github.com/user-attachments/assets/ed5b3c7d-5d08-420d-8b3e-a84c4479cd27" />

After (with debug rectangles):
<img width="994" height="597" alt="Electric Fields 2026-08-15 16-49-11" src="https://github.com/user-attachments/assets/a0d43b3d-530d-4e32-a255-31de8dc91da9" />