### PR TITLE
Rename Trigonometry constants to kCamelCase

### DIFF
--- a/src/openrct2/math/Trigonometry.hpp
+++ b/src/openrct2/math/Trigonometry.hpp
@@ -20,7 +20,7 @@ namespace OpenRCT2::Math::Trigonometry
      * Where L1 represents an incrementing column 0 - 63
      * Note: Must be at least 32bit to ensure all users do not overflow
      */
-    static constexpr CoordsXY YawToDirectionVector[64] = {
+    static constexpr CoordsXY kYawToDirectionVector[64] = {
         { -256, 0 },    { -255, 25 },   { -251, 50 },   { -245, 74 },   { -237, 98 },   { -226, 121 },  { -213, 142 },
         { -198, 162 },  { -181, 181 },  { -162, 198 },  { -142, 213 },  { -121, 226 },  { -98, 237 },   { -74, 245 },
         { -50, 251 },   { -25, 255 },   { 0, 256 },     { 25, 255 },    { 50, 251 },    { 74, 245 },    { 98, 237 },
@@ -33,14 +33,14 @@ namespace OpenRCT2::Math::Trigonometry
         { -255, -25 },
     };
     // Currently OpenRCT2::Entity::Yaw::BaseSpritePrecision is 32, but one day it will be 64.
-    static_assert(std::size(YawToDirectionVector) == 64);
+    static_assert(std::size(kYawToDirectionVector) == 64);
 
     /**
      * The cos and sin of vehicle pitch based on vehicle sprite angles
      * COS((Y1/360)*2*PI())*256,-SIN((Y1/360)*2*PI())*256
      * Where Y1 represents the angle of pitch in degrees
      */
-    constexpr CoordsXY PitchToDirectionVectorFromGeometry[] = {
+    constexpr CoordsXY kPitchToDirectionVectorFromGeometry[] = {
         { 256, 0 },     // flat
         { 251, 49 },    // slopes up
         { 236, 97 },    // slopes up
@@ -103,16 +103,16 @@ namespace OpenRCT2::Math::Trigonometry
         { 252, 44 },    // spiral lift hill up
         { 252, -44 },   // spiral lift hill down
     };
-    static_assert(std::size(PitchToDirectionVectorFromGeometry) == EnumValue(VehiclePitch::pitchCount));
+    static_assert(std::size(kPitchToDirectionVectorFromGeometry) == EnumValue(VehiclePitch::pitchCount));
 
     constexpr int32_t ComputeHorizontalMagnitude(int32_t length, uint8_t pitch)
     {
-        return (-PitchToDirectionVectorFromGeometry[pitch].y * length) / 256;
+        return (-kPitchToDirectionVectorFromGeometry[pitch].y * length) / 256;
     }
 
     constexpr CoordsXY ComputeXYVector(int32_t magnitude, uint8_t yaw)
     {
-        return (static_cast<CoordsXY>(YawToDirectionVector[yaw]) * magnitude) / 256;
+        return (static_cast<CoordsXY>(kYawToDirectionVector[yaw]) * magnitude) / 256;
     }
 
     constexpr CoordsXY ComputeXYVector(int32_t length, uint8_t pitch, uint8_t yaw)

--- a/src/openrct2/ride/Vehicle.Animation.cpp
+++ b/src/openrct2/ride/Vehicle.Animation.cpp
@@ -919,7 +919,7 @@ namespace OpenRCT2
     static constexpr CoordsXYZ ComputeSteamOffset(int32_t height, int32_t length, VehiclePitch pitch, uint8_t yaw)
     {
         uint8_t trueYaw = Entity::Yaw::YawTo64(yaw);
-        auto offsets = Math::Trigonometry::PitchToDirectionVectorFromGeometry[EnumValue(pitch)];
+        auto offsets = Math::Trigonometry::kPitchToDirectionVectorFromGeometry[EnumValue(pitch)];
         int32_t projectedRun = (offsets.x * length - offsets.y * height) / 256;
         int32_t projectedHeight = (offsets.x * height + offsets.y * length) / 256;
         return { Math::Trigonometry::ComputeXYVector(projectedRun, trueYaw), projectedHeight };

--- a/src/openrct2/ride/Vehicle.Collision.cpp
+++ b/src/openrct2/ride/Vehicle.Collision.cpp
@@ -159,7 +159,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
             if (direction < 0x14)
                 continue;
 
-            const CoordsXY directionVector = Math::Trigonometry::YawToDirectionVector[Entity::Yaw::YawTo64(orientation)];
+            const CoordsXY directionVector = Math::Trigonometry::kYawToDirectionVector[Entity::Yaw::YawTo64(orientation)];
 
             const CoordsXY directionVectorToVehicle2 = { vehicle2->x - loc.x, vehicle2->y - loc.y };
             const int32_t directionVectorToVehicle2Length = (directionVectorToVehicle2.x * directionVectorToVehicle2.x)


### PR DESCRIPTION
Renamed constants in "Trigonometry.hpp" to adhere to the "kCamelCase" naming convention:
- YawToDirectionVector -> kYawToDirectionVector
- PitchToDirectionVectorFromGeometry -> kPitchToDirectionVectorFromGeometry