### PR TITLE
Make vehicle subposition writable in API

### DIFF
--- a/distribution/scripting/openrct2.d.ts
+++ b/distribution/scripting/openrct2.d.ts
@@ -3154,7 +3154,7 @@ declare global {
          * The type of subposition coordinates that this vehicle is using to find its
          * position on the track.
          */
-        readonly subposition: number;
+        subposition: number;
 
         /**
          * List of guest IDs ordered by seat.

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -43,7 +43,7 @@ namespace OpenRCT2
 namespace OpenRCT2::Scripting
 {
     // Grepped from CI (.github/workflows/publish-plugin-types.yml); keep the format `kPluginApiVersion = N`.
-    static constexpr int32_t kPluginApiVersion = 121;
+    static constexpr int32_t kPluginApiVersion = 122;
 
     // Versions marking breaking changes.
     static constexpr int32_t kApiVersionPeepDeprecation = 33;

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -468,12 +468,12 @@ namespace OpenRCT2::Scripting
     {
         JS_UNPACK_UINT32(value, ctx, jsValue);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
-        
+
         if (value >= static_cast<uint32_t>(VehicleTrackSubposition::count))
         {
             return JS_ThrowRangeError(ctx, "Invalid vehicle subposition");
         }
-        
+
         auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -93,7 +93,7 @@ namespace OpenRCT2::Scripting
             JS_CGETSET_DEF("trackLocation", &ScVehicle::trackLocation_get, nullptr),
             JS_CGETSET_DEF("trackProgress", &ScVehicle::trackProgress_get, nullptr),
             JS_CGETSET_DEF("remainingDistance", &ScVehicle::remainingDistance_get, nullptr),
-            JS_CGETSET_DEF("subposition", &ScVehicle::subposition_get, nullptr),
+            JS_CGETSET_DEF("subposition", &ScVehicle::subposition_get, &ScVehicle::subposition_set),
             JS_CGETSET_DEF("poweredAcceleration", &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set),
             JS_CGETSET_DEF("poweredMaxSpeed", &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set),
             JS_CGETSET_DEF("status", &ScVehicle::status_get, &ScVehicle::status_set),
@@ -462,6 +462,22 @@ namespace OpenRCT2::Scripting
     {
         auto vehicle = GetVehicle(thisVal);
         return JS_NewUint32(ctx, vehicle != nullptr ? static_cast<uint8_t>(vehicle->TrackSubposition) : 0);
+    }
+
+        JSValue ScVehicle::subposition_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
+    {
+        JS_UNPACK_UINT32(value, ctx, jsValue);
+        JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
+
+        auto vehicle = GetVehicle(thisVal);
+        if (vehicle != nullptr)
+        {
+            vehicle->TrackSubposition = static_cast<VehicleTrackSubposition>(value);
+            vehicle->UpdateTrackChange();
+            EntityTweener::Get().RemoveEntity(vehicle);
+        }
+
+        return JS_UNDEFINED;
     }
 
     JSValue ScVehicle::poweredAcceleration_get(JSContext* ctx, JSValue thisVal)

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -464,7 +464,7 @@ namespace OpenRCT2::Scripting
         return JS_NewUint32(ctx, vehicle != nullptr ? static_cast<uint8_t>(vehicle->TrackSubposition) : 0);
     }
 
-        JSValue ScVehicle::subposition_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
+    JSValue ScVehicle::subposition_set(JSContext* ctx, JSValue thisVal, JSValue jsValue)
     {
         JS_UNPACK_UINT32(value, ctx, jsValue);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -468,7 +468,12 @@ namespace OpenRCT2::Scripting
     {
         JS_UNPACK_UINT32(value, ctx, jsValue);
         JS_THROW_IF_GAME_STATE_NOT_MUTABLE();
-
+        
+        if (value >= static_cast<uint32_t>(VehicleTrackSubposition::count))
+        {
+            return JS_ThrowRangeError(ctx, "Invalid vehicle subposition");
+        }
+        
         auto vehicle = GetVehicle(thisVal);
         if (vehicle != nullptr)
         {

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
@@ -82,6 +82,7 @@ namespace OpenRCT2::Scripting
         static JSValue remainingDistance_get(JSContext* ctx, JSValue thisVal);
 
         static JSValue subposition_get(JSContext* ctx, JSValue thisVal);
+        static JSValue subposition_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);
 
         static JSValue poweredAcceleration_get(JSContext* ctx, JSValue thisVal);
         static JSValue poweredAcceleration_set(JSContext* ctx, JSValue thisVal, JSValue jsValue);


### PR DESCRIPTION
Allows plugins to edit track subposition. E.g. Go kart lanes and chairlift movement subpositions