### PR TITLE
Fix #18415: Preview in the Track Designs Manager is not updated after deleting the first design

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Improved: [#26931] The save prompt now bounces the macOS dock icon, flashes the Windows taskbar button and marks Linux windows urgent when it blocks quitting an unfocused game.
 - Improved: [#26936] Rain is now drawn next to the top toolbar, but only when it is centred.
 - Fix: [#18197] Track Designs Manager does not autoload scenery.
+- Fix: [#18415] Preview in the Track Designs Manager is not updated after deleting the first design.
 - Fix: [#21632] [Plugin] Crash when loading custom image larger than 300 by 300 pixels.
 - Fix: [#24610] Graph tabs on Finances window get a little bit longer every time you switch between them.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -443,6 +443,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 loadDesignsList(_window_track_list_item);
                 selectedListItem = 0;
+                _loadedTrackDesignIndex = kTrackDesignIndexUnloaded;
                 invalidate();
                 _reloadTrackDesigns = false;
             }


### PR DESCRIPTION
Fixes #18415.

Reloading the list after a delete reset `selectedListItem` to 0 but left `_loadedTrackDesignIndex` alone, so `onDraw` skipped re-importing the preview when the deleted design was the first one. Now cleared to `kTrackDesignIndexUnloaded` on reload, as the `WIDX_TOGGLE_SCENERY` handler already does:

https://github.com/OpenRCT2/OpenRCT2/blob/35898a258c35374a458666771990a6e137004a07/src/openrct2-ui/windows/TrackList.cpp#L294-L298

----
_Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff._
