### PR TITLE
Fix #26754: Switching window tabs by touch can crash the game

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
+- Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.
 
 0.5.5 (2026-09-06)

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1024,6 +1024,11 @@ namespace OpenRCT2
         if (w != nullptr)
         {
             w->onPrepareDraw();
+
+            // Switching a window to another page can leave the remembered index out of range.
+            if (static_cast<size_t>(gHoverWidget.widgetIndex) >= w->widgets.size())
+                return;
+
             if (w->widgets[gHoverWidget.widgetIndex].type == WidgetType::flatBtn
                 || w->widgets[gHoverWidget.widgetIndex].type == WidgetType::hiddenButton)
             {


### PR DESCRIPTION
### Description of changes

Closes #26754. `InputWidgetOverFlatbuttonInvalidate` reads the remembered hover widget without checking that it still exists, so this adds the same bounds check that `InvalidateWidget` already performs one call later.

### Rationale behind changes

`gHoverWidget` is only updated when the pointer moves, never on a press. Tapping a tab therefore switches the window to a page with fewer widgets while the remembered index stays behind, and reading it is then out of range. On the ride window's first tab the RCT1 style light buttons are the last four widgets and the income page is shorter, which is the case in the issue. Builds with `_GLIBCXX_ASSERTIONS` abort on it, which covers the Flatpak (the reporter's log shows the assertion firing) and Fedora's packages, since both the freedesktop SDK and redhat-rpm-config enable it by default. Debian and Ubuntu do not, and neither do Windows and macOS builds, so there the wrong widget is read silently.

Every window that swaps pages is exposed rather than just the ride one, since their pages differ in widget count: `Player`, `Staff`, `Finances`, `MapGen`, `About`, `EditorScenarioOptions` and plugin windows with tabs all call `setWidgets` the same way. Hence the check at this shared read rather than in the ride window.

### Suggested testing steps

Needs a build with `-D_GLIBCXX_ASSERTIONS` for the abort to be visible, plus a touchscreen or trackpad for the tap.

1. Set the theme to RCT1, so the ride window shows its light buttons (or use a theme that does so).
2. Open any ride's window.
3. Rest the pointer on the open ride button. Hovering is enough, it does not need clicking.
4. Tap the money tab without moving the pointer again.

Before this change the game aborts on that tap, after it the income page opens normally. Worth also confirming that hover highlighting of flat buttons still behaves as before, since that is what the guarded function is for.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Claude Opus 5 (high reasoning effort) assisted with investigating the reported issue, analysing the code, and drafting the accompanying text. Suggestions were not taken as-is: what to change, and how, was settled over several rounds of back and forth, and based on existing patterns in the code base plus my own knowledge. All changes have been verified by me in-game or with the project's own tooling, and I take responsibility for the diff.
