### PR TITLE
Put lesser-used arguments to MapCanConstructWithClearAt() into a struct

### DIFF
--- a/src/openrct2/actions/footpath/FootpathLayoutPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathLayoutPlaceAction.cpp
@@ -153,7 +153,7 @@ namespace OpenRCT2::GameActions
         auto crossingMode = isQueue || (_slope.type != FootpathSlopeType::flat) ? CreateCrossingMode::none
                                                                                 : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat, crossingMode);
+            { _loc, zLow, zHigh }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), { .crossingMode = crossingMode });
         if (!entrancePath && canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -222,7 +222,7 @@ namespace OpenRCT2::GameActions
                                                                                 : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
             { _loc, zLow, zHigh }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags().with(CommandFlag::apply),
-            kTileSlopeFlat, crossingMode);
+            { .crossingMode = crossingMode });
         if (!entrancePath && canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/actions/footpath/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/footpath/FootpathPlaceAction.cpp
@@ -315,7 +315,7 @@ namespace OpenRCT2::GameActions
         auto crossingMode = isQueue || (_slope.type != FootpathSlopeType::flat) ? CreateCrossingMode::none
                                                                                 : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat, crossingMode);
+            { _loc, zLow, zHigh }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), { .crossingMode = crossingMode });
         if (!entrancePath && canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_CANT_BUILD_FOOTPATH_HERE;
@@ -383,7 +383,7 @@ namespace OpenRCT2::GameActions
                                                                                 : CreateCrossingMode::pathOverTrack;
         auto canBuild = MapCanConstructWithClearAt(
             { _loc, zLow, zHigh }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags().with(CommandFlag::apply),
-            kTileSlopeFlat, crossingMode);
+            { .crossingMode = crossingMode });
         if (!entrancePath && canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_CANT_BUILD_FOOTPATH_HERE;

--- a/src/openrct2/actions/ride/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/ride/MazePlaceTrackAction.cpp
@@ -109,8 +109,7 @@ namespace OpenRCT2::GameActions
         }
 
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags(),
-            kTileSlopeFlat);
+            { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags());
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -175,7 +174,7 @@ namespace OpenRCT2::GameActions
 
         auto canBuild = MapCanConstructWithClearAt(
             { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 },
-            GetFlags().with(CommandFlag::apply), kTileSlopeFlat);
+            GetFlags().with(CommandFlag::apply));
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/actions/ride/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/ride/MazeSetTrackAction.cpp
@@ -150,8 +150,7 @@ namespace OpenRCT2::GameActions
                 return res;
             }
             auto constructResult = MapCanConstructWithClearAt(
-                { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags(),
-                kTileSlopeFlat);
+                { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags());
             if (constructResult.error != Status::ok)
             {
                 constructResult.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -222,7 +221,7 @@ namespace OpenRCT2::GameActions
 
             auto canBuild = MapCanConstructWithClearAt(
                 { _loc.ToTileStart(), baseHeight, clearanceHeight }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 },
-                GetFlags().with(CommandFlag::apply), kTileSlopeFlat);
+                GetFlags().with(CommandFlag::apply));
             if (canBuild.error != Status::ok)
             {
                 canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
@@ -119,7 +119,7 @@ namespace OpenRCT2::GameActions
         }
         auto clear_z = z + (_isExit ? RideExitHeight : RideEntranceHeight);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, z, clear_z }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags(), kTileSlopeFlat);
+            { _loc, z, clear_z }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags());
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = errorTitle;
@@ -188,8 +188,7 @@ namespace OpenRCT2::GameActions
 
         auto clear_z = z + (_isExit ? RideExitHeight : RideEntranceHeight);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, z, clear_z }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags().with(CommandFlag::apply),
-            kTileSlopeFlat);
+            { _loc, z, clear_z }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, GetFlags().with(CommandFlag::apply));
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = errorTitle;
@@ -255,8 +254,7 @@ namespace OpenRCT2::GameActions
         }
         int16_t baseZ = loc.z;
         int16_t clearZ = baseZ + (isExit ? RideExitHeight : RideEntranceHeight);
-        auto canBuild = MapCanConstructWithClearAt(
-            { loc, baseZ, clearZ }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, {}, kTileSlopeFlat);
+        auto canBuild = MapCanConstructWithClearAt({ loc, baseZ, clearZ }, MapPlaceNonSceneryClearFunc, { 0b1111, 0 }, {});
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = errorTitle;

