### PR TITLE
Fix #26056: Freeze when trying to download all objects on save where they are missing

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.
 - Fix: [#25558] [Plugin] Image buttons ignore their explicit border setting when a theme draws borders around them.
+- Fix: [#26056] Freeze when trying to download all objects on save where they are missing.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <chrono>
 #include <mutex>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
@@ -68,6 +69,7 @@ namespace OpenRCT2::Ui::Windows
         std::mutex _downloadedEntriesMutex;
         std::mutex _queueMutex;
         bool _nextDownloadQueued{};
+        std::vector<std::shared_future<void>> _pendingRequests; // Store futures to prevent blocking destructors
 
         DownloadStatusInfo _lastDownloadStatusInfo;
         DownloadStatusInfo _downloadStatusInfo;
@@ -80,6 +82,7 @@ namespace OpenRCT2::Ui::Windows
     public:
         void Begin(const std::vector<ObjectEntryDescriptor>& entries)
         {
+            _pendingRequests.clear();
             _lastDownloadStatusInfo = {};
             _downloadStatusInfo = {};
             _lastDownloadSource = {};
@@ -102,6 +105,10 @@ namespace OpenRCT2::Ui::Windows
 
         void Update()
         {
+            std::erase_if(_pendingRequests, [](const std::shared_future<void>& f) {
+                return f.wait_for(std::chrono::seconds::zero()) == std::future_status::ready;
+            });
+
             std::lock_guard guard(_queueMutex);
             if (_nextDownloadQueued)
             {
@@ -169,11 +176,10 @@ namespace OpenRCT2::Ui::Windows
         {
             try
             {
-                Console::WriteLine("Downloading %s", url.c_str());
                 Http::Request req;
                 req.method = Http::Method::get;
                 req.url = url;
-                Http::DoAsync(req, [this, entry, name](Http::Response response) {
+                _pendingRequests.push_back(Http::DoAsync(req, [this, entry, name](Http::Response response) {
                     if (response.status == Http::Status::ok)
                     {
                         // Check that download operation hasn't been cancelled
@@ -194,7 +200,7 @@ namespace OpenRCT2::Ui::Windows
                         Console::Error::WriteLine("  Failed to download %s", name.c_str());
                     }
                     QueueNextDownload();
-                });
+                }));
             }
             catch (const std::exception&)
             {
@@ -223,7 +229,7 @@ namespace OpenRCT2::Ui::Windows
                 Http::Request req;
                 req.method = Http::Method::get;
                 req.url = kOpenRCT2ApiLegacyObjectURL + name;
-                Http::DoAsync(req, [this, entry, name](Http::Response response) {
+                _pendingRequests.push_back(Http::DoAsync(req, [this, entry, name](Http::Response response) {
                     if (response.status == Http::Status::ok)
                     {
                         auto jresponse = Json::FromString(response.body);
@@ -251,7 +257,7 @@ namespace OpenRCT2::Ui::Windows
                             "  %s query failed (status %d)", name.c_str(), static_cast<int32_t>(response.status));
                         QueueNextDownload();
                     }
-                });
+                }));
             }
             catch (const std::exception&)
             {

--- a/src/openrct2/core/Http.h
+++ b/src/openrct2/core/Http.h
@@ -53,7 +53,7 @@ namespace OpenRCT2::Http
 
     Response Do(const Request& req);
 
-    inline auto DoAsync(const Request& req, std::function<void(Response& res)> fn)
+    [[nodiscard]] inline auto DoAsync(const Request& req, std::function<void(Response& res)> fn)
     {
         return std::async(std::launch::async, [=]() {
             Response res{};

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -264,7 +264,7 @@ namespace OpenRCT2::Network
         }
     }
 
-    std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync(
+    [[nodiscard]] std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync(
         const INetworkEndpoint& broadcastEndpoint) const
     {
         auto broadcastAddress = broadcastEndpoint.GetHostname();
@@ -321,7 +321,7 @@ namespace OpenRCT2::Network
         });
     }
 
-    std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync() const
+    [[nodiscard]] std::future<std::vector<ServerListEntry>> ServerList::FetchLocalServerListAsync() const
     {
         return std::async(std::launch::async, [&] {
             // Get all possible LAN broadcast addresses
@@ -372,7 +372,9 @@ namespace OpenRCT2::Network
         request.url = std::move(masterServerUrl);
         request.method = Http::Method::get;
         request.header["Accept"] = "application/json";
-        Http::DoAsync(request, [p](Http::Response& response) -> void {
+        // Despite DoAsync, the future below is not stored, so it will block the calling thread until the request completes
+        // TOOD: Review if this is acceptable
+        std::ignore = Http::DoAsync(request, [p](Http::Response& response) -> void {
             json_t root;
             try
             {


### PR DESCRIPTION
Per [cppreference](https://en.cppreference.com/cpp/thread/async#:~:text=If%20the%20std%3A%3Afuture%20obtained%20from%20std%3A%3Aasync%20is%20not%20moved%20from%20or%20bound%20to%20a%20reference%2C%20the%20destructor%20of%20the%20std%3A%3Afuture%20will%20block%20at%20the%20end%20of%20the%20full%20expression%20until%20the%20asynchronous%20operation%20completes%2C%20essentially%20making%20code%20such%20as%20the%20following%20synchronous%3A)

> If the [std::future](https://en.cppreference.com/cpp/thread/future) obtained from std::async is not moved from or bound to a reference, the destructor of the [std::future](https://en.cppreference.com/cpp/thread/future) will block at the end of the full expression until the asynchronous operation completes

This patch unfreezes the game, but I have not extensively tested whether it still downloads as expected where the objects are found, I would appreciate help.

[MS Explanation](https://learn.microsoft.com/en-us/cpp/standard-library/future?view=msvc-170#:~:text=The%20class%20templates%20future%20and%20shared_future%20never,wait()%20and%20the%20task%20is%20still%20running) seems slightly clearer:

> The class templates future and shared_future never block in their destructors, except in one case that's preserved for backward compatibility: Unlike all other futures, for a future—or the last shared_future—that's attached to a task started with std::async, the destructor blocks if the task has not completed; that is, it blocks if this thread did not yet call .get() or .wait() and the task is still running