### PR TITLE
Refactor PatrolArea.h members and constexpr code style

### DIFF
--- a/src/openrct2/entity/PatrolArea.cpp
+++ b/src/openrct2/entity/PatrolArea.cpp
@@ -29,84 +29,84 @@ namespace OpenRCT2
         return lhs.y < rhs.y;
     }
 
-    const PatrolArea::Cell* PatrolArea::GetCell(const TileCoordsXY& pos) const
+    const PatrolArea::Cell* PatrolArea::getCell(const TileCoordsXY& pos) const
     {
-        return const_cast<PatrolArea*>(this)->GetCell(pos);
+        return const_cast<PatrolArea*>(this)->getCell(pos);
     }
 
-    PatrolArea::Cell* PatrolArea::GetCell(const TileCoordsXY& pos)
+    PatrolArea::Cell* PatrolArea::getCell(const TileCoordsXY& pos)
     {
-        auto areaPos = TileCoordsXY(pos.x / Cell::Width, pos.y / Cell::Height);
-        if (areaPos.x < 0 || areaPos.x >= CellColumns || areaPos.y < 0 || areaPos.y >= CellRows)
+        auto areaPos = TileCoordsXY(pos.x / Cell::kWidth, pos.y / Cell::kHeight);
+        if (areaPos.x < 0 || areaPos.x >= kCellColumns || areaPos.y < 0 || areaPos.y >= kCellRows)
             return nullptr;
 
-        auto& area = Areas[(areaPos.y * CellColumns) + areaPos.x];
+        auto& area = areas[(areaPos.y * kCellColumns) + areaPos.x];
         return &area;
     }
 
-    bool PatrolArea::IsEmpty() const
+    bool PatrolArea::isEmpty() const
     {
-        return TileCount == 0;
+        return tileCount == 0;
     }
 
-    void PatrolArea::Clear()
+    void PatrolArea::clear()
     {
-        for (auto& area : Areas)
+        for (auto& area : areas)
         {
-            area.SortedTiles.clear();
+            area.sortedTiles.clear();
         }
     }
 
-    bool PatrolArea::Get(const TileCoordsXY& pos) const
+    bool PatrolArea::get(const TileCoordsXY& pos) const
     {
-        auto* area = GetCell(pos);
+        auto* area = getCell(pos);
         if (area == nullptr)
             return false;
 
-        auto it = Algorithm::binaryFind(area->SortedTiles.begin(), area->SortedTiles.end(), pos, CompareTileCoordsXY);
-        auto found = it != area->SortedTiles.end();
+        auto it = Algorithm::binaryFind(area->sortedTiles.begin(), area->sortedTiles.end(), pos, CompareTileCoordsXY);
+        auto found = it != area->sortedTiles.end();
         return found;
     }
 
-    bool PatrolArea::Get(const CoordsXY& pos) const
+    bool PatrolArea::get(const CoordsXY& pos) const
     {
-        return Get(TileCoordsXY(pos));
+        return get(TileCoordsXY(pos));
     }
 
-    void PatrolArea::Set(const TileCoordsXY& pos, bool value)
+    void PatrolArea::set(const TileCoordsXY& pos, bool value)
     {
-        auto* area = GetCell(pos);
+        auto* area = getCell(pos);
         if (area == nullptr)
             return;
 
-        auto it = std::lower_bound(area->SortedTiles.begin(), area->SortedTiles.end(), pos, CompareTileCoordsXY);
-        auto found = it != area->SortedTiles.end() && *it == pos;
+        auto it = std::lower_bound(area->sortedTiles.begin(), area->sortedTiles.end(), pos, CompareTileCoordsXY);
+        auto found = it != area->sortedTiles.end() && *it == pos;
 
         if (!found && value)
         {
-            area->SortedTiles.insert(it, pos);
-            TileCount++;
+            area->sortedTiles.insert(it, pos);
+            tileCount++;
         }
         else if (found && !value)
         {
-            area->SortedTiles.erase(it);
-            assert(TileCount != 0);
-            TileCount--;
+            area->sortedTiles.erase(it);
+            assert(tileCount != 0);
+            tileCount--;
         }
     }
 
-    void PatrolArea::Set(const CoordsXY& pos, bool value)
+    void PatrolArea::set(const CoordsXY& pos, bool value)
     {
-        Set(TileCoordsXY(pos), value);
+        set(TileCoordsXY(pos), value);
     }
 
     void PatrolArea::Union(const PatrolArea& other)
     {
-        for (size_t i = 0; i < Areas.size(); i++)
+        for (size_t i = 0; i < areas.size(); i++)
         {
-            for (const auto& pos : other.Areas[i].SortedTiles)
+            for (const auto& pos : other.areas[i].sortedTiles)
             {
-                Set(pos, true);
+                set(pos, true);
             }
         }
     }
