### PR TITLE
Fix #26222: "Follow this on Main View" follows invisible first car instead of the actual car

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
+- Fix: [#26222] ‘Follow this on Main View’ follows the invisible first car on ride types that have one, making the view turn too early.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 
 0.5.5 (2026-09-06)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -764,6 +764,24 @@ namespace OpenRCT2::Ui::Windows
             return selectedCarIndex;
         }
 
+        static Vehicle* getFirstVisibleCar(EntityId trainHead)
+        {
+            auto& entities = getGameState().entities;
+            auto* head = entities.getEntity<Vehicle>(trainHead);
+
+            auto* vehicle = head;
+            for (auto remaining = Limits::kMaxCarsPerTrain; vehicle != nullptr && remaining > 0; remaining--)
+            {
+                const auto* carEntry = vehicle->Entry();
+                if (carEntry == nullptr || carEntry->isVisible())
+                    return vehicle;
+
+                vehicle = entities.getEntity<Vehicle>(vehicle->next_vehicle_on_train);
+            }
+
+            return head;
+        }
+
     public:
         RideWindow(const Ride& ride)
         {
@@ -1551,23 +1569,10 @@ namespace OpenRCT2::Ui::Windows
 
             if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->numTrains && ride->flags.has(RideFlag::onTrack))
             {
-                auto vehId = ride->vehicles[viewSelectionIndex];
-                const auto* rideEntry = ride->getRideEntry();
-                if (rideEntry != nullptr && rideEntry->TabCar != 0)
+                const auto* vehicle = getFirstVisibleCar(ride->vehicles[viewSelectionIndex]);
+                if (vehicle != nullptr)
                 {
-                    Vehicle* vehicle = getGameState().entities.getEntity<Vehicle>(vehId);
-                    if (vehicle == nullptr)
-                    {
-                        vehId = EntityId::GetNull();
-                    }
-                    else if (!vehicle->next_vehicle_on_train.IsNull())
-                    {
-                        vehId = vehicle->next_vehicle_on_train;
-                    }
-                }
-                if (!vehId.IsNull())
-                {
-                    newFocus = Focus(vehId);
+                    newFocus = Focus(vehicle->id);
                 }
             }
             else if (viewSelectionIndex >= ride->numTrains && viewSelectionIndex < (ride->numTrains + ride->numStations))
@@ -2016,12 +2021,11 @@ namespace OpenRCT2::Ui::Windows
                     {
                         if (_viewIndex <= ride->numTrains)
                         {
-                            Vehicle* vehicle = getGameState().entities.getEntity<Vehicle>(ride->vehicles[_viewIndex - 1]);
+                            const auto* vehicle = getFirstVisibleCar(ride->vehicles[_viewIndex - 1]);
                             if (vehicle != nullptr)
                             {
-                                auto headVehicleSpriteIndex = vehicle->id;
                                 WindowBase* w_main = WindowGetMain();
-                                WindowFollowSprite(*w_main, headVehicleSpriteIndex);
+                                WindowFollowSprite(*w_main, vehicle->id);
                             }
                         }
                     }


### PR DESCRIPTION
### Description of changes

Closes #26222. "Follow this on Main View" followed the head of the train. On ride types that have an invisible car at the front, that is the car it followed.

Added `getFirstVisibleCar()`, which walks a train from the head to the first car with `CarEntry::isVisible()`. Both the main-view follow and the ride window's own viewport focus use it. The viewport focus previously skipped one car when `rideEntry->TabCar != 0`. `TabCar` is the car drawn on the vehicle tab, not the first visible one.

### Rationale behind changes

The camera turns early on tight corners because it tracks a point ahead of the car you are watching. `CarEntry::isVisible()` was added in 4fd07d3216 for the colour tab and answers this directly.

### Suggested testing steps

Build a car ride with a tight turn, select a train in the ride window's view dropdown, and choose "Follow this on Main View". The camera should stay on the visible car. The ride window's own viewport is worth a look on a few stock rides, since that call site changed too.

Checked on Diamond Heights with `rct1.ride.mine_cars`, whose front car has `rotationFrameMask == 0`, with cars per train raised so the invisible head car exists. With temporary logging, the follow option tracked the first visible car instead of the head.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.
