### PR TITLE
Move includes in scripting files inside ENABLE_SCRIPTING

### DIFF
--- a/src/openrct2/scripting/bindings/entity/ScParticle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScParticle.cpp
@@ -7,14 +7,14 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "ScParticle.hpp"
-
-#include "../../../GameState.h"
-#include "../../../core/EnumMap.hpp"
-#include "../../../entity/Particle.h"
-#include "../../../world/Location.hpp"
-
 #ifdef ENABLE_SCRIPTING
+
+    #include "ScParticle.hpp"
+
+    #include "../../../GameState.h"
+    #include "../../../core/EnumMap.hpp"
+    #include "../../../entity/Particle.h"
+    #include "../../../world/Location.hpp"
 
 namespace OpenRCT2::Scripting
 {

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -7,20 +7,20 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "ScVehicle.hpp"
-
-#include "../../../GameState.h"
-#include "../../../core/EnumMap.hpp"
-#include "../../../entity/EntityTweener.h"
-#include "../../../ride/Track.h"
-#include "../../../ride/TrackData.h"
-#include "../../../ride/Vehicle.h"
-#include "../../../ride/ted/TrackElementDescriptor.h"
-#include "../../../world/Map.h"
-#include "../../../world/tile_element/TrackElement.h"
-#include "../ride/ScRide.hpp"
-
 #ifdef ENABLE_SCRIPTING
+
+    #include "ScVehicle.hpp"
+
+    #include "../../../GameState.h"
+    #include "../../../core/EnumMap.hpp"
+    #include "../../../entity/EntityTweener.h"
+    #include "../../../ride/Track.h"
+    #include "../../../ride/TrackData.h"
+    #include "../../../ride/Vehicle.h"
+    #include "../../../ride/ted/TrackElementDescriptor.h"
+    #include "../../../world/Map.h"
+    #include "../../../world/tile_element/TrackElement.h"
+    #include "../ride/ScRide.hpp"
 
 using namespace OpenRCT2::Drawing;
 using namespace OpenRCT2::TrackMetadata;

--- a/src/openrct2/scripting/bindings/game/ScProfiler.hpp
+++ b/src/openrct2/scripting/bindings/game/ScProfiler.hpp
@@ -13,6 +13,7 @@
 
     #include "../../../profiling/Profiling.h"
     #include "../../ScriptEngine.h"
+
 namespace OpenRCT2::Scripting
 {
     class ScProfiler;

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "../../ScriptEngine.h"
-
 #ifdef ENABLE_SCRIPTING
+
+    #include "../../ScriptEngine.h"
 
 namespace OpenRCT2::Scripting
 {


### PR DESCRIPTION
Noticed that a few scripting files don't have their includes within the `ENABLE_SCRIPTING` block.