### PR TITLE
Add transport ride navigation for guests

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3840,3 +3840,7 @@ STR_7040    :Footpath additions
 STR_7041    :Park info panel
 STR_7042    :Date info panel
 STR_7043    :Can’t change land height here…
+STR_7044    :Use free transport rides for navigation
+STR_7045    :Allow guests to use free transport rides as part of a route to another destination.
+STR_7046    :Taking {STRINGID} to reach {STRINGID}
+STR_7047    :Taking {STRINGID} to reach the park exit

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.5 (in development)
 ------------------------------------------------------------------------
+- Feature: [#7758] Add an optional gameplay setting that lets guests use free transport rides to reach their destination.
 - Feature: [#26423] [Plugin] Add `PathNavigator` and `PathConnection` for exploring the footpath network as a graph.
 - Feature: [#26827] [Plugin] Add map resize hook to scripting api.
 - Feature: [#26877] Clear Scenery can remove footpath additions or walls separately.

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -229,6 +229,7 @@ namespace OpenRCT2::Ui::Windows
         WIDX_REAL_NAMES_STAFF_CHECKBOX,
         WIDX_AUTO_STAFF_PLACEMENT,
         WIDX_AUTO_OPEN_SHOPS,
+        WIDX_ENABLE_TRANSPORT_RIDE_NAVIGATION,
         WIDX_DEFAULT_INSPECTION_INTERVAL_LABEL,
         WIDX_DEFAULT_INSPECTION_INTERVAL,
         WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN,
@@ -429,14 +430,15 @@ namespace OpenRCT2::Ui::Windows
         makeWidget({ 10, kScenarioOptionsGroupStart + 32}, {275, 16}, WidgetType::checkbox,     WindowColour::tertiary,  STR_OPTIONS_SCENARIO_UNLOCKING, STR_SCENARIO_UNLOCKING_TIP), // Unlocking of scenarios
         makeWidget({ 10, kScenarioOptionsGroupStart + 47}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary,  STR_ALLOW_EARLY_COMPLETION,     STR_EARLY_COMPLETION_TIP  ), // Allow early scenario completion
 
-        makeWidget({  5,  kTweaksStart + 0}, {300, 96}, WidgetType::groupbox,     WindowColour::secondary, STR_OPTIONS_TWEAKS                                                  ),
+        makeWidget({  5,  kTweaksStart + 0}, {300,111}, WidgetType::groupbox,     WindowColour::secondary, STR_OPTIONS_TWEAKS                                                  ),
         makeWidget({ 10, kTweaksStart + 15}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_REAL_NAME_GUESTS,     STR_REAL_NAME_GUESTS_TIP                  ), // Show 'real' names of guests
         makeWidget({ 10, kTweaksStart + 30}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_REAL_NAME_STAFF,      STR_REAL_NAME_STAFF_TIP                   ), // Show 'real' names of staff
         makeWidget({ 10, kTweaksStart + 45}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_AUTO_STAFF_PLACEMENT, STR_AUTO_STAFF_PLACEMENT_TIP              ), // Auto staff placement
         makeWidget({ 10, kTweaksStart + 60}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_AUTO_OPEN_SHOPS,      STR_AUTO_OPEN_SHOPS_TIP                   ), // Automatically open shops & stalls
-        makeWidget({ 10, kTweaksStart + 77}, {165, 12}, WidgetType::label,        WindowColour::secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
-        makeWidget({175, kTweaksStart + 76}, {125, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                      ), // Default inspection time dropdown
-        makeWidget({288, kTweaksStart + 77}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       )  // Default inspection time dropdown button
+        makeWidget({ 10, kTweaksStart + 75}, {290, 15}, WidgetType::checkbox,     WindowColour::tertiary , STR_ENABLE_TRANSPORT_RIDE_NAVIGATION, STR_ENABLE_TRANSPORT_RIDE_NAVIGATION_TIP),
+        makeWidget({ 10, kTweaksStart + 92}, {165, 12}, WidgetType::label,        WindowColour::secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
+        makeWidget({175, kTweaksStart + 91}, {125, 14}, WidgetType::dropdownMenu, WindowColour::secondary                                                                      ), // Default inspection time dropdown
+        makeWidget({288, kTweaksStart + 92}, { 11, 12}, WidgetType::button,       WindowColour::secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       )  // Default inspection time dropdown button
     );
 
     constexpr int32_t kRCT1Start = 53;
@@ -1848,6 +1850,18 @@ namespace OpenRCT2::Ui::Windows
                     Config::Save();
                     invalidate();
                     break;
+                case WIDX_ENABLE_TRANSPORT_RIDE_NAVIGATION:
+                {
+                    auto& gameState = getGameState();
+                    const bool enabled = !gameState.park.flags.has(ParkFlag::transportRideNavigation);
+                    Config::Get().general.enableTransportRideNavigation = enabled;
+                    Config::Save();
+                    auto action = GameActions::ScenarioSetSettingAction(
+                        GameActions::ScenarioSetSetting::transportRideNavigation, enabled);
+                    GameActions::Execute(&action, gameState);
+                    invalidate();
+                    break;
+                }
                 case WIDX_ALLOW_EARLY_COMPLETION:
                     Config::Get().general.allowEarlyCompletion ^= 1;
                     // only the server can control this setting and needs to send the
@@ -1977,9 +1991,13 @@ namespace OpenRCT2::Ui::Windows
             // The real name setting of clients is fixed to that of the server
             // and the server cannot change the setting during gameplay to prevent desyncs
             const bool inNetwork = Network::GetMode() != Network::Mode::none;
+            const bool isNetworkClient = Network::GetMode() == Network::Mode::client;
             setWidgetDisabled(WIDX_REAL_NAMES_GUESTS_CHECKBOX, inNetwork);
             setWidgetDisabled(WIDX_REAL_NAMES_STAFF_CHECKBOX, inNetwork);
-            setWidgetDisabled(WIDX_ALLOW_EARLY_COMPLETION, Network::GetMode() == Network::Mode::client);
+            setWidgetDisabled(WIDX_ALLOW_EARLY_COMPLETION, isNetworkClient);
+            setWidgetDisabled(WIDX_ENABLE_TRANSPORT_RIDE_NAVIGATION, isNetworkClient);
+            widgets[WIDX_ENABLE_TRANSPORT_RIDE_NAVIGATION].tooltip = isNetworkClient ? STR_OPTION_DISABLED_DURING_NETWORK_PLAY
+                                                                                     : STR_ENABLE_TRANSPORT_RIDE_NAVIGATION_TIP;
             if (inNetwork)
             {
                 widgets[WIDX_REAL_NAMES_GUESTS_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
@@ -1988,7 +2006,7 @@ namespace OpenRCT2::Ui::Windows
                 // Disable the use of the allow_early_completion option during network play on clients.
                 // This is to prevent confusion on clients because changing this setting during network play wouldn't change
                 // the way scenarios are completed during this network-session
-                if (Network::GetMode() == Network::Mode::client)
+                if (isNetworkClient)
                 {
                     widgets[WIDX_ALLOW_EARLY_COMPLETION].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
                 }
@@ -1998,6 +2016,8 @@ namespace OpenRCT2::Ui::Windows
             setCheckboxValue(WIDX_REAL_NAMES_STAFF_CHECKBOX, Config::Get().general.showRealNamesOfStaff);
             setCheckboxValue(WIDX_AUTO_STAFF_PLACEMENT, Config::Get().general.autoStaffPlacement);
             setCheckboxValue(WIDX_AUTO_OPEN_SHOPS, Config::Get().general.autoOpenShops);
+            setCheckboxValue(
+                WIDX_ENABLE_TRANSPORT_RIDE_NAVIGATION, getGameState().park.flags.has(ParkFlag::transportRideNavigation));
             setCheckboxValue(WIDX_ALLOW_EARLY_COMPLETION, Config::Get().general.allowEarlyCompletion);
 
             if (Config::Get().interface.scenarioPreviewScreenshots)

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -43,6 +43,8 @@ static_assert(sizeof(EntitySnapshot) == 0x200);
 
 struct GameStateSnapshot_t
 {
+    static constexpr uint32_t kGuestTransportRideNavigationFlag = 1u << 31;
+
     GameStateSnapshot_t& operator=(GameStateSnapshot_t&& mv) noexcept
     {
         tick = mv.tick;
@@ -73,6 +75,20 @@ struct GameStateSnapshot_t
         return (EntitySizeCheck<T>(ds) && ...);
     }
 
+    bool GuestEntitySizeCheck(DataSerialiser& ds, bool& includeTransportRideNavigation)
+    {
+        uint32_t size = sizeof(Guest);
+        if (ds.IsSaving() && getGameState().park.flags.has(ParkFlag::transportRideNavigation))
+        {
+            size |= kGuestTransportRideNavigationFlag;
+        }
+
+        ds << size;
+        includeTransportRideNavigation = (size & kGuestTransportRideNavigationFlag) != 0;
+        size &= ~kGuestTransportRideNavigationFlag;
+        return !ds.IsLoading() || size == sizeof(Guest);
+    }
+
     // Must pass a function that can access the sprite.
     void SerialiseSprites(std::function<EntitySnapshot*(EntityId)> getEntity, const size_t numSprites, bool saving)
     {
@@ -100,7 +116,9 @@ struct GameStateSnapshot_t
 
         // Encodes and checks the size of each of the entity so that we
         // can fail gracefully when fields added/removed
-        if (!EntitiesSizeCheck<Vehicle, Guest, Staff, Litter, MoneyEffect, Balloon, Duck, JumpingFountain, SteamParticle>(ds))
+        bool includeTransportRideNavigation = false;
+        if (!EntitiesSizeCheck<Vehicle>(ds) || !GuestEntitySizeCheck(ds, includeTransportRideNavigation)
+            || !EntitiesSizeCheck<Staff, Litter, MoneyEffect, Balloon, Duck, JumpingFountain, SteamParticle>(ds))
         {
             LOG_ERROR("Entity index corrupted!");
             return;
@@ -133,7 +151,7 @@ struct GameStateSnapshot_t
                     reinterpret_cast<Vehicle&>(sprite).serialise(ds);
                     break;
                 case EntityType::guest:
-                    reinterpret_cast<Guest&>(sprite).serialise(ds);
+                    reinterpret_cast<Guest&>(sprite).serialise(ds, includeTransportRideNavigation);
                     break;
                 case EntityType::staff:
                     reinterpret_cast<Staff&>(sprite).serialise(ds);
@@ -334,6 +352,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Guest, guestNextInQueue);
         COMPARE_FIELD(Guest, parkEntryTime);
         COMPARE_FIELD(Guest, guestHeadingToRideId);
+        COMPARE_FIELD(Guest, transportRideNavigation);
         COMPARE_FIELD(Guest, guestIsLostCountdown);
         COMPARE_FIELD(Guest, guestTimeOnRide);
         COMPARE_FIELD(Guest, paidToEnter);

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -106,8 +106,9 @@ namespace OpenRCT2
 
     class ReplayManager final : public IReplayManager
     {
-        static constexpr uint16_t kReplayVersion = 11;
+        static constexpr uint16_t kReplayVersion = 12;
         static constexpr uint16_t kReplayMinCompatVersion = 10;
+        static constexpr uint16_t kTransportRideNavigationReplayVersion = 12;
         static constexpr uint32_t kReplayMagic = 0x5243524F; // ORCR.
         static constexpr int kReplayCompressionLevel = 18;
         static constexpr int kNormalRecordingChecksumTicks = 1;
@@ -538,6 +539,10 @@ namespace OpenRCT2
                 // TODO: Have a separate GameState and exchange once loaded.
                 auto& gameState = getGameState();
                 importer->Import(gameState);
+                if (data.version < kTransportRideNavigationReplayVersion)
+                {
+                    gameState.park.flags.unset(ParkFlag::transportRideNavigation);
+                }
 
                 EntityTweener::get().reset();
 

--- a/src/openrct2/actions/general/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/general/ScenarioSetSettingAction.cpp
@@ -178,6 +178,10 @@ namespace OpenRCT2::GameActions
                 park.flags.set(ParkFlag::rct1Interest, _value != 0);
                 break;
             }
+            case ScenarioSetSetting::transportRideNavigation:
+                park.flags.set(ParkFlag::transportRideNavigation, _value != 0);
+                windowMgr->InvalidateByClass(WindowClass::options);
+                break;
             default:
                 LOG_ERROR("Invalid scenario setting %u", _setting);
                 return Result(Status::invalidParameters, STR_ERR_INVALID_PARAMETER, STR_ERR_VALUE_OUT_OF_RANGE);

--- a/src/openrct2/actions/general/ScenarioSetSettingAction.h
+++ b/src/openrct2/actions/general/ScenarioSetSettingAction.h
@@ -38,6 +38,7 @@ namespace OpenRCT2::GameActions
         guestGenerationHigherDifficultyLevel,
         allowEarlyCompletion,
         useRCT1Interest,
+        transportRideNavigation,
         count
     };
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -248,6 +248,7 @@ namespace OpenRCT2::Config
 #endif // _DEBUG
             model->trapCursor = reader->GetBoolean("trap_cursor", false);
             model->autoOpenShops = reader->GetBoolean("auto_open_shops", false);
+            model->enableTransportRideNavigation = reader->GetBoolean("enable_transport_ride_navigation", false);
 
             // Gamepad settings
             model->gamepadDeadzone = reader->GetInt32("gamepad_deadzone", 3600);
@@ -345,6 +346,7 @@ namespace OpenRCT2::Config
         writer->WriteBoolean("multithreading", model->multiThreading);
         writer->WriteBoolean("trap_cursor", model->trapCursor);
         writer->WriteBoolean("auto_open_shops", model->autoOpenShops);
+        writer->WriteBoolean("enable_transport_ride_navigation", model->enableTransportRideNavigation);
 
         // Gamepad settings
         writer->WriteInt32("gamepad_deadzone", model->gamepadDeadzone);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -103,6 +103,7 @@ namespace OpenRCT2::Config
         bool autoStaffPlacement;
         bool handymenMowByDefault;
         bool autoOpenShops;
+        bool enableTransportRideNavigation;
         RideInspection defaultInspectionInterval;
         int32_t windowLimit;
         bool scenarioUnlockingEnabled;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1370,6 +1370,7 @@ namespace OpenRCT2
             return;
 
         guestHeadingToRideId = RideId::GetNull();
+        transportRideNavigation.clear();
 
         auto* windowMgr = Ui::GetWindowManager();
         WindowBase* w = windowMgr->FindByNumber(WindowClass::peep, id);
@@ -1702,6 +1703,10 @@ namespace OpenRCT2
      */
     void Guest::onExitRide(Ride& ride)
     {
+        const bool completedTransportNavigation = transportRideNavigation.isActive()
+            && transportRideNavigation.rideId == ride.id;
+        const bool completedTransportNavigationToExit = completedTransportNavigation && peepFlags.has(PeepFlag::leavingPark);
+
         if (peepFlags.has(PeepFlag::rideShouldBeMarkedAsFavourite))
         {
             peepFlags.unset(PeepFlag::rideShouldBeMarkedAsFavourite);
@@ -1713,14 +1718,32 @@ namespace OpenRCT2
         nausea = nauseaTarget;
         windowInvalidateFlags |= PEEP_INVALIDATE_PEEP_STATS;
 
-        if (peepFlags.has(PeepFlag::leavingPark))
+        if (peepFlags.has(PeepFlag::leavingPark) && !completedTransportNavigationToExit)
             peepFlags.unset(PeepFlag::parkEntranceChosen);
 
-        if (GuestShouldGoOnRideAgain(*this, ride))
+        if (!completedTransportNavigation && GuestShouldGoOnRideAgain(*this, ride))
         {
             guestHeadingToRideId = ride.id;
+            transportRideNavigation.clear();
             guestIsLostCountdown = 200;
             resetPathfindGoal();
+            windowInvalidateFlags |= PEEP_INVALIDATE_PEEP_ACTION;
+        }
+
+        if (completedTransportNavigation)
+        {
+            transportRideNavigation.clear();
+            if (completedTransportNavigationToExit)
+            {
+                pathfindGoal.direction = kInvalidDirection;
+                TileCoordsXYZD nullPos;
+                nullPos.SetNull();
+                std::fill(pathfindHistory.begin(), pathfindHistory.end(), nullPos);
+            }
+            else
+            {
+                resetPathfindGoal();
+            }
             windowInvalidateFlags |= PEEP_INVALIDATE_PEEP_ACTION;
         }
 
@@ -1774,6 +1797,7 @@ namespace OpenRCT2
         {
             // Head to that ride
             guest.guestHeadingToRideId = ride->id;
+            guest.transportRideNavigation.clear();
             guest.guestIsLostCountdown = 200;
             guest.resetPathfindGoal();
             guest.windowInvalidateFlags |= PEEP_INVALIDATE_PEEP_ACTION;
@@ -2374,6 +2398,7 @@ namespace OpenRCT2
     static void GuestResetRideHeading(Guest& guest)
     {
         guest.guestHeadingToRideId = RideId::GetNull();
+        guest.transportRideNavigation.clear();
         guest.windowInvalidateFlags |= PEEP_INVALIDATE_PEEP_ACTION;
     }
 
@@ -3068,6 +3093,7 @@ namespace OpenRCT2
         }
         else
         {
+            guest.transportRideNavigation.clear();
             guest.guestIsLostCountdown = 254;
             guest.peepFlags.set(PeepFlag::leavingPark);
             guest.peepFlags.unset(PeepFlag::parkEntranceChosen);
@@ -3185,6 +3211,7 @@ namespace OpenRCT2
         {
             // Head to that ride
             guest.guestHeadingToRideId = closestRide->id;
+            guest.transportRideNavigation.clear();
             guest.guestIsLostCountdown = 200;
             guest.resetPathfindGoal();
             guest.windowInvalidateFlags |= PEEP_INVALIDATE_PEEP_ACTION;
@@ -4043,18 +4070,25 @@ namespace OpenRCT2
                     auto* seatedGuest = gameState.entities.getEntity<Guest>(vehicle->peep[currentSeat ^ 1]);
                     if (seatedGuest != nullptr)
                     {
-                        if (seatedGuest->rideSubState != PeepRideSubState::enterVehicle)
-                            return;
+                        const bool isAlreadySeated = seatedGuest->state == PeepState::onRide
+                            && seatedGuest->rideSubState == PeepRideSubState::onRide && seatedGuest->currentRide == currentRide
+                            && seatedGuest->currentTrain == currentTrain && seatedGuest->currentCar == currentCar
+                            && seatedGuest->currentSeat == (currentSeat ^ 1);
+                        if (!isAlreadySeated)
+                        {
+                            if (seatedGuest->rideSubState != PeepRideSubState::enterVehicle)
+                                return;
 
-                        vehicle->num_peeps++;
-                        ride->curNumCustomers++;
+                            vehicle->num_peeps++;
+                            ride->curNumCustomers++;
 
-                        vehicle->ApplyMass(seatedGuest->mass);
-                        seatedGuest->moveTo({ kLocationNull, 0, 0 });
-                        seatedGuest->setState(PeepState::onRide);
-                        seatedGuest->guestTimeOnRide = 0;
-                        seatedGuest->rideSubState = PeepRideSubState::onRide;
-                        seatedGuest->onEnterRide(*ride);
+                            vehicle->ApplyMass(seatedGuest->mass);
+                            seatedGuest->moveTo({ kLocationNull, 0, 0 });
+                            seatedGuest->setState(PeepState::onRide);
+                            seatedGuest->guestTimeOnRide = 0;
+                            seatedGuest->rideSubState = PeepRideSubState::onRide;
+                            seatedGuest->onEnterRide(*ride);
+                        }
                     }
                 }
 
@@ -7285,6 +7319,7 @@ namespace OpenRCT2
         peep->resetPathfindGoal();
         peep->removeAllItems();
         peep->guestHeadingToRideId = RideId::GetNull();
+        peep->transportRideNavigation.clear();
         peep->guestNextInQueue = EntityId::GetNull();
         peep->litterCount = 0;
         peep->disgustingCount = 0;
@@ -7651,6 +7686,11 @@ namespace OpenRCT2
         if (guestHeadingToRideId == rideId)
         {
             guestHeadingToRideId = RideId::GetNull();
+            transportRideNavigation.clear();
+        }
+        if (transportRideNavigation.rideId == rideId)
+        {
+            transportRideNavigation.clear();
         }
         if (favouriteRide == rideId)
         {
@@ -7711,11 +7751,26 @@ namespace OpenRCT2
 
     void Guest::serialise(DataSerialiser& stream)
     {
+        serialise(stream, getGameState().park.flags.has(ParkFlag::transportRideNavigation));
+    }
+
+    void Guest::serialise(DataSerialiser& stream, bool includeTransportRideNavigation)
+    {
         Peep::serialise(stream);
         stream << guestNumRides;
         stream << guestNextInQueue;
         stream << parkEntryTime;
         stream << guestHeadingToRideId;
+        if (includeTransportRideNavigation)
+        {
+            stream << transportRideNavigation.rideId;
+            stream << transportRideNavigation.boardingStation;
+            stream << transportRideNavigation.alightingStation;
+        }
+        else if (stream.IsLoading())
+        {
+            transportRideNavigation.clear();
+        }
         stream << guestIsLostCountdown;
         stream << guestTimeOnRide;
         stream << paidToEnter;

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -256,6 +256,26 @@ namespace OpenRCT2
         }
     };
 
+    struct GuestTransportRideNavigation
+    {
+        RideId rideId{ RideId::GetNull() };
+        StationIndex boardingStation{ StationIndex::GetNull() };
+        StationIndex alightingStation{ StationIndex::GetNull() };
+
+        [[nodiscard]] bool isActive() const
+        {
+            return !rideId.IsNull();
+        }
+
+        void clear()
+        {
+            rideId = RideId::GetNull();
+            boardingStation = StationIndex::GetNull();
+            alightingStation = StationIndex::GetNull();
+        }
+    };
+    static_assert(sizeof(GuestTransportRideNavigation) == 4);
+
     struct Guest : Peep
     {
         static constexpr auto kEntityType = EntityType::guest;
@@ -265,6 +285,7 @@ namespace OpenRCT2
         EntityId guestNextInQueue;
         int32_t parkEntryTime;
         RideId guestHeadingToRideId;
+        GuestTransportRideNavigation transportRideNavigation;
         uint8_t guestIsLostCountdown;
         uint8_t guestTimeOnRide;
         money64 paidToEnter;
@@ -360,6 +381,7 @@ namespace OpenRCT2
         void giveItem(ShopItem item);
         bool hasItem(ShopItem peepItem) const;
         void serialise(DataSerialiser& stream);
+        void serialise(DataSerialiser& stream, bool includeTransportRideNavigation);
 
         // Removes the ride from the guests memory, this includes
         // the history, thoughts, etc.

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1329,13 +1329,33 @@ namespace OpenRCT2
                         auto ride = GetRide(guest->guestHeadingToRideId);
                         if (ride != nullptr)
                         {
-                            ft.Add<StringId>(STR_HEADING_FOR);
-                            ride->formatNameTo(ft);
+                            auto transportRide = GetRide(guest->transportRideNavigation.rideId);
+                            if (guest->transportRideNavigation.isActive() && transportRide != nullptr)
+                            {
+                                ft.Add<StringId>(STR_TAKING_TRANSPORT_RIDE_TO_DESTINATION);
+                                transportRide->formatNameTo(ft);
+                                ride->formatNameTo(ft);
+                            }
+                            else
+                            {
+                                ft.Add<StringId>(STR_HEADING_FOR);
+                                ride->formatNameTo(ft);
+                            }
                         }
                     }
                     else
                     {
-                        ft.Add<StringId>(peepFlags.has(PeepFlag::leavingPark) ? STR_LEAVING_PARK : STR_WALKING);
+                        auto transportRide = GetRide(guest->transportRideNavigation.rideId);
+                        if (peepFlags.has(PeepFlag::leavingPark) && guest->transportRideNavigation.isActive()
+                            && transportRide != nullptr)
+                        {
+                            ft.Add<StringId>(STR_TAKING_TRANSPORT_RIDE_TO_PARK_EXIT);
+                            transportRide->formatNameTo(ft);
+                        }
+                        else
+                        {
+                            ft.Add<StringId>(peepFlags.has(PeepFlag::leavingPark) ? STR_LEAVING_PARK : STR_WALKING);
+                        }
                     }
                 }
                 break;
@@ -2308,7 +2328,10 @@ namespace OpenRCT2
         else
         {
             if (guest->guestHeadingToRideId == rideIndex)
+            {
                 guest->guestHeadingToRideId = RideId::GetNull();
+                guest->transportRideNavigation.clear();
+            }
             guest->animationImageIdOffset = _backupAnimationImageIdOffset;
             guest->setState(PeepState::buying);
             guest->currentRide = rideIndex;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1780,6 +1780,11 @@ enum : StringId
 
     STR_CANT_CHANGE_LAND_HEIGHT_HERE = 7043,
 
+    STR_ENABLE_TRANSPORT_RIDE_NAVIGATION = 7044,
+    STR_ENABLE_TRANSPORT_RIDE_NAVIGATION_TIP = 7045,
+    STR_TAKING_TRANSPORT_RIDE_TO_DESTINATION = 7046,
+    STR_TAKING_TRANSPORT_RIDE_TO_PARK_EXIT = 7047,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/management/Marketing.cpp
+++ b/src/openrct2/management/Marketing.cpp
@@ -163,6 +163,7 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaignType)
             peep->voucherType = VOUCHER_TYPE_RIDE_FREE;
             peep->voucherRideId = campaign->rideId;
             peep->guestHeadingToRideId = campaign->rideId;
+            peep->transportRideNavigation.clear();
             peep->guestIsLostCountdown = 240;
             break;
         case ADVERTISING_CAMPAIGN_PARK_ENTRY_HALF_PRICE:
@@ -178,6 +179,7 @@ void MarketingSetGuestCampaign(Guest* peep, int32_t campaignType)
             break;
         case ADVERTISING_CAMPAIGN_RIDE:
             peep->guestHeadingToRideId = campaign->rideId;
+            peep->transportRideNavigation.clear();
             peep->guestIsLostCountdown = 240;
             break;
     }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -47,7 +47,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-constexpr uint8_t kStreamVersion = 4;
+constexpr uint8_t kStreamVersion = 5;
 
 const std::string kStreamID = std::string(kOpenRCT2Version) + "-" + std::to_string(kStreamVersion);
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -17,6 +17,7 @@
 #include "../OpenRCT2.h"
 #include "../ParkImporter.h"
 #include "../Version.h"
+#include "../config/Config.h"
 #include "../core/Console.hpp"
 #include "../core/DataSerialiser.h"
 #include "../core/File.h"
@@ -898,6 +899,10 @@ namespace OpenRCT2
                     cs.readWrite(park.maxBankLoan);
                     cs.readWrite(park.bankLoanInterestRate);
                     cs.readWrite(park.flags.holder);
+                    if (cs.getMode() == OrcaStream::Mode::reading && version < kTransportRideNavigationVersion)
+                    {
+                        park.flags.set(ParkFlag::transportRideNavigation, Config::Get().general.enableTransportRideNavigation);
+                    }
                     if (version <= 18)
                     {
                         money16 tempParkEntranceFee{};
@@ -2316,6 +2321,16 @@ namespace OpenRCT2
         cs.readWrite(guest.guestNextInQueue);
         cs.readWrite(guest.parkEntryTime);
         cs.readWrite(guest.guestHeadingToRideId);
+        if (version >= kTransportRideNavigationVersion)
+        {
+            cs.readWrite(guest.transportRideNavigation.rideId);
+            cs.readWrite(guest.transportRideNavigation.boardingStation);
+            cs.readWrite(guest.transportRideNavigation.alightingStation);
+        }
+        else if (cs.getMode() == OrcaStream::Mode::reading)
+        {
+            guest.transportRideNavigation.clear();
+        }
         cs.readWrite(guest.guestIsLostCountdown);
         cs.readWrite(guest.guestTimeOnRide);
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -19,10 +19,10 @@ namespace OpenRCT2
     struct ObjectRepositoryItem;
 
     // Current version that is saved.
-    constexpr uint32_t kParkFileCurrentVersion = 61;
+    constexpr uint32_t kParkFileCurrentVersion = 62;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t kParkFileMinVersion = 57;
+    constexpr uint32_t kParkFileMinVersion = 62;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!
@@ -61,6 +61,7 @@ namespace OpenRCT2
     constexpr uint16_t kRevertToVanillaFairRidePriceCalculation = 58;
     constexpr uint16_t kParkFileVersionUprightQuarterHelices = 60;
     constexpr uint16_t kExtendedInvertedRollerCoasterVersion = 61;
+    constexpr uint16_t kTransportRideNavigationVersion = 62;
 
     class ParkFileExporter
     {

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -15,6 +15,7 @@
 #include "../entity/Guest.h"
 #include "../entity/Staff.h"
 #include "../profiling/Profiling.h"
+#include "../ride/Ride.h"
 #include "../ride/RideData.h"
 #include "../scenario/Scenario.h"
 #include "../world/Footpath.h"
@@ -40,9 +41,13 @@ namespace OpenRCT2::PathFinding
     static constexpr uint8_t kMaxJunctionsGuestLeavingParkLost = 8;
 
     // Maximum amount of junctions.
-    static constexpr uint8_t kMaxJunctions = std::max(
-        { kMaxJunctionsStaff, kMaxJunctionsGuest, kMaxJunctionsGuestWithMap, kMaxJunctionsGuestLeavingPark,
-          kMaxJunctionsGuestLeavingParkLost });
+    static constexpr uint8_t kMaxJunctions = std::max({ kMaxJunctionsStaff, kMaxJunctionsGuest, kMaxJunctionsGuestWithMap,
+                                                        kMaxJunctionsGuestLeavingPark, kMaxJunctionsGuestLeavingParkLost });
+
+    static constexpr uint8_t kMaxPathfindSteps = 200;
+    static constexpr uint8_t kMaxTransportRidesPerSearch = 2;
+    static constexpr uint8_t kTransportQueueTimeDivisor = 10;
+    static constexpr uint8_t kTransportSegmentTimeDivisor = 3;
 
     struct PathFindingState
     {
@@ -58,6 +63,12 @@ namespace OpenRCT2::PathFinding
             TileCoordsXYZ location;
             Direction direction;
         } history[kMaxJunctions + 1];
+    };
+
+    struct TransportSearchState
+    {
+        GuestTransportRideNavigation firstLeg;
+        uint8_t ridesUsed{};
     };
 
     static int32_t GuestSurfacePathFinding(Peep& peep);
@@ -635,6 +646,87 @@ namespace OpenRCT2::PathFinding
         return xDelta + yDelta + zDelta;
     }
 
+    static bool CanUseRideForTransportNavigation(const Guest& guest, const Ride& ride, StationIndex boardingStation)
+    {
+        const auto& gameState = getGameState();
+        if (!gameState.park.flags.has(ParkFlag::transportRideNavigation) || guest.transportRideNavigation.isActive())
+            return false;
+
+        if (ride.id == guest.guestHeadingToRideId || ride.status != RideStatus::open
+            || ride.flags.hasAny(RideFlag::brokenDown, RideFlag::queueFull)
+            || !ride.getRideTypeDescriptor().flags.has(RtdFlag::isTransportRide))
+        {
+            return false;
+        }
+
+        const auto stations = ride.getStations();
+        if (boardingStation.ToUnderlying() >= stations.size() || stations.size() < 2
+            || stations[boardingStation.ToUnderlying()].Entrance.IsNull())
+        {
+            return false;
+        }
+
+        // Navigation currently treats transport rides like public transit. Restricting
+        // routing to free rides avoids planning a route that could strand a guest.
+        return gameState.park.flags.has(ParkFlag::noMoney) || RideGetPrice(ride) == 0;
+    }
+
+    static std::optional<uint32_t> GetTransportNavigationPenalty(
+        const Guest& guest, const Ride& ride, StationIndex boardingStation, StationIndex alightingStation)
+    {
+        const auto stations = ride.getStations();
+        const auto boardingIndex = boardingStation.ToUnderlying();
+        const auto alightingIndex = alightingStation.ToUnderlying();
+        if (boardingIndex >= stations.size() || alightingIndex >= stations.size() || boardingIndex == alightingIndex)
+            return std::nullopt;
+
+        uint32_t segmentTime = 0;
+        auto currentIndex = boardingIndex;
+        for (size_t stationsVisited = 0; stationsVisited < stations.size(); stationsVisited++)
+        {
+            segmentTime += stations[currentIndex].SegmentTime;
+            currentIndex = (currentIndex + 1) % stations.size();
+            if (currentIndex == alightingIndex)
+                break;
+        }
+        if (currentIndex != alightingIndex)
+            return std::nullopt;
+
+        const uint32_t queuePenalty = stations[boardingIndex].QueueTime / kTransportQueueTimeDivisor;
+        const uint32_t ridePenalty = segmentTime / kTransportSegmentTimeDivisor;
+        const uint32_t unscaledPenalty = std::max<uint32_t>(1, queuePenalty + ridePenalty);
+
+        // The same wait represents more walkable distance to an energetic guest and
+        // less to a tired guest, so energy naturally influences the route choice.
+        const uint32_t energy = std::clamp<uint32_t>(guest.energy, 32, 128);
+        const uint32_t penalty = std::max<uint32_t>(1, (unscaledPenalty * energy + 95) / 96);
+        return penalty;
+    }
+
+    static bool IsTransportNavigationValid(const Guest& guest)
+    {
+        const auto& navigation = guest.transportRideNavigation;
+        const auto& gameState = getGameState();
+        if (!navigation.isActive() || !gameState.park.flags.has(ParkFlag::transportRideNavigation))
+        {
+            return false;
+        }
+
+        const auto* ride = GetRide(navigation.rideId);
+        if (ride == nullptr || ride->status != RideStatus::open || ride->flags.hasAny(RideFlag::brokenDown, RideFlag::queueFull)
+            || !ride->getRideTypeDescriptor().flags.has(RtdFlag::isTransportRide)
+            || (!gameState.park.flags.has(ParkFlag::noMoney) && RideGetPrice(*ride) != 0))
+        {
+            return false;
+        }
+
+        const auto stations = ride->getStations();
+        const auto boardingIndex = navigation.boardingStation.ToUnderlying();
+        const auto alightingIndex = navigation.alightingStation.ToUnderlying();
+        return boardingIndex < stations.size() && alightingIndex < stations.size() && boardingIndex != alightingIndex
+            && !stations[boardingIndex].Entrance.IsNull() && !stations[alightingIndex].Exit.IsNull();
+    }
+
     /**
      * Searches for the tile with the best heuristic score within the search limits
      * starting from the given tile x,y,z and going in the given direction test_edge.
@@ -643,48 +735,58 @@ namespace OpenRCT2::PathFinding
      * (junctions passed through and directions taken).
      *
      * The primary heuristic used is distance from the goal; the secondary
-     * heuristic used (when the primary heuristic gives equal scores) is the number
-     * of steps. i.e. the search gets as close as possible to the goal in as few
-     * steps as possible.
+     * heuristic used (when the primary heuristic
+     * gives equal scores) is route
+     * cost. The search gets as close as possible to the goal with as little
+     * walking,
+     * queuing, and travel time as possible.
      *
      * Each tile is checked to determine if the goal is reached.
-     * When the goal is not reached the search result is only updated at the END
-     * of each search path (some map element that is not a path or a path at which
+     * When
+     * the goal is not reached the search result is only updated at the END
+     * of each search path (some map element that is
+     * not a path or a path at which
      * a search limit is reached), NOT at each step along the way.
-     * This means that the search ignores thin paths that are "no through paths"
-     * no matter how close to the goal they get, but will follow possible "through
+     * This means that
+     * the search ignores thin paths that are "no through paths"
+     * no matter how close to the goal they get, but will
+     * follow possible "through
      * paths".
      *
-     * The implementation is a depth first search of the path layout in xyz
+     * The implementation is a depth first search of the path layout in
+     * xyz
      * according to the search limits.
      * Unlike an A* search, which tracks for each tile a heuristic score (a
-     * function of the xyz distances to the goal) and cost of reaching that tile
-     * (steps to the tile), a single best result "so far" (best heuristic score
-     * with least cost) is tracked via the score parameter.
-     * With this approach, explicit loop detection is necessary to limit the
-     * search space, and each alternate route through the same tile can be
-     * returned as the best result, rather than only the shortest route with A*.
+
+     * * function of the xyz distances to the goal) and cost of reaching that tile (steps to the tile), a single best result "so
+     * far" (best heuristic score with least cost) is tracked via the score parameter. With this approach, explicit loop
+     * detection is necessary to limit the search space, and each alternate route through the same tile can be returned as the
+     * best result, rather than only the shortest route with A*.
      *
      * The parameters that hold the best search result so far are:
      *   - score - the least heuristic distance from the goal
-     *   - endSteps - the least number of steps that achieve the score.
+     *   - endPathCost - the lowest walking and transport cost that achieves the score.
      *
      * The following parameters provide telemetry information on best search path so far:
      *   - endXYZ tracks the end location of the search path.
-     *   - endSteps tracks the number of steps to the end of the search path.
-     *   - endJunctions tracks the number of junctions passed through in the
+     *   - endPathCost tracks the walking and transport cost to the end of the search path.
+     *   - endJunctions tracks the
+     * number of junctions passed through in the
      *     search path.
-     *   - junctionList[] and directionList[] track the junctions and
+     *   - junctionList[] and directionList[] track the
+     * junctions and
      *     corresponding directions of the search path.
-     * Other than debugging purposes, these could potentially be used to visualise
+     * Other than debugging purposes, these could
+     * potentially be used to visualise
      * the pathfinding on the map.
-     *
-     * The parameters/variables that limit the search space are:
-     *   - counter (param) - number of steps walked in the current search path;
-     *   - _peepPathFindTilesChecked (variable) - cumulative number of tiles that can be
+     * The parameters/variables that limit the search
+     * space are:
+     *   - numSteps (param) - number of steps walked in the current search path;
+     *   - _peepPathFindTilesChecked (variable)
+     * - cumulative number of tiles that can be
      *     checked in the entire search;
-     *   - _peepPathFindNumJunctions (variable) - number of thin junctions that can be
-     *     checked in a single search path;
+     *   - _peepPathFindNumJunctions
+     * (variable) - number of thin junctions that can be checked in a single search path;
      *
      * Other global variables/state that affect the search space are:
      *   - Wide paths - to handle broad paths (> 1 tile wide), the search navigates
@@ -713,13 +815,15 @@ namespace OpenRCT2::PathFinding
      */
     static void PeepPathfindHeuristicSearch(
         PathFindingState& state, TileCoordsXYZ loc, const TileCoordsXYZ& goal, const Peep& peep,
-        TileElement* currentTileElement, const bool inPatrolArea, uint8_t numSteps, uint16_t* endScore, Direction testEdge,
-        uint8_t* endJunctions, TileCoordsXYZ junctionList[16], uint8_t directionList[16], TileCoordsXYZ* endXYZ,
-        uint8_t* endSteps)
+        TileElement* currentTileElement, const bool inPatrolArea, uint8_t numSteps, uint32_t pathCost, uint16_t* endScore,
+        Direction testEdge, uint8_t* endJunctions, TileCoordsXYZ junctionList[16], uint8_t directionList[16],
+        TileCoordsXYZ* endXYZ, uint32_t* endPathCost, TransportSearchState& transportState)
     {
+        const auto previousTransportState = transportState;
         PathSearchResult searchResult = PathSearchResult::failed;
 
-        bool currentElementIsWide = currentTileElement->asPath()->isWide();
+        const auto* currentPathElement = currentTileElement->asPath();
+        bool currentElementIsWide = currentPathElement != nullptr && currentPathElement->isWide();
         if (currentElementIsWide)
         {
             const Staff* staff = peep.as<Staff>();
@@ -730,6 +834,7 @@ namespace OpenRCT2::PathFinding
         loc += TileDirectionDelta[testEdge];
 
         ++numSteps;
+        ++pathCost;
         state.countTilesChecked--;
 
         /* If this is where the search started this is a search loop and the
@@ -806,11 +911,61 @@ namespace OpenRCT2::PathFinding
                             direction = tileElement->getDirection();
                             if (direction == testEdge)
                             {
-                                /* The rideIndex will be useful for
-                                 * adding transport rides later. */
                                 rideIndex = tileElement->asEntrance()->getRideIndex();
                                 searchResult = PathSearchResult::rideEntrance;
                                 found = true;
+
+                                const auto* guest = peep.as<Guest>();
+                                auto* ride = GetRide(rideIndex);
+                                const auto boardingStation = tileElement->asEntrance()->getStationIndex();
+                                if (guest != nullptr && ride != nullptr
+                                    && previousTransportState.ridesUsed < kMaxTransportRidesPerSearch
+                                    && (previousTransportState.ridesUsed == 0
+                                        || previousTransportState.firstLeg.rideId != rideIndex)
+                                    && CanUseRideForTransportNavigation(*guest, *ride, boardingStation))
+                                {
+                                    const auto transportAtEntrance = previousTransportState;
+                                    for (const auto& station : ride->getStations())
+                                    {
+                                        const auto alightingStation = ride->getStationIndex(&station);
+                                        if (alightingStation == boardingStation || station.Exit.IsNull())
+                                            continue;
+
+                                        const auto penalty = GetTransportNavigationPenalty(
+                                            *guest, *ride, boardingStation, alightingStation);
+                                        if (!penalty.has_value())
+                                            continue;
+
+                                        auto* exitElement = RideGetStationExitElement(station.Exit.ToCoordsXYZ());
+                                        if (exitElement == nullptr)
+                                            continue;
+
+                                        auto branchTransportState = transportAtEntrance;
+                                        if (branchTransportState.ridesUsed == 0)
+                                        {
+                                            branchTransportState.firstLeg.rideId = rideIndex;
+                                            branchTransportState.firstLeg.boardingStation = boardingStation;
+                                            branchTransportState.firstLeg.alightingStation = alightingStation;
+                                        }
+                                        branchTransportState.ridesUsed++;
+
+                                        const auto scoreBeforeTransport = *endScore;
+                                        const auto costBeforeTransport = *endPathCost;
+                                        const auto savedJunctionCount = state.junctionCount;
+                                        PeepPathfindHeuristicSearch(
+                                            state, TileCoordsXYZ{ station.Exit }, goal, peep, exitElement, nextInPatrolArea,
+                                            numSteps, pathCost + penalty.value(), endScore,
+                                            DirectionReverse(station.Exit.direction), endJunctions, junctionList, directionList,
+                                            endXYZ, endPathCost, branchTransportState);
+                                        state.junctionCount = savedJunctionCount;
+
+                                        if (*endScore < scoreBeforeTransport
+                                            || (*endScore == scoreBeforeTransport && *endPathCost < costBeforeTransport))
+                                        {
+                                            transportState = branchTransportState;
+                                        }
+                                    }
+                                }
                                 break;
                             }
                             continue; // Ride entrance is not facing the right direction.
@@ -910,11 +1065,11 @@ namespace OpenRCT2::PathFinding
             {
                 /* If the search result is better than the best so far (in the parameters),
                  * then update the parameters with this search before continuing to the next map element. */
-                if (newScore < *endScore || (newScore == *endScore && numSteps < *endSteps))
+                if (newScore < *endScore || (newScore == *endScore && pathCost < *endPathCost))
                 {
                     // Update the search results
                     *endScore = newScore;
-                    *endSteps = numSteps;
+                    *endPathCost = pathCost;
                     // Update the end x,y,z
                     *endXYZ = loc;
                     // Update the telemetry
@@ -938,8 +1093,11 @@ namespace OpenRCT2::PathFinding
 
             /* If this map element is not a path, the search cannot be continued.
              * Continue to the next map element without updating the parameters (best result so far). */
+            const bool canSearchTransportQueue = searchResult == PathSearchResult::rideQueue && peep.is<Guest>()
+                && getGameState().park.flags.has(ParkFlag::transportRideNavigation);
             if (searchResult != PathSearchResult::deadEnd && searchResult != PathSearchResult::thin
-                && searchResult != PathSearchResult::junction && searchResult != PathSearchResult::wide)
+                && searchResult != PathSearchResult::junction && searchResult != PathSearchResult::wide
+                && !canSearchTransportQueue)
             {
                 LogPathfinding(
                     &peep, "Search path ends at %d,%d,%d; Steps: %u; Not a path", loc.x >> 5, loc.y >> 5, loc.z, numSteps);
@@ -961,11 +1119,11 @@ namespace OpenRCT2::PathFinding
                  * If the search result is better than the best so far
                  * (in the parameters), then update the parameters with
                  * this search before continuing to the next map element. */
-                if (currentElementIsWide && (newScore < *endScore || (newScore == *endScore && numSteps < *endSteps)))
+                if (currentElementIsWide && (newScore < *endScore || (newScore == *endScore && pathCost < *endPathCost)))
                 {
                     // Update the search results
                     *endScore = newScore;
-                    *endSteps = numSteps;
+                    *endPathCost = pathCost;
                     // Update the end x,y,z
                     *endXYZ = loc;
                     // Update the telemetry
@@ -1012,17 +1170,17 @@ namespace OpenRCT2::PathFinding
 
             /* Check if either of the search limits has been reached:
              * - max number of steps or max tiles checked. */
-            if (numSteps >= 200 || state.countTilesChecked <= 0)
+            if (numSteps >= kMaxPathfindSteps || state.countTilesChecked <= 0)
             {
                 /* The current search ends here.
                  * The path continues, so the goal could still be reachable from here.
                  * If the search result is better than the best so far (in the parameters),
                  * then update the parameters with this search before continuing to the next map element. */
-                if (newScore < *endScore || (newScore == *endScore && numSteps < *endSteps))
+                if (newScore < *endScore || (newScore == *endScore && pathCost < *endPathCost))
                 {
                     // Update the search results
                     *endScore = newScore;
-                    *endSteps = numSteps;
+                    *endPathCost = pathCost;
                     // Update the end x,y,z
                     *endXYZ = loc;
                     // Update the telemetry
@@ -1116,11 +1274,11 @@ namespace OpenRCT2::PathFinding
                      * then update the parameters with this search before continuing to the next map element. */
                     if (state.junctionCount <= 0)
                     {
-                        if (newScore < *endScore || (newScore == *endScore && numSteps < *endSteps))
+                        if (newScore < *endScore || (newScore == *endScore && pathCost < *endPathCost))
                         {
                             // Update the search results
                             *endScore = newScore;
-                            *endSteps = numSteps;
+                            *endPathCost = pathCost;
                             // Update the end x,y,z
                             *endXYZ = loc;
                             // Update the telemetry
@@ -1187,10 +1345,18 @@ namespace OpenRCT2::PathFinding
                     state.history[state.junctionCount + 1].direction = nextTestEdge;
                 }
 
+                auto branchTransportState = previousTransportState;
+                const auto scoreBeforeBranch = *endScore;
+                const auto costBeforeBranch = *endPathCost;
                 PeepPathfindHeuristicSearch(
-                    state, { loc.x, loc.y, height }, goal, peep, tileElement, nextInPatrolArea, numSteps, endScore,
-                    nextTestEdge, endJunctions, junctionList, directionList, endXYZ, endSteps);
+                    state, { loc.x, loc.y, height }, goal, peep, tileElement, nextInPatrolArea, numSteps, pathCost, endScore,
+                    nextTestEdge, endJunctions, junctionList, directionList, endXYZ, endPathCost, branchTransportState);
                 state.junctionCount = savedNumJunctions;
+
+                if (*endScore < scoreBeforeBranch || (*endScore == scoreBeforeBranch && *endPathCost < costBeforeBranch))
+                {
+                    transportState = branchTransportState;
+                }
 
                 LogPathfinding(
                     &peep, "Returned to %d,%d,%d; Steps: %u; edge: %d; Score: %d", loc.x >> 5, loc.y >> 5, loc.z, numSteps,
@@ -1378,7 +1544,8 @@ namespace OpenRCT2::PathFinding
             TileCoordsXYZ bestXYZ;
 
             uint16_t bestScore = 0xFFFF;
-            uint8_t bestSub = 0xFF;
+            uint32_t bestPathCost = std::numeric_limits<uint32_t>::max();
+            TransportSearchState bestTransportState;
 
             LogPathfinding(
                 &peep, "Pathfind start for goal %d,%d,%d from %d,%d,%d", goal.x, goal.y, goal.z, loc.x, loc.y, loc.z);
@@ -1386,7 +1553,7 @@ namespace OpenRCT2::PathFinding
             /* Call the search heuristic on each edge, keeping track of the
              * edge that gives the best (i.e. smallest) value (best_score)
              * or for different edges with equal value, the edge with the
-             * least steps (best_sub). */
+             * lowest route cost. */
             int32_t numEdges = std::popcount(edges);
             for (int32_t testEdge = chosenEdge; testEdge != -1; testEdge = Numerics::bitScanForward(edges))
             {
@@ -1426,7 +1593,7 @@ namespace OpenRCT2::PathFinding
                 endXYZ.y = 0;
                 endXYZ.z = 0;
 
-                uint8_t endSteps = 255;
+                uint32_t endPathCost = std::numeric_limits<uint32_t>::max();
 
                 /* Variable endJunctions is the number of junctions
                  * passed through in the search path.
@@ -1438,6 +1605,7 @@ namespace OpenRCT2::PathFinding
                 uint8_t endJunctions = 0;
                 TileCoordsXYZ endJunctionList[16];
                 uint8_t endDirectionList[16] = { 0 };
+                TransportSearchState transportState;
 
                 bool inPatrolArea = false;
                 auto* staff = peep.as<Staff>();
@@ -1453,14 +1621,14 @@ namespace OpenRCT2::PathFinding
                     &peep, "Pathfind searching in direction: %d from %d,%d,%d", testEdge, loc.x >> 5, loc.y >> 5, loc.z);
 
                 PeepPathfindHeuristicSearch(
-                    state, { loc.x, loc.y, height }, goal, peep, firstTileElement, inPatrolArea, 0, &score, testEdge,
-                    &endJunctions, endJunctionList, endDirectionList, &endXYZ, &endSteps);
+                    state, { loc.x, loc.y, height }, goal, peep, firstTileElement, inPatrolArea, 0, 0, &score, testEdge,
+                    &endJunctions, endJunctionList, endDirectionList, &endXYZ, &endPathCost, transportState);
 
                 if constexpr (kLogPathfinding)
                 {
                     LogPathfinding(
-                        &peep, "Pathfind test edge: %d score: %d steps: %d end: %d,%d,%d junctions: %d", testEdge, score,
-                        endSteps, endXYZ.x, endXYZ.y, endXYZ.z, endJunctions);
+                        &peep, "Pathfind test edge: %d score: %d cost: %u end: %d,%d,%d junctions: %d", testEdge, score,
+                        endPathCost, endXYZ.x, endXYZ.y, endXYZ.z, endJunctions);
                     for (uint8_t listIdx = 0; listIdx < endJunctions; listIdx++)
                     {
                         LogPathfinding(
@@ -1469,11 +1637,12 @@ namespace OpenRCT2::PathFinding
                     }
                 }
 
-                if (score < bestScore || (score == bestScore && endSteps < bestSub))
+                if (score < bestScore || (score == bestScore && endPathCost < bestPathCost))
                 {
                     chosenEdge = testEdge;
                     bestScore = score;
-                    bestSub = endSteps;
+                    bestPathCost = endPathCost;
+                    bestTransportState = transportState;
 
                     if constexpr (kLogPathfinding)
                     {
@@ -1501,9 +1670,14 @@ namespace OpenRCT2::PathFinding
                 return kInvalidDirection;
             }
 
+            if (auto* guest = peep.as<Guest>(); guest != nullptr && bestTransportState.firstLeg.isActive())
+            {
+                guest->transportRideNavigation = bestTransportState.firstLeg;
+            }
+
             if constexpr (kLogPathfinding)
             {
-                LogPathfinding(&peep, "Pathfind best edge %d with score %d steps %d", chosenEdge, bestScore, bestSub);
+                LogPathfinding(&peep, "Pathfind best edge %d with score %d cost %u", chosenEdge, bestScore, bestPathCost);
                 for (uint8_t listIdx = 0; listIdx < bestJunctions; listIdx++)
                 {
                     LogPathfinding(
@@ -1830,6 +2004,45 @@ namespace OpenRCT2::PathFinding
         loc.z = tileElement->baseHeight;
     }
 
+    static std::optional<int32_t> GuestPathfindToTransportRide(Guest& peep, bool preserveUltimateGoal)
+    {
+        if (!peep.transportRideNavigation.isActive())
+            return std::nullopt;
+
+        if (IsTransportNavigationValid(peep))
+        {
+            const auto ultimateGoal = peep.pathfindGoal;
+            const auto ultimateHistory = peep.pathfindHistory;
+
+            const auto* transportRide = GetRide(peep.transportRideNavigation.rideId);
+            const auto& boardingStation = transportRide->getStation(peep.transportRideNavigation.boardingStation);
+            TileCoordsXYZ boardingGoal = boardingStation.Entrance;
+            GetRideQueueEnd(boardingGoal);
+
+            const auto direction = ChooseDirection(
+                TileCoordsXYZ{ peep.nextLoc }, boardingGoal, peep, true, peep.transportRideNavigation.rideId);
+
+            if (preserveUltimateGoal)
+            {
+                peep.pathfindGoal = ultimateGoal;
+                peep.pathfindHistory = ultimateHistory;
+            }
+
+            if (direction != kInvalidDirection)
+            {
+                LogPathfinding(&peep, "Completed CalculateNextDestination - heading for transport ride: %d.", direction);
+                return PeepMoveOneTile(direction, peep);
+            }
+        }
+
+        peep.transportRideNavigation.clear();
+        if (!preserveUltimateGoal)
+        {
+            peep.resetPathfindGoal();
+        }
+        return std::nullopt;
+    }
+
     /*
      * If a ride has multiple entrance stations and is set to sync with
      * adjacent stations, cycle through the entrance stations (based on
@@ -2017,6 +2230,11 @@ namespace OpenRCT2::PathFinding
 
         if (peep.peepFlags.has(PeepFlag::leavingPark))
         {
+            if (const auto transportDirection = GuestPathfindToTransportRide(peep, true); transportDirection.has_value())
+            {
+                return transportDirection.value();
+            }
+
             LogPathfinding(&peep, "Completed CalculateNextDestination - peep is leaving the park.");
 
             return GuestPathFindParkEntranceLeaving(peep, edges);
@@ -2024,6 +2242,7 @@ namespace OpenRCT2::PathFinding
 
         if (peep.guestHeadingToRideId.IsNull())
         {
+            peep.transportRideNavigation.clear();
             LogPathfinding(&peep, "Completed CalculateNextDestination - peep is aimless.");
 
             return GuestPathfindAimless(peep, edges);
@@ -2034,14 +2253,20 @@ namespace OpenRCT2::PathFinding
         auto ride = GetRide(rideIndex);
         if (ride == nullptr || ride->status != RideStatus::open)
         {
+            peep.transportRideNavigation.clear();
             LogPathfinding(&peep, "Completed CalculateNextDestination - peep is heading to closed ride == aimless.");
 
             return GuestPathfindAimless(peep, edges);
         }
 
+        if (const auto transportDirection = GuestPathfindToTransportRide(peep, false); transportDirection.has_value())
+        {
+            return transportDirection.value();
+        }
+
         /* Find the ride's closest entrance station to the peep.
-         * At the same time, count how many entrance stations there are and
-         * which stations are entrance stations. */
+         * At the same time, count how many entrance stations
+         * there are and which stations are entrance stations. */
         auto bestScore = std::numeric_limits<int32_t>::max();
         StationIndex closestStationNum = StationIndex::FromUnderlying(0);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -13,6 +13,7 @@
 #include "../GameState.h"
 #include "../ParkImporter.h"
 #include "../audio/Audio.h"
+#include "../config/Config.h"
 #include "../core/BitSet.hpp"
 #include "../core/Console.hpp"
 #include "../core/FileStream.h"
@@ -2305,6 +2306,7 @@ namespace OpenRCT2::RCT1
 
             // Flags
             park.flags.holder = _s4.parkFlags.without(ParkFlag::antiCheatDeprecated).holder;
+            park.flags.set(OpenRCT2ParkFlag::transportRideNavigation, Config::Get().general.enableTransportRideNavigation);
             park.flags.set(OpenRCT2ParkFlag::rct1Interest);
             // Loopy Landscape parks can set a flag to lock the entry price to free.
             // If this flag is not set, the player can ask money for both rides and entry.
@@ -2990,6 +2992,7 @@ namespace OpenRCT2::RCT1
         dst->previousRide = RCT12RideIdToOpenRCT2RideId(src->PreviousRide);
         dst->previousRideTimeOut = src->PreviousRideTimeOut;
         dst->guestHeadingToRideId = RCT12RideIdToOpenRCT2RideId(src->GuestHeadingToRideID);
+        dst->transportRideNavigation.clear();
         dst->guestIsLostCountdown = src->PeepIsLostCountdown;
         dst->guestNextInQueue = EntityId::FromUnderlying(src->NextInQueue);
         // Guests' favourite ride was only saved in LL.

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -12,6 +12,7 @@
 #include "../Game.h"
 #include "../GameState.h"
 #include "../ParkImporter.h"
+#include "../config/Config.h"
 #include "../core/FileStream.h"
 #include "../core/Path.hpp"
 #include "../core/String.hpp"
@@ -376,6 +377,7 @@ namespace OpenRCT2::RCT2
             park.bankLoan = ToMoney64(_s6.CurrentLoan);
 
             park.flags.holder = _s6.ParkFlags;
+            park.flags.set(ParkFlag::transportRideNavigation, Config::Get().general.enableTransportRideNavigation);
             auto hadNoMoneyScenarioFlag = park.flags.has(ParkFlag::noMoneyScenario);
             park.flags.unset(ParkFlag::noMoneyScenario);
 
@@ -2151,6 +2153,7 @@ namespace OpenRCT2::RCT2
             dstThought->fresh_timeout = srcThought->FreshTimeout;
         }
         dst->guestHeadingToRideId = RCT12RideIdToOpenRCT2RideId(src->GuestHeadingToRideId);
+        dst->transportRideNavigation.clear();
         dst->guestIsLostCountdown = src->PeepIsLostCountdown;
         dst->litterCount = src->LitterCount;
         dst->guestTimeOnRide = src->TimeOnRide;

--- a/src/openrct2/ride/Vehicle.Station.cpp
+++ b/src/openrct2/ride/Vehicle.Station.cpp
@@ -42,6 +42,62 @@ static SynchronisedVehicle _synchronisedVehicles[kSynchronisedVehicleCount] = {}
 
 static SynchronisedVehicle* _lastSynchronisedVehicle = nullptr;
 
+static bool GuestShouldStayOnTransportRide(const Guest& guest, const Ride& ride, StationIndex currentStation)
+{
+    const auto& navigation = guest.transportRideNavigation;
+    const auto& gameState = getGameState();
+    if (!gameState.park.flags.has(ParkFlag::transportRideNavigation) || !navigation.isActive() || navigation.rideId != ride.id
+        || ride.status != RideStatus::open || ride.flags.has(RideFlag::brokenDown)
+        || !ride.getRideTypeDescriptor().flags.has(RtdFlag::isTransportRide))
+    {
+        return false;
+    }
+
+    const auto alightingIndex = navigation.alightingStation.ToUnderlying();
+    const auto stations = ride.getStations();
+    return alightingIndex < stations.size() && !stations[alightingIndex].Exit.IsNull()
+        && currentStation != navigation.alightingStation;
+}
+
+static void PreparePassengersForUnloading(Vehicle& vehicle, const Ride& ride, StationIndex currentStation)
+{
+    static constexpr size_t kMaxPassengersPerVehicle = 32;
+    std::array<EntityId, kMaxPassengersPerVehicle> orderedPeeps;
+    std::array<Drawing::Colour, kMaxPassengersPerVehicle> orderedColours;
+
+    uint8_t writeIndex = 0;
+    uint8_t stayingGuests = 0;
+    for (const bool selectStayingGuests : { true, false })
+    {
+        for (uint8_t peepIndex = 0; peepIndex < vehicle.num_peeps; peepIndex++)
+        {
+            auto* guest = getGameState().entities.getEntity<Guest>(vehicle.peep[peepIndex]);
+            const bool shouldStay = guest != nullptr && GuestShouldStayOnTransportRide(*guest, ride, currentStation);
+            if (shouldStay != selectStayingGuests)
+                continue;
+
+            orderedPeeps[writeIndex] = vehicle.peep[peepIndex];
+            orderedColours[writeIndex] = vehicle.peep_tshirt_colours[peepIndex];
+            if (guest != nullptr)
+            {
+                guest->currentSeat = writeIndex;
+                if (!shouldStay)
+                {
+                    guest->setState(PeepState::leavingRide);
+                    guest->rideSubState = PeepRideSubState::leaveVehicle;
+                }
+            }
+            writeIndex++;
+        }
+        if (selectStayingGuests)
+            stayingGuests = writeIndex;
+    }
+
+    std::copy_n(orderedPeeps.begin(), writeIndex, std::begin(vehicle.peep));
+    std::copy_n(orderedColours.begin(), writeIndex, std::begin(vehicle.peep_tshirt_colours));
+    vehicle.next_free_seat = stayingGuests;
+}
+
 /**
  * Checks if a map position contains a synchronised ride station and adds the vehicle
  * to synchronise to the vehicle synchronisation list.
@@ -973,16 +1029,7 @@ void Vehicle::UpdateUnloadingPassengers()
             if (train->next_free_seat == 0)
                 continue;
 
-            train->next_free_seat = 0;
-            for (uint8_t peepIndex = 0; peepIndex < train->num_peeps; peepIndex++)
-            {
-                Peep* curPeep = getGameState().entities.getEntity<Guest>(train->peep[peepIndex]);
-                if (curPeep != nullptr)
-                {
-                    curPeep->setState(PeepState::leavingRide);
-                    curPeep->rideSubState = PeepRideSubState::leaveVehicle;
-                }
-            }
+            PreparePassengersForUnloading(*train, *curRide, current_station);
         }
     }
 

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -15,6 +15,7 @@
 #include "../GameState.h"
 #include "../actions/GameActionRunner.h"
 #include "../actions/park/ParkSetParameterAction.h"
+#include "../config/Config.h"
 #include "../core/String.hpp"
 #include "../entity/EntityList.h"
 #include "../entity/Litter.h"
@@ -302,6 +303,7 @@ namespace OpenRCT2::Park
         gameState.scenarioOptions.landPrice = 90.00_GBP;
         gameState.scenarioOptions.constructionRightsPrice = 40.00_GBP;
         park.flags = { ParkFlag::noMoney, ParkFlag::showRealGuestNames };
+        park.flags.set(ParkFlag::transportRideNavigation, Config::Get().general.enableTransportRideNavigation);
 
         ResetHistories(park);
         FinanceResetHistory();

--- a/src/openrct2/world/ParkData.h
+++ b/src/openrct2/world/ParkData.h
@@ -56,8 +56,9 @@ enum class ParkFlag : uint32_t
     spritesInitialised = 18,            // After a scenario is loaded this prevents edits in the scenario editor
     sixFlagsDeprecated = 19,            // Not used anymore
 
-    rct1Interest = 30,    // OpenRCT2 only
-    unlockAllPrices = 31, // OpenRCT2 only
+    rct1Interest = 30,            // OpenRCT2 only
+    unlockAllPrices = 31,         // OpenRCT2 only
+    transportRideNavigation = 32, // OpenRCT2 only
 };
 using ParkFlags = FlagHolder<uint64_t, ParkFlag>;
 

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -25,10 +25,12 @@
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/EntityTweener.h>
+#include <openrct2/entity/Guest.h>
 #include <openrct2/entity/Peep.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/ride/RideManager.hpp>
+#include <openrct2/ride/Vehicle.h>
 #include <openrct2/world/MapAnimation.h>
 #include <openrct2/world/Park.h>
 #include <string>
@@ -210,4 +212,104 @@ TEST_F(PlayTests, CarRideWithOneCarOnlyAcceptsTwoGuests)
         ASSERT_LE(numRiding, 2);
         gameStateUpdateLogic();
     }
+}
+
+TEST_F(PlayTests, GuestCanBoardPairedTransportCarBesideThroughPassenger)
+{
+    auto context = localStartGame(TestData::GetParkPath("BigMapTest.sv6"));
+    ASSERT_NE(context.get(), nullptr);
+
+    auto& gameState = getGameState();
+    auto rideManager = RideManager(gameState);
+    auto rideIt = std::find_if(
+        rideManager.begin(), rideManager.end(), [](const auto& ride) { return ride.type == RIDE_TYPE_MINIATURE_RAILWAY; });
+    ASSERT_NE(rideIt, rideManager.end());
+    auto& ride = *rideIt;
+
+    Vehicle* pairedCar = nullptr;
+    uint8_t trainIndex = 0;
+    uint8_t carIndex = 0;
+    for (; trainIndex < ride.numTrains && pairedCar == nullptr; trainIndex++)
+    {
+        uint8_t candidateCarIndex = 0;
+        for (auto* car = gameState.entities.getEntity<Vehicle>(ride.vehicles[trainIndex]); car != nullptr;
+             car = gameState.entities.getEntity<Vehicle>(car->next_vehicle_on_train), candidateCarIndex++)
+        {
+            if (car->IsUsedInPairs() && (car->num_seats & kVehicleSeatNumMask) >= 2 && car->num_peeps == 0)
+            {
+                pairedCar = car;
+                carIndex = candidateCarIndex;
+                break;
+            }
+        }
+    }
+    ASSERT_NE(pairedCar, nullptr);
+    trainIndex--;
+
+    auto* throughPassenger = Park::GenerateGuest();
+    auto* boardingGuest = Park::GenerateGuest();
+    ASSERT_NE(throughPassenger, nullptr);
+    ASSERT_NE(boardingGuest, nullptr);
+
+    throughPassenger->currentRide = ride.id;
+    throughPassenger->currentTrain = trainIndex;
+    throughPassenger->currentCar = carIndex;
+    throughPassenger->currentSeat = 0;
+    throughPassenger->setState(PeepState::onRide);
+    throughPassenger->rideSubState = PeepRideSubState::onRide;
+
+    boardingGuest->currentRide = ride.id;
+    boardingGuest->currentTrain = trainIndex;
+    boardingGuest->currentCar = carIndex;
+    boardingGuest->currentSeat = 1;
+    boardingGuest->setState(PeepState::enteringRide);
+    boardingGuest->rideSubState = PeepRideSubState::enterVehicle;
+    boardingGuest->stepProgress = 255;
+
+    pairedCar->peep[0] = throughPassenger->id;
+    pairedCar->peep[1] = boardingGuest->id;
+    pairedCar->num_peeps = 1;
+    pairedCar->next_free_seat = 2;
+
+    boardingGuest->update();
+
+    EXPECT_EQ(pairedCar->num_peeps, 2);
+    EXPECT_EQ(throughPassenger->state, PeepState::onRide);
+    EXPECT_EQ(throughPassenger->rideSubState, PeepRideSubState::onRide);
+    EXPECT_EQ(boardingGuest->state, PeepState::onRide);
+    EXPECT_EQ(boardingGuest->rideSubState, PeepRideSubState::onRide);
+}
+
+TEST_F(PlayTests, TransportTripToParkExitPreservesChosenEntrance)
+{
+    auto context = localStartGame(TestData::GetParkPath("BigMapTest.sv6"));
+    ASSERT_NE(context.get(), nullptr);
+
+    auto& gameState = getGameState();
+    auto rideManager = RideManager(gameState);
+    auto rideIt = std::find_if(
+        rideManager.begin(), rideManager.end(), [](const auto& ride) { return ride.type == RIDE_TYPE_MINIATURE_RAILWAY; });
+    ASSERT_NE(rideIt, rideManager.end());
+    auto& ride = *rideIt;
+
+    auto* guest = Park::GenerateGuest();
+    ASSERT_NE(guest, nullptr);
+
+    const TileCoordsXYZ expectedGoal{ 12, 34, 6 };
+    guest->peepFlags.set(PeepFlag::leavingPark);
+    guest->peepFlags.set(PeepFlag::parkEntranceChosen);
+    guest->pathfindGoal = { expectedGoal, 2 };
+    guest->pathfindHistory[0] = { TileCoordsXYZ{ 3, 4, 5 }, 1 };
+    guest->transportRideNavigation = { ride.id, StationIndex::FromUnderlying(0), StationIndex::FromUnderlying(1) };
+
+    guest->onExitRide(ride);
+
+    EXPECT_FALSE(guest->transportRideNavigation.isActive());
+    EXPECT_TRUE(guest->peepFlags.has(PeepFlag::parkEntranceChosen));
+    EXPECT_EQ(guest->pathfindGoal.x, expectedGoal.x);
+    EXPECT_EQ(guest->pathfindGoal.y, expectedGoal.y);
+    EXPECT_EQ(guest->pathfindGoal.z, expectedGoal.z);
+    EXPECT_EQ(guest->pathfindGoal.direction, kInvalidDirection);
+    EXPECT_TRUE(std::all_of(
+        guest->pathfindHistory.begin(), guest->pathfindHistory.end(), [](const auto& location) { return location.IsNull(); }));
 }

--- a/test/tests/ReplayTests.cpp
+++ b/test/tests/ReplayTests.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/ReplayManager.h>
+#include <openrct2/config/Config.h>
 #include <openrct2/core/FileScanner.h>
 #include <openrct2/core/Path.hpp>
 #include <openrct2/core/String.hpp>
@@ -65,6 +66,25 @@ static std::vector<ReplayTestData> GetReplayFiles()
 class ReplayTests : public testing::TestWithParam<ReplayTestData>
 {
 protected:
+    void EnableTransportRideNavigationDefault()
+    {
+        auto& value = Config::Get().general.enableTransportRideNavigation;
+        _originalTransportRideNavigationDefault = value;
+        value = true;
+        _transportRideNavigationDefaultChanged = true;
+    }
+
+    void TearDown() override
+    {
+        if (_transportRideNavigationDefaultChanged)
+        {
+            Config::Get().general.enableTransportRideNavigation = _originalTransportRideNavigationDefault;
+        }
+    }
+
+private:
+    bool _originalTransportRideNavigationDefault = false;
+    bool _transportRideNavigationDefaultChanged = false;
 };
 
 TEST_P(ReplayTests, RunReplay)
@@ -78,6 +98,7 @@ TEST_P(ReplayTests, RunReplay)
     auto context = CreateContext();
     bool initialised = context->Initialise();
     ASSERT_TRUE(initialised);
+    EnableTransportRideNavigationDefault();
 
     IReplayManager* replayManager = context->GetReplayManager();
     ASSERT_NE(replayManager, nullptr);

--- a/test/tests/S6ImportExportTests.cpp
+++ b/test/tests/S6ImportExportTests.cpp
@@ -22,8 +22,10 @@
 #include <openrct2/core/MemoryStream.h>
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
+#include <openrct2/entity/EntityList.h>
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/EntityTweener.h>
+#include <openrct2/entity/Guest.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/park/ParkFile.h>
 #include <openrct2/rct2/RCT2.h>
@@ -227,6 +229,50 @@ TEST(S6ImportExportBasic, all)
     CompareStates(importBuffer, exportBuffer, snapshotStream);
 
     SUCCEED();
+}
+
+TEST(ParkFileGuestState, TransportRideNavigationRoundTrips)
+{
+    gOpenRCT2Headless = true;
+    gOpenRCT2NoGraphics = true;
+
+    MemoryStream sourceBuffer;
+    MemoryStream exportBuffer;
+    EntityId guestId = EntityId::GetNull();
+    const GuestTransportRideNavigation expected = { RideId::FromUnderlying(1), StationIndex::FromUnderlying(0),
+                                                    StationIndex::FromUnderlying(1) };
+
+    {
+        auto context = CreateContext();
+        ASSERT_NE(context, nullptr);
+        ASSERT_TRUE(context->Initialise());
+
+        const auto testParkPath = TestData::GetParkPath("BigMapTest.sv6");
+        ASSERT_TRUE(LoadFileToBuffer(sourceBuffer, testParkPath));
+        ASSERT_TRUE(ImportS6(sourceBuffer, context, false));
+
+        auto guests = EntityList<Guest>();
+        ASSERT_NE(guests.begin(), guests.end());
+        auto* guest = *guests.begin();
+        EXPECT_FALSE(guest->transportRideNavigation.isActive());
+        guestId = guest->id;
+        guest->transportRideNavigation = expected;
+
+        ASSERT_TRUE(ExportSave(exportBuffer, context));
+    }
+
+    {
+        auto context = CreateContext();
+        ASSERT_NE(context, nullptr);
+        ASSERT_TRUE(context->Initialise());
+        ASSERT_TRUE(ImportPark(exportBuffer, context, true));
+
+        const auto* guest = getGameState().entities.getEntity<Guest>(guestId);
+        ASSERT_NE(guest, nullptr);
+        EXPECT_EQ(guest->transportRideNavigation.rideId, expected.rideId);
+        EXPECT_EQ(guest->transportRideNavigation.boardingStation, expected.boardingStation);
+        EXPECT_EQ(guest->transportRideNavigation.alightingStation, expected.alightingStation);
+    }
 }
 
 TEST(S6ImportExportAdvanceTicks, all)


### PR DESCRIPTION
### Description of changes

Adds an optional synchronised gameplay setting, “Use free transport rides for navigation”.

When enabled, guests can use free multi-station transport rides to reach rides, facilities, park exits, and disconnected path networks. Guests retain their ultimate destination, choose an appropriate destination station, remain aboard at intermediate stations, and leave seats available for new passengers where possible.

Transport navigation state is saved with the park and synchronised for multiplayer. Compatibility handling is included for older parks and replays.

**IMPORTANT:** 
This feature can still be improved. I realised after making that there was no need for it to be limited to free transport rides only, due to the ATM feature of RCT2.
The message in guest window 'Using [transport] to reach [destination] also may need a little tinkering. It can swap between this new message and the old 'Heading for [destination]'.
Have not thoroughly tested beyond playing in a custom map / sandbox mode. Bound to be edge cases I haven't thought of.
Could use some game balance in regards to happiness - e.g. if a guest who doesn't like low intensity rides has to use a transport to get somewhere. Avoided touching anything like that in this build.
Added as a 'game options setting' in order to try and avoid damaging areas outside of scope / preserve vanilla behaviour if not toggled on.

### Rationale behind changes

Transport rides currently behave mostly like ordinary rides rather than practical transportation. This implements the behaviour discussed in #7758, allowing guests to use transport rides rationally when doing so reduces walking or provides the only route to their destination.

### Suggested testing steps

1. Enable the setting under Options → Miscellaneous → Tweaks.
2. Build a free transport ride with several stations.
3. Place a ride or facility near a distant station and confirm guests use the transport.
4. Confirm guests remain aboard through intermediate stations.
5. Confirm new passengers can occupy free seats beside through-passengers.
6. Test a destination on a disconnected path network.
7. Test a guest leaving the park via transport.
8. Save and reload while a guest is making a transport journey.

Release build succeeds and all 277 automated tests pass.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Codex (Sol 5.6) was used to research the existing implementation and related forks, add regression tests and propose solutions.