### PR TITLE
Fix result.position.z of SmallSceneryPlaceAction

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#23872] Loading a park outside the game now sets the folder of the load/save window, as loading one in-game does.
 - Improved: [#26099] The ride type selection cheat has been moved into the ride operations tab.
 - Improved: [#26099] The ride visiblity cheat has been moved into the ride colour/appearance tab.
+- Improved: [#26441, #26958] Change result.position.z of SmallScenery- and WallPlaceAction to match the actual position of the placed tile element.
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
 - Improved: [#26931] The save prompt now bounces the macOS dock icon, flashes the Windows taskbar button and marks Linux windows urgent when it blocks quitting an unfocused game.
 - Improved: [#26936] Rain is now drawn next to the top toolbar, but only when it is centred.

--- a/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
@@ -99,7 +99,6 @@ namespace OpenRCT2::GameActions
         if (_loc.z != 0)
         {
             surfaceHeight = _loc.z;
-            res.position.z = surfaceHeight;
         }
 
         if (!LocationValid(_loc))
@@ -165,6 +164,7 @@ namespace OpenRCT2::GameActions
         if (_loc.z == 0)
         {
             targetHeight = surfaceHeight;
+            res.position.z = targetHeight;
         }
 
         if (gLegacyScene != LegacyScene::scenarioEditor && !gameState.cheats.sandboxMode
@@ -307,7 +307,6 @@ namespace OpenRCT2::GameActions
         if (_loc.z != 0)
         {
             surfaceHeight = _loc.z;
-            res.position.z = surfaceHeight;
         }
 
         auto* sceneryEntry = ObjectEntryManager::GetObjectEntry<SmallSceneryEntry>(_sceneryType);
@@ -355,6 +354,7 @@ namespace OpenRCT2::GameActions
         if (_loc.z == 0)
         {
             targetHeight = surfaceHeight;
+            res.position.z = targetHeight;
         }
 
         if (!GetFlags().has(CommandFlag::ghost))

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -43,7 +43,7 @@ namespace OpenRCT2
 namespace OpenRCT2::Scripting
 {
     // Grepped from CI (.github/workflows/publish-plugin-types.yml); keep the format `kPluginApiVersion = N`.
-    static constexpr int32_t kPluginApiVersion = 120;
+    static constexpr int32_t kPluginApiVersion = 121;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;


### PR DESCRIPTION
Follow-up on https://github.com/OpenRCT2/OpenRCT2/pull/26441
Enables plugins to use the result of a small scenery place action to remove the small scenery.