### PR TITLE
Adjust mouse drag sensitivity to account for window scaling.

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -601,6 +601,8 @@ namespace OpenRCT2
                 const bool posY = differentialCoords.y > 0;
                 differentialCoords.x = (viewport->zoom + 1).ApplyTo(-std::abs(differentialCoords.x));
                 differentialCoords.y = (viewport->zoom + 1).ApplyTo(-std::abs(differentialCoords.y));
+                differentialCoords.x /= Config::Get().general.windowScale;
+                differentialCoords.y /= Config::Get().general.windowScale;
                 differentialCoords.x = posX ? -differentialCoords.x : differentialCoords.x;
                 differentialCoords.y = posY ? -differentialCoords.y : differentialCoords.y;
 


### PR DESCRIPTION
### Description of changes

Viewport dragging is now scaled by the scaling factor.

### Rationale behind changes

When playing at an increased scale factor dragging the viewport with the right-mouse button seemed to behave erratically due to moving way too fast. Scaling the differential coordinates ensures that behaviour is consistent with playing at a scale factor of 1 at similar zoom levels. This makes dragging the viewport a lot more predictable.

### Suggested testing steps

Someone with a non high-DPI monitor/resolution should ensure dragging at 1.0 scale factor is unchanged. Lower scale factors should be verified that erratic behaviour does not now occur. Both are too small on my display to be sure I didn't miss some details when testing myself. Viewports other than the main map should probably be tested too, they seemed fine to me, but I don't normally scroll them that way.

### Did you use AI to help find, test, or implement this issue or feature?

Only to write the commit message itself.
