### PR TITLE
Fix #21973: mouse position is offset when macOS clamps the window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Fix: [#21973] The mouse pointer is misaligned on macOS when the game window is larger than the screen allows, for example after using fullscreen.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -21,6 +21,7 @@
 #include "title/TitleSequencePlayer.h"
 
 #include <SDL.h>
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
@@ -76,6 +77,7 @@ private:
     SDL_Window* _window = nullptr;
     int32_t _width = 0;
     int32_t _height = 0;
+    int32_t _mouseYCorrection = 0;
     ScaleQuality _scaleQuality = ScaleQuality::nearestNeighbour;
 
     std::vector<Resolution> _fsResolutions;
@@ -290,6 +292,7 @@ public:
     {
         ScreenCoordsXY cursorPosition;
         SDL_GetMouseState(&cursorPosition.x, &cursorPosition.y);
+        cursorPosition.y -= _mouseYCorrection;
         return cursorPosition;
     }
 
@@ -381,6 +384,16 @@ public:
                                 Config::Get().general.defaultDisplay = displayIndex;
                                 Config::Save();
                             }
+
+                            // macOS can re-clamp the frame on another display without a resize event.
+                            auto correction = _mouseYCorrection;
+                            updateMouseYCorrection();
+                            if (correction != _mouseYCorrection)
+                            {
+                                int32_t width, height;
+                                SDL_GetWindowSize(_window, &width, &height);
+                                OnResize(width, height);
+                            }
                             break;
                         }
                     }
@@ -398,8 +411,7 @@ public:
                     }
                     break;
                 case SDL_MOUSEMOTION:
-                    _cursorState.position = { static_cast<int32_t>(e.motion.x / Config::Get().general.windowScale),
-                                              static_cast<int32_t>(e.motion.y / Config::Get().general.windowScale) };
+                    _cursorState.position = mouseToCanvas(e.motion.x, e.motion.y);
                     break;
                 case SDL_MOUSEWHEEL:
                     if (_inGameConsole.IsOpen())
@@ -415,8 +427,7 @@ public:
                     {
                         break;
                     }
-                    ScreenCoordsXY mousePos = { static_cast<int32_t>(e.button.x / Config::Get().general.windowScale),
-                                                static_cast<int32_t>(e.button.y / Config::Get().general.windowScale) };
+                    ScreenCoordsXY mousePos = mouseToCanvas(e.button.x, e.button.y);
                     switch (e.button.button)
                     {
                         case SDL_BUTTON_LEFT:
@@ -451,8 +462,7 @@ public:
                     {
                         break;
                     }
-                    ScreenCoordsXY mousePos = { static_cast<int32_t>(e.button.x / Config::Get().general.windowScale),
-                                                static_cast<int32_t>(e.button.y / Config::Get().general.windowScale) };
+                    ScreenCoordsXY mousePos = mouseToCanvas(e.button.x, e.button.y);
                     switch (e.button.button)
                     {
                         case SDL_BUTTON_LEFT:
@@ -843,11 +853,44 @@ private:
         TriggerResize();
     }
 
+    /**
+     * Points of mouse y to discard: macOS clamps a window that does not fit, SDL keeps reporting
+     * the size it asked for, and its Cocoa backend flips mouse y with that height.
+     */
+    void updateMouseYCorrection()
+    {
+        _mouseYCorrection = 0;
+#ifdef __MACOSX__
+        int windowWidth, windowHeight, drawableWidth, drawableHeight;
+        SDL_GetWindowSize(_window, &windowWidth, &windowHeight);
+        SDL_GetWindowSizeInPixels(_window, &drawableWidth, &drawableHeight);
+        if (windowWidth <= 0 || windowHeight <= 0 || drawableWidth <= 0 || drawableHeight <= 0)
+            return;
+
+        // A clamped axis reads low, so whichever axis macOS left alone gives the scale.
+        auto backingScale = std::round(
+            std::max(static_cast<float>(drawableWidth) / windowWidth, static_cast<float>(drawableHeight) / windowHeight));
+        if (backingScale < 1.0f)
+            return;
+
+        _mouseYCorrection = windowHeight - static_cast<int32_t>(drawableHeight / backingScale);
+#endif
+    }
+
+    ScreenCoordsXY mouseToCanvas(int32_t x, int32_t y) const
+    {
+        auto scale = Config::Get().general.windowScale;
+        return { static_cast<int32_t>(x / scale), static_cast<int32_t>((y - _mouseYCorrection) / scale) };
+    }
+
     void OnResize(int32_t width, int32_t height)
     {
+        updateMouseYCorrection();
+
         // Scale the native window size to the game's canvas size
+        auto contentHeight = height - _mouseYCorrection;
         _width = static_cast<int32_t>(width / Config::Get().general.windowScale);
-        _height = static_cast<int32_t>(height / Config::Get().general.windowScale);
+        _height = static_cast<int32_t>(contentHeight / Config::Get().general.windowScale);
 
         DrawingEngineResize();
 


### PR DESCRIPTION
### Description of changes

When macOS will not give the game the window size it asked for, the game now checks what size it actually got and lines the mouse up with that, rather than trusting what it requested. The drawing area follows the same corrected size. Other platforms are unaffected, and so is any window whose requested size the system actually gives.

### Rationale behind changes

macOS will not hand out a window taller than the space left between the menu bar and the dock. When it refuses, SDL carries on reporting the size that was asked for, and appears to work the mouse position out from that wrong height, which would place the pointer lower than it really is. Clicks on the top toolbar still land, everything further down the window quietly misses, and it gets worse towards the bottom.

On a 3440x1440 screen, asking for a window 1300 tall gets one 1275 tall, and every click lands 25 too low: exactly the difference. Asking for 1200, which fits, is accurate everywhere.

That also clears up two things from the issue:

- The offset measured the same everywhere in the window, so the reports of it growing further down may have been comparing different window sizes rather than different spots in one window. The drawing area was stretched by the same wrong height, which would account for it feeling worse lower down.
- The window size looks like what decides whether it happens, which would explain why the older SDL test builds all still showed it.

The SDL issue behind it (libsdl-org/SDL#3217) was closed as fixed in 2023, with an invitation to reopen it if anyone still ran into it, and the mismatch is still there in the SDL 2.32.8 we ship. SDL3 works the mouse position out from the same remembered height, though whether its size can go stale in the same way is untested. Either way there is nothing to wait for, and it looks worth reopening upstream now that there is a way to reproduce it.

Closes #21973.

### Suggested testing steps

On macOS, set `window_height` in `config.ini` to the full height of your screen. Pressing the green fullscreen button, quitting and relaunching should get there too, since the code that saves the window size persists such a height by itself. Before this change, clicks land on the top toolbar but miss further down the window; afterwards close buttons, tabs and list rows all respond where they are drawn.

Worth trying, all of which behaved here:

- a regular and a Retina screen
- dragging the window from one screen to another
- a window size that does fit, which should behave exactly as it does today
- Windows or Linux, where nothing changes at all

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.
