### PR TITLE
Add missing "drag_path_area" PermissionType to plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 - Fix: [#27056] [Plugin] Loading water palettes from plugin does not update the palette correctly.
+- Fix: [#27084] [Plugin] `PermissionType` for `drag_path_area` is missing.
 - Fix: [#27087] The ‘Update available’ widget is offset incorrectly.
 - Fix: [#27093] Pause and fast forward buttons are shown in multiplayer.
 

--- a/distribution/scripting/openrct2.d.ts
+++ b/distribution/scripting/openrct2.d.ts
@@ -4280,7 +4280,8 @@ declare global {
         "toggle_scenery_cluster" |
         "passwordless_login" |
         "modify_tile" |
-        "edit_scenario_options";
+        "edit_scenario_options" |
+        "drag_path_area";
 
     /**
      * Park APIs

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -48,6 +48,10 @@ namespace OpenRCT2::Network
         return Permission::count;
     }
 
+    /*
+     * When adding an action, also add its permission name (everything following the "PERMISSION_" prefix, in lowercase)
+     * to PermissionType in distribution/scripting/openrct2.d.ts.
+     */
     const std::array<NetworkAction, static_cast<size_t>(Permission::count)> NetworkActions::kActions = {
         NetworkAction{
             STR_ACTION_CHAT,


### PR DESCRIPTION
### Description of changes

- Fixes #26819 by adding  `"drag_path_area"` to the plugin API's `PermissionType`.
- Also adds comment above `NetworkAction.cpp`'s `kActions` array about syncing permission names with it when extending it in the future. (@sjoerddebruin can you check I implemented your suggestion as you imagined it here?)

### Rationale behind changes

The "Drag areas of path" action was added a while back, but its name was still missing from the PermissionType in the plugin API typings.

### Suggested testing steps

Create a plugin querying for the `"drag_path_area"` permission of a player and check if the result is valid.

### Did you use AI to help find, test, or implement this issue or feature?

No.
