### PR TITLE
Prune outdated pragma warning disable directives

### DIFF
--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "Theme.h"
 
 #include "../UiStringIds.h"

--- a/src/openrct2/drawing/Image.cpp
+++ b/src/openrct2/drawing/Image.cpp
@@ -31,12 +31,6 @@ static uint32_t _allocatedImageCount;
 #ifdef DEBUG_LEVEL_1
 static std::list<ImageList> _allocatedLists;
 
-    // MSVC's compiler doesn't support the [[maybe_unused]] attribute for unused static functions. Until this has been resolved,
-    // we need to explicitly tell the compiler to temporarily disable the warning. See discussion at
-    // https://github.com/OpenRCT2/OpenRCT2/pull/7617
-    #pragma warning(push)
-    #pragma warning(disable : 4505) // unreferenced local function has been removed
-
 [[maybe_unused]] static bool AllocatedListContains(uint32_t baseImageId, uint32_t count)
 {
     bool contains = std::any_of(
@@ -45,8 +39,6 @@ static std::list<ImageList> _allocatedLists;
         });
     return contains;
 }
-
-    #pragma warning(pop)
 
 static bool AllocatedListRemove(uint32_t baseImageId, uint32_t count)
 {

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "LargeSceneryObject.h"
 
 #include "../core/Guard.hpp"

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "RideObject.h"
 
 #include "../audio/Audio.h"

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "SceneryGroupObject.h"
 
 #include "../Context.h"

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "SmallSceneryObject.h"
 
 #include "../core/Guard.hpp"

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "TerrainSurfaceObject.h"
 
 #include "../Context.h"

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma warning(disable : 4706) // assignment within conditional expression
-
 #include "WaterObject.h"
 
 #include "../core/Guard.hpp"


### PR DESCRIPTION
### Description of changes

Over the years, we've added pragma warning directives whenever we encountered an overzealous compiler warning, particularly for MSVC. I have removed these.

### Rationale behind changes

It appears these are no longer necessary with current compilers, as CI passes fine without them. Some of these date back to 2018, so it makes sense that compilers have caught up.

### Suggested testing steps

Compile-only, so suggest we look at CI passing.

### Did you use AI to help find, test, or implement this issue or feature?

No