### PR TITLE
Fix: sanitise packed object filenames

### DIFF
--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -25,6 +25,7 @@
 #include "../core/String.hpp"
 #include "../localisation/LocalisationService.h"
 #include "../park/Legacy.h"
+#include "../platform/Platform.h"
 #include "../sawyer_coding/SawyerChunkReader.h"
 #include "../sawyer_coding/SawyerCoding.h"
 #include "Object.h"
@@ -578,7 +579,12 @@ namespace OpenRCT2
             auto userObjPath = _env.GetDirectoryPath(DirBase::user, DirId::objects);
             Path::CreateDirectory(userObjPath);
 
-            auto fileName = u8string(jsonIdentifier);
+            // The identifier comes from park data; sanitise the storage path so it stays within the objects directory.
+            auto fileName = Platform::SanitiseFilename(jsonIdentifier);
+            if (fileName.empty())
+            {
+                fileName = "object_with_invalid_name";
+            }
             auto extension = u8string(u8".parkobj");
             return updateFileName(fileName, extension);
         }


### PR DESCRIPTION
Derived from https://github.com/OpenRCT2/OpenRCT2/pull/26345. Removed the tests, which had a few issues.

Do not squash merge, this needs to keep the original author.