### PR TITLE
Refactor enums/enum-like structures to enum class

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -90,7 +90,7 @@ namespace OpenRCT2::Ui::Windows
             auto maxObjects = getObjectEntryGroupCount(objectType);
             for (auto i = 0u; i < maxObjects; i++)
             {
-                Editor::ClearSelectedObject(objectType, i, ObjectSelectionFlags::AllFlags);
+                Editor::ClearSelectedObject(objectType, i);
             }
         }
 
@@ -99,7 +99,7 @@ namespace OpenRCT2::Ui::Windows
         for (const auto& ride : RideManager(gameState))
         {
             Editor::SetSelectedObject(
-                ObjectType::ride, ride.subtype, ObjectSelectionFlags::Selected | ObjectSelectionFlags::InUse);
+                ObjectType::ride, ride.subtype, { ObjectSelectionFlag::selected, ObjectSelectionFlag::inUse });
         }
     }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -107,7 +107,7 @@ namespace OpenRCT2::Ui::Windows
     {
         const ObjectRepositoryItem* repositoryItem;
         std::unique_ptr<RideFilters> filter;
-        uint8_t* flags;
+        ObjectSelectionFlags* flags;
     };
 
     static constexpr uint8_t _numSourceGameItems = 8;
@@ -615,8 +615,8 @@ namespace OpenRCT2::Ui::Windows
                 return;
 
             ObjectListItem* listItem = &_listItems[selected_object];
-            uint8_t object_selection_flags = *listItem->flags;
-            if (object_selection_flags & ObjectSelectionFlags::Flag6)
+            ObjectSelectionFlags objectSelectionFlags = *listItem->flags;
+            if (objectSelectionFlags.has(ObjectSelectionFlag::flag5))
                 return;
 
             invalidate();
@@ -651,7 +651,7 @@ namespace OpenRCT2::Ui::Windows
 
             Editor::InputFlags inputFlags = { Editor::InputFlag::unk1, Editor::InputFlag::selectObjectsInSceneryGroup };
             // If already selected
-            if (!(object_selection_flags & ObjectSelectionFlags::Selected))
+            if (!objectSelectionFlags.has(ObjectSelectionFlag::selected))
                 inputFlags.set(Editor::InputFlag::select);
 
             Editor::gSceneryGroupPartialSelectError.clear();
