### PR TITLE
Fix #26982: Best value park award given without an entrance fee

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#26954] Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.
 - Fix: [#26965] When showing missing objects, some types show up as ‘Unknown type’.
 - Fix: [#26965] The window with missing objects is displayed under the ‘Load game’ window.
+- Fix: [#26982] The ‘Best value park’ award can be won while park entry is free and rides are charged for.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -184,7 +184,10 @@ static bool AwardIsDeservedBestValue(GameState_t& gameState, Park::ParkData& par
     if (activeAwardTypes & EnumToFlag(AwardType::mostDisappointing))
         return false;
 
-    if (park.flags.has(ParkFlag::noMoney) || !Park::EntranceFeeUnlocked(park))
+    if (park.flags.has(ParkFlag::noMoney))
+        return false;
+
+    if (Park::RidePricesUnlocked(park) && Park::GetEntranceFee(park) == 0.00_GBP)
         return false;
 
     if (park.totalRideValueForMoney < 10.00_GBP)


### PR DESCRIPTION
Closes #26982.

`AwardIsDeservedBestValue` checked whether the park is *allowed* to charge for entry, not whether it actually does, so a park with free entry and paid rides won the award. This goes back to be0123dec (#12630), which replaced the vanilla free entry test with the unlocked test.

RCT1 imports are the only parks that hit this out of the box, as 54 of the 85 RCT1 scenarios do not lock entry at free and the importer unlocks all prices for them.

The award is now withheld from parks that charge for rides while entry is free. The old check is subsumed by the new one, as a park that cannot charge for entry always has free entry and a fee of zero.

Verified with a throwaway unit test covering each charging mode, which fails on the old check and passes on the new one. It is not part of this PR.

----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._
