### PR TITLE
Fix track style buttons overlapping with banking ones

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1649,7 +1649,8 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_TITLE].setString(_windowTitle.c_str());
         }
 
-        static void onDrawUpdateCoveredPieces(const TrackDrawerDescriptor& trackDrawerDescriptor, std::span<Widget> widgets)
+        static void onDrawUpdateCoveredPieces(
+            const TrackDrawerDescriptor& trackDrawerDescriptor, std::span<Widget> widgets, bool hasFlatRollBanking)
         {
             widgets[WIDX_U_TRACK].setHidden();
             widgets[WIDX_O_TRACK].setHidden();
@@ -1676,6 +1677,9 @@ namespace OpenRCT2::Ui::Windows
             widgets[WIDX_O_TRACK].image = ImageId(trackDrawerDescriptor.Covered.icon);
             widgets[WIDX_U_TRACK].tooltip = trackDrawerDescriptor.Regular.tooltip;
             widgets[WIDX_O_TRACK].tooltip = trackDrawerDescriptor.Covered.tooltip;
+
+            widgets[WIDX_U_TRACK].moveToX(hasFlatRollBanking ? 25 : 41);
+            widgets[WIDX_O_TRACK].moveToX(hasFlatRollBanking ? 128 : 144);
         }
 
         void onDraw(Drawing::RenderTarget& rt) override
@@ -1931,7 +1935,7 @@ namespace OpenRCT2::Ui::Windows
                 widgets[WIDX_BANK_LEFT].setVisible(hasFlatRollBanking);
                 widgets[WIDX_BANK_STRAIGHT].setVisible(hasFlatRollBanking);
                 widgets[WIDX_BANK_RIGHT].setVisible(hasFlatRollBanking);
-                onDrawUpdateCoveredPieces(trackDrawerDescriptor, widgets);
+                onDrawUpdateCoveredPieces(trackDrawerDescriptor, widgets, hasFlatRollBanking);
             }
             else
             {


### PR DESCRIPTION
Fixes #27002 by moving the buttons [iff](https://en.wikipedia.org/wiki/If_and_only_if) banking buttons are present as well.

<img width="318" height="259" alt="Screenshot_2026-08-28_at_10 56 51" src="https://github.com/user-attachments/assets/f94194d3-0acd-4053-8706-6b9036341f0b" />

<img width="317" height="262" alt="Screenshot_2026-08-28_at_10 57 09" src="https://github.com/user-attachments/assets/4dbcd2b0-6118-403d-ad87-fef076d1b819" />
