### PR TITLE
Remove AddFuncs calls in ScWidget.hpp

### DIFF
--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -44,15 +44,15 @@ namespace OpenRCT2::Scripting
         return img;
     }
 
-    class ScWidget;
-    extern ScWidget gScWidget;
-
     struct WidgetData
     {
         WindowClass _class{};
         WindowNumber _number{};
         WidgetIndex _widgetIndex{};
     };
+
+    class ScWidget;
+    extern ScWidget gScWidget;
 
     class ScWidget : public ScBase
     {
@@ -446,7 +446,7 @@ namespace OpenRCT2::Scripting
 
         void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("window", ScWidget::window_get, nullptr),
                 JS_CGETSET_DEF("name", ScWidget::name_get, ScWidget::name_set),
                 JS_CGETSET_DEF("type", ScWidget::type_get, nullptr),
@@ -458,11 +458,11 @@ namespace OpenRCT2::Scripting
                 JS_CGETSET_DEF("isDisabled", ScWidget::isDisabled_get, &ScWidget::isDisabled_set),
                 JS_CGETSET_DEF("isVisible", ScWidget::isVisible_get, &ScWidget::isVisible_set),
             };
-            RegisterBase(ctx, "Widget", Finalize, funcs);
+            RegisterBase(ctx, "Widget", Finalise, kFuncs);
         }
 
     private:
-        static void Finalize(JSRuntime* rt, JSValue thisVal)
+        static void Finalise(JSRuntime* rt, JSValue thisVal)
         {
             WidgetData* data = gScWidget.GetOpaque<WidgetData*>(thisVal);
             if (data)
@@ -541,20 +541,21 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    class ScButtonWidget;
+    extern ScButtonWidget gScButtonWidget;
+
     class ScButtonWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            // In the future it might be worth properly subclassing the widget type here.
-            // Not just for this button class but also for all the other widget subclasses.
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("border", ScButtonWidget::border_get, ScButtonWidget::border_set),
                 JS_CGETSET_DEF("isPressed", ScButtonWidget::isPressed_get, ScButtonWidget::isPressed_set),
                 JS_CGETSET_DEF("image", ScButtonWidget::image_get, ScButtonWidget::image_set),
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -637,16 +638,19 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    class ScCheckBoxWidget;
+    extern ScCheckBoxWidget gScCheckBoxWidget;
+
     class ScCheckBoxWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("isChecked", ScCheckBoxWidget::isChecked_get, ScCheckBoxWidget::isChecked_set),
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -675,15 +679,18 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    class ScColourPickerWidget;
+    extern ScColourPickerWidget gScColourPickerWidget;
+
     class ScColourPickerWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("colour", ScColourPickerWidget::colour_get, ScColourPickerWidget::colour_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -712,17 +719,20 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    class ScDropdownWidget;
+    extern ScDropdownWidget gScDropdownWidget;
+
     class ScDropdownWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("items", ScDropdownWidget::items_get, ScDropdownWidget::items_set),
                 JS_CGETSET_DEF("selectedIndex", ScDropdownWidget::selectedIndex_get, ScDropdownWidget::selectedIndex_set),
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -786,28 +796,34 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    class ScGroupBoxWidget;
+    extern ScGroupBoxWidget gScGroupBoxWidget;
+
     class ScGroupBoxWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
     };
+
+    class ScLabelWidget;
+    extern ScLabelWidget gScLabelWidget;
 
     class ScLabelWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set),
                 JS_CGETSET_DEF("textAlign", ScLabelWidget::textAlign_get, ScLabelWidget::textAlign_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -839,12 +855,16 @@ namespace OpenRCT2::Scripting
             return JS_UNDEFINED;
         }
     };
+
+    class ScListViewWidget;
+    extern ScListViewWidget gScListViewWidget;
+
     class ScListViewWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("canSelect", ScListViewWidget::canSelect_get, ScListViewWidget::canSelect_set),
                 JS_CGETSET_DEF("isStriped", ScListViewWidget::isStriped_get, ScListViewWidget::isStriped_set),
                 JS_CGETSET_DEF("scrollbars", ScListViewWidget::scrollbars_get, ScListViewWidget::scrollbars_set),
