### PR TITLE
Fix partial/no car drawn on vehicle tab if ride has <1 cars per train

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#26954] Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.
 - Fix: [#26965] When showing missing objects, some types show up as ‘Unknown type’.
 - Fix: [#26965] The window with missing objects is displayed under the ‘Load game’ window.
+- Fix: [#26992] A partial or no car is drawn on the ride vehicle tab if the ride has 0 or less cars per train.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,7 +27,7 @@
 - Fix: [#26954] Land paint price is not updated when selecting columns or rows of tiles by holding down Ctrl.
 - Fix: [#26965] When showing missing objects, some types show up as ‘Unknown type’.
 - Fix: [#26965] The window with missing objects is displayed under the ‘Load game’ window.
-- Fix: [#26992] A partial or no car is drawn on the ride vehicle tab if the ride has 0 or less cars per train.
+- Fix: [#26992] A partial or no car is drawn on the ride vehicle tab if the ride has 0 or fewer cars per train.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1331,7 +1331,7 @@ namespace OpenRCT2::Ui::Windows
                     spriteCoords.y *= 2;
                 }
 
-                const auto vehicle = RideEntryGetVehicleAtPosition(ride->subtype, ride->numCarsPerTrain, rideEntry->TabCar);
+                const auto vehicle = RideEntryGetVehicleAtPosition(ride->subtype, rideEntry->zero_cars + 1, rideEntry->TabCar);
                 const auto& carEntry = rideEntry->Cars[vehicle];
 
                 spriteCoords.y += carEntry.tabHeight;


### PR DESCRIPTION
Currently, rides that have zero-cars can be set to "0" or "-1 cars per train", but many then show nothing or only partial train parts on the ride vehicle tab:
<img width="632" height="669" alt="image" src="https://github.com/user-attachments/assets/679761d2-75a4-4216-82a1-c7ae1ea30002" />

This fix always draws the first non-zero car to make `RideEntryGetVehicleAtPosition` return a meaningful / non-empty sprite (as if "1 car per train" is chosen).