@@ -115,16 +115,16 @@ namespace OpenRCT2
     {
         for (const auto& pos : other)
         {
-            Set(pos, true);
+            set(pos, true);
         }
     }
 
-    std::vector<TileCoordsXY> PatrolArea::ToVector() const
+    std::vector<TileCoordsXY> PatrolArea::toVector() const
     {
         std::vector<TileCoordsXY> result;
-        for (const auto& area : Areas)
+        for (const auto& area : areas)
         {
-            for (const auto& pos : area.SortedTiles)
+            for (const auto& pos : area.sortedTiles)
             {
                 result.push_back(pos);
             }
@@ -143,7 +143,7 @@ namespace OpenRCT2
         {
             // Reset all of the merged data for the type.
             auto& mergedArea = _consolidatedPatrolArea[staffType];
-            mergedArea.Clear();
+            mergedArea.clear();
 
             for (auto staff : EntityList<Staff>())
             {
@@ -160,7 +160,7 @@ namespace OpenRCT2
 
     bool IsPatrolAreaSetForStaffType(StaffType type, const CoordsXY& coords)
     {
-        return _consolidatedPatrolArea[EnumValue(type)].Get(coords);
+        return _consolidatedPatrolArea[EnumValue(type)].get(coords);
     }
 
     std::variant<StaffType, EntityId> GetPatrolAreaToRender()

--- a/src/openrct2/entity/PatrolArea.cpp
+++ b/src/openrct2/entity/PatrolArea.cpp
@@ -100,7 +100,7 @@ namespace OpenRCT2
         set(TileCoordsXY(pos), value);
     }
 
-    void PatrolArea::Union(const PatrolArea& other)
+    void PatrolArea::unify(const PatrolArea& other)
     {
         for (size_t i = 0; i < areas.size(); i++)
         {
@@ -111,7 +111,7 @@ namespace OpenRCT2
         }
     }
 
-    void PatrolArea::Union(const std::vector<TileCoordsXY>& other)
+    void PatrolArea::unify(const std::vector<TileCoordsXY>& other)
     {
         for (const auto& pos : other)
         {
@@ -153,7 +153,7 @@ namespace OpenRCT2
                 if (staff->patrolInfo == nullptr)
                     continue;
 
-                mergedArea.Union(*staff->patrolInfo);
+                mergedArea.unify(*staff->patrolInfo);
             }
         }
     }

--- a/src/openrct2/entity/PatrolArea.h
+++ b/src/openrct2/entity/PatrolArea.h
@@ -52,8 +52,8 @@ namespace OpenRCT2
         bool get(const CoordsXY& pos) const;
         void set(const TileCoordsXY& pos, bool value);
         void set(const CoordsXY& pos, bool value);
-        void Union(const PatrolArea& other);
-        void Union(const std::vector<TileCoordsXY>& other);
+        void unify(const PatrolArea& other);
+        void unify(const std::vector<TileCoordsXY>& other);
         std::vector<TileCoordsXY> toVector() const;
     };
 

--- a/src/openrct2/entity/PatrolArea.h
+++ b/src/openrct2/entity/PatrolArea.h
@@ -28,33 +28,33 @@ namespace OpenRCT2
     private:
         struct Cell
         {
-            static constexpr auto Width = 64;
-            static constexpr auto Height = 64;
-            static constexpr auto NumTiles = Width * Height;
+            static constexpr auto kWidth = 64;
+            static constexpr auto kHeight = 64;
+            static constexpr auto kNumTiles = kWidth * kHeight;
 
-            std::vector<TileCoordsXY> SortedTiles;
+            std::vector<TileCoordsXY> sortedTiles;
         };
 
-        static constexpr auto CellColumns = (kMaximumMapSizeTechnical + (Cell::Width - 1)) / Cell::Width;
-        static constexpr auto CellRows = (kMaximumMapSizeTechnical + (Cell::Height - 1)) / Cell::Height;
-        static constexpr auto NumCells = CellColumns * CellRows;
+        static constexpr auto kCellColumns = (kMaximumMapSizeTechnical + (Cell::kWidth - 1)) / Cell::kWidth;
+        static constexpr auto kCellRows = (kMaximumMapSizeTechnical + (Cell::kHeight - 1)) / Cell::kHeight;
+        static constexpr auto kNumCells = kCellColumns * kCellRows;
 
-        std::array<Cell, NumCells> Areas;
-        size_t TileCount{};
+        std::array<Cell, kNumCells> areas;
+        size_t tileCount{};
 
-        const Cell* GetCell(const TileCoordsXY& pos) const;
-        Cell* GetCell(const TileCoordsXY& pos);
+        const Cell* getCell(const TileCoordsXY& pos) const;
+        Cell* getCell(const TileCoordsXY& pos);
 
     public:
-        bool IsEmpty() const;
-        void Clear();
-        bool Get(const TileCoordsXY& pos) const;
-        bool Get(const CoordsXY& pos) const;
-        void Set(const TileCoordsXY& pos, bool value);
-        void Set(const CoordsXY& pos, bool value);
+        bool isEmpty() const;
+        void clear();
+        bool get(const TileCoordsXY& pos) const;
+        bool get(const CoordsXY& pos) const;
+        void set(const TileCoordsXY& pos, bool value);
+        void set(const CoordsXY& pos, bool value);
         void Union(const PatrolArea& other);
         void Union(const std::vector<TileCoordsXY>& other);
-        std::vector<TileCoordsXY> ToVector() const;
+        std::vector<TileCoordsXY> toVector() const;
     };
 
     void UpdateConsolidatedPatrolAreas();

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -257,7 +257,7 @@ namespace OpenRCT2
     {
         if (patrolInfo != nullptr)
         {
-            return patrolInfo->Get(coords);
+            return patrolInfo->get(coords);
         }
         return false;
     }