@@ -855,7 +875,7 @@ namespace OpenRCT2::Scripting
                 JS_CGETSET_DEF("columns", ScListViewWidget::columns_get, ScListViewWidget::columns_set),
                 JS_CGETSET_DEF("items", ScListViewWidget::items_get, ScListViewWidget::items_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -1048,29 +1068,36 @@ namespace OpenRCT2::Scripting
             return nullptr;
         }
     };
+
+    class ScSpinnerWidget;
+    extern ScSpinnerWidget gScSpinnerWidget;
+
     class ScSpinnerWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
     };
+
+    class ScTextBoxWidget;
+    extern ScTextBoxWidget gScTextBoxWidget;
 
     class ScTextBoxWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("maxLength", ScTextBoxWidget::maxLength_get, ScTextBoxWidget::maxLength_set),
                 JS_CGETSET_DEF("caret", ScTextBoxWidget::caret_get, ScTextBoxWidget::caret_set),
                 JS_CGETSET_DEF("text", ScWidget::text_get, ScWidget::text_set), JS_CFUNC_DEF("focus", 0, ScTextBoxWidget::focus)
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -1146,15 +1173,18 @@ namespace OpenRCT2::Scripting
         }
     };
 
+    class ScViewportWidget;
+    extern ScViewportWidget gScViewportWidget;
+
     class ScViewportWidget : public ScWidget
     {
     public:
-        static void AddFuncs(JSContext* ctx, JSValue obj)
+        void Register(JSContext* ctx)
         {
-            static constexpr JSCFunctionListEntry funcs[] = {
+            static constexpr JSCFunctionListEntry kFuncs[] = {
                 JS_CGETSET_DEF("viewport", ScViewportWidget::viewport_get, nullptr),
             };
-            JS_SetPropertyFunctionList(ctx, obj, funcs, std::size(funcs));
+            RegisterDerived(ctx, gScWidget, kFuncs);
         }
 
     private:
@@ -1176,49 +1206,47 @@ namespace OpenRCT2::Scripting
 
     inline JSValue ScWidget::New(JSContext* ctx, WindowBase* w, WidgetIndex widgetIndex)
     {
-        JSValue newObj = MakeWithOpaque(ctx, new WidgetData{ w->classification, w->number, widgetIndex });
-        // TODO: Adding these functions like this in New() is probably slower than creating a proto for each type in Register()
-        // and using that.
+        JSValue widgetProto = GetProto();
         switch (w->widgets[widgetIndex].type)
         {
             case WidgetType::button:
             case WidgetType::flatBtn:
             case WidgetType::imgBtn:
             case WidgetType::hiddenButton:
-                ScButtonWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScButtonWidget.GetProto();
                 break;
             case WidgetType::checkbox:
-                ScCheckBoxWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScCheckBoxWidget.GetProto();
                 break;
             case WidgetType::colourBtn:
-                ScColourPickerWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScColourPickerWidget.GetProto();
                 break;
             case WidgetType::dropdownMenu:
-                ScDropdownWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScDropdownWidget.GetProto();
                 break;
             case WidgetType::groupbox:
-                ScGroupBoxWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScGroupBoxWidget.GetProto();
                 break;
             case WidgetType::label:
             case WidgetType::labelCentred:
-                ScLabelWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScLabelWidget.GetProto();
                 break;
             case WidgetType::scroll:
-                ScListViewWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScListViewWidget.GetProto();
                 break;
             case WidgetType::spinner:
-                ScSpinnerWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScSpinnerWidget.GetProto();
                 break;
             case WidgetType::textBox:
-                ScTextBoxWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScTextBoxWidget.GetProto();
                 break;
             case WidgetType::viewport:
-                ScViewportWidget::AddFuncs(ctx, newObj);
+                widgetProto = gScViewportWidget.GetProto();
                 break;
             default:
                 break;
         }
-        return newObj;
+        return MakeWithOpaqueAndProto(ctx, new WidgetData{ w->classification, w->number, widgetIndex }, widgetProto);
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2-ui/scripting/UiExtensions.cpp
+++ b/src/openrct2-ui/scripting/UiExtensions.cpp
@@ -104,17 +104,17 @@ void UiScriptExtensions::Unregister()
     gScUi.Unregister();
     gScViewport.Unregister();
 
-    gScViewportWidget.Unregister();
-    gScTextBoxWidget.Unregister();
-    gScSpinnerWidget.Unregister();
-    gScListViewWidget.Unregister();
-    gScLabelWidget.Unregister();
-    gScGroupBoxWidget.Unregister();
-    gScDropdownWidget.Unregister();
-    gScColourPickerWidget.Unregister();
-    gScCheckBoxWidget.Unregister();
-    gScButtonWidget.Unregister();
     gScWidget.Unregister();
+    gScButtonWidget.Unregister();
+    gScCheckBoxWidget.Unregister();
+    gScColourPickerWidget.Unregister();
+    gScDropdownWidget.Unregister();
+    gScGroupBoxWidget.Unregister();
+    gScLabelWidget.Unregister();
+    gScListViewWidget.Unregister();
+    gScSpinnerWidget.Unregister();
+    gScTextBoxWidget.Unregister();
+    gScViewportWidget.Unregister();
 
     gScTitleSequence.Unregister();
     gScTitleSequenceManager.Unregister();

--- a/src/openrct2-ui/scripting/UiExtensions.cpp
+++ b/src/openrct2-ui/scripting/UiExtensions.cpp
@@ -33,6 +33,16 @@ ScUi OpenRCT2::Scripting::gScUi;
 ScViewport OpenRCT2::Scripting::gScViewport;
 
 ScWidget OpenRCT2::Scripting::gScWidget;
+ScButtonWidget OpenRCT2::Scripting::gScButtonWidget;
+ScCheckBoxWidget OpenRCT2::Scripting::gScCheckBoxWidget;
+ScColourPickerWidget OpenRCT2::Scripting::gScColourPickerWidget;
+ScDropdownWidget OpenRCT2::Scripting::gScDropdownWidget;
+ScGroupBoxWidget OpenRCT2::Scripting::gScGroupBoxWidget;
+ScLabelWidget OpenRCT2::Scripting::gScLabelWidget;
+ScListViewWidget OpenRCT2::Scripting::gScListViewWidget;
+ScSpinnerWidget OpenRCT2::Scripting::gScSpinnerWidget;
+ScTextBoxWidget OpenRCT2::Scripting::gScTextBoxWidget;
+ScViewportWidget OpenRCT2::Scripting::gScViewportWidget;
 
 ScTitleSequence OpenRCT2::Scripting::gScTitleSequence;
 ScTitleSequenceManager OpenRCT2::Scripting::gScTitleSequenceManager;
@@ -59,6 +69,16 @@ void UiScriptExtensions::Extend(ScriptEngine& scriptEngine)
     gScViewport.Register(ctx);
 
     gScWidget.Register(ctx);
+    gScButtonWidget.Register(ctx);
+    gScCheckBoxWidget.Register(ctx);
+    gScColourPickerWidget.Register(ctx);
+    gScDropdownWidget.Register(ctx);
+    gScGroupBoxWidget.Register(ctx);
+    gScLabelWidget.Register(ctx);
+    gScListViewWidget.Register(ctx);
+    gScSpinnerWidget.Register(ctx);
+    gScTextBoxWidget.Register(ctx);
+    gScViewportWidget.Register(ctx);
 
     gScTitleSequence.Register(ctx);
     gScTitleSequenceManager.Register(ctx);
@@ -84,6 +104,16 @@ void UiScriptExtensions::Unregister()
     gScUi.Unregister();
     gScViewport.Unregister();
 
+    gScViewportWidget.Unregister();
+    gScTextBoxWidget.Unregister();
+    gScSpinnerWidget.Unregister();
+    gScListViewWidget.Unregister();
+    gScLabelWidget.Unregister();
+    gScGroupBoxWidget.Unregister();
+    gScDropdownWidget.Unregister();
+    gScColourPickerWidget.Unregister();
+    gScCheckBoxWidget.Unregister();
+    gScButtonWidget.Unregister();
     gScWidget.Unregister();
 
     gScTitleSequence.Unregister();


### PR DESCRIPTION
### Description of changes

For #27043: Remove AddFuncs calls in ScWidget.hpp for Register() pattern.

### Rationale behind changes

Register() pattern is faster than AddFuncs().

### Suggested testing steps

Test that plugins widgets still work as expected.

### Did you use AI to help find, test, or implement this issue or feature?

AI was not used.
