### PR TITLE
Replace SDL.h headers with SDL sub headers

### DIFF
--- a/src/openrct2-ui/UiContext.Android.cpp
+++ b/src/openrct2-ui/UiContext.Android.cpp
@@ -11,7 +11,7 @@
 
     #include "UiContext.h"
 
-    #include <SDL.h>
+    #include <SDL_messagebox.h>
     #include <dlfcn.h>
     #include <jni.h>
     #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -13,7 +13,7 @@
 
     #include "UiStringIds.h"
 
-    #include <SDL.h>
+    #include <SDL_messagebox.h>
     #include <algorithm>
     #include <dlfcn.h>
     #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -22,7 +22,6 @@
     // Then the rest
     #include "UiContext.h"
 
-    #include <SDL.h>
     #include <SDL_syswm.h>
     #include <openrct2/Diagnostic.h>
     #include <openrct2/core/Path.hpp>

--- a/src/openrct2-ui/UiContext.macOS.mm
+++ b/src/openrct2-ui/UiContext.macOS.mm
@@ -22,7 +22,7 @@
     #include <ApplicationServices/ApplicationServices.h>
     #include <Cocoa/Cocoa.h>
     #include <CoreFoundation/CFBundle.h>
-    #include <SDL.h>
+    #include <SDL_video.h>
     #include <mach-o/dyld.h>
     #pragma clang diagnostic pop
     #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/audio/AudioFormat.h
+++ b/src/openrct2-ui/audio/AudioFormat.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <SDL.h>
+#include <SDL_audio.h>
 #include <cstdint>
 
 namespace OpenRCT2::Audio

--- a/src/openrct2-ui/audio/AudioMixer.h
+++ b/src/openrct2-ui/audio/AudioMixer.h
@@ -13,7 +13,7 @@
 #include "AudioFormat.h"
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL_audio.h>
 #include <cstdint>
 #include <list>
 #include <memory>

--- a/src/openrct2-ui/audio/FlacAudioSource.cpp
+++ b/src/openrct2-ui/audio/FlacAudioSource.cpp
@@ -14,7 +14,7 @@
 
 #ifndef DISABLE_FLAC
     #include <FLAC/all.h>
-    #include <SDL.h>
+    #include <SDL_rwops.h>
     #include <cstring>
     #include <vector>
 #endif

--- a/src/openrct2-ui/audio/MemoryAudioSource.cpp
+++ b/src/openrct2-ui/audio/MemoryAudioSource.cpp
@@ -11,7 +11,7 @@
 #include "AudioFormat.h"
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL_audio.h>
 #include <algorithm>
 #include <openrct2/audio/AudioSource.h>
 #include <stdexcept>

--- a/src/openrct2-ui/audio/OggAudioSource.cpp
+++ b/src/openrct2-ui/audio/OggAudioSource.cpp
@@ -14,7 +14,7 @@
 #include <stdexcept>
 
 #ifndef DISABLE_VORBIS
-    #include <SDL.h>
+    #include <SDL_audio.h>
     #include <optional>
     #include <vector>
     #include <vorbis/vorbisfile.h>

--- a/src/openrct2-ui/audio/SDLAudioSource.h
+++ b/src/openrct2-ui/audio/SDLAudioSource.h
@@ -11,7 +11,7 @@
 
 #include "AudioFormat.h"
 
-#include <SDL.h>
+#include <SDL_audio.h>
 #include <atomic>
 #include <memory>
 #include <openrct2/audio/AudioSource.h>

--- a/src/openrct2-ui/audio/WavAudioSource.cpp
+++ b/src/openrct2-ui/audio/WavAudioSource.cpp
@@ -9,7 +9,7 @@
 
 #include "SDLAudioSource.h"
 
-#include <SDL.h>
+#include <SDL_rwops.h>
 #include <stdexcept>
 
 namespace OpenRCT2::Audio

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -9,7 +9,9 @@
 
 #include "DrawingEngineFactory.hpp"
 
-#include <SDL.h>
+#include <SDL_hints.h>
+#include <SDL_render.h>
+#include <SDL_version.h>
 #include <cmath>
 #include <memory>
 #include <openrct2/Diagnostic.h>

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -23,7 +23,7 @@
     #include "TextureCache.h"
     #include "TransparencyDepth.h"
 
-    #include <SDL.h>
+    #include <SDL_video.h>
     #include <algorithm>
     #include <cassert>
     #include <cmath>

--- a/src/openrct2/core/Http.Android.cpp
+++ b/src/openrct2/core/Http.Android.cpp
@@ -14,7 +14,7 @@
     #include "../Version.h"
     #include "../platform/Platform.h"
 
-    #include <SDL.h>
+    #include <SDL_system.h>
     #include <android/log.h>
     #include <jni.h>
 

--- a/src/openrct2/core/ZipAndroid.cpp
+++ b/src/openrct2/core/ZipAndroid.cpp
@@ -15,7 +15,7 @@
     #include "MemoryStream.h"
     #include "Zip.h"
 
-    #include <SDL.h>
+    #include <SDL_system.h>
     #include <jni.h>
     #include <string>
 

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -19,7 +19,7 @@
     #include "../drawing/Font.h"
     #include "../localisation/Language.h"
 
-    #include <SDL.h>
+    #include <SDL_system.h>
     #include <algorithm>
     #include <android/asset_manager.h>
     #include <android/asset_manager_jni.h>


### PR DESCRIPTION
Similar to https://github.com/OpenRCT2/OpenRCT2/pull/26915 by removing `SDL.h` includes with SDL sub headers.