### PR TITLE
Fix boat draw recursion crash/freeze

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.
 - Fix: [#25558] [Plugin] Image buttons ignore their explicit border setting when a theme draws borders around them.
 - Fix: [#26056] Freeze when trying to download all objects on save where they are missing.
+- Fix: [#26802] Opening rides with 0 or -1 water cars per train crash the game.
 - Fix: [#26811] Crash when a ride points to a non-existing station object.
 - Fix: [#26816] Water rides ignore zero clearances, preventing adjacent terrain modifications and building them anywhere.
 - Fix: [#26880] Max negative G-Force stat on flat track erroneously reads as 0.49g.

--- a/src/openrct2/paint/vehicle/Vehicle.SplashBoats.cpp
+++ b/src/openrct2/paint/vehicle/Vehicle.SplashBoats.cpp
@@ -27,6 +27,14 @@ namespace OpenRCT2
         PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
         const CarEntry* carEntry)
     {
+        // Prevent infinite paint recursion for 0 or -1 cars per train
+        const auto ride = GetRide(vehicle->ride);
+        if (ride == nullptr)
+            return;
+        const auto rideEntry = ride->getRideEntry();
+        if (rideEntry == nullptr || ride->numCarsPerTrain - rideEntry->zero_cars < 1)
+            return;
+
         // TODO: pass as parameter?
         auto& entityRegistry = getGameState().entities;
 


### PR DESCRIPTION
Fixes #26802 

Skips drawing for 0 or -1 cars per train for `VehiclePaintStyle::splashBoatsOrWaterCoaster` that caused the recursion since they would be invisible anyway even if the recursion would be detected.

Tested with 0, -1, and normal amount of cars per train and various numbers of trains. Everything looks fine, and 0 and -1 cars per ride simply draw nothing now.

**Question:** Why do such vehicles support zero cars anyway if all they do is crash the game? Shouldn't this be fixed instead to allow 1 to 255 cars instead?