@@ -691,8 +691,8 @@ namespace OpenRCT2::Ui::Windows
             if (selectedObject != -1)
             {
                 ObjectListItem* listItem = &_listItems[selectedObject];
-                uint8_t objectSelectionFlags = *listItem->flags;
-                if (objectSelectionFlags & ObjectSelectionFlags::Flag6)
+                ObjectSelectionFlags objectSelectionFlags = *listItem->flags;
+                if (objectSelectionFlags.has(ObjectSelectionFlag::flag5))
                 {
                     selectedObject = -1;
                 }
@@ -738,7 +738,7 @@ namespace OpenRCT2::Ui::Windows
                 if (screenCoords.y + kScrollableRowHeight >= rt.y && screenCoords.y <= rt.y + rt.height)
                 {
                     // Draw checkbox
-                    if (gLegacyScene != LegacyScene::trackDesignsManager && !(*listItem.flags & 0x20))
+                    if (gLegacyScene != LegacyScene::trackDesignsManager && !listItem.flags->has(ObjectSelectionFlag::flag5))
                         Rectangle::fillInset(
                             rt, { { 2, screenCoords.y }, { 11, screenCoords.y + 10 } }, colours[1],
                             Rectangle::BorderStyle::inset, Rectangle::FillBrightness::dark,
@@ -746,7 +746,7 @@ namespace OpenRCT2::Ui::Windows
 
                     // Highlight background
                     auto highlighted = i == static_cast<size_t>(selectedListItem)
-                        && !(*listItem.flags & ObjectSelectionFlags::Flag6);
+                        && !listItem.flags->has(ObjectSelectionFlag::flag5);
                     if (highlighted)
                     {
                         auto bottom = screenCoords.y + (kScrollableRowHeight - 1);
@@ -754,12 +754,12 @@ namespace OpenRCT2::Ui::Windows
                     }
 
                     // Draw checkmark
-                    if (gLegacyScene != LegacyScene::trackDesignsManager && (*listItem.flags & ObjectSelectionFlags::Selected))
+                    if (gLegacyScene != LegacyScene::trackDesignsManager && listItem.flags->has(ObjectSelectionFlag::selected))
                     {
                         screenCoords.x = 2;
                         auto darkness = highlighted ? TextDarkness::extraDark : TextDarkness::dark;
                         auto colour2 = colours[1].withFlag(ColourFlag::translucent, false);
-                        if (*listItem.flags & (ObjectSelectionFlags::InUse | ObjectSelectionFlags::AlwaysRequired))
+                        if (listItem.flags->hasAny(ObjectSelectionFlag::inUse, ObjectSelectionFlag::alwaysRequired))
                             colour2.flags.set(ColourFlag::inset, true);
 
                         drawText(rt, screenCoords, kCheckMarkString, { colour2, FontStyle::medium, darkness });
@@ -773,7 +773,7 @@ namespace OpenRCT2::Ui::Windows
 
                     Drawing::Colour colour = Drawing::Colour::black;
                     auto darkness = TextDarkness::regular;
-                    if (*listItem.flags & ObjectSelectionFlags::Flag6)
+                    if (listItem.flags->has(ObjectSelectionFlag::flag5))
                     {
                         colour = colours[1].colour;
                         darkness = TextDarkness::dark;
@@ -1180,9 +1180,9 @@ namespace OpenRCT2::Ui::Windows
             const ObjectRepositoryItem* items = ObjectRepositoryGetItems();
             for (int32_t i = 0; i < numObjects; i++)
             {
-                uint8_t selectionFlags = Editor::_objectSelectionFlags[i];
+                auto selectionFlags = Editor::_objectSelectionFlags[i];
                 const ObjectRepositoryItem* item = &items[i];
-                if (item->Type == GetSelectedObjectType() && !(selectionFlags & ObjectSelectionFlags::Flag6)
+                if (item->Type == GetSelectedObjectType() && !selectionFlags.has(ObjectSelectionFlag::flag5)
                     && FilterSource(item) && FilterString(*item) && FilterChunks(item) && FilterSelected(selectionFlags)
                     && FilterCompatibilityObject(*item, selectionFlags))
                 {
@@ -1410,7 +1410,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        bool FilterSelected(uint8_t objectFlag)
+        bool FilterSelected(ObjectSelectionFlags objectFlags)
         {
             // Track Manager has no concept of selection filtering, so always return true
             if (gLegacyScene == LegacyScene::trackDesignsManager)
@@ -1421,11 +1421,11 @@ namespace OpenRCT2::Ui::Windows
             {
                 return true;
             }
-            if (IsFilterActive(FILTER_SELECTED) && (objectFlag & ObjectSelectionFlags::Selected))
+            if (IsFilterActive(FILTER_SELECTED) && objectFlags.has(ObjectSelectionFlag::selected))
             {
                 return true;
             }
-            if (IsFilterActive(FILTER_NONSELECTED) && !(objectFlag & ObjectSelectionFlags::Selected))
+            if (IsFilterActive(FILTER_NONSELECTED) && !objectFlags.has(ObjectSelectionFlag::selected))
             {
                 return true;
             }
@@ -1433,10 +1433,10 @@ namespace OpenRCT2::Ui::Windows
             return false;
         }
 
-        bool FilterCompatibilityObject(const ObjectRepositoryItem& item, uint8_t objectFlag)
+        bool FilterCompatibilityObject(const ObjectRepositoryItem& item, ObjectSelectionFlags objectFlags)
         {
             // only show compat objects if they are selected already.
-            return !(item.Flags & ObjectItemFlags::IsCompatibilityObject) || (objectFlag & ObjectSelectionFlags::Selected);
+            return !(item.Flags & ObjectItemFlags::IsCompatibilityObject) || objectFlags.has(ObjectSelectionFlag::selected);
         }
 
         bool IsFilterActive(const uint16_t filter) const
@@ -1682,7 +1682,7 @@ namespace OpenRCT2::Ui::Windows
         bool showFallbackWarning = false;
         for (int32_t i = 0; i < numItems; i++)
         {
-            if (Editor::_objectSelectionFlags[i] & ObjectSelectionFlags::Selected)
+            if (Editor::_objectSelectionFlags[i].has(ObjectSelectionFlag::selected))
             {
                 const auto* item = &items[i];
                 auto descriptor = ObjectEntryDescriptor(*item);

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -34,15 +34,15 @@ namespace OpenRCT2
     using ObjectVersion = std::tuple<uint16_t, uint16_t, uint16_t>;
     static_assert(std::tuple_size<ObjectVersion>{} == VersionNumFields);
 
-    namespace ObjectSelectionFlags
+    enum class ObjectSelectionFlag : uint8_t
     {
-        constexpr uint8_t Selected = (1 << 0);
-        constexpr uint8_t InUse = (1 << 2);
-        // constexpr uint8_t Required = (1 << 3);               // Unused feature
-        constexpr uint8_t AlwaysRequired = (1 << 4);
-        constexpr uint8_t Flag6 = (1 << 5);
-        constexpr uint8_t AllFlags = 0xFF;
-    } // namespace ObjectSelectionFlags
+        selected,
+        inUse = 2,
+        // required = 3, // Unused feature
+        alwaysRequired = 4,
+        flag5 = 5,
+    };
+    using ObjectSelectionFlags = FlagHolder<uint8_t, ObjectSelectionFlag>;
 
 #pragma pack(push, 1)
     /**

--- a/src/openrct2/scenes/editor/EditorController.cpp
+++ b/src/openrct2/scenes/editor/EditorController.cpp
@@ -54,12 +54,12 @@
 namespace OpenRCT2::Editor
 {
     u8string gSceneryGroupPartialSelectError;
-    std::vector<uint8_t> _objectSelectionFlags;
+    std::vector<ObjectSelectionFlags> _objectSelectionFlags;
     uint32_t _numSelectedObjectsForType[EnumValue(ObjectType::count)];
 
     static int32_t _numAvailableObjectsForType[EnumValue(ObjectType::count)];
 
-    static std::array<std::vector<uint8_t>, EnumValue(ObjectType::count)> _editorSelectedObjectFlags;
+    static std::array<std::vector<ObjectSelectionFlags>, EnumValue(ObjectType::count)> _editorSelectedObjectFlags;
 
     void ObjectListLoad()
     {
@@ -204,9 +204,9 @@ namespace OpenRCT2::Editor
         return { true, kStringIdNone };
     }
 
-    uint8_t GetSelectedObjectFlags(ObjectType objectType, size_t index)
+    ObjectSelectionFlags GetSelectedObjectFlags(ObjectType objectType, size_t index)
     {
-        uint8_t result = 0;
+        ObjectSelectionFlags result{};
         auto& list = _editorSelectedObjectFlags[EnumValue(objectType)];
         if (list.size() > index)
         {
@@ -215,17 +215,17 @@ namespace OpenRCT2::Editor
         return result;
     }
 
-    void ClearSelectedObject(ObjectType objectType, size_t index, uint32_t flags)
+    void ClearSelectedObject(ObjectType objectType, size_t index)
     {
         auto& list = _editorSelectedObjectFlags[EnumValue(objectType)];
         if (list.size() <= index)
         {
             list.resize(index + 1);
         }
-        list[index] &= ~flags;
+        list[index] = {};
     }
 
-    void SetSelectedObject(ObjectType objectType, size_t index, uint32_t flags)
+    void SetSelectedObject(ObjectType objectType, size_t index, ObjectSelectionFlags flags)
     {
         if (index != kObjectEntryIndexNull)
         {
@@ -271,17 +271,17 @@ namespace OpenRCT2::Editor
         const ObjectRepositoryItem* items = ObjectRepositoryGetItems();
         for (int32_t i = 0; i < numObjects; i++)
         {
-            uint8_t* selectionFlags = &_objectSelectionFlags[i];
+            ObjectSelectionFlags* selectionFlags = &_objectSelectionFlags[i];
             const ObjectRepositoryItem* item = &items[i];
             if (item->Type == ObjectType::ride)
             {
-                *selectionFlags |= ObjectSelectionFlags::Flag6;
+                selectionFlags->set(ObjectSelectionFlag::flag5);
 
                 for (auto rideType : item->RideInfo.RideType)
                 {
                     if (GetRideTypeDescriptor(rideType).flags.has(RtdFlag::hasTrack))
                     {
-                        *selectionFlags &= ~ObjectSelectionFlags::Flag6;
+                        selectionFlags->unset(ObjectSelectionFlag::flag5);
                         break;
                     }
                 }
@@ -300,11 +300,11 @@ namespace OpenRCT2::Editor
         selectTrackDesignerObjects();
         for (int32_t i = 0; i < numObjects; i++)
         {
-            uint8_t* selectionFlags = &_objectSelectionFlags[i];
+            ObjectSelectionFlags* selectionFlags = &_objectSelectionFlags[i];
             const ObjectRepositoryItem* item = &items[i];
             if (item->Type == ObjectType::ride)
             {
-                *selectionFlags |= ObjectSelectionFlags::Flag6;
+                selectionFlags->set(ObjectSelectionFlag::flag5);
 
                 for (auto rideType : item->RideInfo.RideType)
                 {
@@ -312,7 +312,7 @@ namespace OpenRCT2::Editor
                     {
                         if (GetRideTypeDescriptor(rideType).flags.has(RtdFlag::showInTrackDesigner))
                         {
-                            *selectionFlags &= ~ObjectSelectionFlags::Flag6;
+                            selectionFlags->unset(ObjectSelectionFlag::flag5);
                             break;
                         }
                     }
@@ -333,12 +333,12 @@ namespace OpenRCT2::Editor
         {
             for (auto i = 0u; i < getObjectEntryGroupCount(objectType); i++)
             {
-                ClearSelectedObject(objectType, i, ObjectSelectionFlags::AllFlags);
+                ClearSelectedObject(objectType, i);
 
                 auto loadedObj = objectMgr.GetLoadedObject(objectType, i);
                 if (loadedObj != nullptr)
                 {
-                    SetSelectedObject(objectType, i, ObjectSelectionFlags::Selected);
+                    SetSelectedObject(objectType, i, ObjectSelectionFlag::selected);
                 }
             }
         }
@@ -358,8 +358,8 @@ namespace OpenRCT2::Editor
                     auto surfaceIndex = surfaceEl->getSurfaceObjectIndex();
                     auto edgeIndex = surfaceEl->getEdgeObjectIndex();
 
-                    Editor::SetSelectedObject(ObjectType::terrainSurface, surfaceIndex, ObjectSelectionFlags::InUse);
-                    Editor::SetSelectedObject(ObjectType::terrainEdge, edgeIndex, ObjectSelectionFlags::InUse);
+                    Editor::SetSelectedObject(ObjectType::terrainSurface, surfaceIndex, ObjectSelectionFlag::inUse);
+                    Editor::SetSelectedObject(ObjectType::terrainEdge, edgeIndex, ObjectSelectionFlag::inUse);
                     break;
                 }
                 case TileElementType::track:
@@ -372,23 +372,23 @@ namespace OpenRCT2::Editor
                     {
                         auto surfaceEntryIndex = footpathEl->getSurfaceEntryIndex();
                         auto railingEntryIndex = footpathEl->getRailingsEntryIndex();
-                        Editor::SetSelectedObject(ObjectType::footpathSurface, surfaceEntryIndex, ObjectSelectionFlags::InUse);
-                        Editor::SetSelectedObject(ObjectType::footpathRailings, railingEntryIndex, ObjectSelectionFlags::InUse);
+                        Editor::SetSelectedObject(ObjectType::footpathSurface, surfaceEntryIndex, ObjectSelectionFlag::inUse);
+                        Editor::SetSelectedObject(ObjectType::footpathRailings, railingEntryIndex, ObjectSelectionFlag::inUse);
                     }
                     else
                     {
-                        Editor::SetSelectedObject(ObjectType::paths, legacyPathEntryIndex, ObjectSelectionFlags::InUse);
+                        Editor::SetSelectedObject(ObjectType::paths, legacyPathEntryIndex, ObjectSelectionFlag::inUse);
                     }
                     if (footpathEl->hasAddition())
                     {
                         auto pathAdditionEntryIndex = footpathEl->getAdditionEntryIndex();
-                        SetSelectedObject(ObjectType::pathAdditions, pathAdditionEntryIndex, ObjectSelectionFlags::InUse);
+                        SetSelectedObject(ObjectType::pathAdditions, pathAdditionEntryIndex, ObjectSelectionFlag::inUse);
                     }
                     break;
                 }
                 case TileElementType::smallScenery:
                     type = iter.element->asSmallScenery()->getEntryIndex();
-                    Editor::SetSelectedObject(ObjectType::smallScenery, type, ObjectSelectionFlags::InUse);
+                    Editor::SetSelectedObject(ObjectType::smallScenery, type, ObjectSelectionFlag::inUse);
                     break;
                 case TileElementType::entrance:
                 {
@@ -397,7 +397,7 @@ namespace OpenRCT2::Editor
                         break;
 
                     type = iter.element->asEntrance()->getEntryIndex();
-                    Editor::SetSelectedObject(ObjectType::parkEntrance, type, ObjectSelectionFlags::InUse);
+                    Editor::SetSelectedObject(ObjectType::parkEntrance, type, ObjectSelectionFlag::inUse);
 
                     if (parkEntranceEl->getSequenceIndex() != ParkEntranceSequence::centre)
                         break;
@@ -406,21 +406,21 @@ namespace OpenRCT2::Editor
                     if (legacyPathEntryIndex == kObjectEntryIndexNull)
                     {
                         auto surfaceEntryIndex = parkEntranceEl->getSurfaceEntryIndex();
-                        Editor::SetSelectedObject(ObjectType::footpathSurface, surfaceEntryIndex, ObjectSelectionFlags::InUse);
+                        Editor::SetSelectedObject(ObjectType::footpathSurface, surfaceEntryIndex, ObjectSelectionFlag::inUse);
                     }
                     else
                     {
-                        Editor::SetSelectedObject(ObjectType::paths, legacyPathEntryIndex, ObjectSelectionFlags::InUse);
+                        Editor::SetSelectedObject(ObjectType::paths, legacyPathEntryIndex, ObjectSelectionFlag::inUse);
                     }
                     break;
                 }
                 case TileElementType::wall:
                     type = iter.element->asWall()->getEntryIndex();
-                    Editor::SetSelectedObject(ObjectType::walls, type, ObjectSelectionFlags::InUse);
+                    Editor::SetSelectedObject(ObjectType::walls, type, ObjectSelectionFlag::inUse);
                     break;
                 case TileElementType::largeScenery:
                     type = iter.element->asLargeScenery()->getEntryIndex();
-                    Editor::SetSelectedObject(ObjectType::largeScenery, type, ObjectSelectionFlags::InUse);
+                    Editor::SetSelectedObject(ObjectType::largeScenery, type, ObjectSelectionFlag::inUse);
                     break;
                 case TileElementType::banner:
                 {
@@ -428,7 +428,7 @@ namespace OpenRCT2::Editor
                     if (banner != nullptr)
                     {
                         type = banner->type;
-                        Editor::SetSelectedObject(ObjectType::banners, type, ObjectSelectionFlags::InUse);
+                        Editor::SetSelectedObject(ObjectType::banners, type, ObjectSelectionFlag::inUse);
                     }
                     break;
                 }
@@ -438,9 +438,9 @@ namespace OpenRCT2::Editor
         auto& gameState = getGameState();
         for (auto& ride : RideManager(gameState))
         {
-            Editor::SetSelectedObject(ObjectType::ride, ride.subtype, ObjectSelectionFlags::InUse);
-            Editor::SetSelectedObject(ObjectType::station, ride.entranceStyle, ObjectSelectionFlags::InUse);
-            Editor::SetSelectedObject(ObjectType::music, ride.music, ObjectSelectionFlags::InUse);
+            Editor::SetSelectedObject(ObjectType::ride, ride.subtype, ObjectSelectionFlag::inUse);
+            Editor::SetSelectedObject(ObjectType::station, ride.entranceStyle, ObjectSelectionFlag::inUse);
+            Editor::SetSelectedObject(ObjectType::music, ride.music, ObjectSelectionFlag::inUse);
         }
 
         ObjectEntryIndex lastIndex = kObjectEntryIndexNull;
@@ -450,7 +450,7 @@ namespace OpenRCT2::Editor
                 continue;
 
             lastIndex = peep->animationObjectIndex;
-            Editor::SetSelectedObject(ObjectType::peepAnimations, lastIndex, ObjectSelectionFlags::InUse);
+            Editor::SetSelectedObject(ObjectType::peepAnimations, lastIndex, ObjectSelectionFlag::inUse);
         }
         for (auto* peep : EntityList<Staff>())
         {
@@ -458,7 +458,7 @@ namespace OpenRCT2::Editor
                 continue;
 
             lastIndex = peep->animationObjectIndex;
-            Editor::SetSelectedObject(ObjectType::peepAnimations, lastIndex, ObjectSelectionFlags::InUse);
+            Editor::SetSelectedObject(ObjectType::peepAnimations, lastIndex, ObjectSelectionFlag::inUse);
         }
 
         // Apply selected object status for hacked vehicles that may not have an associated ride
@@ -467,7 +467,7 @@ namespace OpenRCT2::Editor
             ObjectEntryIndex type = vehicle->ride_subtype;
             if (type != kObjectEntryIndexNull) // cable lifts use index null. Ignore them
             {
-                Editor::SetSelectedObject(ObjectType::ride, type, ObjectSelectionFlags::InUse);
+                Editor::SetSelectedObject(ObjectType::ride, type, ObjectSelectionFlag::inUse);
             }
         }
         for (auto vehicle : EntityList<Vehicle>())
@@ -475,7 +475,7 @@ namespace OpenRCT2::Editor
             ObjectEntryIndex type = vehicle->ride_subtype;
             if (type != kObjectEntryIndexNull) // cable lifts use index null. Ignore them
             {
-                Editor::SetSelectedObject(ObjectType::ride, type, ObjectSelectionFlags::InUse);
+                Editor::SetSelectedObject(ObjectType::ride, type, ObjectSelectionFlag::inUse);
             }
         }
 
@@ -485,7 +485,7 @@ namespace OpenRCT2::Editor
         {
             auto* selectionFlags = &_objectSelectionFlags[i];
             const auto* item = &items[i];
-            *selectionFlags &= ~ObjectSelectionFlags::InUse;
+            selectionFlags->unset(ObjectSelectionFlag::inUse);
 
             if (item->LoadedObject != nullptr)
             {
@@ -503,7 +503,7 @@ namespace OpenRCT2::Editor
     void Sub6AB211()
     {
         int32_t numObjects = static_cast<int32_t>(ObjectRepositoryGetItemsCount());
-        _objectSelectionFlags = std::vector<uint8_t>(numObjects);
+        _objectSelectionFlags = std::vector<ObjectSelectionFlags>(numObjects);
 
         for (uint8_t objectType = 0; objectType < EnumValue(ObjectType::count); objectType++)
         {
@@ -606,7 +606,7 @@ namespace OpenRCT2::Editor
 
         for (int32_t i = 0; i < numItems; i++)
         {
-            if (!(_objectSelectionFlags[i] & ObjectSelectionFlags::Selected))
+            if (!(_objectSelectionFlags[i].has(ObjectSelectionFlag::selected)))
             {
                 auto descriptor = ObjectEntryDescriptor(items[i]);
                 if (!IsIntransientObjectType(items[i].Type))
@@ -696,7 +696,7 @@ namespace OpenRCT2::Editor
         for (int32_t i = 0; i < numObjects; i++)
         {
             ObjectType objectType = items[i].Type;
-            if (_objectSelectionFlags[i] & ObjectSelectionFlags::Selected)
+            if (_objectSelectionFlags[i].has(ObjectSelectionFlag::selected))
             {
                 _numSelectedObjectsForType[EnumValue(objectType)]++;
             }
@@ -757,20 +757,20 @@ namespace OpenRCT2::Editor
             }
         }
 
-        uint8_t* selectionFlags = &_objectSelectionFlags[index];
+        ObjectSelectionFlags* selectionFlags = &_objectSelectionFlags[index];
         if (!flags.has(InputFlag::select))
         {
-            if (!(*selectionFlags & ObjectSelectionFlags::Selected))
+            if (!(selectionFlags->has(ObjectSelectionFlag::selected)))
             {
                 return { true };
             }
 
-            if (*selectionFlags & ObjectSelectionFlags::InUse)
+            if (selectionFlags->has(ObjectSelectionFlag::inUse))
             {
                 return ObjectSelectionError(isMasterObject, STR_OBJECT_SELECTION_ERR_CURRENTLY_IN_USE);
             }
 
-            if (*selectionFlags & ObjectSelectionFlags::AlwaysRequired)
+            if (selectionFlags->has(ObjectSelectionFlag::alwaysRequired))
             {
                 return ObjectSelectionError(isMasterObject, STR_OBJECT_SELECTION_ERR_ALWAYS_REQUIRED);
             }
@@ -785,7 +785,7 @@ namespace OpenRCT2::Editor
             }
 
             _numSelectedObjectsForType[EnumValue(objectType)]--;
-            *selectionFlags &= ~ObjectSelectionFlags::Selected;
+            selectionFlags->unset(ObjectSelectionFlag::selected);
             return { true };
         }
 
@@ -793,11 +793,11 @@ namespace OpenRCT2::Editor
         {
             if (flags.has(InputFlag::objectAlwaysRequired))
             {
-                *selectionFlags |= ObjectSelectionFlags::AlwaysRequired;
+                selectionFlags->set(ObjectSelectionFlag::alwaysRequired);
             }
         }
 
-        if (*selectionFlags & ObjectSelectionFlags::Selected)
+        if (selectionFlags->has(ObjectSelectionFlag::selected))
         {
             return { true };
         }
@@ -853,7 +853,7 @@ namespace OpenRCT2::Editor
 
         _numSelectedObjectsForType[EnumValue(objectType)]++;
 
-        *selectionFlags |= ObjectSelectionFlags::Selected;
+        selectionFlags->set(ObjectSelectionFlag::selected);
         return { true };
     }
 
@@ -873,7 +873,7 @@ namespace OpenRCT2::Editor
         for (size_t i = 0; i < numObjects; i++)
         {
             auto objectType = items[i].Type;
-            if (checkObjectType == objectType && (_objectSelectionFlags[i] & ObjectSelectionFlags::Selected))
+            if (checkObjectType == objectType && (_objectSelectionFlags[i].has(ObjectSelectionFlag::selected)))
             {
                 return true;
             }
@@ -889,7 +889,7 @@ namespace OpenRCT2::Editor
         for (size_t i = 0; i < numObjects; i++)
         {
             const auto isAnimObjectType = items[i].Type == ObjectType::peepAnimations;
-            const bool isSelected = _objectSelectionFlags[i] & ObjectSelectionFlags::Selected;
+            const bool isSelected = _objectSelectionFlags[i].has(ObjectSelectionFlag::selected);
             if (isAnimObjectType && isSelected && items[i].PeepAnimationsInfo.PeepType == peepType)
             {
                 return true;
@@ -906,7 +906,7 @@ namespace OpenRCT2::Editor
         {
             const auto& ori = items[i];
             auto isQueue = (ori.FootpathSurfaceInfo.Flags & FOOTPATH_ENTRY_FLAG_IS_QUEUE) != 0;
-            if (ori.Type == ObjectType::footpathSurface && (_objectSelectionFlags[i] & ObjectSelectionFlags::Selected)
+            if (ori.Type == ObjectType::footpathSurface && (_objectSelectionFlags[i].has(ObjectSelectionFlag::selected))
                 && queue == isQueue)
             {
                 return true;
@@ -926,10 +926,10 @@ namespace OpenRCT2::Editor
         int32_t numUnselectedObjects = 0;
         for (int32_t i = 0; i < numObjects; i++)
         {
-            if (_objectSelectionFlags[i] & ObjectSelectionFlags::Selected)
+            if (_objectSelectionFlags[i].has(ObjectSelectionFlag::selected))
             {
-                if (!(_objectSelectionFlags[i] & ObjectSelectionFlags::InUse)
-                    && !(_objectSelectionFlags[i] & ObjectSelectionFlags::AlwaysRequired))
+                if (!(_objectSelectionFlags[i].has(ObjectSelectionFlag::inUse))
+                    && !(_objectSelectionFlags[i].has(ObjectSelectionFlag::alwaysRequired)))
                 {
                     const ObjectRepositoryItem* item = &items[i];
                     ObjectType objectType = item->Type;
@@ -957,7 +957,7 @@ namespace OpenRCT2::Editor
                         continue;
 
                     _numSelectedObjectsForType[EnumValue(objectType)]--;
-                    _objectSelectionFlags[i] &= ~ObjectSelectionFlags::Selected;
+                    _objectSelectionFlags[i].unset(ObjectSelectionFlag::selected);
                     numUnselectedObjects++;
                 }
             }

--- a/src/openrct2/scenes/editor/EditorController.h
+++ b/src/openrct2/scenes/editor/EditorController.h
@@ -24,6 +24,8 @@ namespace OpenRCT2
 {
     struct ObjectEntryDescriptor;
     struct ObjectRepositoryItem;
+    enum class ObjectSelectionFlag : uint8_t;
+    using ObjectSelectionFlags = FlagHolder<uint8_t, ObjectSelectionFlag>;
 } // namespace OpenRCT2
 
 namespace OpenRCT2::Editor
@@ -38,16 +40,16 @@ namespace OpenRCT2::Editor
     using InputFlags = FlagHolder<uint8_t, InputFlag>;
 
     extern u8string gSceneryGroupPartialSelectError;
-    extern std::vector<uint8_t> _objectSelectionFlags;
+    extern std::vector<ObjectSelectionFlags> _objectSelectionFlags;
     extern uint32_t _numSelectedObjectsForType[EnumValue(ObjectType::count)];
 
     void ObjectListLoad();
     ResultWithMessage CheckPark();
     std::pair<ObjectType, StringId> CheckObjectSelection();
 
-    uint8_t GetSelectedObjectFlags(ObjectType objectType, size_t index);
-    void ClearSelectedObject(ObjectType objectType, size_t index, uint32_t flags);
-    void SetSelectedObject(ObjectType objectType, size_t index, uint32_t flags);
+    ObjectSelectionFlags GetSelectedObjectFlags(ObjectType objectType, size_t index);
+    void ClearSelectedObject(ObjectType objectType, size_t index);
+    void SetSelectedObject(ObjectType objectType, size_t index, ObjectSelectionFlags flags);
 
     bool CheckObjectGroupAtLeastOneSelected(ObjectType checkObjectType);
     bool CheckObjectGroupAtLeastOneOfPeepTypeSelected(uint8_t peepType);

--- a/src/openrct2/world/tile_element/TrackElement.cpp
+++ b/src/openrct2/world/tile_element/TrackElement.cpp
@@ -64,7 +64,7 @@ namespace OpenRCT2
 
     void TrackElement::setSeatRotation(uint8_t newSeatRotation)
     {
-        uRide.colourScheme &= ~TRACK_ELEMENT_COLOUR_SEAT_ROTATION_MASK;
+        uRide.colourScheme &= ~kTrackElementColourSeatRotationMask;
         uRide.colourScheme |= (newSeatRotation << 4);
     }
 
@@ -155,24 +155,24 @@ namespace OpenRCT2
 
     uint8_t TrackElement::getDoorAState() const
     {
-        return (uRide.colourScheme & TRACK_ELEMENT_COLOUR_DOOR_A_MASK) >> 2;
+        return (uRide.colourScheme & kTrackElementColourDoorAMask) >> 2;
     }
 
     uint8_t TrackElement::getDoorBState() const
     {
-        return (uRide.colourScheme & TRACK_ELEMENT_COLOUR_DOOR_B_MASK) >> 5;
+        return (uRide.colourScheme & kTrackElementColourDoorBMask) >> 5;
     }
 
     void TrackElement::setDoorAState(uint8_t newState)
     {
-        uRide.colourScheme &= ~TRACK_ELEMENT_COLOUR_DOOR_A_MASK;
-        uRide.colourScheme |= ((newState << 2) & TRACK_ELEMENT_COLOUR_DOOR_A_MASK);
+        uRide.colourScheme &= ~kTrackElementColourDoorAMask;
+        uRide.colourScheme |= ((newState << 2) & kTrackElementColourDoorAMask);
     }
 
     void TrackElement::setDoorBState(uint8_t newState)
     {
-        uRide.colourScheme &= ~TRACK_ELEMENT_COLOUR_DOOR_B_MASK;
-        uRide.colourScheme |= ((newState << 5) & TRACK_ELEMENT_COLOUR_DOOR_B_MASK);
+        uRide.colourScheme &= ~kTrackElementColourDoorBMask;
+        uRide.colourScheme |= ((newState << 5) & kTrackElementColourDoorBMask);
     }
 
     RideId TrackElement::getRideIndex() const
@@ -187,13 +187,13 @@ namespace OpenRCT2
 
     uint8_t TrackElement::getColourScheme() const
     {
-        return uRide.colourScheme & TRACK_ELEMENT_COLOUR_SCHEME_MASK;
+        return uRide.colourScheme & kTrackElementColourSchemeMask;
     }
 
     void TrackElement::setColourScheme(RideColourScheme newColourScheme)
     {
-        uRide.colourScheme &= ~TRACK_ELEMENT_COLOUR_SCHEME_MASK;
-        uRide.colourScheme |= (EnumValue(newColourScheme) & TRACK_ELEMENT_COLOUR_SCHEME_MASK);
+        uRide.colourScheme &= ~kTrackElementColourSchemeMask;
+        uRide.colourScheme |= (EnumValue(newColourScheme) & kTrackElementColourSchemeMask);
     }
 
     bool TrackElement::hasCableLift() const

--- a/src/openrct2/world/tile_element/TrackElement.h
+++ b/src/openrct2/world/tile_element/TrackElement.h
@@ -33,14 +33,11 @@ namespace OpenRCT2
     };
     using TrackTileElementFlags = FlagHolder<uint8_t, TrackTileElementFlag>;
 
-    enum
-    {
-        TRACK_ELEMENT_COLOUR_SCHEME_MASK = 0b00000011,
-        // Not colour related, but shares the field.
-        TRACK_ELEMENT_COLOUR_DOOR_A_MASK = 0b00011100,
-        TRACK_ELEMENT_COLOUR_DOOR_B_MASK = 0b11100000,
-        TRACK_ELEMENT_COLOUR_SEAT_ROTATION_MASK = 0b11110000,
-    };
+    constexpr uint8_t kTrackElementColourSchemeMask = 0b00000011;
+    // Not colour related, but shares the field.
+    constexpr uint8_t kTrackElementColourDoorAMask = 0b00011100;
+    constexpr uint8_t kTrackElementColourDoorBMask = 0b11100000;
+    constexpr uint8_t kTrackElementColourSeatRotationMask = 0b11110000;
 
     constexpr int32_t kLandEdgeDoorFrameClosed = 0;
     constexpr int32_t kLandEdgeDoorFrameOpening = 1;


### PR DESCRIPTION
For https://github.com/OpenRCT2/OpenRCT2/issues/26913. Refactor the following enums/enum-like structures into enum class:
- TRACK_ELEMENT_*_MASK (to constexpr, as they are not enums)
- ObjectSelectionFlags