### PR TITLE
Fix #1514: Wrong capitalisation for descriptions in Guest List

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -1157,7 +1157,7 @@ STR_1816    :Select information type to show in guest list
 STR_1817    :({COMMA32})
 STR_1818    :{WINDOW_COLOUR_2}All guests
 STR_1819    :{WINDOW_COLOUR_2}All guests (summarised)
-STR_1820    :{WINDOW_COLOUR_2}Guests {STRINGID}
+STR_1820    :{WINDOW_COLOUR_2}{STRINGID}
 STR_1821    :{WINDOW_COLOUR_2}Guests thinking {SMALLFONT}{STRINGID}
 STR_1822    :{WINDOW_COLOUR_2}Guests thinking about {POP16}{STRINGID}
 STR_1823    :Show guests’ thoughts about this ride/attraction
@@ -3840,3 +3840,17 @@ STR_7046    :Status bar (RCT1 style)
 STR_7047    :Step control (Track Designer)
 STR_7048    :Step control (Scenario Editor)
 STR_7049    :OpenRCT2
+STR_7050    :Guests walking
+STR_7051    :Guests heading for {STRINGID}
+STR_7052    :Guests queuing for {STRINGID}
+STR_7053    :Guests drowning
+STR_7054    :Guests on {STRINGID}
+STR_7055    :Guests in {STRINGID}
+STR_7056    :Guests at {STRINGID}
+STR_7057    :Guests sitting
+STR_7058    :Guests picked up
+STR_7059    :Guests watching {STRINGID}
+STR_7060    :Guests watching construction of {STRINGID}
+STR_7061    :Guests looking at scenery
+STR_7062    :Guests leaving the park
+STR_7063    :Guests watching new ride being constructed

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#21400] The selector for setting staff patrol areas is now drawn on the water as well as on the surface under water.
 - Improved: [#26947] Rain is now drawn next to the bottom info panels (in RCT2 style).
+- Fix: [#1514] Wrong capitalisation for strings in the Guest List window.
 - Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -39,6 +39,7 @@
 #include <openrct2/network/Network.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/PeepAnimationsObject.h>
+#include <openrct2/peep/PeepActionFormat.h>
 #include <openrct2/peep/PeepSpriteIds.h>
 #include <openrct2/ride/RideManager.hpp>
 #include <openrct2/ride/ShopItem.h>
@@ -807,7 +808,7 @@ namespace OpenRCT2::Ui::Windows
 
             {
                 auto ft = Formatter();
-                peep->formatActionTo(ft);
+                formatPeepActionTo(*peep, ft);
                 int32_t textWidth = actionLabelWidget.width() - 1;
                 drawTextEllipsised(rt, screenPos, textWidth, STR_BLACK_STRING, ft, { TextAlignment::centre });
             }

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -195,8 +195,8 @@ namespace OpenRCT2::Ui::Windows
                     if (guestRide != nullptr)
                     {
                         ft.Add<StringId>(
-                            guestRide->getRideTypeDescriptor().flags.has(RtdFlag::describeAsInside) ? STR_IN_RIDE
-                                                                                                    : STR_ON_RIDE);
+                            guestRide->getRideTypeDescriptor().flags.has(RtdFlag::describeAsInside) ? STR_GUESTS_IN_RIDE
+                                                                                                    : STR_GUESTS_ON_RIDE);
                         guestRide->formatNameTo(ft);
 
                         _selectedFilter = GuestFilterType::guests;
@@ -211,7 +211,7 @@ namespace OpenRCT2::Ui::Windows
                     auto guestRide = GetRide(RideId::FromUnderlying(index));
                     if (guestRide != nullptr)
                     {
-                        ft.Add<StringId>(STR_QUEUING_FOR);
+                        ft.Add<StringId>(STR_GUESTS_QUEUING_FOR);
                         guestRide->formatNameTo(ft);
 
                         _selectedFilter = GuestFilterType::guests;
@@ -868,7 +868,7 @@ namespace OpenRCT2::Ui::Windows
             switch (type)
             {
                 case GuestViewType::actions:
-                    formatPeepActionTo(peep, ft);
+                    formatPeepActionTo(peep, ft, true);
                     break;
                 case GuestViewType::thoughts:
                 {

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -26,6 +26,7 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Formatting.h>
 #include <openrct2/object/PeepAnimationsObject.h>
+#include <openrct2/peep/PeepActionFormat.h>
 #include <openrct2/peep/PeepThoughts.h>
 #include <openrct2/ride/RideData.h>
 #include <openrct2/ui/WindowManager.h>
@@ -677,7 +678,7 @@ namespace OpenRCT2::Ui::Windows
 
                             // Action
                             ft = Formatter();
-                            peep->formatActionTo(ft);
+                            formatPeepActionTo(*peep, ft);
                             drawTextEllipsised(rt, { 133, y }, 314, format, ft);
                             break;
                         case GuestViewType::thoughts:
@@ -867,7 +868,7 @@ namespace OpenRCT2::Ui::Windows
             switch (type)
             {
                 case GuestViewType::actions:
-                    peep.formatActionTo(ft);
+                    formatPeepActionTo(peep, ft);
                     break;
                 case GuestViewType::thoughts:
                 {

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -35,6 +35,7 @@
 #include <openrct2/network/Network.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/PeepAnimationsObject.h>
+#include <openrct2/peep/PeepActionFormat.h>
 #include <openrct2/peep/PeepAnimations.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
@@ -559,7 +560,7 @@ namespace OpenRCT2::Ui::Windows
                 return;
             }
             auto ft = Formatter();
-            staff->formatActionTo(ft);
+            formatPeepActionTo(*staff, ft);
             const auto& widget = widgets[WIDX_BTM_LABEL];
             auto screenPos = windowPos + ScreenCoordsXY{ widget.midX(), widget.top };
             int32_t widgetWidth = widget.width() - 1;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -40,6 +40,7 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/object/ObjectManager.h>
 #include <openrct2/object/PeepAnimationsObject.h>
+#include <openrct2/peep/PeepActionFormat.h>
 #include <openrct2/ui/WindowManager.h>
 #include <openrct2/windows/Intent.h>
 #include <vector>
@@ -413,7 +414,7 @@ namespace OpenRCT2::Ui::Windows
                     drawTextEllipsised(rt, { 0, y }, nameColumnSize, format, ft);
 
                     ft = Formatter();
-                    peep->formatActionTo(ft);
+                    formatPeepActionTo(*peep, ft);
                     drawTextEllipsised(rt, { actionOffset, y }, actionColumnSize, format, ft);
 
                     // True if a patrol path is set for the worker

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -37,6 +37,7 @@
 #include "../object/ObjectManager.h"
 #include "../object/PeepAnimationsObject.h"
 #include "../peep/GuestPathfinding.h"
+#include "../peep/PeepActionFormat.h"
 #include "../profiling/Profiling.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"
@@ -1278,47 +1279,31 @@ namespace OpenRCT2
         }
     }
 
-    void Peep::formatActionTo(Formatter& ft) const
+    PeepActionDescription Peep::getActionDescription() const
     {
         switch (state)
         {
             case PeepState::falling:
-                ft.Add<StringId>(action == PeepActionType::drowning ? STR_DROWNING : STR_WALKING);
-                break;
+                if (action == PeepActionType::drowning)
+                    return { PeepActionDescriptionType::drowning };
+
+                return { PeepActionDescriptionType::walking };
             case PeepState::one:
-                ft.Add<StringId>(STR_WALKING);
-                break;
+                return { PeepActionDescriptionType::walking };
             case PeepState::onRide:
             case PeepState::leavingRide:
             case PeepState::enteringRide:
             {
-                auto ride = GetRide(currentRide);
-                if (ride != nullptr)
+                const auto ride = GetRide(currentRide);
+                if (ride != nullptr && ride->getRideTypeDescriptor().flags.has(RtdFlag::describeAsInside))
                 {
-                    ft.Add<StringId>(
-                        ride->getRideTypeDescriptor().flags.has(RtdFlag::describeAsInside) ? STR_IN_RIDE : STR_ON_RIDE);
-                    ride->formatNameTo(ft);
+                    return { PeepActionDescriptionType::inRide, currentRide };
                 }
-                else
-                {
-                    ft.Add<StringId>(STR_ON_RIDE).Add<StringId>(kStringIdNone);
-                }
-                break;
+
+                return { PeepActionDescriptionType::onRide, currentRide };
             }
             case PeepState::buying:
-            {
-                ft.Add<StringId>(STR_AT_RIDE);
-                auto ride = GetRide(currentRide);
-                if (ride != nullptr)
-                {
-                    ride->formatNameTo(ft);
-                }
-                else
-                {
-                    ft.Add<StringId>(kStringIdNone);
-                }
-                break;
-            }
+                return { PeepActionDescriptionType::atShop, currentRide };
             case PeepState::walking:
             case PeepState::usingBin:
             {
@@ -1326,135 +1311,68 @@ namespace OpenRCT2
                 {
                     if (!guest->guestHeadingToRideId.IsNull())
                     {
-                        auto ride = GetRide(guest->guestHeadingToRideId);
-                        if (ride != nullptr)
-                        {
-                            ft.Add<StringId>(STR_HEADING_FOR);
-                            ride->formatNameTo(ft);
-                        }
-                    }
-                    else
-                    {
-                        ft.Add<StringId>(peepFlags.has(PeepFlag::leavingPark) ? STR_LEAVING_PARK : STR_WALKING);
+                        return { PeepActionDescriptionType::headingFor, guest->guestHeadingToRideId };
                     }
                 }
-                break;
+
+                if (peepFlags.has(PeepFlag::leavingPark))
+                    return { PeepActionDescriptionType::leavingPark };
+
+                return { PeepActionDescriptionType::walking };
             }
             case PeepState::queuingFront:
             case PeepState::queuing:
-            {
-                auto ride = GetRide(currentRide);
-                if (ride != nullptr)
-                {
-                    ft.Add<StringId>(STR_QUEUING_FOR);
-                    ride->formatNameTo(ft);
-                }
-                break;
-            }
+                return { PeepActionDescriptionType::queuingFor, currentRide };
             case PeepState::sitting:
-                ft.Add<StringId>(STR_SITTING);
-                break;
+                return { PeepActionDescriptionType::sitting };
             case PeepState::watching:
                 if (!currentRide.IsNull())
                 {
                     auto ride = GetRide(currentRide);
                     if (ride != nullptr)
                     {
-                        ft.Add<StringId>((standingFlags & 0x1) ? STR_WATCHING_CONSTRUCTION_OF : STR_WATCHING_RIDE);
-                        ride->formatNameTo(ft);
+                        auto baseType = (standingFlags & 0x1) ? PeepActionDescriptionType::watchingRideConstruction
+                                                              : PeepActionDescriptionType::watchingRide;
+                        return { baseType, currentRide };
                     }
                 }
-                else
-                {
-                    ft.Add<StringId>((standingFlags & 0x1) ? STR_WATCHING_NEW_RIDE_BEING_CONSTRUCTED : STR_LOOKING_AT_SCENERY);
-                }
-                break;
+
+                return { (standingFlags & 0x1) ? PeepActionDescriptionType::watchingRideConstructionUnspecific
+                                               : PeepActionDescriptionType::watchingScenery };
             case PeepState::picked:
-                ft.Add<StringId>(STR_SELECT_LOCATION);
-                break;
+                return { PeepActionDescriptionType::pickedUp };
             case PeepState::patrolling:
             case PeepState::enteringPark:
             case PeepState::leavingPark:
-                ft.Add<StringId>(STR_WALKING);
-                break;
+                return { PeepActionDescriptionType::walking };
             case PeepState::mowing:
-                ft.Add<StringId>(STR_MOWING_GRASS);
-                break;
+                return { PeepActionDescriptionType::mowingGrass };
             case PeepState::sweeping:
-                ft.Add<StringId>(STR_SWEEPING_FOOTPATH);
-                break;
+                return { PeepActionDescriptionType::sweepingFootpath };
             case PeepState::watering:
-                ft.Add<StringId>(STR_WATERING_GARDENS);
-                break;
+                return { PeepActionDescriptionType::wateringGardens };
             case PeepState::emptyingBin:
-                ft.Add<StringId>(STR_EMPTYING_LITTER_BIN);
-                break;
+                return { PeepActionDescriptionType::emptyingBin };
             case PeepState::answering:
                 if (subState == 0)
                 {
-                    ft.Add<StringId>(STR_WALKING);
+                    return { PeepActionDescriptionType::walking };
                 }
-                else if (subState == 1)
+                if (subState == 1)
                 {
-                    ft.Add<StringId>(STR_ANSWERING_RADIO_CALL);
+                    return { PeepActionDescriptionType::answeringRadioCall };
                 }
-                else
-                {
-                    ft.Add<StringId>(STR_RESPONDING_TO_RIDE_BREAKDOWN_CALL);
-                    auto ride = GetRide(currentRide);
-                    if (ride != nullptr)
-                    {
-                        ride->formatNameTo(ft);
-                    }
-                    else
-                    {
-                        ft.Add<StringId>(kStringIdNone);
-                    }
-                }
-                break;
+
+                return { PeepActionDescriptionType::respondingToBreakdownCall, currentRide };
             case PeepState::fixing:
-            {
-                ft.Add<StringId>(STR_FIXING_RIDE);
-                auto ride = GetRide(currentRide);
-                if (ride != nullptr)
-                {
-                    ride->formatNameTo(ft);
-                }
-                else
-                {
-                    ft.Add<StringId>(kStringIdNone);
-                }
-                break;
-            }
+                return { PeepActionDescriptionType::fixingRide, currentRide };
             case PeepState::headingToInspection:
-            {
-                ft.Add<StringId>(STR_HEADING_TO_RIDE_FOR_INSPECTION);
-                auto ride = GetRide(currentRide);
-                if (ride != nullptr)
-                {
-                    ride->formatNameTo(ft);
-                }
-                else
-                {
-                    ft.Add<StringId>(kStringIdNone);
-                }
-                break;
-            }
+                return { PeepActionDescriptionType::headingToInspectRide, currentRide };
             case PeepState::inspecting:
-            {
-                ft.Add<StringId>(STR_INSPECTING_RIDE);
-                auto ride = GetRide(currentRide);
-                if (ride != nullptr)
-                {
-                    ride->formatNameTo(ft);
-                }
-                else
-                {
-                    ft.Add<StringId>(kStringIdNone);
-                }
-                break;
-            }
+                return { PeepActionDescriptionType::inspectingRide, currentRide };
         }
+
+        return { PeepActionDescriptionType::walking };
     }
 
     static constexpr StringId kStaffNames[] = {
@@ -1569,13 +1487,13 @@ namespace OpenRCT2
             ft.Add<StringId>(peep->peepFlags.has(PeepFlag::tracking) ? STR_TRACKED_GUEST_MAP_TIP : STR_GUEST_MAP_TIP);
             ft.Add<uint32_t>(GetPeepFaceSpriteSmall(guest));
             guest->formatNameTo(ft);
-            guest->formatActionTo(ft);
+            formatPeepActionTo(*peep, ft);
         }
         else
         {
             ft.Add<StringId>(STR_STAFF_MAP_TIP);
             peep->formatNameTo(ft);
-            peep->formatActionTo(ft);
+            formatPeepActionTo(*peep, ft);
         }
 
         auto intent = Intent(INTENT_ACTION_SET_MAP_TOOLTIP);

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -303,6 +303,42 @@ namespace OpenRCT2
         PEEP_INVALIDATE_PEEP_ACTION = 1 << 5, // Currently set only when guestHeadingToRideId is changed
     };
 
+    enum class PeepActionDescriptionType : uint8_t
+    {
+        walking,
+        sitting,
+        watchingScenery,
+        drowning,
+        pickedUp,
+        headingFor,
+        watchingRide,
+        watchingRideConstruction,
+        watchingRideConstructionUnspecific,
+        queuingFor,
+        onRide,
+        inRide,
+        atShop,
+        leavingPark,
+        sweepingFootpath,
+        emptyingBin,
+        wateringGardens,
+        mowingGrass,
+        headingToInspectRide,
+        inspectingRide,
+        fixingRide,
+        answeringRadioCall,
+        respondingToBreakdownCall,
+
+        count,
+    };
+    constexpr size_t kNumPeepActionDescriptionTypes = static_cast<size_t>(PeepActionDescriptionType::count);
+
+    struct PeepActionDescription
+    {
+        PeepActionDescriptionType type;
+        RideId rideId = RideId::GetNull();
+    };
+
     struct Guest;
 
     struct Peep : EntityBase
@@ -400,7 +436,7 @@ namespace OpenRCT2
         void pickupAbort(int32_t old_x);
         [[nodiscard]] GameActions::Result place(const TileCoordsXYZ& location, bool apply);
         void removeFromRide();
-        void formatActionTo(Formatter&) const;
+        PeepActionDescription getActionDescription() const;
         void formatNameTo(Formatter&) const;
         [[nodiscard]] std::string getName() const;
         bool setName(std::string_view value);

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -448,6 +448,7 @@
     <ClInclude Include="park\ParkPreview.h" />
     <ClInclude Include="peep\Guest.h" />
     <ClInclude Include="peep\GuestPathfinding.h" />
+    <ClInclude Include="peep\PeepActionFormat.h" />
     <ClInclude Include="peep\PeepAnimations.h" />
     <ClInclude Include="peep\PeepSpriteIds.h" />
     <ClInclude Include="peep\PeepThoughts.h" />
@@ -1153,6 +1154,7 @@
     <ClCompile Include="park\ParkFile.cpp" />
     <ClCompile Include="park\ParkPreview.cpp" />
     <ClCompile Include="peep\GuestPathfinding.cpp" />
+    <ClCompile Include="peep\PeepActionFormat.cpp" />
     <ClCompile Include="peep\PeepAnimations.cpp" />
     <ClCompile Include="peep\PeepThoughts.cpp" />
     <ClCompile Include="peep\RideUseSystem.cpp" />

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1780,6 +1780,21 @@ enum : StringId
 
     STR_CANT_CHANGE_LAND_HEIGHT_HERE = 7043,
 
+    STR_GUESTS_WALKING = 7050,
+    STR_GUESTS_HEADING_FOR = 7051,
+    STR_GUESTS_QUEUING_FOR = 7052,
+    STR_GUESTS_DROWNING = 7053,
+    STR_GUESTS_ON_RIDE = 7054,
+    STR_GUESTS_IN_RIDE = 7055,
+    STR_GUESTS_AT_RIDE = 7056,
+    STR_GUESTS_SITTING = 7057,
+    STR_GUESTS_PICKED_UP = 7058,
+    STR_GUESTS_WATCHING_RIDE = 7059,
+    STR_GUESTS_WATCHING_CONSTRUCTION_OF = 7060,
+    STR_GUESTS_LOOKING_AT_SCENERY = 7061,
+    STR_GUESTS_LEAVING_PARK = 7062,
+    STR_GUESTS_WATCHING_NEW_RIDE_BEING_CONSTRUCTED = 7063,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/peep/PeepActionFormat.cpp
+++ b/src/openrct2/peep/PeepActionFormat.cpp
@@ -1,0 +1,60 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "PeepActionFormat.h"
+
+#include "../entity/Peep.h"
+#include "../localisation/StringIds.h"
+#include "../ride/Ride.h"
+
+namespace OpenRCT2
+{
+    constexpr auto kPeepActionToStringMapping = std::to_array<StringId>({
+        STR_WALKING,                             // PeepActionDescriptionType::walking
+        STR_SITTING,                             // PeepActionDescriptionType::sitting
+        STR_LOOKING_AT_SCENERY,                  // PeepActionDescriptionType::watchingScenery
+        STR_DROWNING,                            // PeepActionDescriptionType::drowning
+        STR_SELECT_LOCATION,                     // PeepActionDescriptionType::pickedUp
+        STR_HEADING_FOR,                         // PeepActionDescriptionType::headingFor
+        STR_WATCHING_RIDE,                       // PeepActionDescriptionType::watchingRide
+        STR_WATCHING_CONSTRUCTION_OF,            // PeepActionDescriptionType::watchingRideConstruction
+        STR_WATCHING_NEW_RIDE_BEING_CONSTRUCTED, // PeepActionDescriptionType::watchingRideConstructionUnspecific
+        STR_QUEUING_FOR,                         // PeepActionDescriptionType::queuingFor
+        STR_ON_RIDE,                             // PeepActionDescriptionType::onRide
+        STR_IN_RIDE,                             // PeepActionDescriptionType::inRide
+        STR_AT_RIDE,                             // PeepActionDescriptionType::atShop
+        STR_LEAVING_PARK,                        // PeepActionDescriptionType::leavingPark
+        STR_SWEEPING_FOOTPATH,                   // PeepActionDescriptionType::sweepingFootpath
+        STR_EMPTYING_LITTER_BIN,                 // PeepActionDescriptionType::emptyingBin
+        STR_WATERING_GARDENS,                    // PeepActionDescriptionType::wateringGardens
+        STR_MOWING_GRASS,                        // PeepActionDescriptionType::mowingGrass
+        STR_HEADING_TO_RIDE_FOR_INSPECTION,      // PeepActionDescriptionType::headingToInspectRide
+        STR_INSPECTING_RIDE,                     // PeepActionDescriptionType::inspectingRide
+        STR_FIXING_RIDE,                         // PeepActionDescriptionType::fixingRide
+        STR_ANSWERING_RADIO_CALL,                // PeepActionDescriptionType::answeringRadioCall
+        STR_RESPONDING_TO_RIDE_BREAKDOWN_CALL,   // PeepActionDescriptionType::respondingToBreakdownCall
+    });
+    static_assert(std::size(kPeepActionToStringMapping) == kNumPeepActionDescriptionTypes);
+
+    void formatPeepActionTo(const Peep& peep, Formatter& ft)
+    {
+        auto description = peep.getActionDescription();
+        auto stringId = kPeepActionToStringMapping[EnumValue(description.type)];
+        ft.Add<StringId>(stringId);
+
+        if (!description.rideId.IsNull())
+        {
+            const auto* ride = GetRide(description.rideId);
+            if (ride != nullptr)
+            {
+                ride->formatNameTo(ft);
+            }
+        }
+    }
+} // namespace OpenRCT2

--- a/src/openrct2/peep/PeepActionFormat.cpp
+++ b/src/openrct2/peep/PeepActionFormat.cpp
@@ -15,38 +15,45 @@
 
 namespace OpenRCT2
 {
-    constexpr auto kPeepActionToStringMapping = std::to_array<StringId>({
-        STR_WALKING,                             // PeepActionDescriptionType::walking
-        STR_SITTING,                             // PeepActionDescriptionType::sitting
-        STR_LOOKING_AT_SCENERY,                  // PeepActionDescriptionType::watchingScenery
-        STR_DROWNING,                            // PeepActionDescriptionType::drowning
-        STR_SELECT_LOCATION,                     // PeepActionDescriptionType::pickedUp
-        STR_HEADING_FOR,                         // PeepActionDescriptionType::headingFor
-        STR_WATCHING_RIDE,                       // PeepActionDescriptionType::watchingRide
-        STR_WATCHING_CONSTRUCTION_OF,            // PeepActionDescriptionType::watchingRideConstruction
-        STR_WATCHING_NEW_RIDE_BEING_CONSTRUCTED, // PeepActionDescriptionType::watchingRideConstructionUnspecific
-        STR_QUEUING_FOR,                         // PeepActionDescriptionType::queuingFor
-        STR_ON_RIDE,                             // PeepActionDescriptionType::onRide
-        STR_IN_RIDE,                             // PeepActionDescriptionType::inRide
-        STR_AT_RIDE,                             // PeepActionDescriptionType::atShop
-        STR_LEAVING_PARK,                        // PeepActionDescriptionType::leavingPark
-        STR_SWEEPING_FOOTPATH,                   // PeepActionDescriptionType::sweepingFootpath
-        STR_EMPTYING_LITTER_BIN,                 // PeepActionDescriptionType::emptyingBin
-        STR_WATERING_GARDENS,                    // PeepActionDescriptionType::wateringGardens
-        STR_MOWING_GRASS,                        // PeepActionDescriptionType::mowingGrass
-        STR_HEADING_TO_RIDE_FOR_INSPECTION,      // PeepActionDescriptionType::headingToInspectRide
-        STR_INSPECTING_RIDE,                     // PeepActionDescriptionType::inspectingRide
-        STR_FIXING_RIDE,                         // PeepActionDescriptionType::fixingRide
-        STR_ANSWERING_RADIO_CALL,                // PeepActionDescriptionType::answeringRadioCall
-        STR_RESPONDING_TO_RIDE_BREAKDOWN_CALL,   // PeepActionDescriptionType::respondingToBreakdownCall
+    struct MappingStrings
+    {
+        StringId singular;
+        StringId group;
+    };
+
+    constexpr auto kPeepActionToStringMapping = std::to_array<MappingStrings>({
+        { STR_WALKING, STR_GUESTS_WALKING },                                   // walking
+        { STR_SITTING, STR_GUESTS_SITTING },                                   // sitting
+        { STR_LOOKING_AT_SCENERY, STR_GUESTS_LOOKING_AT_SCENERY },             // watchingScenery
+        { STR_DROWNING, STR_GUESTS_DROWNING },                                 // drowning
+        { STR_SELECT_LOCATION, STR_GUESTS_PICKED_UP },                         // pickedUp
+        { STR_HEADING_FOR, STR_GUESTS_HEADING_FOR },                           // headingFor
+        { STR_WATCHING_RIDE, STR_GUESTS_WATCHING_RIDE },                       // watchingRide
+        { STR_WATCHING_CONSTRUCTION_OF, STR_GUESTS_WATCHING_CONSTRUCTION_OF }, // watchingRideConstruction
+        { STR_WATCHING_NEW_RIDE_BEING_CONSTRUCTED,
+          STR_GUESTS_WATCHING_NEW_RIDE_BEING_CONSTRUCTED },        // watchingRideConstructionUnspecific
+        { STR_QUEUING_FOR, STR_GUESTS_QUEUING_FOR },               // queuingFor
+        { STR_ON_RIDE, STR_GUESTS_ON_RIDE },                       // onRide
+        { STR_IN_RIDE, STR_GUESTS_IN_RIDE },                       // inRide
+        { STR_AT_RIDE, STR_GUESTS_AT_RIDE },                       // atShop
+        { STR_LEAVING_PARK, STR_GUESTS_LEAVING_PARK },             // leavingPark
+        { STR_SWEEPING_FOOTPATH, kStringIdEmpty },                 // sweepingFootpath
+        { STR_EMPTYING_LITTER_BIN, kStringIdEmpty },               // emptyingBin
+        { STR_WATERING_GARDENS, kStringIdEmpty },                  // wateringGardens
+        { STR_MOWING_GRASS, kStringIdEmpty },                      // mowingGrass
+        { STR_HEADING_TO_RIDE_FOR_INSPECTION, kStringIdEmpty },    // headingToInspectRide
+        { STR_INSPECTING_RIDE, kStringIdEmpty },                   // inspectingRide
+        { STR_FIXING_RIDE, kStringIdEmpty },                       // fixingRide
+        { STR_ANSWERING_RADIO_CALL, kStringIdEmpty },              // answeringRadioCall
+        { STR_RESPONDING_TO_RIDE_BREAKDOWN_CALL, kStringIdEmpty }, // respondingToBreakdownCall
     });
     static_assert(std::size(kPeepActionToStringMapping) == kNumPeepActionDescriptionTypes);
 
-    void formatPeepActionTo(const Peep& peep, Formatter& ft)
+    void formatPeepActionTo(const Peep& peep, Formatter& ft, bool asGroup)
     {
         auto description = peep.getActionDescription();
-        auto stringId = kPeepActionToStringMapping[EnumValue(description.type)];
-        ft.Add<StringId>(stringId);
+        auto stringIds = kPeepActionToStringMapping[EnumValue(description.type)];
+        ft.Add<StringId>(asGroup ? stringIds.group : stringIds.singular);
 
         if (!description.rideId.IsNull())
         {

--- a/src/openrct2/peep/PeepActionFormat.h
+++ b/src/openrct2/peep/PeepActionFormat.h
@@ -1,0 +1,19 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2026 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+namespace OpenRCT2
+{
+    class Formatter;
+    struct Peep;
+
+    void formatPeepActionTo(const Peep& peep, Formatter&);
+
+} // namespace OpenRCT2

--- a/src/openrct2/peep/PeepActionFormat.h
+++ b/src/openrct2/peep/PeepActionFormat.h
@@ -14,6 +14,6 @@ namespace OpenRCT2
     class Formatter;
     struct Peep;
 
-    void formatPeepActionTo(const Peep& peep, Formatter&);
+    void formatPeepActionTo(const Peep& peep, Formatter&, bool asGroup = false);
 
 } // namespace OpenRCT2


### PR DESCRIPTION
This PR consists of two commits. The first splits out the code to determine what action to present to the user (e.g. "Walking") and the actual strings. It also moves the string handling out of the Peep struct.

The second fixes the actual issue, by creating new strings for all the peep actions and returning those for the guest list. This allows translators to create proper translations, as most languages cannot just smash "Guests" and a string like "Walking" together and expect the result to be grammatically correct. (Even in English it’s somewhat iffy capitalisation.)

I haven’t yet added a changelog entry as I don’t expect to get this in for v0.5.5.