### PR TITLE
Fix #26957: The frame 0 image is skipped when changing the state from 'swim' to 'flyAway'.

### DIFF
--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -70,6 +70,10 @@ static constexpr uint8_t kDuckAnimationFlyAway[] =
         kDuckAnimationFlyAway,     //  DuckState::FlyAway,
     };
 
+    static constexpr size_t kDuckAnimationSize[] = { std::size(kDuckAnimationFlyToWater), std::size(kDuckAnimationSwim),
+                                                     std::size(kDuckAnimationDrink), std::size(kDuckAnimationDoubleDrink),
+                                                     std::size(kDuckAnimationFlyAway) };
+
     template<>
     bool EntityBase::is<Duck>() const
     {
@@ -95,7 +99,7 @@ static constexpr uint8_t kDuckAnimationFlyAway[] =
             return;
 
         frame++;
-        if (frame >= std::size(kDuckAnimationFlyToWater))
+        if (frame >= kDuckAnimationSize[EnumValue(state)])
         {
             frame = 0;
         }
@@ -180,6 +184,7 @@ static constexpr uint8_t kDuckAnimationFlyAway[] =
             if (currentMonth >= MONTH_SEPTEMBER && (randomNumber >> 16) < 218)
             {
                 state = DuckState::flyAway;
+                frame = std::numeric_limits<uint16_t>::max();
                 updateFlyAway();
             }
             else
@@ -191,6 +196,7 @@ static constexpr uint8_t kDuckAnimationFlyAway[] =
                 if (z < landZ || waterZ == 0)
                 {
                     state = DuckState::flyAway;
+                    frame = std::numeric_limits<uint16_t>::max();
                     updateFlyAway();
                 }
                 else
@@ -254,7 +260,7 @@ static constexpr uint8_t kDuckAnimationFlyAway[] =
         if ((getGameState().currentTicks & 3) == 0)
         {
             frame++;
-            if (frame >= std::size(kDuckAnimationFlyAway))
+            if (frame >= kDuckAnimationSize[EnumValue(state)])
             {
                 frame = 0;
             }
@@ -272,6 +278,10 @@ static constexpr uint8_t kDuckAnimationFlyAway[] =
             {
                 remove();
             }
+        }
+        else
+        {
+            frame = frame == std::numeric_limits<uint16_t>::max() ? frame + 1 : frame;
         }
     }
 


### PR DESCRIPTION
### Description of changes
_Originally posted by @OpenRCT2-git-bot in #26957._
I fixed an issue where the frame 0 was skipped and frame 1 was rendered under certain conditions when the state changed from 'swim' to 'flyAway'.
Because the frame was not set to the maximum `uint16_t` value.

### Rationale behind changes
The `frame` value defaults to 0 if not explicitly set when changing the state from `swim` to `flyAway`.

Since the `frame` value may increment upon calling `updateFlyAway()`, it was initialized to the maximum `uint16_t` value.

Additionally, a conditional statement was added because assigning the maximum value caused an overflow when the condition `if ((getGameState().currentTicks & 3) == 0)` evaluated to false within `updateFlyAway()`.

### Suggested testing steps
1. Enter a park with a river.
2. Create a duck and change its state from 'swim' to 'flyAway'.
3. Check the frame value.

### Did you use AI to help find, test, or implement this issue or feature?
No