### PR TITLE
Disable cheats that have no use in the scenario editor or track designer

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -268,6 +268,7 @@ Appreciation for contributors who have provided substantial work, but are no lon
 * Michael Hlas (mhlas7)
 * (byteraidhost)
 * Ray (RayKoopa)
+* Chris Jasper (NearlyGold)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
 - Improved: [#21400] The selector for setting staff patrol areas is now drawn on the water as well as on the surface under water.
+- Change: [#27074] When in the scenario editor or track designer, cheats that have no use are disabled.
 - Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -539,6 +539,16 @@ static StringId window_cheats_page_titles[] = {
                     setCheckboxValue(WIDX_ALLOW_SPECIAL_COLOUR_SCHEMES, gameState.cheats.allowSpecialColourSchemes);
                     break;
                 case WINDOW_CHEATS_PAGE_RIDES:
+                    setWidgetDisabled(WIDX_FIX_ALL, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_RENEW_RIDES, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_RESET_CRASH_STATUS, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_10_MINUTE_INSPECTIONS, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_MAKE_DESTRUCTIBLE, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_DISABLE_BRAKES_FAILURE, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_DISABLE_ALL_BREAKDOWNS, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_DISABLE_RIDE_VALUE_AGING, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_IGNORE_RESEARCH_STATUS, isInTrackDesignerOrManager());
+
                     setCheckboxValue(WIDX_UNLOCK_OPERATING_LIMITS, gameState.cheats.unlockOperatingLimits);
                     setCheckboxValue(WIDX_DISABLE_BRAKES_FAILURE, gameState.cheats.disableBrakesFailure);
                     setCheckboxValue(WIDX_DISABLE_ALL_BREAKDOWNS, gameState.cheats.disableAllBreakdowns);

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -515,6 +515,19 @@ static StringId window_cheats_page_titles[] = {
                     break;
                 }
                 case WINDOW_CHEATS_PAGE_PARK:
+                    setWidgetDisabled(WIDX_GENERAL_GROUP, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_OWN_ALL_LAND, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_REMOVE_PARK_FENCES, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_OPEN_CLOSE_PARK, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_OBJECTIVE_GROUP, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_NEVERENDING_MARKETING, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_FORCE_PARK_RATING, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_PARK_RATING_SPINNER, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_INCREASE_PARK_RATING, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_DECREASE_PARK_RATING, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_WIN_SCENARIO, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_HAVE_FUN, isInTrackDesignerOrManager());
+
                     widgets[WIDX_OPEN_CLOSE_PARK].text = STR_CHEAT_OPEN_PARK;
                     if (gameState.park.flags.has(ParkFlag::parkOpen))
                         widgets[WIDX_OPEN_CLOSE_PARK].text = STR_CHEAT_CLOSE_PARK;
@@ -626,12 +639,17 @@ static StringId window_cheats_page_titles[] = {
             }
             else if (page == WINDOW_CHEATS_PAGE_PARK)
             {
+                auto colour = colours[1];
                 auto ft = Formatter();
                 ft.Add<int32_t>(_parkRatingSpinnerValue);
 
+                if (isWidgetDisabled(WIDX_PARK_RATING_SPINNER))
+                {
+                    colour.flags.set(ColourFlag::inset, true);
+                }
+
                 auto& widget = widgets[WIDX_PARK_RATING_SPINNER];
-                drawText(
-                    rt, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 2 }, STR_FORMAT_INTEGER, ft, { colours[1] });
+                drawText(rt, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 2 }, STR_FORMAT_INTEGER, ft, { colour });
             }
             else if (page == WINDOW_CHEATS_PAGE_STAFF)
             {

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -488,12 +488,13 @@ static StringId window_cheats_page_titles[] = {
             // Set title
             widgets[WIDX_TITLE].text = window_cheats_page_titles[page];
 
+            const bool isInEditor = isInEditorMode();
             auto& gameState = getGameState();
             switch (page)
             {
                 case WINDOW_CHEATS_PAGE_MONEY:
                 {
-                    setWidgetDisabled(WIDX_NO_MONEY, isInEditorMode());
+                    setWidgetDisabled(WIDX_NO_MONEY, isInEditor);
 
                     auto moneyDisabled = gameState.park.flags.has(ParkFlag::noMoney);
                     setCheckboxValue(WIDX_NO_MONEY, moneyDisabled);
@@ -515,18 +516,18 @@ static StringId window_cheats_page_titles[] = {
                     break;
                 }
                 case WINDOW_CHEATS_PAGE_PARK:
-                    setWidgetDisabled(WIDX_GENERAL_GROUP, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_OWN_ALL_LAND, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_REMOVE_PARK_FENCES, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_OPEN_CLOSE_PARK, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_OBJECTIVE_GROUP, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_NEVERENDING_MARKETING, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_FORCE_PARK_RATING, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_PARK_RATING_SPINNER, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_INCREASE_PARK_RATING, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_DECREASE_PARK_RATING, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_WIN_SCENARIO, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_HAVE_FUN, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_GENERAL_GROUP, isInEditor);
+                    setWidgetDisabled(WIDX_OWN_ALL_LAND, isInEditor);
+                    setWidgetDisabled(WIDX_REMOVE_PARK_FENCES, isInEditor);
+                    setWidgetDisabled(WIDX_OPEN_CLOSE_PARK, isInEditor);
+                    setWidgetDisabled(WIDX_OBJECTIVE_GROUP, isInEditor);
+                    setWidgetDisabled(WIDX_NEVERENDING_MARKETING, isInEditor);
+                    setWidgetDisabled(WIDX_FORCE_PARK_RATING, isInEditor);
+                    setWidgetDisabled(WIDX_PARK_RATING_SPINNER, isInEditor);
+                    setWidgetDisabled(WIDX_INCREASE_PARK_RATING, isInEditor);
+                    setWidgetDisabled(WIDX_DECREASE_PARK_RATING, isInEditor);
+                    setWidgetDisabled(WIDX_WIN_SCENARIO, isInEditor);
+                    setWidgetDisabled(WIDX_HAVE_FUN, isInEditor);
 
                     widgets[WIDX_OPEN_CLOSE_PARK].text = STR_CHEAT_OPEN_PARK;
                     if (gameState.park.flags.has(ParkFlag::parkOpen))
@@ -539,15 +540,15 @@ static StringId window_cheats_page_titles[] = {
                     setCheckboxValue(WIDX_ALLOW_SPECIAL_COLOUR_SCHEMES, gameState.cheats.allowSpecialColourSchemes);
                     break;
                 case WINDOW_CHEATS_PAGE_RIDES:
-                    setWidgetDisabled(WIDX_FIX_ALL, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_RENEW_RIDES, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_RESET_CRASH_STATUS, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_10_MINUTE_INSPECTIONS, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_MAKE_DESTRUCTIBLE, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_DISABLE_BRAKES_FAILURE, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_DISABLE_ALL_BREAKDOWNS, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_DISABLE_RIDE_VALUE_AGING, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_IGNORE_RESEARCH_STATUS, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_FIX_ALL, isInEditor);
+                    setWidgetDisabled(WIDX_RENEW_RIDES, isInEditor);
+                    setWidgetDisabled(WIDX_RESET_CRASH_STATUS, isInEditor);
+                    setWidgetDisabled(WIDX_10_MINUTE_INSPECTIONS, isInEditor);
+                    setWidgetDisabled(WIDX_MAKE_DESTRUCTIBLE, isInEditor);
+                    setWidgetDisabled(WIDX_DISABLE_BRAKES_FAILURE, isInEditor);
+                    setWidgetDisabled(WIDX_DISABLE_ALL_BREAKDOWNS, isInEditor);
+                    setWidgetDisabled(WIDX_DISABLE_RIDE_VALUE_AGING, isInEditor);
+                    setWidgetDisabled(WIDX_IGNORE_RESEARCH_STATUS, isInEditor);
 
                     setCheckboxValue(WIDX_UNLOCK_OPERATING_LIMITS, gameState.cheats.unlockOperatingLimits);
                     setCheckboxValue(WIDX_DISABLE_BRAKES_FAILURE, gameState.cheats.disableBrakesFailure);
@@ -569,10 +570,10 @@ static StringId window_cheats_page_titles[] = {
                     setCheckboxValue(WIDX_DISABLE_GRASS_GROWING, gameState.cheats.disableGrassGrowing);
                     break;
                 case WINDOW_CHEATS_PAGE_WEATHER:
-                    setWidgetDisabled(WIDX_FREEZE_WEATHER, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_FAUNA_GROUP, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_CREATE_DUCKS, isInTrackDesignerOrManager());
-                    setWidgetDisabled(WIDX_REMOVE_DUCKS, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_FREEZE_WEATHER, isInEditor);
+                    setWidgetDisabled(WIDX_FAUNA_GROUP, isInEditor);
+                    setWidgetDisabled(WIDX_CREATE_DUCKS, isInEditor);
+                    setWidgetDisabled(WIDX_REMOVE_DUCKS, isInEditor);
 
                     setCheckboxValue(WIDX_FREEZE_WEATHER, gameState.cheats.freezeWeather);
                     break;
@@ -592,10 +593,10 @@ static StringId window_cheats_page_titles[] = {
                 widgets[WIDX_STAFF_SPEED].text = _staffSpeedNames[EnumValue(gameState.cheats.selectedStaffSpeed)];
             }
 
-            setWidgetDisabled(WIDX_TAB_2, isInEditorMode());
-            setWidgetDisabled(WIDX_TAB_3, isInEditorMode());
-            setWidgetDisabled(WIDX_TAB_4, isInTrackDesignerOrManager());
-            if (isInEditorMode())
+            setWidgetDisabled(WIDX_TAB_2, isInEditor);
+            setWidgetDisabled(WIDX_TAB_3, isInEditor);
+            setWidgetDisabled(WIDX_TAB_4, isInEditor);
+            if (isInEditor)
             {
                 UpdateTabPositions();
             }

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -569,6 +569,11 @@ static StringId window_cheats_page_titles[] = {
                     setCheckboxValue(WIDX_DISABLE_GRASS_GROWING, gameState.cheats.disableGrassGrowing);
                     break;
                 case WINDOW_CHEATS_PAGE_WEATHER:
+                    setWidgetDisabled(WIDX_FREEZE_WEATHER, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_FAUNA_GROUP, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_CREATE_DUCKS, isInTrackDesignerOrManager());
+                    setWidgetDisabled(WIDX_REMOVE_DUCKS, isInTrackDesignerOrManager());
+
                     setCheckboxValue(WIDX_FREEZE_WEATHER, gameState.cheats.freezeWeather);
                     break;
             }

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -566,6 +566,7 @@ static StringId window_cheats_page_titles[] = {
 
             setWidgetDisabled(WIDX_TAB_2, isInEditorMode());
             setWidgetDisabled(WIDX_TAB_3, isInEditorMode());
+            setWidgetDisabled(WIDX_TAB_4, isInTrackDesignerOrManager());
             if (isInEditorMode())
             {
                 UpdateTabPositions();


### PR DESCRIPTION
### Description of changes

<!-- Briefly describe what was changed in the PR -->
Cheats that have no use in the scenario editor, track designer and manager have been disabled.

The entire staff cheats tab has been hidden.

Most cheats in the park tab have been disabled. Only the ride construction related cheats remain.

Ride maintenance and value cheats have been disabled as rides cannot be maintained and have no value in this mode.

### Rationale behind changes

<!-- Why were these changes made? What problem does it solve, or what does it improve? -->
Many cheats are useless in these modes, so they can be hidden or disabled.

Activating some cheats in this mode could result in unexpected behaviour. For instance, clicking the "Win scenario" button without selecting any ride types would result in a game crash.

Relates to #13356.

### Suggested testing steps

<!-- Any particular areas of the game we need to look at? You can include example save games if needed. -->
1. Start any scenario and open the cheats window.
2. The "Staff cheats" tab is visible and enabled.
3. All cheats in the following tabs are also enabled: "Park cheats", "Ride cheats", "Weather cheats".
7. Open the track designer and open the cheats window.
8. The "Staff cheats" tab is not visible.
9. On the "Park cheats" tab, all cheats outside of the "Construction" group are disabled.
10. On the "Ride cheats" tab, all breakdown-related cheats are disabled as well as "all destructible", "rides don't decrease in value over time", and "ignore research status".
11. On the "Nature/weather cheats" tab, only the "change weather" dropdown is enabled.

### Did you use AI to help find, test, or implement this issue or feature?

<!-- Please answer honestly. If you answer yes, please provide a brief explanation as to how you used it. -->
No.
