### PR TITLE
Only cycle the actually animated parts of the palette

### DIFF
--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -45,7 +45,7 @@ static constexpr uint8_t kPaletteLengthWaterWaves = 5;
 static constexpr uint8_t kPaletteLengthWaterSparkles = 5;
 
 static constexpr auto kPaletteOffsetAnimated = PaletteIndex::waterWaves0;
-static constexpr uint8_t kPaletteLengthAnimated = 16;
+static constexpr uint8_t kPaletteLengthAnimated = 13;
 
 GamePalette gPalette;
 GamePalette gGamePalette;


### PR DESCRIPTION
There are 5 water wave indices, 5 water sparkle indices and 3 chainlift animation indices. That’s 13 in total, rather than the 16 it rotated. This was not normally visible, as the 3 colours in the overrun were in the primary remap, which normally does not appear as itself (partly due to this bug). Changing this may result in a marginal speed increase, but it also opens up the possibility of storing additional shades in the space of the primary remap, similar to how the second and tertiary remap double up as a regular colour.