### PR TITLE
Fix #7858: dropdowns do not close when an action by a plugin or another player in multiplayer closes their parent window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Improved: [#26931] The save prompt now bounces the macOS dock icon, flashes the Windows taskbar button and marks Linux windows urgent when it blocks quitting an unfocused game.
 - Improved: [#26936] Rain is now drawn next to the top toolbar, but only when it is centred.
 - Improved: [#26996] Ride names in scenarios can now be autopatched.
+- Fix: [#7858] Dropdowns do not close when an action by a plugin or another player in multiplayer closes their parent window.
 - Fix: [#15891] Lower case hard sign is drawn as upper case.
 - Fix: [#18197] Track Designs Manager does not autoload scenery.
 - Fix: [#18415] Preview in the Track Designs Manager is not updated after deleting the first design.

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1257,6 +1257,9 @@ namespace OpenRCT2
         WindowBase* cursor_w = windowMgr->FindByNumber(cursor_w_class, cursor_w_number);
         if (cursor_w == nullptr)
         {
+            if (_inputState == InputState::dropdownActive)
+                WindowDropdownClose();
+
             _inputState = InputState::reset;
             return;
         }


### PR DESCRIPTION
### Description of changes

Closes #7858. A dropdown whose parent window disappears is now closed along with it. `InputStateWidgetPressed` already detects that the parent is gone, but it only reset the input state and left the dropdown on screen.

### Rationale behind changes

The leftover dropdown was still a live window that had lost its parent. The input state reset also stops that handler from running again, so nothing came back for it and it stayed on screen until another dropdown was opened.

Closing a window yourself takes its dropdown with it, which is why clicking never reproduced this. It needs a game action to close the parent, so a plugin or another player in multiplayer demolishing the ride, or a guest/staff member disappearing while their window and a dropdown is open.

### Suggested testing steps

Put this plugin in your plugin folder. It closes a ride, guest or staff window while that window has a dropdown open, which is what a plugin or another player would otherwise do.

- Ride: open a ride window and open its view dropdown. The plugin demolishes the ride underneath it.
- Guest: click a guest that is walking around, then open the locate dropdown in their window. The plugin removes the guest underneath it.
- Staff: same as a guest, using the patrol area, costume or locate dropdown. Staff windows share the guest window class, so the plugin handles them the same.

Before this change the dropdown stayed on screen with no parent in each case, and only disappeared once another dropdown was opened. This can still be replicated on develop using the same plugin.

<details>
<summary>Plugin</summary>

```js
// Closes a ride or peep window from under its own open dropdown.
registerPlugin({
    name: 'ghost-repro',
    version: '2.0',
    authors: ['test'],
    type: 'local',
    licence: 'MIT',
    targetApiVersion: 122,
    main: function () {
        context.setInterval(function () {
            var ride = null, peep = null, dropdownOpen = false;
            for (var i = 0; i < ui.windows; i++) {
                var w = ui.getWindow(i);
                if (w.classification === 12) ride = w;                // ride window
                else if (w.classification === 23) peep = w;           // guest/staff window
                else if (w.classification === 6) dropdownOpen = true; // dropdown
            }
            if (!dropdownOpen)
                return;

            if (ride !== null) {
                context.executeAction('ridedemolish', { ride: ride.number, modifyType: 0 }, function () {});
            } else if (peep !== null) {
                var entity = map.getEntity(peep.number);
                if (entity !== null)
                    entity.remove();
            }
        }, 200);
    }
});
```
</details>

Normal dropdown use should be unaffected: opening, selecting, clicking away, and closing a window yourself with its dropdown open.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.