### PR TITLE
Fix land paint price not updating when holding Ctrl

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,7 @@
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
-- Fix: [#26837] Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.
+- Fix: [#26954] Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
 - Fix: [#26903] Making a ride visible or invisible is always denied in multiplayer.
 - Fix: [#26917] Tile Inspector does not show indestructible track status correctly when ‘Make all track pieces destructible’ cheat is enabled.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
+- Fix: [#26837] Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.
 - Fix: [#26903] Making a ride visible or invisible is always denied in multiplayer.
 - Fix: [#26917] Tile Inspector does not show indestructible track status correctly when ‘Make all track pieces destructible’ cheat is enabled.

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -306,7 +306,8 @@ namespace OpenRCT2::Ui::Windows
                 screenCoords.y += 50;
 
                 // Draw paint price
-                numTiles = gLandToolSize * gLandToolSize;
+                const bool mapCtrlPressed = GetInputManager().isModifierKeyPressed(ModifierKey::ctrl);
+                numTiles = mapCtrlPressed ? gLandToolSize : gLandToolSize * gLandToolSize;
                 price = 0;
                 if (gLandToolTerrainSurface != kObjectEntryIndexNull)
                 {


### PR DESCRIPTION
Cherry picked from https://github.com/OpenRCT2/OpenRCT2/pull/26837 as requested by @Gymnasiast :

- Fix: Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.