### PR TITLE
Fix #27023: Transparent plugin sprites do not work correctly in software rendering mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,7 +4,6 @@
 - Feature: [#26827] [Plugin] Add map resize hook to scripting api.
 - Feature: [#26877] Clear Scenery can remove footpath additions or walls separately.
 - Feature: [#26938] [Plugin] Allow getting and setting caret position for textbox while it is in focus.
-
 - Improved: [#16269] Unnamed rides in the original Added Attractions & Loopy Landscapes scenarios now use their official names from Rollercoaster Tycoon Classic.
 - Improved: [#19000] Add sprite font glyph for the Won (₩).
 - Improved: [#21441] Add sprite font glyph for the Hryvnia (₴).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#26827] [Plugin] Add map resize hook to scripting api.
 - Feature: [#26877] Clear Scenery can remove footpath additions or walls separately.
 - Feature: [#26938] [Plugin] Allow getting and setting caret position for textbox while it is in focus.
+- Fix: [#27023] [Plugin] Fix transparency for custom sprites in software render mode.
 - Improved: [#16269] Unnamed rides in the original Added Attractions & Loopy Landscapes scenarios now use their official names from Rollercoaster Tycoon Classic.
 - Improved: [#19000] Add sprite font glyph for the Won (₩).
 - Improved: [#21441] Add sprite font glyph for the Hryvnia (₴).

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,7 +4,7 @@
 - Feature: [#26827] [Plugin] Add map resize hook to scripting api.
 - Feature: [#26877] Clear Scenery can remove footpath additions or walls separately.
 - Feature: [#26938] [Plugin] Allow getting and setting caret position for textbox while it is in focus.
-- Fix: [#27023] [Plugin] Fix transparency for custom sprites in software render mode.
+
 - Improved: [#16269] Unnamed rides in the original Added Attractions & Loopy Landscapes scenarios now use their official names from Rollercoaster Tycoon Classic.
 - Improved: [#19000] Add sprite font glyph for the Won (₩).
 - Improved: [#21441] Add sprite font glyph for the Hryvnia (₴).
@@ -45,6 +45,7 @@
 - Fix: [#26996] Correct spelling of some rides in Heide-Park, Diamond Heights and Alton Towers.
 - Fix: [#26996] Scenario patch for Okinawa Coast doesn’t work for CD versions of Wacky Worlds (meaning landscape ownership fixes do not get applied).
 - Fix: [#27004] Windows are moved off-screen when mouse is released outside of the game window.
+- Fix: [#27023] [Plugin] Fix transparency for custom sprites in software render mode.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -44,7 +44,7 @@
 - Fix: [#26996] Correct spelling of some rides in Heide-Park, Diamond Heights and Alton Towers.
 - Fix: [#26996] Scenario patch for Okinawa Coast doesn’t work for CD versions of Wacky Worlds (meaning landscape ownership fixes do not get applied).
 - Fix: [#27004] Windows are moved off-screen when mouse is released outside of the game window.
-- Fix: [#27023] [Plugin] Fix transparency for custom sprites in software render mode.
+- Fix: [#27023] [Plugin] Transparent plugin sprites do not work correctly in software rendering mode.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -441,7 +441,7 @@ namespace OpenRCT2::Scripting
             newg1.offset = reinterpret_cast<uint8_t*>(rt.bits);
             newg1.width = size.width;
             newg1.height = size.height;
-            newg1.flags = G1Flag::hasTransparency;
+            newg1.flags = { G1Flag::hasTransparency };
             GfxSetG1Element(id, &newg1);
         }
 

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -441,7 +441,7 @@ namespace OpenRCT2::Scripting
             newg1.offset = reinterpret_cast<uint8_t*>(rt.bits);
             newg1.width = size.width;
             newg1.height = size.height;
-            newg1.flags = {};
+            newg1.flags = G1Flag::hasTransparency;
             GfxSetG1Element(id, &newg1);
         }
 


### PR DESCRIPTION
### Description of changes

Make custom images (from plugin) start with the g1flag for transparency.

### Rationale behind changes

The was a discrepancy in how index 0 colours were rendered between software and opengl render modes. OpenGL would render pixels that were transparent as transparent. Software mode would always render it black. Now both work the same. 

### Suggested testing steps

See the ticket attached, download that plugin, and follow the steps there. 

### Did you use AI to help find, test, or implement this issue or feature?

No AI