@@ -276,7 +276,7 @@ namespace OpenRCT2
             }
         }
 
-        patrolInfo->Set(coords, value);
+        patrolInfo->set(coords, value);
     }
 
     void Staff::setPatrolArea(const MapRange& range, bool value)
@@ -298,7 +298,7 @@ namespace OpenRCT2
 
     bool Staff::hasPatrolArea() const
     {
-        return patrolInfo == nullptr ? false : !patrolInfo->IsEmpty();
+        return patrolInfo == nullptr ? false : !patrolInfo->isEmpty();
     }
 
     /**

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2497,7 +2497,7 @@ namespace OpenRCT2
                     entity.patrolInfo = new PatrolArea();
                 else
                     entity.patrolInfo->clear();
-                entity.patrolInfo->Union(patrolArea);
+                entity.patrolInfo->unify(patrolArea);
             }
         }
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2482,7 +2482,7 @@ namespace OpenRCT2
         std::vector<TileCoordsXY> patrolArea;
         if (cs.getMode() == OrcaStream::Mode::writing && entity.patrolInfo != nullptr)
         {
-            patrolArea = entity.patrolInfo->ToVector();
+            patrolArea = entity.patrolInfo->toVector();
         }
         cs.readWriteVector(patrolArea, [&cs](TileCoordsXY& value) { cs.readWrite(value); });
         if (cs.getMode() == OrcaStream::Mode::reading)
@@ -2496,7 +2496,7 @@ namespace OpenRCT2
                 if (entity.patrolInfo == nullptr)
                     entity.patrolInfo = new PatrolArea();
                 else
-                    entity.patrolInfo->Clear();
+                    entity.patrolInfo->clear();
                 entity.patrolInfo->Union(patrolArea);
             }
         }

--- a/src/openrct2/scripting/bindings/entity/ScStaff.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.cpp
@@ -647,7 +647,7 @@ namespace OpenRCT2::Scripting
         auto staff = GetStaff(thisVal);
         if (staff != nullptr && staff->patrolInfo != nullptr)
         {
-            auto tiles = staff->patrolInfo->ToVector();
+            auto tiles = staff->patrolInfo->toVector();
 
             auto index = 0;
             for (const auto& tile : tiles)

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2265,10 +2265,10 @@ namespace OpenRCT2
                         auto patrol = staff->patrolInfo;
                         if (patrol != nullptr)
                         {
-                            auto positions = patrol->ToVector();
+                            auto positions = patrol->toVector();
                             for (auto& p : positions)
                                 shiftIfNotNull(p, amount);
-                            patrol->Clear();
+                            patrol->clear();
                             patrol->Union(positions);
                         }
                     }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2269,7 +2269,7 @@ namespace OpenRCT2
                             for (auto& p : positions)
                                 shiftIfNotNull(p, amount);
                             patrol->clear();
-                            patrol->Union(positions);
+                            patrol->unify(positions);
                         }
                     }
                 }


### PR DESCRIPTION
### Description of changes

For https://github.com/OpenRCT2/OpenRCT2/issues/26521, refactor PatrolArea.h members to camelCase and constexpr to kCamelCase.

### Rationale behind changes

Make codebase more consistent.

### Suggested testing steps

N/A

### Did you use AI to help find, test, or implement this issue or feature?

AI was not used.