--- a/src/openrct2/actions/scenery/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/LargeSceneryPlaceAction.cpp
@@ -139,8 +139,7 @@ namespace OpenRCT2::GameActions
             QuarterTile quarterTile = QuarterTile{ tile.corners, 0 }.Rotate(_loc.direction);
             const auto isTree = sceneryEntry->flags.has(LargeSceneryFlag::isTree);
             auto canBuild = MapCanConstructWithClearAt(
-                { curTile, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
-                CreateCrossingMode::none, isTree);
+                { curTile, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags(), { .isTree = isTree });
             if (canBuild.error != Status::ok)
             {
                 canBuild.errorTitle = STR_CANT_POSITION_THIS_HERE;
@@ -271,8 +270,7 @@ namespace OpenRCT2::GameActions
             QuarterTile quarterTile = QuarterTile{ tile.corners, 0 }.Rotate(_loc.direction);
             const auto isTree = sceneryEntry->flags.has(LargeSceneryFlag::isTree);
             auto canBuild = MapCanConstructWithClearAt(
-                { curTile, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
-                CreateCrossingMode::none, isTree);
+                { curTile, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags(), { .isTree = isTree });
             if (canBuild.error != Status::ok)
             {
                 if (banner != nullptr)

--- a/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/scenery/SmallSceneryPlaceAction.cpp
@@ -265,8 +265,7 @@ namespace OpenRCT2::GameActions
         QuarterTile quarterTile = QuarterTile{ collisionQuadrants, supports }.Rotate(quadRotation);
         const auto isTree = sceneryEntry->flags.has(SmallSceneryFlag::isTree);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat, CreateCrossingMode::none,
-            isTree);
+            { _loc, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags(), { .isTree = isTree });
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_CANT_POSITION_THIS_HERE;
@@ -405,8 +404,8 @@ namespace OpenRCT2::GameActions
         QuarterTile quarterTile = QuarterTile{ collisionQuadrants, supports }.Rotate(quadRotation);
         const auto isTree = sceneryEntry->flags.has(SmallSceneryFlag::isTree);
         auto canBuild = MapCanConstructWithClearAt(
-            { _loc, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags().with(CommandFlag::apply), kTileSlopeFlat,
-            CreateCrossingMode::none, isTree);
+            { _loc, zLow, zHigh }, MapPlaceSceneryClearFunc, quarterTile, GetFlags().with(CommandFlag::apply),
+            { .isTree = isTree });
         if (canBuild.error != Status::ok)
         {
             canBuild.errorTitle = STR_CANT_POSITION_THIS_HERE;

--- a/src/openrct2/actions/terraform/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/terraform/LandSetHeightAction.cpp
@@ -138,7 +138,7 @@ namespace OpenRCT2::GameActions
 
             auto clearResult = MapCanConstructWithClearAt(
                 { _coords, _height * kCoordsZStep, zCorner * kCoordsZStep }, MapSetLandHeightClearFunc, { 0b1111, 0 }, {},
-                _style, CreateCrossingMode::none);
+                { .slope = _style });
             if (clearResult.error != Status::ok)
             {
                 clearResult.error = Status::disallowed;

--- a/src/openrct2/actions/track/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/track/TrackPlaceAction.cpp
@@ -270,8 +270,8 @@ namespace OpenRCT2::GameActions
             // When placing from a track design, ignore track elements from the same ride to allow it to intersect itself.
             auto ignoreRideId = _fromTrackDesign ? _rideIndex : RideId::GetNull();
             auto canBuild = MapCanConstructWithClearAt(
-                { mapLoc, baseZ, clearanceZ }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(), kTileSlopeFlat,
-                crossingMode, false, ignoreRideId);
+                { mapLoc, baseZ, clearanceZ }, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags(),
+                { .crossingMode = crossingMode, .ignoreRideId = ignoreRideId });
             if (canBuild.error != Status::ok)
             {
                 canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
@@ -482,7 +482,7 @@ namespace OpenRCT2::GameActions
             auto ignoreRideId = _fromTrackDesign ? _rideIndex : RideId::GetNull();
             auto canBuild = MapCanConstructWithClearAt(
                 mapLocWithClearance, MapPlaceNonSceneryClearFunc, quarterTile, GetFlags().with(CommandFlag::apply),
-                kTileSlopeFlat, crossingMode, false, ignoreRideId);
+                { .crossingMode = crossingMode, .ignoreRideId = ignoreRideId });
             if (canBuild.error != Status::ok)
             {
                 canBuild.errorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -180,7 +180,7 @@ static bool MapLoc68BABCShouldContinue(
  */
 GameActions::Result MapCanConstructWithClearAt(
     const CoordsXYRangedZ& pos, ClearingFunction clearFunc, const QuarterTile quarterTile, const CommandFlags flags,
-    const uint8_t slope, const CreateCrossingMode crossingMode, const bool isTree, const RideId ignoreRideId)
+    MapProposedConstructionInfo additionalInfo)
 {
     auto res = GameActions::Result();
 
@@ -214,8 +214,8 @@ GameActions::Result MapCanConstructWithClearAt(
         if (tileElement->getType() != TileElementType::surface)
         {
             // Skip track elements belonging to the ride that's being ignored for rides that intersect themselves.
-            if (!ignoreRideId.IsNull() && tileElement->getType() == TileElementType::track
-                && tileElement->asTrack()->getRideIndex() == ignoreRideId)
+            if (!additionalInfo.ignoreRideId.IsNull() && tileElement->getType() == TileElementType::track
+                && tileElement->asTrack()->getRideIndex() == additionalInfo.ignoreRideId)
             {
                 continue;
             }
@@ -226,7 +226,8 @@ GameActions::Result MapCanConstructWithClearAt(
                 if (tileElement->getOccupiedQuadrants() & (quarterTile.GetBaseQuarterOccupied()))
                 {
                     if (MapLoc68BABCShouldContinue(
-                            &tileElement, pos, clearFunc, flags, res.cost, crossingMode, canBuildCrossing, slope))
+                            &tileElement, pos, clearFunc, flags, res.cost, additionalInfo.crossingMode, canBuildCrossing,
+                            additionalInfo.slope))
                     {
                         continue;
                     }
@@ -254,7 +255,7 @@ GameActions::Result MapCanConstructWithClearAt(
             }
         }
 
-        if (getGameState().park.flags.has(ParkFlag::forbidHighConstruction) && !isTree)
+        if (getGameState().park.flags.has(ParkFlag::forbidHighConstruction) && !additionalInfo.isTree)
         {
             const auto heightFromGround = pos.clearanceZ - tileElement->getBaseZ();
 
@@ -297,7 +298,8 @@ GameActions::Result MapCanConstructWithClearAt(
                 }
 
                 if (MapLoc68BABCShouldContinue(
-                        &tileElement, pos, clearFunc, flags, res.cost, crossingMode, canBuildCrossing, slope))
+                        &tileElement, pos, clearFunc, flags, res.cost, additionalInfo.crossingMode, canBuildCrossing,
+                        additionalInfo.slope))
                 {
                     continue;
                 }
@@ -323,7 +325,7 @@ static bool dummyClearFunc(
 
 GameActions::Result MapCanConstructAt(const CoordsXYRangedZ& pos, QuarterTile bl)
 {
-    return MapCanConstructWithClearAt(pos, dummyClearFunc, bl, {}, kTileSlopeFlat);
+    return MapCanConstructWithClearAt(pos, dummyClearFunc, bl, {});
 }
 
 /**

--- a/src/openrct2/world/ConstructionClearance.h
+++ b/src/openrct2/world/ConstructionClearance.h
@@ -13,6 +13,7 @@
 #include "../actions/CommandFlag.h"
 #include "../actions/GameActionResult.h"
 #include "Location.hpp"
+#include "tile_element/Slope.h"
 
 #include <cstdint>
 
@@ -53,10 +54,17 @@ struct ConstructClearResult
     uint8_t GroundFlags{ 0 };
 };
 
+struct MapProposedConstructionInfo
+{
+    uint8_t slope = OpenRCT2::kTileSlopeFlat;
+    CreateCrossingMode crossingMode = CreateCrossingMode::none;
+    bool isTree = false;
+    RideId ignoreRideId = RideId::GetNull();
+};
+
 [[nodiscard]] OpenRCT2::GameActions::Result MapCanConstructWithClearAt(
     const CoordsXYRangedZ& pos, ClearingFunction clearFunc, QuarterTile quarterTile, OpenRCT2::GameActions::CommandFlags flags,
-    uint8_t slope, CreateCrossingMode crossingMode = CreateCrossingMode::none, bool isTree = false,
-    RideId ignoreRideId = RideId::GetNull());
+    MapProposedConstructionInfo additionalInfo = {});
 
 [[nodiscard]] OpenRCT2::GameActions::Result MapCanConstructAt(const CoordsXYRangedZ& pos, QuarterTile bl);
 


### PR DESCRIPTION
Originally written for https://github.com/OpenRCT2/OpenRCT2/pull/25418