### PR TITLE
Fix #27056: Loading water palettes from plugin would not update the palette correctly.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,6 +47,7 @@
 - Fix: [#26996] Scenario patch for Okinawa Coast doesn’t work for CD versions of Wacky Worlds (meaning landscape ownership fixes do not get applied).
 - Fix: [#27004] Windows are moved off-screen when mouse is released outside of the game window.
 - Fix: [#27023] [Plugin] Transparent plugin sprites do not work correctly in software rendering mode.
+- Fix: [#27056] [Plugin] Loading water palettes from plugin would not update the palette correctly.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -47,7 +47,7 @@
 - Fix: [#26996] Scenario patch for Okinawa Coast doesn’t work for CD versions of Wacky Worlds (meaning landscape ownership fixes do not get applied).
 - Fix: [#27004] Windows are moved off-screen when mouse is released outside of the game window.
 - Fix: [#27023] [Plugin] Transparent plugin sprites do not work correctly in software rendering mode.
-- Fix: [#27056] [Plugin] Loading water palettes from plugin would not update the palette correctly.
+- Fix: [#27056] [Plugin] Loading water palettes from plugin does not update the palette correctly.
 
 0.5.4 (2026-08-02)
 ------------------------------------------------------------------------

--- a/src/openrct2/scripting/bindings/object/ScObjectManager.cpp
+++ b/src/openrct2/scripting/bindings/object/ScObjectManager.cpp
@@ -12,10 +12,10 @@
     #include "ScObjectManager.h"
 
     #include "../../../Context.h"
+    #include "../../../drawing/Drawing.h"
     #include "../../../object/ObjectList.h"
     #include "../../../ride/RideData.h"
     #include "../../../windows/Intent.h"
-    #include "../../../drawing/Drawing.h"
     #include "ScInstalledObject.hpp"
     #include "ScObject.hpp"
 

--- a/src/openrct2/scripting/bindings/object/ScObjectManager.cpp
+++ b/src/openrct2/scripting/bindings/object/ScObjectManager.cpp
@@ -15,6 +15,7 @@
     #include "../../../object/ObjectList.h"
     #include "../../../ride/RideData.h"
     #include "../../../windows/Intent.h"
+    #include "../../../drawing/Drawing.h"
     #include "ScInstalledObject.hpp"
     #include "ScObject.hpp"
 
@@ -88,6 +89,7 @@ JSValue ScObjectManager::load(JSContext* ctx, JSValue thisVal, int argc, JSValue
 
         JSValue result = JS_NewArray(ctx);
         int64_t index = 0;
+        bool loadedWater = false;
         for (const auto& descriptor : descriptors)
         {
             auto obj = objectManager.LoadObject(descriptor);
@@ -97,6 +99,9 @@ JSValue ScObjectManager::load(JSContext* ctx, JSValue thisVal, int argc, JSValue
                 auto objIndex = objectManager.GetLoadedObjectEntryIndex(obj);
                 auto scLoadedObject = CreateScObject(ctx, obj->GetObjectType(), objIndex);
                 JS_SetPropertyInt64(ctx, result, index, scLoadedObject);
+
+                if (obj->GetObjectType() == ObjectType::water)
+                    loadedWater = true;
             }
             else
             {
@@ -105,6 +110,11 @@ JSValue ScObjectManager::load(JSContext* ctx, JSValue thisVal, int argc, JSValue
             index++;
         }
         RefreshResearchedItems();
+        if (loadedWater)
+        {
+            LoadPalette();
+        }
+
         return result;
     }
     else
@@ -133,6 +143,12 @@ JSValue ScObjectManager::load(JSContext* ctx, JSValue thisVal, int argc, JSValue
                     {
                         MarkAsResearched(obj);
                         RefreshResearchedItems();
+
+                        if (obj->GetObjectType() == ObjectType::water)
+                        {
+                            LoadPalette();
+                        }
+
                         auto objIndex = objectManager.GetLoadedObjectEntryIndex(obj);
                         return CreateScObject(ctx, obj->GetObjectType(), objIndex);
                     }
@@ -145,6 +161,12 @@ JSValue ScObjectManager::load(JSContext* ctx, JSValue thisVal, int argc, JSValue
                 {
                     MarkAsResearched(obj);
                     RefreshResearchedItems();
+
+                    if (obj->GetObjectType() == ObjectType::water)
+                    {
+                        LoadPalette();
+                    }
+
                     auto objIndex = objectManager.GetLoadedObjectEntryIndex(obj);
                     return CreateScObject(ctx, obj->GetObjectType(), objIndex);
                 }


### PR DESCRIPTION
### Description of changes

The LoadPallete has been added to scripting object manager, so that it can load the palettes if one has been loaded from plugin, similar to how the normal object manager does it.

### Rationale behind changes

If you load a palette, it should actually load. Since the normal object manager seems to do it just fine, I figured I'd use the method it used.

### Suggested testing steps

Load a palette using a plugin, and see it work.

### Did you use AI to help find, test, or implement this issue or feature?

I used AI to help find where the checkboxes in the object manager are, to find out what happens after the user clicks on one, so I could replicate it for the scripting object manager.
