### PR TITLE
Rename RideStation struct members in Ride.h

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -395,7 +395,7 @@ namespace OpenRCT2::Ui
                     stationIndex = tileElement->asTrack()->getStationIndex().ToUnderlying();
 
                 for (int32_t i = stationIndex; i >= 0; i--)
-                    if (ride->getStations()[i].Start.IsNull())
+                    if (ride->getStations()[i].start.IsNull())
                         stationIndex--;
                 stationIndex++;
                 ft.Add<uint16_t>(stationIndex);

--- a/src/openrct2-ui/ride/Construction.cpp
+++ b/src/openrct2-ui/ride/Construction.cpp
@@ -405,7 +405,7 @@ namespace OpenRCT2
             return entranceExitCoords;
         }
 
-        auto stationBaseZ = ride->getStation(gRideEntranceExitPlaceStationIndex).GetBaseZ();
+        auto stationBaseZ = ride->getStation(gRideEntranceExitPlaceStationIndex).getBaseZ();
 
         auto coordsAtHeight = ScreenGetMapXYWithZ(screenCoords, stationBaseZ);
         if (!coordsAtHeight.has_value())
@@ -422,7 +422,7 @@ namespace OpenRCT2
             return entranceExitCoords;
         }
 
-        auto stationStart = ride->getStation(gRideEntranceExitPlaceStationIndex).Start;
+        auto stationStart = ride->getStation(gRideEntranceExitPlaceStationIndex).start;
         if (stationStart.IsNull())
         {
             entranceExitCoords.SetNull();

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1511,7 +1511,7 @@ namespace OpenRCT2::Ui::Windows
 
             for (const auto& station : ride->getStations())
             {
-                if (!station.Start.IsNull() && viewSelectionIndex-- == 0)
+                if (!station.start.IsNull() && viewSelectionIndex-- == 0)
                 {
                     const auto stationIndex = ride->getStationIndex(&station);
                     return std::make_optional(stationIndex);
@@ -1559,7 +1559,7 @@ namespace OpenRCT2::Ui::Windows
                 auto stationIndex = GetStationIndexFromViewSelection();
                 if (stationIndex)
                 {
-                    const auto location = ride->getStation(*stationIndex).GetStart();
+                    const auto location = ride->getStation(*stationIndex).getStart();
                     newFocus = Focus(location);
                 }
             }
@@ -2546,21 +2546,21 @@ namespace OpenRCT2::Ui::Windows
             // Entrance / exit
             if (ride->status == RideStatus::closed)
             {
-                if (station.Entrance.IsNull())
+                if (station.entrance.IsNull())
                     stringId = STR_NO_ENTRANCE;
-                else if (station.Exit.IsNull())
+                else if (station.exit.IsNull())
                     stringId = STR_NO_EXIT;
             }
             else
             {
-                if (station.Entrance.IsNull())
+                if (station.entrance.IsNull())
                     stringId = STR_EXIT_ONLY;
             }
             // Queue length
             if (stringId == kStringIdEmpty)
             {
                 stringId = STR_QUEUE_EMPTY;
-                uint16_t queueLength = ride->getStation(*stationIndex).QueueLength;
+                uint16_t queueLength = ride->getStation(*stationIndex).queueLength;
                 if (queueLength == 1)
                     stringId = STR_QUEUE_ONE_PERSON;
                 else if (queueLength > 1)
@@ -6006,7 +6006,7 @@ namespace OpenRCT2::Ui::Windows
                             for (int32_t i = 0; i < std::min<int32_t>(ride->numStations, 4); i++)
                             {
                                 StationIndex stationIndex = StationIndex::FromUnderlying(numTimes);
-                                auto time = ride->getStation(stationIndex).SegmentTime;
+                                auto time = ride->getStation(stationIndex).segmentTime;
                                 if (time != 0)
                                 {
                                     ft.Add<uint16_t>(STR_RIDE_TIME_ENTRY_WITH_SEPARATOR);
@@ -6045,7 +6045,7 @@ namespace OpenRCT2::Ui::Windows
                         for (int32_t i = 0; i < std::min<int32_t>(ride->numStations, 4); i++)
                         {
                             StationIndex stationIndex = StationIndex::FromUnderlying(i);
-                            auto length = ride->getStation(stationIndex).SegmentLength;
+                            auto length = ride->getStation(stationIndex).segmentLength;
                             if (length != 0)
                             {
                                 length >>= 16;
@@ -7278,7 +7278,7 @@ namespace OpenRCT2::Ui::Windows
         // View
         for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
         {
-            if (ride.getStations()[i].Start.IsNull())
+            if (ride.getStations()[i].start.IsNull())
             {
                 stationIndex = StationIndex::FromUnderlying(stationIndex.ToUnderlying() - 1);
             }

--- a/src/openrct2/actions/cheats/CheatSetAction.cpp
+++ b/src/openrct2/actions/cheats/CheatSetAction.cpp
@@ -717,8 +717,8 @@ namespace OpenRCT2::GameActions
 
             for (auto& station : ride.getStations())
             {
-                station.QueueLength = 0;
-                station.LastPeepInQueue = EntityId::GetNull();
+                station.queueLength = 0;
+                station.lastPeepInQueue = EntityId::GetNull();
             }
 
             for (auto trainIndex : ride.vehicles)

--- a/src/openrct2/actions/ride/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/ride/MazePlaceTrackAction.cpp
@@ -198,8 +198,8 @@ namespace OpenRCT2::GameActions
         MapInvalidateTileFull(startLoc);
 
         ride->mazeTiles++;
-        ride->getStation().SetBaseZ(trackElement->getBaseZ());
-        ride->getStation().Start = { 0, 0 };
+        ride->getStation().setBaseZ(trackElement->getBaseZ());
+        ride->getStation().start = { 0, 0 };
 
         if (ride->mazeTiles == 1)
         {

--- a/src/openrct2/actions/ride/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/ride/MazeSetTrackAction.cpp
@@ -247,8 +247,8 @@ namespace OpenRCT2::GameActions
             MapInvalidateTileFull(startLoc);
 
             ride->mazeTiles++;
-            ride->getStation().SetBaseZ(tileElement->getBaseZ());
-            ride->getStation().Start = { 0, 0 };
+            ride->getStation().setBaseZ(tileElement->getBaseZ());
+            ride->getStation().start = { 0, 0 };
 
             if (_initialPlacement && !flags.has(CommandFlag::ghost))
             {

--- a/src/openrct2/actions/ride/RideCreateAction.cpp
+++ b/src/openrct2/actions/ride/RideCreateAction.cpp
@@ -150,9 +150,9 @@ namespace OpenRCT2::GameActions
 
         // Default initialize all stations.
         RideStation station{};
-        station.Start.SetNull();
-        station.Entrance.SetNull();
-        station.Exit.SetNull();
+        station.start.SetNull();
+        station.entrance.SetNull();
+        station.exit.SetNull();
         std::ranges::fill(ride->getStations(), station);
 
         ride->status = RideStatus::closed;

--- a/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitPlaceAction.cpp
@@ -88,7 +88,7 @@ namespace OpenRCT2::GameActions
         }
 
         const auto& station = ride->getStation(_stationNum);
-        const auto location = _isExit ? station.Exit : station.Entrance;
+        const auto location = _isExit ? station.exit : station.entrance;
 
         if (!location.IsNull())
         {
@@ -103,7 +103,7 @@ namespace OpenRCT2::GameActions
             }
         }
 
-        auto z = ride->getStation(_stationNum).GetBaseZ();
+        auto z = ride->getStation(_stationNum).getBaseZ();
         if (!LocationValid(_loc))
         {
             return Result(Status::invalidParameters, errorTitle, STR_OFF_EDGE_OF_MAP);
@@ -164,7 +164,7 @@ namespace OpenRCT2::GameActions
         }
 
         auto& station = ride->getStation(_stationNum);
-        const auto location = _isExit ? station.Exit : station.Entrance;
+        const auto location = _isExit ? station.exit : station.entrance;
         if (!location.IsNull())
         {
             auto rideEntranceExitRemove = RideEntranceExitRemoveAction(location.ToCoordsXY(), _rideIndex, _stationNum, _isExit);
@@ -178,7 +178,7 @@ namespace OpenRCT2::GameActions
             }
         }
 
-        auto z = station.GetBaseZ();
+        auto z = station.getBaseZ();
         if (!GetFlags().has(CommandFlag::allowDuringPaused) && !GetFlags().has(CommandFlag::ghost)
             && !gameState.cheats.disableClearanceChecks)
         {
@@ -212,13 +212,13 @@ namespace OpenRCT2::GameActions
 
         if (_isExit)
         {
-            station.Exit = TileCoordsXYZD(CoordsXYZD{ _loc, z, entranceElement->getDirection() });
+            station.exit = TileCoordsXYZD(CoordsXYZD{ _loc, z, entranceElement->getDirection() });
         }
         else
         {
-            station.Entrance = TileCoordsXYZD(CoordsXYZD{ _loc, z, entranceElement->getDirection() });
-            station.LastPeepInQueue = EntityId::GetNull();
-            station.QueueLength = 0;
+            station.entrance = TileCoordsXYZD(CoordsXYZD{ _loc, z, entranceElement->getDirection() });
+            station.lastPeepInQueue = EntityId::GetNull();
+            station.queueLength = 0;
 
             MapAnimations::MarkTileForInvalidation(TileCoordsXY(_loc));
         }

--- a/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/ride/RideEntranceExitRemoveAction.cpp
@@ -156,11 +156,11 @@ namespace OpenRCT2::GameActions
         auto& station = ride->getStation(_stationNum);
         if (_isExit)
         {
-            station.Exit.SetNull();
+            station.exit.SetNull();
         }
         else
         {
-            station.Entrance.SetNull();
+            station.entrance.SetNull();
         }
 
         FootpathUpdateQueueChains();

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -1912,7 +1912,7 @@ namespace OpenRCT2
                 // Rides without queues can only have one peep waiting at a time.
                 if (!atQueue)
                 {
-                    if (!station.LastPeepInQueue.IsNull())
+                    if (!station.lastPeepInQueue.IsNull())
                     {
                         GuestTriedToEnterFullQueue(*this, ride);
                         return false;
@@ -1921,7 +1921,7 @@ namespace OpenRCT2
                 else
                 {
                     // Check if there's room in the queue for the peep to enter.
-                    Guest* lastPeepInQueue = getGameState().entities.getEntity<Guest>(station.LastPeepInQueue);
+                    Guest* lastPeepInQueue = getGameState().entities.getEntity<Guest>(station.lastPeepInQueue);
                     if (lastPeepInQueue != nullptr && (abs(lastPeepInQueue->z - z) <= 6))
                     {
                         int32_t dx = abs(lastPeepInQueue->x - x);
@@ -2452,13 +2452,13 @@ namespace OpenRCT2
     void Guest::goToRideEntrance(const Ride& ride)
     {
         const auto& station = ride.getStation(currentRideStation);
-        if (station.Entrance.IsNull())
+        if (station.entrance.IsNull())
         {
             removeFromQueue();
             return;
         }
 
-        auto location = station.Entrance.ToCoordsXYZD().ToTileCentre();
+        auto location = station.entrance.ToCoordsXYZD().ToTileCentre();
         int16_t x_shift = DirectionOffsets[location.direction].x;
         int16_t y_shift = DirectionOffsets[location.direction].y;
 
@@ -2516,7 +2516,7 @@ namespace OpenRCT2
         }
         else
         {
-            chosen_train = ride.getStation(guest.currentRideStation).TrainAtStation;
+            chosen_train = ride.getStation(guest.currentRideStation).trainAtStation;
         }
         if (chosen_train >= Limits::kMaxTrainsPerRide)
         {
@@ -3173,7 +3173,7 @@ namespace OpenRCT2
             auto ride = GetRide(potentialRides[i]);
             if (ride != nullptr)
             {
-                auto rideLocation = ride->getStation().Start;
+                auto rideLocation = ride->getStation().start;
                 int32_t distance = abs(rideLocation.x - guest.x) + abs(rideLocation.y - guest.y);
                 if (distance < closestRideDistance)
                 {
@@ -3429,7 +3429,7 @@ namespace OpenRCT2
                 if (xy_distance < 16)
                 {
                     const auto& station = ride->getStation(currentRideStation);
-                    auto entrance = station.Entrance.ToCoordsXYZ();
+                    auto entrance = station.entrance.ToCoordsXYZ();
                     actionZ = entrance.z + 2;
                 }
                 moveTo({ loc.value(), actionZ });
@@ -3518,7 +3518,7 @@ namespace OpenRCT2
 
     void PeepUpdateRideLeaveEntranceSpiralSlide(Guest& guest, Ride& ride, CoordsXYZD& entrance_loc)
     {
-        entrance_loc = { ride.getStation(guest.currentRideStation).GetStart(), entrance_loc.direction };
+        entrance_loc = { ride.getStation(guest.currentRideStation).getStart(), entrance_loc.direction };
 
         TileElement* tile_element = RideGetStationStartTrackElement(ride, guest.currentRideStation);
 
@@ -3585,11 +3585,11 @@ namespace OpenRCT2
     void Guest::updateRideLeaveEntranceWaypoints(const Ride& ride)
     {
         const auto& station = ride.getStation(currentRideStation);
-        if (station.Entrance.IsNull())
+        if (station.entrance.IsNull())
         {
             return;
         }
-        uint8_t direction_entrance = station.Entrance.direction;
+        uint8_t direction_entrance = station.entrance.direction;
 
         TileElement* tile_element = RideGetStationStartTrackElement(ride, currentRideStation);
 
@@ -3653,7 +3653,7 @@ namespace OpenRCT2
                 rideSubState = PeepRideSubState::freeVehicleCheck;
             }
 
-            actionZ = ride->getStation(currentRideStation).GetBaseZ();
+            actionZ = ride->getStation(currentRideStation).getBaseZ();
 
             distanceThreshold += 4;
             if (xy_distance < distanceThreshold)
@@ -3674,7 +3674,7 @@ namespace OpenRCT2
         if (ride->getRideTypeDescriptor().flags.has(RtdFlag::noVehicles))
         {
             const auto& station = ride->getStation(currentRideStation);
-            auto entranceLocation = station.Entrance.ToCoordsXYZD();
+            auto entranceLocation = station.entrance.ToCoordsXYZD();
             if (entranceLocation.IsNull())
             {
                 return;
@@ -3764,7 +3764,7 @@ namespace OpenRCT2
         guest.moveTo({ x, y, z });
 
         Guard::Assert(guest.currentRideStation.ToUnderlying() < Limits::kMaxStationsPerRide);
-        auto exit = ride.getStation(guest.currentRideStation).Exit;
+        auto exit = ride.getStation(guest.currentRideStation).exit;
         x = exit.x;
         y = exit.y;
         x *= 32;
@@ -3836,9 +3836,9 @@ namespace OpenRCT2
 
         queueTime /= 2;
         auto& station = ride.getStation(currentRideStation);
-        if (queueTime != station.QueueTime)
+        if (queueTime != station.queueTime)
         {
-            station.QueueTime = queueTime;
+            station.queueTime = queueTime;
             auto* windowMgr = Ui::GetWindowManager();
             windowMgr->InvalidateByNumber(WindowClass::ride, currentRide.ToUnderlying());
         }
@@ -3876,7 +3876,7 @@ namespace OpenRCT2
      */
     static void PeepUpdateRideNoFreeVehicleRejoinQueue(Guest& guest, Ride& ride)
     {
-        TileCoordsXYZD entranceLocation = ride.getStation(guest.currentRideStation).Entrance;
+        TileCoordsXYZD entranceLocation = ride.getStation(guest.currentRideStation).entrance;
 
         int32_t x = entranceLocation.x * 32;
         int32_t y = entranceLocation.y * 32;
@@ -4139,9 +4139,9 @@ namespace OpenRCT2
 
         if (!carEntry->flags.has(CarEntryFlag::loadingWaypoints))
         {
-            TileCoordsXYZD exitLocation = station.Exit;
+            TileCoordsXYZD exitLocation = station.exit;
             CoordsXYZD platformLocation;
-            platformLocation.z = station.GetBaseZ();
+            platformLocation.z = station.getBaseZ();
 
             platformLocation.direction = DirectionReverse(exitLocation.direction);
 
@@ -4249,14 +4249,14 @@ namespace OpenRCT2
                     carEntry->guestLoadingPositions.size());
             }
 
-            platformLocation.z = station.GetBaseZ();
+            platformLocation.z = station.getBaseZ();
 
             PeepGoToRideExit(
                 *this, *ride, platformLocation.x, platformLocation.y, platformLocation.z, platformLocation.direction);
             return;
         }
 
-        auto exitLocation = station.Exit.ToCoordsXYZD();
+        auto exitLocation = station.exit.ToCoordsXYZD();
         if (exitLocation.IsNull())
         {
             return;
@@ -4317,7 +4317,7 @@ namespace OpenRCT2
         if (ride == nullptr || currentRideStation.ToUnderlying() >= std::size(ride->getStations()))
             return;
 
-        auto exit = ride->getStation(currentRideStation).Exit;
+        auto exit = ride->getStation(currentRideStation).exit;
         auto newDestination = exit.ToCoordsXY().ToTileCentre();
 
         auto [xShift, yShift] = [exit]() {
@@ -4384,7 +4384,7 @@ namespace OpenRCT2
         {
             if (xy_distance >= 16)
             {
-                int16_t actionZ = ride->getStation(currentRideStation).GetBaseZ();
+                int16_t actionZ = ride->getStation(currentRideStation).getBaseZ();
 
                 actionZ += ride->getRideTypeDescriptor().Heights.PlatformHeight;
                 moveTo({ loc.value(), actionZ });
@@ -4409,7 +4409,7 @@ namespace OpenRCT2
 
     CoordsXY GetGuestWaypointLocationDefault(const Vehicle& vehicle, const Ride& ride, const StationIndex& CurrentRideStation)
     {
-        return ride.getStation(CurrentRideStation).Start.ToTileCentre();
+        return ride.getStation(CurrentRideStation).start.ToTileCentre();
     }
 
     CoordsXY GetGuestWaypointLocationEnterprise(
@@ -4478,7 +4478,7 @@ namespace OpenRCT2
     {
         auto ride = GetRide(guest.currentRide);
         // Motion simulators have steps. This moves the peeps up the steps.
-        int16_t actionZ = ride->getStation(guest.currentRideStation).GetBaseZ() + 2;
+        int16_t actionZ = ride->getStation(guest.currentRideStation).getBaseZ() + 2;
 
         uint8_t waypoint = guest.var37 & 3;
         if (waypoint == 2)
@@ -4518,7 +4518,7 @@ namespace OpenRCT2
 
             if (ride->getRideTypeDescriptor().specialType == RtdSpecialType::motionSimulator)
             {
-                actionZ = ride->getStation(currentRideStation).GetBaseZ() + 2;
+                actionZ = ride->getStation(currentRideStation).getBaseZ() + 2;
 
                 if ((var37 & 3) == 1)
                 {
@@ -4577,7 +4577,7 @@ namespace OpenRCT2
 
         var37 |= 3;
 
-        auto targetLoc = ride->getStation(currentRideStation).Exit.ToCoordsXYZD().ToTileCentre();
+        auto targetLoc = ride->getStation(currentRideStation).exit.ToCoordsXYZD().ToTileCentre();
         uint8_t exit_direction = DirectionReverse(targetLoc.direction);
 
         int16_t x_shift = DirectionOffsets[exit_direction].x;
@@ -4653,7 +4653,7 @@ namespace OpenRCT2
 
             if (lastRide)
             {
-                auto exit = ride->getStation(currentRideStation).Exit;
+                auto exit = ride->getStation(currentRideStation).exit;
                 waypoint = 1;
                 auto directionTemp = exit.direction;
                 if (exit.direction == kInvalidDirection)
@@ -4661,7 +4661,7 @@ namespace OpenRCT2
                     directionTemp = 0;
                 }
                 var37 = (directionTemp * 4) | (var37 & 0x30) | waypoint;
-                CoordsXY targetLoc = ride->getStation(currentRideStation).Start;
+                CoordsXY targetLoc = ride->getStation(currentRideStation).start;
 
                 assert(rtd.specialType == RtdSpecialType::spiralSlide);
                 targetLoc += kSpiralSlideWalkingPath[var37];
@@ -4676,7 +4676,7 @@ namespace OpenRCT2
         // Actually increment the real peep waypoint
         var37++;
 
-        CoordsXY targetLoc = ride->getStation(currentRideStation).Start;
+        CoordsXY targetLoc = ride->getStation(currentRideStation).start;
 
         assert(rtd.specialType == RtdSpecialType::spiralSlide);
         targetLoc += kSpiralSlideWalkingPath[var37];
@@ -4738,7 +4738,7 @@ namespace OpenRCT2
                     return;
                 case PeepSpiralSlideSubState::finishedSliding:
                 {
-                    auto newLocation = ride->getStation(currentRideStation).Start;
+                    auto newLocation = ride->getStation(currentRideStation).start;
                     uint8_t dir = (var37 / 4) & 3;
 
                     // Set the location that the guest walks to go on slide again
@@ -4771,7 +4771,7 @@ namespace OpenRCT2
         uint8_t waypoint = 2;
         var37 = (var37 * 4 & 0x30) + waypoint;
 
-        CoordsXY targetLoc = ride->getStation(currentRideStation).Start;
+        CoordsXY targetLoc = ride->getStation(currentRideStation).start;
 
         targetLoc += kSpiralSlideWalkingPath[var37];
 
@@ -4810,7 +4810,7 @@ namespace OpenRCT2
             waypoint--;
             // Actually decrement the peep waypoint
             var37--;
-            CoordsXY targetLoc = ride->getStation(currentRideStation).Start;
+            CoordsXY targetLoc = ride->getStation(currentRideStation).start;
 
             [[maybe_unused]] const auto& rtd = ride->getRideTypeDescriptor();
             assert(rtd.specialType == RtdSpecialType::spiralSlide);
@@ -4823,7 +4823,7 @@ namespace OpenRCT2
         // Actually force the final waypoint
         var37 |= 3;
 
-        auto targetLoc = ride->getStation(currentRideStation).Exit.ToCoordsXYZD().ToTileCentre();
+        auto targetLoc = ride->getStation(currentRideStation).exit.ToCoordsXYZD().ToTileCentre();
 
         int16_t xShift = DirectionOffsets[DirectionReverse(targetLoc.direction)].x;
         int16_t yShift = DirectionOffsets[DirectionReverse(targetLoc.direction)].y;
@@ -4891,7 +4891,7 @@ namespace OpenRCT2
 
         auto targetLoc = getDestination().ToTileStart();
 
-        auto stationBaseZ = ride->getStation().GetBaseZ();
+        auto stationBaseZ = ride->getStation().getBaseZ();
 
         // Find the station track element
         auto trackElement = MapGetTrackElementAt({ targetLoc, stationBaseZ });
@@ -4999,7 +4999,7 @@ namespace OpenRCT2
         {
             if (ride != nullptr)
             {
-                moveTo({ loc.value(), ride->getStation(currentRideStation).GetBaseZ() });
+                moveTo({ loc.value(), ride->getStation(currentRideStation).getBaseZ() });
             }
             return;
         }
@@ -7517,19 +7517,19 @@ namespace OpenRCT2
         auto& station = ride->getStation(currentRideStation);
         // Make sure we don't underflow, building while paused might reset it to 0 where peeps have
         // not yet left the queue.
-        if (station.QueueLength > 0)
+        if (station.queueLength > 0)
         {
-            station.QueueLength--;
+            station.queueLength--;
         }
 
-        if (id == station.LastPeepInQueue)
+        if (id == station.lastPeepInQueue)
         {
-            station.LastPeepInQueue = guestNextInQueue;
+            station.lastPeepInQueue = guestNextInQueue;
             return;
         }
 
         auto& gameState = getGameState();
-        auto* otherGuest = gameState.entities.getEntity<Guest>(station.LastPeepInQueue);
+        auto* otherGuest = gameState.entities.getEntity<Guest>(station.lastPeepInQueue);
         if (otherGuest == nullptr)
         {
             LOG_ERROR("Invalid Guest Queue list!");

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -1712,10 +1712,10 @@ namespace OpenRCT2
             guest->interactionRideIndex = rideIndex;
 
             auto& station = ride->getStation(stationNum);
-            auto previous_last = station.LastPeepInQueue;
-            station.LastPeepInQueue = guest->id;
+            auto previous_last = station.lastPeepInQueue;
+            station.lastPeepInQueue = guest->id;
             guest->guestNextInQueue = previous_last;
-            station.QueueLength++;
+            station.queueLength++;
 
             guest->currentRide = rideIndex;
             guest->currentRideStation = stationNum;
@@ -2160,10 +2160,10 @@ namespace OpenRCT2
 
                         // Add the peep to the ride queue.
                         auto& station = ride->getStation(stationNum);
-                        auto old_last_peep = station.LastPeepInQueue;
-                        station.LastPeepInQueue = guest->id;
+                        auto old_last_peep = station.lastPeepInQueue;
+                        station.lastPeepInQueue = guest->id;
                         guest->guestNextInQueue = old_last_peep;
-                        station.QueueLength++;
+                        station.queueLength++;
 
                         PeepDecrementNumRiders(guest);
                         guest->currentRide = rideIndex;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -634,10 +634,10 @@ namespace OpenRCT2
         if (ride != nullptr && (state == PeepState::answering || state == PeepState::headingToInspection)
             && (ScenarioRand() & 1))
         {
-            auto location = ride->getStation(currentRideStation).Exit;
+            auto location = ride->getStation(currentRideStation).exit;
             if (location.IsNull())
             {
-                location = ride->getStation(currentRideStation).Entrance;
+                location = ride->getStation(currentRideStation).entrance;
             }
 
             direction = DirectionFromTo(CoordsXY(x, y), location.ToCoordsXY());
@@ -715,10 +715,10 @@ namespace OpenRCT2
         {
             /* Find location of the exit for the target ride station
              * or if the ride has no exit, the entrance. */
-            TileCoordsXYZD location = ride->getStation(currentRideStation).Exit;
+            TileCoordsXYZD location = ride->getStation(currentRideStation).exit;
             if (location.IsNull())
             {
-                location = ride->getStation(currentRideStation).Entrance;
+                location = ride->getStation(currentRideStation).entrance;
 
                 // If no entrance is present either. This is an incorrect state.
                 if (location.IsNull())
@@ -1269,7 +1269,7 @@ namespace OpenRCT2
             return;
         }
 
-        if (ride->getStation(currentRideStation).Exit.IsNull())
+        if (ride->getStation(currentRideStation).exit.IsNull())
         {
             ride->flags.unset(RideFlag::dueInspection);
             setState(PeepState::falling);
@@ -1323,7 +1323,7 @@ namespace OpenRCT2
 
             if (pathingResult & PATHING_RIDE_ENTRANCE)
             {
-                if (!ride->getStation(exitIndex).Exit.IsNull())
+                if (!ride->getStation(exitIndex).exit.IsNull())
                 {
                     return;
                 }
@@ -1343,7 +1343,7 @@ namespace OpenRCT2
         int16_t delta_y = abs(getLocation().y - getDestination().y);
         if (auto loc = updateAction(); loc.has_value())
         {
-            auto newZ = ride->getStation(currentRideStation).GetBaseZ();
+            auto newZ = ride->getStation(currentRideStation).getBaseZ();
             if (delta_y < 20)
             {
                 newZ += ride->getRideTypeDescriptor().Heights.PlatformHeight;
@@ -1428,7 +1428,7 @@ namespace OpenRCT2
 
             if (pathingResult & PATHING_RIDE_ENTRANCE)
             {
-                if (!ride->getStation(exitIndex).Exit.IsNull())
+                if (!ride->getStation(exitIndex).exit.IsNull())
                 {
                     return;
                 }
@@ -1450,7 +1450,7 @@ namespace OpenRCT2
         int16_t delta_y = abs(y - getDestination().y);
         if (auto loc = updateAction(); loc.has_value())
         {
-            auto newZ = ride->getStation(currentRideStation).GetBaseZ();
+            auto newZ = ride->getStation(currentRideStation).getBaseZ();
             if (delta_y < 20)
             {
                 newZ += ride->getRideTypeDescriptor().Heights.PlatformHeight;
@@ -2276,7 +2276,7 @@ namespace OpenRCT2
                 return true;
             }
 
-            auto stationPos = ride.getStation(currentRideStation).GetStart();
+            auto stationPos = ride.getStation(currentRideStation).getStart();
             if (stationPos.IsNull())
             {
                 return true;
@@ -2363,7 +2363,7 @@ namespace OpenRCT2
                 return true;
             }
 
-            auto stationPosition = ride.getStation(currentRideStation).GetStart();
+            auto stationPosition = ride.getStation(currentRideStation).getStart();
             if (stationPosition.IsNull())
             {
                 return true;
@@ -2509,10 +2509,10 @@ namespace OpenRCT2
     {
         if (!firstRun)
         {
-            auto stationPosition = ride.getStation(currentRideStation).Exit.ToCoordsXY();
+            auto stationPosition = ride.getStation(currentRideStation).exit.ToCoordsXY();
             if (stationPosition.IsNull())
             {
-                stationPosition = ride.getStation(currentRideStation).Entrance.ToCoordsXY();
+                stationPosition = ride.getStation(currentRideStation).entrance.ToCoordsXY();
 
                 if (stationPosition.IsNull())
                 {
@@ -2589,10 +2589,10 @@ namespace OpenRCT2
     {
         if (!firstRun)
         {
-            auto exitPosition = ride.getStation(currentRideStation).Exit.ToCoordsXY();
+            auto exitPosition = ride.getStation(currentRideStation).exit.ToCoordsXY();
             if (exitPosition.IsNull())
             {
-                exitPosition = ride.getStation(currentRideStation).Entrance.ToCoordsXY();
+                exitPosition = ride.getStation(currentRideStation).entrance.ToCoordsXY();
 
                 if (exitPosition.IsNull())
                 {
@@ -2613,7 +2613,7 @@ namespace OpenRCT2
         int16_t xy_distance;
         if (auto loc = updateAction(xy_distance); loc.has_value())
         {
-            auto stationHeight = ride.getStation(currentRideStation).GetBaseZ();
+            auto stationHeight = ride.getStation(currentRideStation).getBaseZ();
             if (xy_distance >= 16)
             {
                 stationHeight += ride.getRideTypeDescriptor().Heights.PlatformHeight;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1456,18 +1456,18 @@ namespace OpenRCT2
                     // Stations
                     cs.readWrite(ride.numStations);
                     cs.readWriteArray(ride.getStations(), [&cs](RideStation& station) {
-                        cs.readWrite(station.Start);
-                        cs.readWrite(station.Height);
-                        cs.readWrite(station.Length);
-                        cs.readWrite(station.Depart);
-                        cs.readWrite(station.TrainAtStation);
-                        cs.readWrite(station.Entrance);
-                        cs.readWrite(station.Exit);
-                        cs.readWrite(station.SegmentLength);
-                        cs.readWrite(station.SegmentTime);
-                        cs.readWrite(station.QueueTime);
-                        cs.readWrite(station.QueueLength);
-                        cs.readWrite(station.LastPeepInQueue);
+                        cs.readWrite(station.start);
+                        cs.readWrite(station.height);
+                        cs.readWrite(station.length);
+                        cs.readWrite(station.depart);
+                        cs.readWrite(station.trainAtStation);
+                        cs.readWrite(station.entrance);
+                        cs.readWrite(station.exit);
+                        cs.readWrite(station.segmentLength);
+                        cs.readWrite(station.segmentTime);
+                        cs.readWrite(station.queueTime);
+                        cs.readWrite(station.queueLength);
+                        cs.readWrite(station.lastPeepInQueue);
                         return true;
                     });
 

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -2051,7 +2051,7 @@ namespace OpenRCT2::PathFinding
         for (const auto& station : ride->getStations())
         {
             // Skip if stationNum has no entrance (so presumably an exit only station)
-            if (station.Entrance.IsNull())
+            if (station.entrance.IsNull())
                 continue;
 
             const auto stationIndex = ride->getStationIndex(&station);
@@ -2059,7 +2059,7 @@ namespace OpenRCT2::PathFinding
             numEntranceStations++;
             entranceStations[stationIndex.ToUnderlying()] = true;
 
-            TileCoordsXYZD entranceLocation = station.Entrance;
+            TileCoordsXYZD entranceLocation = station.entrance;
             auto score = CalculateHeuristicPathingScore(entranceLocation, TileCoordsXYZ{ peep.nextLoc });
             if (score < bestScore)
             {
@@ -2081,14 +2081,14 @@ namespace OpenRCT2::PathFinding
         {
             // closestStationNum is always 0 here.
             const auto& closestStation = ride->getStation(closestStationNum);
-            auto entranceXY = TileCoordsXY(closestStation.Start);
+            auto entranceXY = TileCoordsXY(closestStation.start);
             loc.x = entranceXY.x;
             loc.y = entranceXY.y;
-            loc.z = closestStation.Height;
+            loc.z = closestStation.height;
         }
         else
         {
-            TileCoordsXYZD entranceXYZD = ride->getStation(closestStationNum).Entrance;
+            TileCoordsXYZD entranceXYZD = ride->getStation(closestStationNum).entrance;
             loc.x = entranceXYZD.x;
             loc.y = entranceXYZD.y;
             loc.z = entranceXYZD.z;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -880,46 +880,46 @@ namespace OpenRCT2::RCT1
                 auto& dstStation = dst->getStation(StationIndex::FromUnderlying(i));
                 if (src->stationStarts[i].IsNull())
                 {
-                    dstStation.Start.SetNull();
+                    dstStation.start.SetNull();
                 }
                 else
                 {
                     auto tileStartLoc = TileCoordsXY{ src->stationStarts[i].x, src->stationStarts[i].y };
-                    dstStation.Start = tileStartLoc.ToCoordsXY();
+                    dstStation.start = tileStartLoc.ToCoordsXY();
                 }
-                dstStation.SetBaseZ(src->stationHeights[i] * Limits::kCoordsZStep);
-                dstStation.Length = src->stationLengths[i];
-                dstStation.Depart = src->stationLights[i];
+                dstStation.setBaseZ(src->stationHeights[i] * Limits::kCoordsZStep);
+                dstStation.length = src->stationLengths[i];
+                dstStation.depart = src->stationLights[i];
 
-                dstStation.TrainAtStation = src->stationDeparts[i];
+                dstStation.trainAtStation = src->stationDeparts[i];
 
                 // Direction is fixed later.
                 if (src->entrances[i].IsNull())
-                    dstStation.Entrance.SetNull();
+                    dstStation.entrance.SetNull();
                 else
-                    dstStation.Entrance = { src->entrances[i].x, src->entrances[i].y, src->stationHeights[i] / 2, 0 };
+                    dstStation.entrance = { src->entrances[i].x, src->entrances[i].y, src->stationHeights[i] / 2, 0 };
 
                 if (src->exits[i].IsNull())
-                    dstStation.Exit.SetNull();
+                    dstStation.exit.SetNull();
                 else
-                    dstStation.Exit = { src->exits[i].x, src->exits[i].y, src->stationHeights[i] / 2, 0 };
+                    dstStation.exit = { src->exits[i].x, src->exits[i].y, src->stationHeights[i] / 2, 0 };
 
-                dstStation.QueueTime = src->queueTime[i];
-                dstStation.LastPeepInQueue = EntityId::FromUnderlying(src->lastPeepInQueue[i]);
-                dstStation.QueueLength = src->numPeepsInQueue[i];
+                dstStation.queueTime = src->queueTime[i];
+                dstStation.lastPeepInQueue = EntityId::FromUnderlying(src->lastPeepInQueue[i]);
+                dstStation.queueLength = src->numPeepsInQueue[i];
 
-                dstStation.SegmentTime = src->time[i];
-                dstStation.SegmentLength = src->length[i];
+                dstStation.segmentTime = src->time[i];
+                dstStation.segmentLength = src->length[i];
             }
             // All other values take 0 as their default. Since they're already memset to that, no need to do it again.
             for (int32_t i = Limits::kMaxStationsPerRide; i < OpenRCT2::Limits::kMaxStationsPerRide; i++)
             {
                 auto& dstStation = dst->getStation(StationIndex::FromUnderlying(i));
-                dstStation.Start.SetNull();
-                dstStation.TrainAtStation = RideStation::kNoTrain;
-                dstStation.Entrance.SetNull();
-                dstStation.Exit.SetNull();
-                dstStation.LastPeepInQueue = EntityId::GetNull();
+                dstStation.start.SetNull();
+                dstStation.trainAtStation = RideStation::kNoTrain;
+                dstStation.entrance.SetNull();
+                dstStation.exit.SetNull();
+                dstStation.lastPeepInQueue = EntityId::GetNull();
             }
 
             dst->numStations = src->numStations;

--- a/src/openrct2/rct12/ScenarioPatcher.cpp
+++ b/src/openrct2/rct12/ScenarioPatcher.cpp
@@ -525,10 +525,10 @@ static void SwapRideEntranceAndExit(RideId rideId)
     if (ride != nullptr)
     {
         auto& station = ride->getStation();
-        auto entranceCoords = station.Exit;
-        auto exitCoords = station.Entrance;
-        station.Entrance = entranceCoords;
-        station.Exit = exitCoords;
+        auto entranceCoords = station.exit;
+        auto exitCoords = station.entrance;
+        station.entrance = entranceCoords;
+        station.exit = exitCoords;
 
         auto entranceElement = MapGetRideExitElementAt(entranceCoords.ToCoordsXYZD(), false);
         entranceElement->setEntranceType(EntranceType::rideEntrance);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -764,37 +764,37 @@ namespace OpenRCT2::RCT2
 
                 if (src->stationStarts[i].IsNull())
                 {
-                    destStation.Start.SetNull();
+                    destStation.start.SetNull();
                 }
                 else
                 {
                     auto tileStartLoc = TileCoordsXY(src->stationStarts[i].x, src->stationStarts[i].y);
-                    destStation.Start = tileStartLoc.ToCoordsXY();
+                    destStation.start = tileStartLoc.ToCoordsXY();
                 }
-                destStation.Height = src->stationHeights[i];
-                destStation.Length = src->stationLength[i];
-                destStation.Depart = src->stationDepart[i];
-                destStation.TrainAtStation = src->trainAtStation[i];
+                destStation.height = src->stationHeights[i];
+                destStation.length = src->stationLength[i];
+                destStation.depart = src->stationDepart[i];
+                destStation.trainAtStation = src->trainAtStation[i];
                 // Direction is fixed later.
 
                 if (src->entrances[i].IsNull())
-                    destStation.Entrance.SetNull();
+                    destStation.entrance.SetNull();
                 else
-                    destStation.Entrance = { src->entrances[i].x, src->entrances[i].y, src->stationHeights[i], 0 };
+                    destStation.entrance = { src->entrances[i].x, src->entrances[i].y, src->stationHeights[i], 0 };
 
                 if (src->exits[i].IsNull())
-                    destStation.Exit.SetNull();
+                    destStation.exit.SetNull();
                 else
-                    destStation.Exit = { src->exits[i].x, src->exits[i].y, src->stationHeights[i], 0 };
+                    destStation.exit = { src->exits[i].x, src->exits[i].y, src->stationHeights[i], 0 };
 
-                destStation.LastPeepInQueue = EntityId::FromUnderlying(src->lastPeepInQueue[i]);
+                destStation.lastPeepInQueue = EntityId::FromUnderlying(src->lastPeepInQueue[i]);
 
-                destStation.SegmentLength = src->length[i];
-                destStation.SegmentTime = src->time[i];
+                destStation.segmentLength = src->length[i];
+                destStation.segmentTime = src->time[i];
 
-                destStation.QueueTime = src->queueTime[i];
+                destStation.queueTime = src->queueTime[i];
 
-                destStation.QueueLength = src->queueLength[i];
+                destStation.queueLength = src->queueLength[i];
             }
             // All other values take 0 as their default. Since they're already memset to that, no need to do it again.
             for (int32_t i = Limits::kMaxStationsPerRide; i < OpenRCT2::Limits::kMaxStationsPerRide; i++)
@@ -802,11 +802,11 @@ namespace OpenRCT2::RCT2
                 StationIndex stationIndex = StationIndex::FromUnderlying(i);
                 auto& destStation = dst->getStation(stationIndex);
 
-                destStation.Start.SetNull();
-                destStation.TrainAtStation = RideStation::kNoTrain;
-                destStation.Entrance.SetNull();
-                destStation.Exit.SetNull();
-                destStation.LastPeepInQueue = EntityId::GetNull();
+                destStation.start.SetNull();
+                destStation.trainAtStation = RideStation::kNoTrain;
+                destStation.entrance.SetNull();
+                destStation.exit.SetNull();
+                destStation.lastPeepInQueue = EntityId::GetNull();
             }
 
             for (int32_t i = 0; i < Limits::kMaxTrainsPerRide; i++)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -337,8 +337,8 @@ namespace OpenRCT2
     {
         int32_t queueLength = 0;
         for (const auto& station : stations)
-            if (!station.Entrance.IsNull())
-                queueLength += station.QueueLength;
+            if (!station.entrance.IsNull())
+                queueLength += station.queueLength;
         return queueLength;
     }
 
@@ -346,8 +346,8 @@ namespace OpenRCT2
     {
         uint8_t queueTime = 0;
         for (const auto& station : stations)
-            if (!station.Entrance.IsNull())
-                queueTime = std::max(queueTime, station.QueueTime);
+            if (!station.entrance.IsNull())
+                queueTime = std::max(queueTime, station.queueTime);
         return static_cast<int32_t>(queueTime);
     }
 
@@ -355,7 +355,7 @@ namespace OpenRCT2
     {
         Guest* peep;
         Guest* result = nullptr;
-        auto spriteIndex = getStation(stationIndex).LastPeepInQueue;
+        auto spriteIndex = getStation(stationIndex).lastPeepInQueue;
         while ((peep = getGameState().entities.tryGetEntity<Guest>(spriteIndex)) != nullptr)
         {
             spriteIndex = peep->guestNextInQueue;
@@ -369,13 +369,13 @@ namespace OpenRCT2
         uint16_t count = 0;
         Guest* peep;
         auto& station = getStation(stationIndex);
-        auto spriteIndex = station.LastPeepInQueue;
+        auto spriteIndex = station.lastPeepInQueue;
         while ((peep = getGameState().entities.tryGetEntity<Guest>(spriteIndex)) != nullptr)
         {
             spriteIndex = peep->guestNextInQueue;
             count++;
         }
-        station.QueueLength = count;
+        station.queueLength = count;
     }
 
     void Ride::queueInsertGuestAtFront(StationIndex stationIndex, Guest* peep)
@@ -387,7 +387,7 @@ namespace OpenRCT2
         auto* queueHeadGuest = getQueueHeadGuest(peep->currentRideStation);
         if (queueHeadGuest == nullptr)
         {
-            getStation(peep->currentRideStation).LastPeepInQueue = peep->id;
+            getStation(peep->currentRideStation).lastPeepInQueue = peep->id;
         }
         else
         {
@@ -592,7 +592,7 @@ namespace OpenRCT2
     {
         int32_t totalLength = 0;
         for (int32_t i = 0; i < numStations; i++)
-            totalLength += stations[i].SegmentLength;
+            totalLength += stations[i].segmentLength;
         return totalLength;
     }
 
@@ -600,7 +600,7 @@ namespace OpenRCT2
     {
         int32_t totalTime = 0;
         for (int32_t i = 0; i < numStations; i++)
-            totalTime += stations[i].SegmentTime;
+            totalTime += stations[i].segmentTime;
         return totalTime;
     }
 
@@ -766,7 +766,7 @@ namespace OpenRCT2
         StationIndex::UnderlyingType nullStationsSeen{ 0 };
         for (size_t i = 0; i < in.ToUnderlying(); i++)
         {
-            if (stations[i].Start.IsNull())
+            if (stations[i].start.IsNull())
             {
                 nullStationsSeen++;
             }
@@ -987,10 +987,10 @@ namespace OpenRCT2
         // Invalidate something related to station start
         for (int32_t i = 0; i < Limits::kMaxStationsPerRide; i++)
         {
-            if (ride.stations[i].Start.IsNull())
+            if (ride.stations[i].start.IsNull())
                 continue;
 
-            auto startLoc = ride.stations[i].Start;
+            auto startLoc = ride.stations[i].start;
 
             TileElement* tileElement = RideGetStationStartTrackElement(ride, StationIndex::FromUnderlying(i));
             if (tileElement == nullptr)
@@ -1493,11 +1493,11 @@ namespace OpenRCT2
 
         // Get either exit position or entrance position if there is no exit
         const auto& station = ride.getStation(stationIndex);
-        TileCoordsXYZD location = station.Exit;
+        TileCoordsXYZD location = station.exit;
         if (location.IsNull())
         {
-            location = station.Entrance;
-            if (station.Entrance.IsNull())
+            location = station.entrance;
+            if (station.entrance.IsNull())
                 return nullptr;
         }
 
@@ -1668,7 +1668,7 @@ namespace OpenRCT2
             return;
         }
 
-        CoordsXYZ rideCoords = ride.getStation().GetStart().ToTileCentre();
+        CoordsXYZ rideCoords = ride.getStation().getStart().ToTileCentre();
 
         const auto sampleRate = RideMusicSampleRate(ride);
 
@@ -1706,7 +1706,7 @@ namespace OpenRCT2
             return;
         }
 
-        CoordsXYZ rideCoords = ride.getStation().GetStart().ToTileCentre();
+        CoordsXYZ rideCoords = ride.getStation().getStart().ToTileCentre();
 
         int32_t sampleRate = RideMusicSampleRate(ride);
 
@@ -2048,9 +2048,9 @@ namespace OpenRCT2
     {
         for (auto& station : ride.getStations())
         {
-            auto station_start = station.Start;
-            auto entrance = station.Entrance;
-            auto exit = station.Exit;
+            auto station_start = station.start;
+            auto entrance = station.entrance;
+            auto exit = station.exit;
 
             if (station_start.IsNull())
                 continue;
@@ -2083,7 +2083,7 @@ namespace OpenRCT2
 
     static void RideShopConnected(const Ride& ride)
     {
-        auto shopLoc = TileCoordsXY(ride.getStation().Start);
+        auto shopLoc = TileCoordsXY(ride.getStation().start);
         if (shopLoc.IsNull())
             return;
 
@@ -2217,9 +2217,9 @@ namespace OpenRCT2
             // Get the queue length
             int32_t queueLength = 0;
             const auto stationIndex = entranceElement.getStationIndex();
-            if (!ride->getStation(stationIndex).Entrance.IsNull())
+            if (!ride->getStation(stationIndex).entrance.IsNull())
             {
-                queueLength = ride->getStation(stationIndex).QueueLength;
+                queueLength = ride->getStation(stationIndex).queueLength;
             }
 
             auto ft = Formatter();
@@ -2304,7 +2304,7 @@ namespace OpenRCT2
         uint16_t numStations = 0;
         for (const auto& station : ride.getStations())
         {
-            if (!station.Start.IsNull())
+            if (!station.start.IsNull())
             {
                 numStations++;
             }
@@ -2377,22 +2377,22 @@ namespace OpenRCT2
         uint8_t exit = 0;
         for (const auto& station : ride->getStations())
         {
-            if (station.Start.IsNull())
+            if (station.start.IsNull())
                 continue;
 
-            if (!station.Entrance.IsNull())
+            if (!station.entrance.IsNull())
             {
                 entrance = 1;
             }
 
-            if (!station.Exit.IsNull())
+            if (!station.exit.IsNull())
             {
                 exit = 1;
             }
 
             // If station start and no entrance/exit
             // Sets same error message as no entrance
-            if (station.Exit.IsNull() && station.Entrance.IsNull())
+            if (station.exit.IsNull() && station.entrance.IsNull())
             {
                 entrance = 0;
                 break;
@@ -2420,14 +2420,14 @@ namespace OpenRCT2
     {
         for (const auto& station : stations)
         {
-            if (station.Entrance.IsNull())
+            if (station.entrance.IsNull())
                 continue;
 
-            auto mapLocation = station.Entrance.ToCoordsXYZ();
+            auto mapLocation = station.entrance.ToCoordsXYZ();
 
             // This will fire for every entrance on this x, y and z, regardless whether that actually belongs to
             // the ride or not.
-            TileElement* tileElement = MapGetFirstElementAt(station.Entrance);
+            TileElement* tileElement = MapGetFirstElementAt(station.entrance);
             if (tileElement != nullptr)
             {
                 do
@@ -2764,13 +2764,13 @@ namespace OpenRCT2
         TileCoordsXYZD* position = positions;
         for (const auto& station : ride.getStations())
         {
-            if (!station.Entrance.IsNull())
+            if (!station.entrance.IsNull())
             {
-                *position++ = station.Entrance;
+                *position++ = station.entrance;
             }
-            if (!station.Exit.IsNull())
+            if (!station.exit.IsNull())
             {
-                *position++ = station.Exit;
+                *position++ = station.exit;
             }
         }
         position->SetNull();
@@ -3386,7 +3386,7 @@ namespace OpenRCT2
         flags.set(RideFlag::onTrack);
         for (int32_t i = 0; i < Limits::kMaxStationsPerRide; i++)
         {
-            stations[i].Depart = (stations[i].Depart & kStationDepartFlag) | 1;
+            stations[i].depart = (stations[i].depart & kStationDepartFlag) | 1;
         }
 
         const auto& rtd = getRideTypeDescriptor();
@@ -3523,7 +3523,7 @@ namespace OpenRCT2
     {
         for (const auto& station : ride.getStations())
         {
-            CoordsXYZ trackStart = station.GetStart();
+            CoordsXYZ trackStart = station.getStart();
             if (trackStart.IsNull())
                 continue;
 
@@ -3695,17 +3695,17 @@ namespace OpenRCT2
         const RideStation* incompleteStation = nullptr;
         for (const auto& station : stations)
         {
-            if (station.Start.IsNull())
+            if (station.start.IsNull())
                 continue;
 
-            if (station.Entrance.IsNull())
+            if (station.entrance.IsNull())
             {
                 entranceOrExit = WC_RIDE_CONSTRUCTION__WIDX_ENTRANCE;
                 incompleteStation = &station;
                 break;
             }
 
-            if (station.Exit.IsNull())
+            if (station.exit.IsNull())
             {
                 entranceOrExit = WC_RIDE_CONSTRUCTION__WIDX_EXIT;
                 incompleteStation = &station;
@@ -3721,7 +3721,7 @@ namespace OpenRCT2
         const auto& rtd = getRideTypeDescriptor();
         if (rtd.specialType != RtdSpecialType::maze)
         {
-            auto location = incompleteStation->GetStart();
+            auto location = incompleteStation->getStart();
             WindowScrollToLocation(*w, location);
 
             CoordsXYE trackElement;
@@ -3763,7 +3763,7 @@ namespace OpenRCT2
      */
     TrackElement* Ride::getOriginElement(StationIndex stationIndex) const
     {
-        auto stationLoc = getStation(stationIndex).Start;
+        auto stationLoc = getStation(stationIndex).start;
         TileElement* tileElement = MapGetFirstElementAt(stationLoc);
         if (tileElement == nullptr)
             return nullptr;
@@ -4723,11 +4723,11 @@ namespace OpenRCT2
         std::optional<int32_t> result;
         for (const auto& station : ride.getStations())
         {
-            if (!station.Start.IsNull())
+            if (!station.start.IsNull())
             {
-                if (!result.has_value() || station.Length < result.value())
+                if (!result.has_value() || station.length < result.value())
                 {
-                    result = station.Length;
+                    result = station.length;
                 }
             }
         }
@@ -4747,7 +4747,7 @@ namespace OpenRCT2
 
         for (const auto& station : ride.getStations())
         {
-            trackStart = station.GetStart();
+            trackStart = station.getStart();
             if (trackStart.IsNull())
                 continue;
 
@@ -5186,7 +5186,7 @@ namespace OpenRCT2
          * adjacent station on either side. */
         for (const auto& station : ride.getStations())
         {
-            auto stationStart = station.GetStart();
+            auto stationStart = station.getStart();
             if (!stationStart.IsNull())
             {
                 /* Get the map element for the station start. */
@@ -5330,8 +5330,8 @@ namespace OpenRCT2
             for (auto& station : ride.getStations())
             {
                 auto stationIndex = ride.getStationIndex(&station);
-                TileCoordsXYZD entranceLoc = station.Entrance;
-                TileCoordsXYZD exitLoc = station.Exit;
+                TileCoordsXYZD entranceLoc = station.entrance;
+                TileCoordsXYZD exitLoc = station.exit;
                 bool fixEntrance = false;
                 bool fixExit = false;
 
@@ -5347,7 +5347,7 @@ namespace OpenRCT2
                     }
                     else
                     {
-                        station.Entrance.direction = entranceElement->getDirection();
+                        station.entrance.direction = entranceElement->getDirection();
                     }
                 }
 
@@ -5362,7 +5362,7 @@ namespace OpenRCT2
                     }
                     else
                     {
-                        station.Exit.direction = entranceElement->getDirection();
+                        station.exit.direction = entranceElement->getDirection();
                     }
                 }
 
@@ -5400,20 +5400,20 @@ namespace OpenRCT2
                                 }
 
                                 // The expected height is where entrances and exit reside in non-hacked parks.
-                                const uint8_t expectedHeight = station.Height;
+                                const uint8_t expectedHeight = station.height;
 
                                 if (fixEntrance && entranceElement->getEntranceType() == EntranceType::rideEntrance)
                                 {
                                     if (alreadyFoundEntrance)
                                     {
-                                        if (station.Entrance.z == expectedHeight)
+                                        if (station.entrance.z == expectedHeight)
                                             continue;
-                                        if (station.Entrance.z > entranceElement->baseHeight)
+                                        if (station.entrance.z > entranceElement->baseHeight)
                                             continue;
                                     }
 
                                     // Found our entrance
-                                    station.Entrance = { x, y, entranceElement->baseHeight, entranceElement->getDirection() };
+                                    station.entrance = { x, y, entranceElement->baseHeight, entranceElement->getDirection() };
                                     alreadyFoundEntrance = true;
 
                                     LOG_VERBOSE(
@@ -5424,14 +5424,14 @@ namespace OpenRCT2
                                 {
                                     if (alreadyFoundExit)
                                     {
-                                        if (station.Exit.z == expectedHeight)
+                                        if (station.exit.z == expectedHeight)
                                             continue;
-                                        if (station.Exit.z > entranceElement->baseHeight)
+                                        if (station.exit.z > entranceElement->baseHeight)
                                             continue;
                                     }
 
                                     // Found our exit
-                                    station.Exit = { x, y, entranceElement->baseHeight, entranceElement->getDirection() };
+                                    station.exit = { x, y, entranceElement->baseHeight, entranceElement->getDirection() };
                                     alreadyFoundExit = true;
 
                                     LOG_VERBOSE(
@@ -5445,12 +5445,12 @@ namespace OpenRCT2
 
                 if (fixEntrance && !alreadyFoundEntrance)
                 {
-                    station.Entrance.SetNull();
+                    station.entrance.SetNull();
                     LOG_VERBOSE("Cleared disconnected entrance of ride %d, station %d.", ride.id, stationIndex);
                 }
                 if (fixExit && !alreadyFoundExit)
                 {
-                    station.Exit.SetNull();
+                    station.exit.SetNull();
                     LOG_VERBOSE("Cleared disconnected exit of ride %d, station %d.", ride.id, stationIndex);
                 }
             }
@@ -5634,7 +5634,7 @@ namespace OpenRCT2
 
     ResultWithMessage Ride::changeStatusGetStartElement(StationIndex stationIndex, CoordsXYE& trackElement)
     {
-        auto startLoc = getStation(stationIndex).Start;
+        auto startLoc = getStation(stationIndex).start;
         trackElement.x = startLoc.x;
         trackElement.y = startLoc.y;
         trackElement.element = reinterpret_cast<TileElement*>(getOriginElement(stationIndex));

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -168,22 +168,22 @@ namespace OpenRCT2
     {
         static constexpr uint8_t kNoTrain = std::numeric_limits<uint8_t>::max();
 
-        CoordsXY Start;
-        uint8_t Height{};
-        uint8_t Length{};
-        uint8_t Depart{};
-        uint8_t TrainAtStation{ kNoTrain };
-        TileCoordsXYZD Entrance;
-        TileCoordsXYZD Exit;
-        int32_t SegmentLength{}; // Length of track between this station and the next.
-        uint16_t SegmentTime{};  // Time for train to reach the next station from this station.
-        uint8_t QueueTime{};
-        uint16_t QueueLength{};
-        EntityId LastPeepInQueue{ EntityId::GetNull() };
+        CoordsXY start;
+        uint8_t height{};
+        uint8_t length{};
+        uint8_t depart{};
+        uint8_t trainAtStation{ kNoTrain };
+        TileCoordsXYZD entrance;
+        TileCoordsXYZD exit;
+        int32_t segmentLength{}; // Length of track between this station and the next.
+        uint16_t segmentTime{};  // Time for train to reach the next station from this station.
+        uint8_t queueTime{};
+        uint16_t queueLength{};
+        EntityId lastPeepInQueue{ EntityId::GetNull() };
 
-        int32_t GetBaseZ() const;
-        void SetBaseZ(int32_t newZ);
-        CoordsXYZ GetStart() const;
+        int32_t getBaseZ() const;
+        void setBaseZ(int32_t newZ);
+        CoordsXYZ getStart() const;
     };
 
     struct RideMeasurement

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -403,7 +403,7 @@ namespace OpenRCT2
             }
 
             for (size_t i = 0; i < Limits::kMaxStationsPerRide; i++)
-                stations[i].TrainAtStation = RideStation::kNoTrain;
+                stations[i].trainAtStation = RideStation::kNoTrain;
 
             // Also clean up orphaned vehicles for good measure.
             for (auto* vehicle : TrainManager::View())
@@ -465,7 +465,7 @@ namespace OpenRCT2
         auto exitPosition = CoordsXYZD{ 0, 0, 0, kInvalidDirection };
         if (!stationIndex.IsNull())
         {
-            auto location = getStation(stationIndex).Exit.ToCoordsXYZD();
+            auto location = getStation(stationIndex).exit.ToCoordsXYZD();
             if (!location.IsNull())
             {
                 auto direction = DirectionReverse(location.direction);
@@ -1394,10 +1394,10 @@ namespace OpenRCT2
             // find the stations of the ride to begin stepping over track elements from
             for (const auto& station : stations)
             {
-                if (station.Start.IsNull())
+                if (station.start.IsNull())
                     continue;
 
-                CoordsXYZ location = station.GetStart();
+                CoordsXYZ location = station.getStart();
                 uint8_t direction = kInvalidDirection;
 
                 bool specialTrack = false;
@@ -1500,16 +1500,16 @@ namespace OpenRCT2
         sfl::static_vector<TileCoordsXYZD, kMaxStationLocations> locations;
         for (auto& station : stations)
         {
-            if (!station.Entrance.IsNull())
+            if (!station.entrance.IsNull())
             {
-                locations.push_back(station.Entrance);
-                station.Entrance.SetNull();
+                locations.push_back(station.entrance);
+                station.entrance.SetNull();
             }
 
-            if (!station.Exit.IsNull())
+            if (!station.exit.IsNull())
             {
-                locations.push_back(station.Exit);
-                station.Exit.SetNull();
+                locations.push_back(station.exit);
+                station.exit.SetNull();
             }
         }
 
@@ -1600,20 +1600,20 @@ namespace OpenRCT2
                     if (tileElement->asEntrance()->getEntranceType() == EntranceType::rideExit)
                     {
                         // if the location is already set for this station, big problem!
-                        if (!station.Exit.IsNull())
+                        if (!station.exit.IsNull())
                             break;
                         // set the station's exit location to this one
-                        CoordsXYZD loc = { location, station.GetBaseZ(), tileElement->getDirection() };
-                        station.Exit = TileCoordsXYZD{ loc };
+                        CoordsXYZD loc = { location, station.getBaseZ(), tileElement->getDirection() };
+                        station.exit = TileCoordsXYZD{ loc };
                     }
                     else
                     {
                         // if the location is already set for this station, big problem!
-                        if (!station.Entrance.IsNull())
+                        if (!station.entrance.IsNull())
                             break;
                         // set the station's entrance location to this one
-                        CoordsXYZD loc = { location, station.GetBaseZ(), tileElement->getDirection() };
-                        station.Entrance = TileCoordsXYZD{ loc };
+                        CoordsXYZD loc = { location, station.getBaseZ(), tileElement->getDirection() };
+                        station.entrance = TileCoordsXYZD{ loc };
                     }
                     // set the entrance's StationIndex as this station
                     tileElement->asEntrance()->setStationIndex(stationId);
@@ -1693,15 +1693,15 @@ namespace OpenRCT2
 
         for (auto& station : ride.getStations())
         {
-            if (station.Start.IsNull())
+            if (station.start.IsNull())
             {
                 continue;
             }
-            if (station.Entrance.IsNull())
+            if (station.entrance.IsNull())
             {
                 return { false, STR_ENTRANCE_NOT_YET_BUILT };
             }
-            if (station.Exit.IsNull())
+            if (station.exit.IsNull())
             {
                 return { false, STR_EXIT_NOT_YET_BUILT };
             }

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -395,7 +395,7 @@ namespace OpenRCT2
                 {
                     auto entranceIndex = tileElement->asTrack()->getStationIndex();
                     state.StationFlags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
-                    if (ride->getStation(entranceIndex).Entrance.IsNull())
+                    if (ride->getStation(entranceIndex).entrance.IsNull())
                     {
                         state.StationFlags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
                     }
@@ -543,15 +543,15 @@ namespace OpenRCT2
 
         for (auto& station : ride->getStations())
         {
-            if (!station.Start.IsNull())
+            if (!station.start.IsNull())
             {
                 state.StationFlags &= ~RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
-                if (station.Entrance.IsNull())
+                if (station.entrance.IsNull())
                 {
                     state.StationFlags |= RIDE_RATING_STATION_FLAG_NO_ENTRANCE;
                 }
 
-                auto location = station.GetStart();
+                auto location = station.getStart();
                 state.Proximity = location;
                 state.ProximityTrackType = TrackElemType::none;
                 state.ProximityStart = location;
@@ -1763,17 +1763,17 @@ namespace OpenRCT2
         const auto& rtd = ride.getRideTypeDescriptor();
         if (rtd.specialType == RtdSpecialType::maze)
         {
-            location = ride.getStation().Entrance.ToCoordsXY();
+            location = ride.getStation().entrance.ToCoordsXY();
         }
         else
         {
-            location = ride.getStation(stationIndex).Start;
+            location = ride.getStation(stationIndex).start;
         }
 
         int32_t z = TileElementHeight(location);
 
         // Check if station is underground, returns a fixed mediocre score since you can't have scenery underground
-        if (z > ride.getStation(stationIndex).GetBaseZ())
+        if (z > ride.getStation(stationIndex).getBaseZ())
         {
             return 40;
         }
@@ -2100,7 +2100,7 @@ namespace OpenRCT2
 
     static void RideRatingsApplyRequirementLength(RideRating::Tuple& ratings, const Ride& ride, RatingsModifier modifier)
     {
-        if (ride.getStation().SegmentLength < modifier.threshold)
+        if (ride.getStation().segmentLength < modifier.threshold)
         {
             ratings.excitement /= modifier.excitement;
             ratings.intensity /= modifier.intensity;

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -34,7 +34,7 @@ namespace OpenRCT2
      */
     void RideUpdateStation(Ride& ride, StationIndex stationIndex)
     {
-        if (ride.getStation(stationIndex).Start.IsNull())
+        if (ride.getStation(stationIndex).start.IsNull())
             return;
 
         switch (ride.mode)
@@ -67,16 +67,16 @@ namespace OpenRCT2
         if ((ride.status == RideStatus::closed && ride.numRiders == 0)
             || (tileElement != nullptr && tileElement->asTrack()->isBrakeClosed()))
         {
-            station.Depart &= ~kStationDepartFlag;
+            station.depart &= ~kStationDepartFlag;
 
-            if ((station.Depart & kStationDepartFlag) || (tileElement != nullptr && tileElement->asTrack()->hasGreenLight()))
+            if ((station.depart & kStationDepartFlag) || (tileElement != nullptr && tileElement->asTrack()->hasGreenLight()))
                 RideInvalidateStationStart(ride, stationIndex, false);
         }
         else
         {
-            if (!(station.Depart & kStationDepartFlag))
+            if (!(station.depart & kStationDepartFlag))
             {
-                station.Depart |= kStationDepartFlag;
+                station.depart |= kStationDepartFlag;
                 RideInvalidateStationStart(ride, stationIndex, true);
             }
             else if (tileElement != nullptr && tileElement->asTrack()->hasGreenLight())
@@ -98,7 +98,7 @@ namespace OpenRCT2
         // but since dodgems do not have station lights there is no point.
         if (ride.status == RideStatus::closed || ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
         {
-            station.Depart &= ~kStationDepartFlag;
+            station.depart &= ~kStationDepartFlag;
             return;
         }
 
@@ -117,12 +117,12 @@ namespace OpenRCT2
 
                 // End match
                 ride.flags.unset(RideFlag::passStationNoStopping);
-                station.Depart &= ~kStationDepartFlag;
+                station.depart &= ~kStationDepartFlag;
                 return;
             }
 
             // Continue match
-            station.Depart |= kStationDepartFlag;
+            station.depart |= kStationDepartFlag;
         }
         else
         {
@@ -135,14 +135,14 @@ namespace OpenRCT2
 
                 if (vehicle->status != Vehicle::Status::waitingToDepart)
                 {
-                    station.Depart &= ~kStationDepartFlag;
+                    station.depart &= ~kStationDepartFlag;
                     return;
                 }
             }
 
             // Begin the match
             ride.flags.set(RideFlag::passStationNoStopping);
-            station.Depart |= kStationDepartFlag;
+            station.depart |= kStationDepartFlag;
             ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
         }
     }
@@ -154,7 +154,7 @@ namespace OpenRCT2
     static void RideUpdateStationNormal(Ride& ride, StationIndex stationIndex)
     {
         auto& station = ride.getStation(stationIndex);
-        int32_t time = station.Depart & kStationDepartMask;
+        int32_t time = station.depart & kStationDepartMask;
         const auto currentTicks = getGameState().currentTicks;
         if (ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed)
             || (ride.status == RideStatus::closed && ride.numRiders == 0))
@@ -162,14 +162,14 @@ namespace OpenRCT2
             if (time != 0 && time != 127 && !(currentTicks & 7))
                 time--;
 
-            station.Depart = time;
+            station.depart = time;
             RideInvalidateStationStart(ride, stationIndex, false);
         }
         else
         {
             if (time == 0)
             {
-                station.Depart |= kStationDepartFlag;
+                station.depart |= kStationDepartFlag;
                 RideInvalidateStationStart(ride, stationIndex, true);
             }
             else
@@ -177,7 +177,7 @@ namespace OpenRCT2
                 if (time != 127 && !(currentTicks & 31))
                     time--;
 
-                station.Depart = time;
+                station.depart = time;
                 RideInvalidateStationStart(ride, stationIndex, false);
             }
         }
@@ -192,9 +192,9 @@ namespace OpenRCT2
         auto& station = ride.getStation(stationIndex);
         if (ride.status == RideStatus::closed || ride.flags.hasAny(RideFlag::brokenDown, RideFlag::crashed))
         {
-            if (station.Depart & kStationDepartFlag)
+            if (station.depart & kStationDepartFlag)
             {
-                station.Depart &= ~kStationDepartFlag;
+                station.depart &= ~kStationDepartFlag;
                 RideInvalidateStationStart(ride, stationIndex, false);
             }
             return;
@@ -225,9 +225,9 @@ namespace OpenRCT2
 
                     // Race is over
                     ride.flags.unset(RideFlag::passStationNoStopping);
-                    if (station.Depart & kStationDepartFlag)
+                    if (station.depart & kStationDepartFlag)
                     {
-                        station.Depart &= ~kStationDepartFlag;
+                        station.depart &= ~kStationDepartFlag;
                         RideInvalidateStationStart(ride, stationIndex, false);
                     }
                     return;
@@ -235,7 +235,7 @@ namespace OpenRCT2
             }
 
             // Continue racing
-            station.Depart |= kStationDepartFlag;
+            station.depart |= kStationDepartFlag;
         }
         else
         {
@@ -248,9 +248,9 @@ namespace OpenRCT2
 
                 if (vehicle->status != Vehicle::Status::waitingToDepart && vehicle->status != Vehicle::Status::departing)
                 {
-                    if (station.Depart & kStationDepartFlag)
+                    if (station.depart & kStationDepartFlag)
                     {
-                        station.Depart &= ~kStationDepartFlag;
+                        station.depart &= ~kStationDepartFlag;
                         RideInvalidateStationStart(ride, stationIndex, false);
                     }
                     return;
@@ -260,9 +260,9 @@ namespace OpenRCT2
             // Begin the race
             RideRaceInitVehicleSpeeds(ride);
             ride.flags.set(RideFlag::passStationNoStopping);
-            if (!(station.Depart & kStationDepartFlag))
+            if (!(station.depart & kStationDepartFlag))
             {
-                station.Depart |= kStationDepartFlag;
+                station.depart |= kStationDepartFlag;
                 RideInvalidateStationStart(ride, stationIndex, true);
             }
             ride.windowInvalidateFlags.set(RideInvalidateFlag::main, RideInvalidateFlag::list);
@@ -327,7 +327,7 @@ namespace OpenRCT2
      */
     static void RideInvalidateStationStart(Ride& ride, StationIndex stationIndex, bool greenLight)
     {
-        auto startPos = ride.getStation(stationIndex).Start;
+        auto startPos = ride.getStation(stationIndex).start;
         TileElement* tileElement = RideGetStationStartTrackElement(ride, stationIndex);
 
         // If no station track found return
@@ -344,7 +344,7 @@ namespace OpenRCT2
 
     TileElement* RideGetStationStartTrackElement(const Ride& ride, StationIndex stationIndex)
     {
-        auto stationStart = ride.getStation(stationIndex).GetStart();
+        auto stationStart = ride.getStation(stationIndex).getStart();
 
         // Find the station track element
         TileElement* tileElement = MapGetFirstElementAt(stationStart);
@@ -381,7 +381,7 @@ namespace OpenRCT2
     {
         for (const auto& station : ride.getStations())
         {
-            if (!station.Exit.IsNull())
+            if (!station.exit.IsNull())
             {
                 return ride.getStationIndex(&station);
             }
@@ -393,7 +393,7 @@ namespace OpenRCT2
     {
         for (const auto& station : ride.getStations())
         {
-            if (!station.Start.IsNull())
+            if (!station.start.IsNull())
             {
                 return ride.getStationIndex(&station);
             }
@@ -405,7 +405,7 @@ namespace OpenRCT2
     {
         for (const auto& station : ride.getStations())
         {
-            if (station.Start.IsNull())
+            if (station.start.IsNull())
             {
                 return ride.getStationIndex(&station);
             }
@@ -413,18 +413,18 @@ namespace OpenRCT2
         return StationIndex::GetNull();
     }
 
-    int32_t RideStation::GetBaseZ() const
+    int32_t RideStation::getBaseZ() const
     {
-        return Height * kCoordsZStep;
+        return height * kCoordsZStep;
     }
 
-    void RideStation::SetBaseZ(int32_t newZ)
+    void RideStation::setBaseZ(int32_t newZ)
     {
-        Height = newZ / kCoordsZStep;
+        height = newZ / kCoordsZStep;
     }
 
-    CoordsXYZ RideStation::GetStart() const
+    CoordsXYZ RideStation::getStart() const
     {
-        return { Start, GetBaseZ() };
+        return { start, getBaseZ() };
     }
 } // namespace OpenRCT2

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -75,10 +75,10 @@ static void ride_remove_station(Ride& ride, const CoordsXYZ& location)
 {
     for (auto& station : ride.getStations())
     {
-        auto stationStart = station.GetStart();
+        auto stationStart = station.getStart();
         if (stationStart == location)
         {
-            station.Start.SetNull();
+            station.start.SetNull();
             ride.numStations--;
             break;
         }
@@ -111,11 +111,11 @@ ResultWithMessage TrackAddStationElement(CoordsXYZD loc, RideId rideIndex, Comma
             assert(!stationIndex.IsNull());
 
             auto& station = ride->getStation(stationIndex);
-            station.Start.x = loc.x;
-            station.Start.y = loc.y;
-            station.Height = loc.z / kCoordsZStep;
-            station.Depart = 1;
-            station.Length = 0;
+            station.start.x = loc.x;
+            station.start.y = loc.y;
+            station.height = loc.z / kCoordsZStep;
+            station.depart = 1;
+            station.length = 0;
             ride->numStations++;
         }
         return { true };
@@ -203,10 +203,10 @@ ResultWithMessage TrackAddStationElement(CoordsXYZD loc, RideId rideIndex, Comma
                     else
                     {
                         auto& station = ride->getStation(stationIndex);
-                        station.Start = loc;
-                        station.Height = loc.z / kCoordsZStep;
-                        station.Depart = 1;
-                        station.Length = stationLength;
+                        station.start = loc;
+                        station.height = loc.z / kCoordsZStep;
+                        station.depart = 1;
+                        station.length = stationLength;
                         ride->numStations++;
                     }
 
@@ -337,10 +337,10 @@ ResultWithMessage TrackRemoveStationElement(const CoordsXYZD& loc, RideId rideIn
                     else
                     {
                         auto& station = ride->getStation(stationIndex);
-                        station.Start = currentLoc;
-                        station.Height = currentLoc.z / kCoordsZStep;
-                        station.Depart = 1;
-                        station.Length = stationLength != 0 ? stationLength : ByteF441D1;
+                        station.start = currentLoc;
+                        station.height = currentLoc.z / kCoordsZStep;
+                        station.depart = 1;
+                        station.length = stationLength != 0 ? stationLength : ByteF441D1;
                         ride->numStations++;
                     }
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -270,16 +270,16 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
     {
         for (const auto& station : ride.getStations())
         {
-            z = station.GetBaseZ();
+            z = station.getBaseZ();
 
             TileCoordsXYZD location;
             if (i == 0)
             {
-                location = station.Entrance;
+                location = station.entrance;
             }
             else
             {
-                location = station.Exit;
+                location = station.exit;
             }
 
             if (location.IsNull())
@@ -390,7 +390,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, cons
         x = 0;
     }
 
-    auto location = ride.getStation().Entrance;
+    auto location = ride.getStation().entrance;
     if (location.IsNull())
     {
         return { false, STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY };
@@ -417,7 +417,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, cons
     mazeEntrance.isExit = false;
     entranceElements.push_back(mazeEntrance);
 
-    location = ride.getStation().Exit;
+    location = ride.getStation().exit;
     if (location.IsNull())
     {
         return { false, STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY };

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -110,7 +110,7 @@ bool TrackPaintUtilHasFence(
     auto entranceId = trackElement.getStationIndex();
     const auto& station = ride.getStation(entranceId);
 
-    return (entranceLoc != station.Entrance && entranceLoc != station.Exit);
+    return (entranceLoc != station.entrance && entranceLoc != station.exit);
 }
 
 void TrackPaintUtilPaintFloor(

--- a/src/openrct2/ride/Vehicle.BoatHire.cpp
+++ b/src/openrct2/ride/Vehicle.BoatHire.cpp
@@ -55,10 +55,10 @@ void Vehicle::UpdateDepartingBoatHire()
         return;
 
     auto& station = curRide->getStation(current_station);
-    station.Depart &= kStationDepartFlag;
+    station.depart &= kStationDepartFlag;
     uint8_t waitingTime = std::max(curRide->minWaitingTime, static_cast<uint8_t>(3));
     waitingTime = std::min(waitingTime, static_cast<uint8_t>(127));
-    station.Depart |= waitingTime;
+    station.depart |= waitingTime;
     UpdateTravellingBoatHireSetup();
 }
 

--- a/src/openrct2/ride/Vehicle.MiniGolf.cpp
+++ b/src/openrct2/ride/Vehicle.MiniGolf.cpp
@@ -625,11 +625,11 @@ void Vehicle::Loc6DCE02(const Ride& curRide)
 
     for (const auto& station : curRide.getStations())
     {
-        if (TrackLocation != station.Start)
+        if (TrackLocation != station.start)
         {
             continue;
         }
-        if (TrackLocation.z != station.GetBaseZ())
+        if (TrackLocation.z != station.getBaseZ())
         {
             continue;
         }

--- a/src/openrct2/ride/Vehicle.Station.cpp
+++ b/src/openrct2/ride/Vehicle.Station.cpp
@@ -94,7 +94,7 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
 
     /* Station is not ready to depart, so just return;
      * vehicle_id for this station is SPRITE_INDEX_NULL. */
-    if (!(ride->getStation(stationIndex).Depart & kStationDepartFlag))
+    if (!(ride->getStation(stationIndex).depart & kStationDepartFlag))
     {
         return true;
     }
@@ -149,7 +149,7 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
 static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex stationIndex)
 {
     const auto& station = ride.getStation(stationIndex);
-    auto location = station.GetStart();
+    auto location = station.getStart();
 
     auto tileElement = MapGetTrackElementAt(location);
     if (tileElement == nullptr)
@@ -184,7 +184,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
     }
 
     // Other search direction.
-    location = station.GetStart();
+    location = station.getStart();
     direction = DirectionReverse(direction) & 3;
     spaceBetween = maxCheckDistance;
     while (_lastSynchronisedVehicle < &_synchronisedVehicles[kSynchronisedVehicleCount - 1])
@@ -217,7 +217,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
             {
                 if (sv_ride->isBlockSectioned())
                 {
-                    if (!(sv_ride->getStation(sv->stationIndex).Depart & kStationDepartFlag))
+                    if (!(sv_ride->getStation(sv->stationIndex).depart & kStationDepartFlag))
                     {
                         sv = _synchronisedVehicles;
                         RideId rideId = RideId::GetNull();
@@ -477,7 +477,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         // Boat Hire with passengers on it.
         if (curRide->status != RideStatus::closed || (curRide->numRiders != 0 && rtd.specialType != RtdSpecialType::boatHire))
         {
-            curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
+            curRide->getStation(current_station).trainAtStation = RideStation::kNoTrain;
             sub_state = 2;
             return;
         }
@@ -488,7 +488,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         uint8_t seat = ((-flatRideAnimationFrame) / 8) & 0xF;
         if (!peep[seat].IsNull())
         {
-            curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
+            curRide->getStation(current_station).trainAtStation = RideStation::kNoTrain;
             SetState(Status::unloadingPassengers);
             return;
         }
@@ -496,7 +496,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
         if (num_peeps == 0)
             return;
 
-        curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
+        curRide->getStation(current_station).trainAtStation = RideStation::kNoTrain;
         sub_state = 2;
         return;
     }
@@ -504,7 +504,7 @@ void Vehicle::TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_se
     if (num_peeps_on_train == 0)
         return;
 
-    curRide->getStation(current_station).TrainAtStation = RideStation::kNoTrain;
+    curRide->getStation(current_station).trainAtStation = RideStation::kNoTrain;
     SetState(Status::waitingForPassengers);
 }
 
@@ -526,9 +526,9 @@ void Vehicle::UpdateWaitingForPassengers()
             return;
 
         auto& station = curRide->getStation(current_station);
-        if (station.Entrance.IsNull())
+        if (station.entrance.IsNull())
         {
-            station.TrainAtStation = RideStation::kNoTrain;
+            station.trainAtStation = RideStation::kNoTrain;
             sub_state = 2;
             return;
         }
@@ -539,10 +539,10 @@ void Vehicle::UpdateWaitingForPassengers()
             return;
         }
 
-        if (station.TrainAtStation != RideStation::kNoTrain)
+        if (station.trainAtStation != RideStation::kNoTrain)
             return;
 
-        station.TrainAtStation = trainIndex.value();
+        station.trainAtStation = trainIndex.value();
         sub_state = 1;
         time_waiting = 0;
 
@@ -720,7 +720,7 @@ void Vehicle::UpdateWaitingToDepart()
             }
             else
             {
-                if (!currentStation.Exit.IsNull())
+                if (!currentStation.exit.IsNull())
                 {
                     SetState(Status::unloadingPassengers);
                     return;
@@ -734,7 +734,7 @@ void Vehicle::UpdateWaitingToDepart()
             {
                 if (trainCar->num_peeps != 0)
                 {
-                    if (!currentStation.Exit.IsNull())
+                    if (!currentStation.exit.IsNull())
                     {
                         SetState(Status::unloadingPassengers);
                         return;
@@ -747,7 +747,7 @@ void Vehicle::UpdateWaitingToDepart()
 
     if (!skipCheck)
     {
-        if (!(currentStation.Depart & kStationDepartFlag))
+        if (!(currentStation.depart & kStationDepartFlag))
             return;
     }
 
@@ -950,7 +950,7 @@ void Vehicle::UpdateUnloadingPassengers()
     }
     else
     {
-        if (currentStation.Exit.IsNull())
+        if (currentStation.exit.IsNull())
         {
             if (sub_state != 1)
                 return;
@@ -1268,7 +1268,7 @@ void Vehicle::FinishDeparting()
     if (curRide->mode != RideMode::race && !curRide->isBlockSectioned())
     {
         auto& currentStation = curRide->getStation(current_station);
-        currentStation.Depart &= kStationDepartFlag;
+        currentStation.depart &= kStationDepartFlag;
         uint8_t waitingTime = 3;
         if (curRide->departFlags & RIDE_DEPART_WAIT_FOR_MINIMUM_LENGTH)
         {
@@ -1276,7 +1276,7 @@ void Vehicle::FinishDeparting()
             waitingTime = std::min(waitingTime, static_cast<uint8_t>(127));
         }
 
-        currentStation.Depart |= waitingTime;
+        currentStation.depart |= waitingTime;
     }
     lost_time_out = 0;
     SetState(Status::travelling, 1);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -457,7 +457,7 @@ namespace OpenRCT2
             return;
 
         const auto& currentStation = curRide->getStation(curRide->currentTestStation);
-        if (!currentStation.Entrance.IsNull())
+        if (!currentStation.entrance.IsNull())
         {
             uint8_t test_segment = curRide->currentTestSegment;
             StationIndex stationIndex = StationIndex::FromUnderlying(test_segment);
@@ -476,13 +476,13 @@ namespace OpenRCT2
             if (curRide->averageSpeedTestTimeout == 0 && absVelocity > 0)
             {
                 curRide->averageSpeed = AddClamp<int32_t>(curRide->averageSpeed, absVelocity);
-                stationForTestSegment.SegmentTime++;
+                stationForTestSegment.segmentTime++;
             }
 
             int32_t distance = abs(((velocity + acceleration) >> 10) * 42);
             if (NumLaps == 0)
             {
-                stationForTestSegment.SegmentLength = AddClamp<int32_t>(stationForTestSegment.SegmentLength, distance);
+                stationForTestSegment.segmentLength = AddClamp<int32_t>(stationForTestSegment.segmentLength, distance);
             }
 
             if (curRide->getRideTypeDescriptor().flags.has(RtdFlag::hasGForces))
@@ -517,7 +517,7 @@ namespace OpenRCT2
         {
             curRide->curTestTrackLocation = curTrackLoc;
 
-            if (currentStation.Entrance.IsNull())
+            if (currentStation.entrance.IsNull())
                 return;
 
             auto trackElemType = GetTrackType();
@@ -705,7 +705,7 @@ namespace OpenRCT2
             }
         }
 
-        if (currentStation.Entrance.IsNull())
+        if (currentStation.entrance.IsNull())
             return;
 
         if (x == kLocationNull)
@@ -919,22 +919,22 @@ namespace OpenRCT2
         auto rideStations = ride.getStations();
         for (int32_t i = ride.numStations - 1; i >= 1; i--)
         {
-            if (rideStations[i - 1].SegmentTime != 0)
+            if (rideStations[i - 1].segmentTime != 0)
                 continue;
 
-            uint16_t oldTime = rideStations[i - 1].SegmentTime;
-            rideStations[i - 1].SegmentTime = rideStations[i].SegmentTime;
-            rideStations[i].SegmentTime = oldTime;
+            uint16_t oldTime = rideStations[i - 1].segmentTime;
+            rideStations[i - 1].segmentTime = rideStations[i].segmentTime;
+            rideStations[i].segmentTime = oldTime;
 
-            int32_t oldLength = rideStations[i - 1].SegmentLength;
-            rideStations[i - 1].SegmentLength = rideStations[i].SegmentLength;
-            rideStations[i].SegmentLength = oldLength;
+            int32_t oldLength = rideStations[i - 1].segmentLength;
+            rideStations[i - 1].segmentLength = rideStations[i].segmentLength;
+            rideStations[i].segmentLength = oldLength;
         }
 
         uint32_t totalTime = 0;
         for (uint8_t i = 0; i < ride.numStations; ++i)
         {
-            totalTime += rideStations[i].SegmentTime;
+            totalTime += rideStations[i].segmentTime;
         }
 
         totalTime = std::max(totalTime, 1u);
@@ -988,8 +988,8 @@ namespace OpenRCT2
         ride.specialTrackElements.clearAll();
         for (auto& station : ride.getStations())
         {
-            station.SegmentLength = 0;
-            station.SegmentTime = 0;
+            station.segmentLength = 0;
+            station.segmentTime = 0;
         }
         ride.totalAirTime = 0;
         ride.currentTestStation = curStation;
@@ -1137,7 +1137,7 @@ namespace OpenRCT2
 
         // This is slightly different to the vanilla function
         auto& currentStation = curRide->getStation(current_station);
-        currentStation.Depart &= kStationDepartFlag;
+        currentStation.depart &= kStationDepartFlag;
         uint8_t waitingTime = 3;
         if (curRide->departFlags & RIDE_DEPART_WAIT_FOR_MINIMUM_LENGTH)
         {
@@ -1145,7 +1145,7 @@ namespace OpenRCT2
             waitingTime = std::min(waitingTime, static_cast<uint8_t>(127));
         }
 
-        currentStation.Depart |= waitingTime;
+        currentStation.depart |= waitingTime;
     }
 
     /**

--- a/src/openrct2/scripting/bindings/ride/ScRideStation.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRideStation.cpp
@@ -63,7 +63,7 @@ namespace OpenRCT2::Scripting
         auto station = GetRideStation(thisVal);
         if (station != nullptr)
         {
-            auto start = CoordsXYZ(station->Start, station->GetBaseZ());
+            auto start = CoordsXYZ(station->start, station->getBaseZ());
             return ToJSValue(ctx, start);
         }
         return JS_NULL;
@@ -77,8 +77,8 @@ namespace OpenRCT2::Scripting
         if (station != nullptr)
         {
             auto start = JSToCoordsXYZ(ctx, value);
-            station->Start = { start.x, start.y };
-            station->SetBaseZ(start.z);
+            station->start = { start.x, start.y };
+            station->setBaseZ(start.z);
         }
         return JS_UNDEFINED;
     }
@@ -86,7 +86,7 @@ namespace OpenRCT2::Scripting
     JSValue ScRideStation::length_get(JSContext* ctx, JSValue thisVal)
     {
         auto station = GetRideStation(thisVal);
-        return JS_NewInt32(ctx, station != nullptr ? station->Length : 0);
+        return JS_NewInt32(ctx, station != nullptr ? station->length : 0);
     }
 
     JSValue ScRideStation::length_set(JSContext* ctx, JSValue thisVal, JSValue value)
@@ -97,7 +97,7 @@ namespace OpenRCT2::Scripting
         auto station = GetRideStation(thisVal);
         if (station != nullptr)
         {
-            station->Length = valueInt;
+            station->length = valueInt;
         }
         return JS_UNDEFINED;
     }
@@ -107,7 +107,7 @@ namespace OpenRCT2::Scripting
         auto station = GetRideStation(thisVal);
         if (station != nullptr)
         {
-            return ToJSValue(ctx, station->Entrance.ToCoordsXYZD());
+            return ToJSValue(ctx, station->entrance.ToCoordsXYZD());
         }
         return JS_NULL;
     }
@@ -119,7 +119,7 @@ namespace OpenRCT2::Scripting
         auto station = GetRideStation(thisVal);
         if (station != nullptr)
         {
-            station->Entrance = JSToCoordsXYZD(ctx, value);
+            station->entrance = JSToCoordsXYZD(ctx, value);
         }
         return JS_UNDEFINED;
     }
@@ -129,7 +129,7 @@ namespace OpenRCT2::Scripting
         auto station = GetRideStation(thisVal);
         if (station != nullptr)
         {
-            return ToJSValue(ctx, station->Exit.ToCoordsXYZD());
+            return ToJSValue(ctx, station->exit.ToCoordsXYZD());
         }
         return JS_NULL;
     }
@@ -141,7 +141,7 @@ namespace OpenRCT2::Scripting
         auto station = GetRideStation(thisVal);
         if (station != nullptr)
         {
-            station->Exit = JSToCoordsXYZD(ctx, value);
+            station->exit = JSToCoordsXYZD(ctx, value);
         }
         return JS_UNDEFINED;
     }
@@ -149,7 +149,7 @@ namespace OpenRCT2::Scripting
     JSValue ScRideStation::queueTime_get(JSContext* ctx, JSValue thisVal)
     {
         auto station = GetRideStation(thisVal);
-        return JS_NewUint32(ctx, station != nullptr ? station->QueueTime : 0);
+        return JS_NewUint32(ctx, station != nullptr ? station->queueTime : 0);
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -947,10 +947,10 @@ namespace OpenRCT2
 
             for (const auto& station : ride->getStations())
             {
-                if (station.Entrance.IsNull())
+                if (station.entrance.IsNull())
                     continue;
 
-                TileElement* tileElement = MapGetFirstElementAt(station.Entrance);
+                TileElement* tileElement = MapGetFirstElementAt(station.entrance);
                 if (tileElement != nullptr)
                 {
                     do
@@ -964,7 +964,7 @@ namespace OpenRCT2
 
                         Direction direction = DirectionReverse(tileElement->getDirection());
                         FootpathChainRideQueue(
-                            rideIndex, ride->getStationIndex(&station), station.Entrance.ToCoordsXY(), tileElement, direction);
+                            rideIndex, ride->getStationIndex(&station), station.entrance.ToCoordsXY(), tileElement, direction);
                     } while (!(tileElement++)->isLastForTile());
                 }
             }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -2283,9 +2283,9 @@ namespace OpenRCT2
             auto stations = ride.getStations();
             for (auto& station : stations)
             {
-                shiftIfNotNull(station.Start, amountToMove);
-                shiftIfNotNull(station.Entrance, amount);
-                shiftIfNotNull(station.Exit, amount);
+                shiftIfNotNull(station.start, amountToMove);
+                shiftIfNotNull(station.entrance, amount);
+                shiftIfNotNull(station.exit, amount);
             }
 
             shiftIfNotNull(ride.overallView, amountToMove);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -124,7 +124,7 @@ namespace OpenRCT2::Park
                     continue;
                 if (!ride.getRideTypeDescriptor().flags.has(RtdFlag::hasDataLogging))
                     continue;
-                if (ride.getStation().SegmentLength < (600 << 16))
+                if (ride.getStation().segmentLength < (600 << 16))
                     continue;
                 if (ride.ratings.excitement < RideRating::make(6, 00))
                     continue;

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -239,8 +239,8 @@ namespace OpenRCT2::TileInspector
                     {
                         auto stationIndex = tileElement->asEntrance()->getStationIndex();
                         auto& station = ride->getStation(stationIndex);
-                        auto entrance = station.Entrance;
-                        auto exit = station.Exit;
+                        auto entrance = station.entrance;
+                        auto exit = station.exit;
                         auto entranceType = tileElement->asEntrance()->getEntranceType();
                         uint8_t z = tileElement->baseHeight;
 
@@ -248,13 +248,13 @@ namespace OpenRCT2::TileInspector
                         if (entranceType == EntranceType::rideEntrance && entrance.x == loc.x / kCoordsXYStep
                             && entrance.y == loc.y / kCoordsXYStep && entrance.z == z)
                         {
-                            station.Entrance = { entrance, newRotation };
+                            station.entrance = { entrance, newRotation };
                         }
                         else if (
                             entranceType == EntranceType::rideExit && exit.x == loc.x / kCoordsXYStep
                             && exit.y == loc.y / kCoordsXYStep && exit.z == z)
                         {
-                            station.Exit = { exit, newRotation };
+                            station.exit = { exit, newRotation };
                         }
                     }
                     break;
@@ -469,15 +469,15 @@ namespace OpenRCT2::TileInspector
                     {
                         auto entranceIndex = tileElement->asEntrance()->getStationIndex();
                         auto& station = ride->getStation(entranceIndex);
-                        const auto& entranceLoc = station.Entrance;
-                        const auto& exitLoc = station.Exit;
+                        const auto& entranceLoc = station.entrance;
+                        const auto& exitLoc = station.exit;
                         uint8_t z = tileElement->baseHeight;
 
                         // Make sure this is the correct entrance or exit
                         if (entranceType == EntranceType::rideEntrance && entranceLoc == TileCoordsXYZ{ loc, z })
-                            station.Entrance = { entranceLoc, z + heightOffset, entranceLoc.direction };
+                            station.entrance = { entranceLoc, z + heightOffset, entranceLoc.direction };
                         else if (entranceType == EntranceType::rideExit && exitLoc == TileCoordsXYZ{ loc, z })
-                            station.Exit = { exitLoc, z + heightOffset, exitLoc.direction };
+                            station.exit = { exitLoc, z + heightOffset, exitLoc.direction };
                     }
                 }
             }
@@ -656,10 +656,10 @@ namespace OpenRCT2::TileInspector
             switch (entranceElement->asEntrance()->getEntranceType())
             {
                 case EntranceType::rideEntrance:
-                    station.Entrance = { loc, entranceElement->baseHeight, entranceElement->getDirection() };
+                    station.entrance = { loc, entranceElement->baseHeight, entranceElement->getDirection() };
                     break;
                 case EntranceType::rideExit:
-                    station.Exit = { loc, entranceElement->baseHeight, entranceElement->getDirection() };
+                    station.exit = { loc, entranceElement->baseHeight, entranceElement->getDirection() };
                     break;
                 default:
                     break;

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -198,7 +198,7 @@ TEST_P(SimplePathfindingTest, CanFindPathFromStartToGoal)
     auto ride = FindRideByName(scenario.name);
     ASSERT_NE(ride, nullptr);
 
-    auto entrancePos = ride->getStation().Entrance;
+    auto entrancePos = ride->getStation().entrance;
     TileCoordsXYZ goal = TileCoordsXYZ(
         entrancePos.x - TileDirectionDelta[entrancePos.direction].x,
         entrancePos.y - TileDirectionDelta[entrancePos.direction].y, entrancePos.z);
@@ -236,7 +236,7 @@ TEST_P(ImpossiblePathfindingTest, CannotFindPathFromStartToGoal)
     auto ride = FindRideByName(scenario.name);
     ASSERT_NE(ride, nullptr);
 
-    auto entrancePos = ride->getStation().Entrance;
+    auto entrancePos = ride->getStation().entrance;
     TileCoordsXYZ goal = TileCoordsXYZ(
         entrancePos.x + TileDirectionDelta[entrancePos.direction].x,
         entrancePos.y + TileDirectionDelta[entrancePos.direction].y, entrancePos.z);


### PR DESCRIPTION
### Description of changes

For https://github.com/OpenRCT2/OpenRCT2/issues/26521. Rename members in the `RideStation` struct in `Ride.h` to `camelCase`.

### Rationale behind changes

To make code style more consistent.

### Suggested testing steps

N/A

### Did you use AI to help find, test, or implement this issue or feature?

AI was not used.
