### PR TITLE
Close #21400: draw staff patrol area selector on the water

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Improved: [#21400] The selector for setting staff patrol areas is now drawn on the water as well as on the surface under water.
 - Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -485,9 +485,9 @@ namespace OpenRCT2::Ui::Windows
                 state_changed++;
             }
 
-            if (gMapSelectType != MapSelectType::fullLandRights)
+            if (gMapSelectType != MapSelectType::fullTerrainAndWater)
             {
-                gMapSelectType = MapSelectType::fullLandRights;
+                gMapSelectType = MapSelectType::fullTerrainAndWater;
                 state_changed++;
             }
 

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -7,8 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "../interface/ViewportQuery.h"
-
 #include <openrct2-ui/interface/LandTool.h>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/interface/Window.h>
@@ -162,7 +160,7 @@ namespace OpenRCT2::Ui::Windows
             if (!gMapSelectFlags.has(MapSelectFlag::enable))
                 stateChanged = true;
 
-            if (gMapSelectType != MapSelectType::full)
+            if (gMapSelectType != MapSelectType::fullTerrainAndWater)
                 stateChanged = true;
 
             auto toolSize = std::max<uint16_t>(1, gLandToolSize);
@@ -182,7 +180,7 @@ namespace OpenRCT2::Ui::Windows
             if (stateChanged)
             {
                 gMapSelectFlags.set(MapSelectFlag::enable);
-                gMapSelectType = MapSelectType::full;
+                gMapSelectType = MapSelectType::fullTerrainAndWater;
                 gMapSelectPositionA = posA;
                 gMapSelectPositionB = posB;
             }
@@ -279,8 +277,14 @@ namespace OpenRCT2::Ui::Windows
 
         std::optional<CoordsXY> GetBestCoordsFromPos(const ScreenCoordsXY& pos)
         {
-            auto coords = FootpathGetCoordinatesFromPos(pos, nullptr, nullptr);
-            return coords.isNull() ? std::nullopt : std::make_optional(coords);
+            auto info = GetMapCoordinatesFromPos(
+                pos,
+                EnumsToFlags(
+                    ViewportInteractionItem::terrain, ViewportInteractionItem::water, ViewportInteractionItem::footpath));
+            if (info.interactionType == ViewportInteractionItem::none)
+                return std::nullopt;
+
+            return info.Loc;
         }
     };
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1131,7 +1131,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, image_id, 0, 0);
             }
-            else if (mapSelectionType == MapSelectType::fullLandRights)
+            else if (mapSelectionType == MapSelectType::fullTerrainAndWater)
             {
                 auto [waterHeight, waterSurfaceShape] = SurfaceGetHeightAboveWater(tileElement, height, surfaceShape);
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -806,7 +806,8 @@ static std::pair<int32_t, int32_t> SurfaceGetHeightAboveWater(
 
 std::optional<OpenRCT2::Drawing::Colour> GetPatrolAreaTileColour(const CoordsXY& pos)
 {
-    bool selected = gMapSelectFlags.has(MapSelectFlag::enable) && gMapSelectType == MapSelectType::full
+    bool selected = gMapSelectFlags.has(MapSelectFlag::enable)
+        && (gMapSelectType == MapSelectType::full || gMapSelectType == MapSelectType::fullTerrainAndWater)
         && pos.x >= gMapSelectPositionA.x && pos.x <= gMapSelectPositionB.x && pos.y >= gMapSelectPositionA.y
         && pos.y <= gMapSelectPositionB.y;
 

--- a/src/openrct2/world/MapSelection.h
+++ b/src/openrct2/world/MapSelection.h
@@ -35,7 +35,7 @@ enum class MapSelectType : uint8_t
     corner3,
     full,
     fullWater,
-    fullLandRights,
+    fullTerrainAndWater,
     quarter0,
     quarter1,
     quarter2,


### PR DESCRIPTION
### Description of changes

Closes #21400. `MapSelectType::fullLandRights` is renamed to `fullTerrainAndWater`, since the marker it draws was never specific to land rights: on a dry tile it is identical to `MapSelectType::full`, on a submerged one it adds a second draw at the water height. The patrol area tool now uses that type, and its coordinate lookup moves from `FootpathGetCoordinatesFromPos`, which queries only footpaths and terrain, to `GetMapCoordinatesFromPos` over terrain, water and footpaths. `GetPatrolAreaTileColour` decides whether a patrol tile is hovered by comparing against `MapSelectType::full`, so it now accepts the new type as well; without that, tiles under the cursor stopped lighting up.

| Before | After |
| --- | --- |
| <img width="700" height="420" alt="patrol-water-before" src="https://github.com/user-attachments/assets/14699b72-96fd-4511-8df1-0d1cd97b743c" /> | <img width="700" height="420" alt="patrol-water-after" src="https://github.com/user-attachments/assets/17bd631e-31cc-4495-b485-1bee3a884a32" />

### Rationale behind changes

The selection grid sank to the seabed over water, away from the pointer, because the tool resolved the cursor against the terrain and ignored water.

The patrol area overlay has been drawn on the water since https://github.com/OpenRCT2/OpenRCT2/pull/682, and land rights followed in https://github.com/OpenRCT2/OpenRCT2/pull/18632.

### Suggested testing steps

Set a patrol area over water: the grid should follow the cursor on the water surface, with a fainter copy visible on the seabed, as land rights already does. Tiles under the cursor should light up while hovering, both on land and on water. Dry land, raised footpaths and buying land rights should all be unchanged.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.
