### PR TITLE
Fix editor inadvertently showing the pause and fast-forward buttons

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1149,6 +1149,9 @@ namespace OpenRCT2::Ui::Windows
 
         void ApplyNetworkMode()
         {
+            if (isInEditorMode())
+                return;
+
             const auto mode = Network::GetMode();
             widgets[WIDX_NETWORK].setHidden(mode == Network::Mode::none);
             widgets[WIDX_CHAT].setHidden(mode == Network::Mode::none);


### PR DESCRIPTION
### Description of changes

The pause and fast-forward buttons had become visible outside the game scene, e.g. the scenario editor. This is the result of the refactor on #26801. This is a regression that fortunately has not made it into a release yet.

### Rationale behind changes

Fixes #27020

### Suggested testing steps

Open the scenario editor. No pause button or fast-forward buttons should appear.

### Did you use AI to help find, test, or implement this issue or feature?

No