### PR TITLE
Fix #18151: Park value and company value are out of date after loading a save

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Fix: [#18151] Park value and company value are out of date after loading a save.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -79,6 +79,7 @@
 #include "ui/WindowManager.h"
 #include "world/MapAnimation.h"
 #include "world/MapSelection.h"
+#include "world/Park.h"
 
 #include <chrono>
 #include <cmath>
@@ -810,6 +811,10 @@ namespace OpenRCT2
                     }
 #endif
                     GameLoadInit(); // NB: calls `setActiveScene`
+
+                    // Park::Update only recalculates these every ~13 seconds, so a save can hold a value that
+                    // predates this park being loaded. Scenarios get the same treatment from ScenarioReset.
+                    Park::updateValuations(gameState.park, gameState);
 #ifndef DISABLE_NETWORK
                     if (_network.GetMode() == Network::Mode::server)
                     {

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -87,8 +87,7 @@ void ScenarioReset(GameState_t& gameState)
 
     auto& park = gameState.park;
     park.rating = Park::CalculateParkRating(park, gameState);
-    park.value = Park::CalculateParkValue(park, gameState);
-    park.companyValue = Park::CalculateCompanyValue(park);
+    Park::updateValuations(park, gameState);
     park.historicalProfit = gameState.scenarioOptions.initialCash - park.bankLoan;
     park.cash = gameState.scenarioOptions.initialCash;
 

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -311,6 +311,12 @@ namespace OpenRCT2::Park
         gameState.scenarioOptions.details = String::toStd(LanguageGetString(STR_NO_DETAILS_YET));
     }
 
+    void updateValuations(ParkData& park, const GameState_t& gameState)
+    {
+        park.value = CalculateParkValue(park, gameState);
+        park.companyValue = CalculateCompanyValue(park);
+    }
+
     void Update(ParkData& park, GameState_t& gameState)
     {
         PROFILED_FUNCTION();
@@ -328,8 +334,7 @@ namespace OpenRCT2::Park
         if (currentTicks % 512 == 0)
         {
             park.rating = CalculateParkRating(park, gameState);
-            park.value = CalculateParkValue(park, gameState);
-            park.companyValue = CalculateCompanyValue(park);
+            updateValuations(park, gameState);
             park.totalRideValueForMoney = calculateTotalRideValueForMoney(park, gameState);
             park.suggestedGuestMaximum = calculateSuggestedMaxGuests(park, gameState);
             park.guestGenerationProbability = calculateGuestGenerationProbability(park);

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -30,6 +30,7 @@ namespace OpenRCT2::Park
     int32_t CalculateParkRating(const ParkData& park, const GameState_t& gameState);
     money64 CalculateParkValue(const ParkData& park, const GameState_t& gameState);
     money64 CalculateCompanyValue(const ParkData& park);
+    void updateValuations(ParkData& park, const GameState_t& gameState);
 
     Guest* GenerateGuest();
 


### PR DESCRIPTION
### Description of changes

Fixes #18151. Recalculate the park value and the company value when a saved game is loaded, instead of using whatever the file stored.

### Rationale behind changes

Both are only recalculated every 512 ticks. `ScenarioReset` refreshes them when a scenario begins, but loading a saved game never goes through it, so the park keeps the figures that came out of the file until the first periodic tick. For an RCT1 save that park value used the RCT1 formula, and a scenario completing in those few seconds records it as the score.

The park rating is left alone: RCT1 imports it as-is, and `calculateGuestGenerationProbability` starts from it and is compared against `ScenarioRand`, so refreshing it on load would change guest generation in every existing save.

### Suggested testing steps

Load an RCT1 save and compare the company value in the finances window the moment it opens with the one it settles on seconds later. They should now match.

The save in #18151 no longer wins on its own, since Windstorm dropped just under the required 7.00 excitement when #18146 gave the Classic Wooden Roller Coaster its own ratings. Raising that locally makes it win on load again, and the score goes from roughly €41,500 to €386,626.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.
