### PR TITLE
Fix #27046: 'GameActions' is not cleared when transitioning from the game scene to the title scene.

### DIFF
--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -61,6 +61,7 @@ namespace OpenRCT2
         gInMapInitCode = true;
         gameState.currentTicks = 0;
 
+        GameActions::ClearQueue();
         MapInit(mapSize);
         Park::Initialise(gameState.park, gameState);
         FinanceInit();


### PR DESCRIPTION
### Description of changes
_Originally posted by @WisdomK-ROK  in #27046._
I changed the logic to clear 'GameActions' during the transition from the game scene to the title scene.

### Rationale behind changes
<img width="1765" height="397" alt="image" src="https://github.com/user-attachments/assets/126208e9-2572-4217-b12a-8e95f3c604f1" />

A 'GameAction' remains in the queue when transitioning from the game scene to the title scene.

### Suggested testing steps
1. Enter the park.
2. Transition to the title scene while maintaining the guest pickup state.

### Did you use AI to help find, test, or implement this issue or feature?
No