### PR TITLE
Fix UI misbehaviors when releasing mouse outside of game window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Fix: [#15891] Lower case hard sign is drawn as upper case.
 - Fix: [#18197] Track Designs Manager does not autoload scenery.
 - Fix: [#18415] Preview in the Track Designs Manager is not updated after deleting the first design.
+- Fix: [#18782] Dropdowns do not close and become non-functional when mouse is released outside of the game window.
 - Fix: [#21632] [Plugin] Crash when loading custom image larger than 300 by 300 pixels.
 - Fix: [#22854] Network connections of plugins pile up every time another park is loaded.
 - Fix: [#24610] Graph tabs on Finances window get a little bit longer every time you switch between them.
@@ -42,6 +43,7 @@
 - Fix: [#26992] A partial or no car is drawn on the ride vehicle tab if the ride has 0 or fewer cars per train.
 - Fix: [#26996] Correct spelling of some rides in Heide-Park, Diamond Heights and Alton Towers.
 - Fix: [#26996] Scenario patch for Okinawa Coast doesn’t work for CD versions of Wacky Worlds (meaning landscape ownership fixes do not get applied).
+- Fix: [#27004] Windows are moved off-screen when mouse is released outside of the game window.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -484,8 +484,12 @@ namespace OpenRCT2
     static void InputWindowPositionContinue(
         WindowBase& w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords)
     {
+        // Ensure releasing mouse outside of game window does not move window off-screen on X (Y is clamped by toolbars)
+        ScreenCoordsXY newScreenCoordsInside = newScreenCoords;
+        newScreenCoordsInside.x = std::clamp(newScreenCoordsInside.x, 0, ContextGetWidth() - 1);
+
         int32_t snapProximity = w.flags.has(WindowFlag::noSnapping) ? 0 : Config::Get().general.windowSnapProximity;
-        WindowMoveAndSnap(w, newScreenCoords - lastScreenCoords, snapProximity);
+        WindowMoveAndSnap(w, newScreenCoordsInside - lastScreenCoords, snapProximity);
     }
 
     static void InputWindowPositionEnd(WindowBase& w, const ScreenCoordsXY& screenCoords)
@@ -1397,6 +1401,11 @@ namespace OpenRCT2
                             }
                             cursor_w->onDropdown(cursor_widgetIndex, dropdown_index);
                         }
+                    }
+                    else
+                    {
+                        // Close dropdowns even if mouse is released outside of any window
+                        windowMgr->CloseByClass(WindowClass::dropdown);
                     }
                 }
 


### PR DESCRIPTION
This fixes two issues:

- #18782 Dropdowns do not close and become non-functional when mouse is released outside of the game window.
  - This is fixed by also closing dropdowns even if the mouse is released above "no" window (as is the case when it is released outside of the game window).

- Windows are moved off-screen when mouse is released outside of the game window.
  - To be exact, this only happens when releasing the mouse to the left or right of the game window, as the Y coordinate was already clamped by the top and bottom toolbars. This clamps the X dragging coordinate aswell to stay inside the game window.