### PR TITLE
Fix #24520: close button ignores sprite font with enlarged UI

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -230,7 +230,6 @@ STR_0820    :Nov
 STR_0821    :Dec
 STR_0822    :Unable to access graphic data file
 STR_0823    :Missing or inaccessible data file
-STR_0824    :{BLACK}❌
 STR_0825    :Chosen name in use already
 STR_0826    :Too many names defined
 STR_0827    :Not enough cash - requires {CURRENCY2DP}
@@ -3201,7 +3200,6 @@ STR_6160    :{WINDOW_COLOUR_2}Available vehicles: {BLACK}{STRING}
 STR_6161    :Gridlines display toggle
 STR_6162    :Spinning Wild Mouse
 STR_6163    :Mouse shaped cars speed through tight corners and short drops, gently spinning around to disorientate the riders
-STR_6164    :{WHITE}❌
 STR_6165    :Use vertical sync
 STR_6166    :Synchronises each frame displayed to the monitor’s refresh rate, preventing screen tearing.
 STR_6167    :Advanced

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#18782] Dropdowns do not close and become non-functional when mouse is released outside of the game window.
 - Fix: [#21632] [Plugin] Crash when loading custom image larger than 300 by 300 pixels.
 - Fix: [#22854] Network connections of plugins pile up every time another park is loaded.
+- Fix: [#24520] The close button does not use the sprite font on languages using a TTF font when the enlarged UI is enabled.
 - Fix: [#24610] Graph tabs on Finances window get a little bit longer every time you switch between them.
 - Fix: [#25169] The convert command strips custom objects from the resulting park.
 - Fix: [#25496] The guest pickup button does not grey out when the guest’s state changes while the window is open.

--- a/src/openrct2-ui/UiStringIds.h
+++ b/src/openrct2-ui/UiStringIds.h
@@ -276,8 +276,6 @@ namespace OpenRCT2
         STR_OR = 7000,
 
         // Widgets
-        STR_CLOSE_X = 824,
-        STR_CLOSE_X_WHITE = 6164,
         STR_DROPDOWN_BULLET_OPTION = 6795,
         STR_DROPDOWN_BULLET_OPTION_CHECKED = 6796, // Used as STR_DROPDOWN_BULLET_OPTION + 1
         STR_DROPDOWN_GLYPH = 876,

--- a/src/openrct2/core/UnicodeChar.h
+++ b/src/openrct2/core/UnicodeChar.h
@@ -215,6 +215,7 @@ namespace OpenRCT2
         left = 0x25C0,
         air = 0x2601,
         tick = 0x2713,
+        dingbatMultiply = 0x2715,
         plus = 0x2795,
         minus = 0x2796,
 

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -596,6 +596,7 @@ namespace OpenRCT2::Drawing
             case UnicodeChar::down:
             case UnicodeChar::leftguillemet:
             case UnicodeChar::tick:
+            case UnicodeChar::dingbatMultiply:
             case UnicodeChar::cross:
             case UnicodeChar::right:
             case UnicodeChar::rightguillemet:

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -237,11 +237,12 @@ static const std::unordered_map<UnicodeChar, int32_t> kCodepointOffsetMap = {
     { UnicodeChar::left, EnumValue(CSChar::left) - kCSSpriteFontOffset },
     { UnicodeChar::air, EnumValue(CSChar::air) - kCSSpriteFontOffset },
     { UnicodeChar::tick, EnumValue(CSChar::tick) - kCSSpriteFontOffset },
+    { UnicodeChar::dingbatMultiply, EnumValue(CSChar::cross) - kCSSpriteFontOffset },
     { UnicodeChar::plus, '+' - kCSSpriteFontOffset },
     { UnicodeChar::minus, '-' - kCSSpriteFontOffset },
 
     // Emoji
-    { UnicodeChar::cross, EnumValue(CSChar::cross) - kCSSpriteFontOffset },
+    { UnicodeChar::cross, 'X' - kCSSpriteFontOffset },
     { UnicodeChar::water, EnumValue(CSChar::water) - kCSSpriteFontOffset },
     { UnicodeChar::eye, SPR_FONTS_EYE - SPR_FONTS_BEGIN },
     { UnicodeChar::road, EnumValue(CSChar::road) - kCSSpriteFontOffset },

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -74,10 +74,10 @@ namespace OpenRCT2
         SCROLL_BOTH = SCROLL_HORIZONTAL | SCROLL_VERTICAL
     };
 
-    constexpr const char* kCloseBoxStringBlackNormal = u8"{BLACK}❌";
-    constexpr const char* kCloseBoxStringBlackLarge = u8"{BLACK}X";
-    constexpr const char* kCloseBoxStringWhiteNormal = u8"{WHITE}❌";
-    constexpr const char* kCloseBoxStringWhiteLarge = u8"{WHITE}X";
+    constexpr const char* kCloseBoxStringBlackNormal = u8"{BLACK}✕";
+    constexpr const char* kCloseBoxStringBlackLarge = u8"{BLACK}❌";
+    constexpr const char* kCloseBoxStringWhiteNormal = u8"{WHITE}✕";
+    constexpr const char* kCloseBoxStringWhiteLarge = u8"{WHITE}❌";
 
     struct Widget
     {

--- a/src/openrct2/rct12/CSStringConverter.cpp
+++ b/src/openrct2/rct12/CSStringConverter.cpp
@@ -78,7 +78,7 @@ namespace OpenRCT2
         { CSChar::aOgonekUc, UnicodeChar::aOgonekUc }, { CSChar::up, UnicodeChar::up },
         { CSChar::cAcuteUc, UnicodeChar::cAcuteUc },   { CSChar::eOgonekUc, UnicodeChar::eOgonekUc },
         { CSChar::lStrokeUc, UnicodeChar::lStrokeUc }, { CSChar::down, UnicodeChar::down },
-        { CSChar::tick, UnicodeChar::tick },           { CSChar::cross, UnicodeChar::cross },
+        { CSChar::tick, UnicodeChar::tick },           { CSChar::cross, UnicodeChar::dingbatMultiply },
         { CSChar::right, UnicodeChar::right },         { CSChar::railway, UnicodeChar::railway },
         { CSChar::quoteOpen, UnicodeChar::quoteOpen }, { CSChar::euro, UnicodeChar::euro },
         { CSChar::road, UnicodeChar::road },           { CSChar::air, UnicodeChar::air },


### PR DESCRIPTION
### Description of changes

The enlarged UI's close button now uses ❌ in place of a literal ASCII `X`, and the normal-sized one uses ✕ (`U+2715 MULTIPLICATION X`) in place of ❌. ❌ is repointed at the sprite font's large `X` glyph, and ✕ takes over its old mapping to the small cross.

`STR_CLOSE_X` (824) and `STR_CLOSE_X_WHITE` (6164) go as well, in a separate commit. They have been unreferenced since 883845bcf9.

### Rationale behind changes

Fixes #24520. ASCII `X` is not in `shouldUseSpriteForCodepoint`, so on languages using a TTF font the enlarged close button was drawn by the TTF renderer instead of the sprite font.

A codepoint maps to exactly one sprite, so putting ❌ on the enlarged button leaves the normal one needing a codepoint of its own. `CSStringConverter` follows that move: RCT2's byte `0xAD` is the small cross, so it now converts to ✕ rather than ❌, and imported park, scenario and object names keep the glyph they always had.

Naming is `dingbatMultiply`, as suggested, after the Unicode name `MULTIPLICATION X` and distinct from the multiplication sign at `U+00D7`.

### Suggested testing steps

With the enlarged UI on, open a window in Japanese, Korean, Chinese or Arabic: the close button should match English and the other sprite-font languages.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.
