### PR TITLE
Re-include unistd.h in Platform.Linux.cpp

### DIFF
--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -15,6 +15,7 @@
     #include <fnmatch.h>
     #include <locale.h>
     #include <pwd.h>
+    #include <unistd.h>
     #include <vector>
     #if defined(__FreeBSD__) || defined(__NetBSD__)
         #include <stddef.h>


### PR DESCRIPTION
It turns out Arch, at least, still needs this.