### PR TITLE
Fix #18197: Track Designs Manager does not autoload scenery

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Improved: [#26862] Add a Liquid Glass app icon for macOS 26 and later.
 - Improved: [#26931] The save prompt now bounces the macOS dock icon, flashes the Windows taskbar button and marks Linux windows urgent when it blocks quitting an unfocused game.
 - Improved: [#26936] Rain is now drawn next to the top toolbar, but only when it is centred.
+- Fix: [#18197] Track Designs Manager does not autoload scenery.
 - Fix: [#21632] [Plugin] Crash when loading custom image larger than 300 by 300 pixels.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -393,7 +393,8 @@ namespace OpenRCT2
                     loadedObject = object;
                     list[*slot] = object;
                     UpdateSceneryGroupIndexes();
-                    ResetTypeToRideEntryIndexMap();
+                    if (objectType == ObjectType::ride)
+                        ResetTypeToRideEntryIndexMap();
                 }
             }
             return loadedObject;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -628,9 +628,31 @@ static void TrackDesignLoadSceneryObjects(const TrackDesign& td)
     {
         if (scenery.sceneryObject.HasValue())
         {
-            objectManager.LoadObject(scenery.sceneryObject);
+            // When dealing with a legacy path entry, we must first check if a mapping exists, because calling LoadObject()
+            // on the old DAT identifier will return null for official objects. If no mapping exists, it’s likely a custom DAT
+            // object, which can be loaded as normal.
+            if (scenery.sceneryObject.GetType() == ObjectType::paths)
+            {
+                auto mapping = RCT2::GetFootpathSurfaceId(ObjectEntryDescriptor(scenery.sceneryObject));
+                if (mapping != nullptr)
+                {
+                    objectManager.LoadObject(mapping->NormalSurface);
+                    objectManager.LoadObject(mapping->QueueSurface);
+                    objectManager.LoadObject(mapping->Railing);
+                }
+                else
+                {
+                    objectManager.LoadObject(scenery.sceneryObject);
+                }
+            }
+            else
+            {
+                objectManager.LoadObject(scenery.sceneryObject);
+            }
         }
     }
+
+    objectManager.LoadObject(td.appearance.stationObjectIdentifier);
 }
 
 struct TrackSceneryEntry
@@ -706,12 +728,15 @@ static std::optional<TrackSceneryEntry> TrackDesignPlaceSceneryElementGetEntry(c
             result.SecondaryIndex = objectMgr.GetLoadedObjectEntryIndex(ObjectEntryDescriptor(footpathMapping->Railing));
         }
 
+        // Legacy footpaths consist of a single object for both surface and railing.
+        const bool secondaryIndexRequired = result.Type != ObjectType::paths;
+
         if (result.Index == kObjectEntryIndexNull)
             result.Index = TrackDesignGetDefaultSurfaceIndex(scenery.isQueue());
-        if (result.SecondaryIndex == kObjectEntryIndexNull)
+        if (secondaryIndexRequired && result.SecondaryIndex == kObjectEntryIndexNull)
             result.SecondaryIndex = TrackDesignGetDefaultRailingIndex();
 
-        if (result.Index == kObjectEntryIndexNull || result.SecondaryIndex == kObjectEntryIndexNull)
+        if (result.Index == kObjectEntryIndexNull || (secondaryIndexRequired && result.SecondaryIndex == kObjectEntryIndexNull))
         {
             _trackDesignPlaceStateSceneryUnavailable = true;
             return {};


### PR DESCRIPTION
This has been broken since the NSF was introduced, which made some changes to how paths were handled. The introduction of station objects broke it a little bit more, though at least that didn’t cause all of the scenery to disappear.

Tested with several designs, including those using custom paths.