### PR TITLE
Add Flatpak Steam paths to RCT2/RCTC detection

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Improved: [#27097] On Linux, Flatpak Steam RCTC/RCT2 paths are auto-detected.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -383,6 +383,23 @@ namespace OpenRCT2::Platform
             {
                 ret.roots.emplace_back(snapLocalShareSteamPath);
             }
+
+            // The Flatpak build of Steam keeps its data in the app's sandboxed home directory. Depending on the
+            // Flatpak version, either of these two paths is the real directory; the other one is a symlink to it,
+            // so only the first one found is added.
+            constexpr u8string_view kFlatpakSteamPaths[] = {
+                u8".var/app/com.valvesoftware.Steam/.local/share/Steam",
+                u8".var/app/com.valvesoftware.Steam/data/Steam",
+            };
+            for (const auto& flatpakSteamPath : kFlatpakSteamPaths)
+            {
+                auto fullFlatpakSteamPath = Path::Combine(homeDir, flatpakSteamPath);
+                if (Path::DirectoryExists(fullFlatpakSteamPath))
+                {
+                    ret.roots.emplace_back(fullFlatpakSteamPath);
+                    break;
+                }
+            }
         }
 
         return ret;

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -94,7 +94,7 @@ namespace OpenRCT2::Platform
 
     struct SteamPaths
     {
-        sfl::static_vector<u8string, 5> roots{};
+        sfl::static_vector<u8string, 6> roots{};
         /**
          * Used by native applications and applications installed through Steam Play.
          */


### PR DESCRIPTION
This will allow users of the Steam Flatpak
(https://flathub.org/en/apps/com.valvesoftware.Steam) to have their installations auto-detected.

I used an LLM to generate the patch, but it's a pretty simple patch that I audited for correctness. (Honestly if I were less lazy I could have written this myself).

Assisted-by: LLM

### Description of changes

Added Flatpak Steam paths (`~/.var/app/com.valvesoftware.Steam/.local/share/Steam` / `~/.var/app/com.valvesoftware.Steam/data/Steam`) to RCT2 / RCTC asset detection.

### Rationale behind changes

Improves the experience for Flatpak Steam users, they will have their installations auto-detected.

### Suggested testing steps

- Install Flatpak Steam, log in, download Rollercoaster Tycoon Classic (or RCT2)
- Build OpenRCT2, open it without the config populated
- OpenRCT2 should detect RCTC / RCT2 automatically

### Did you use AI to help find, test, or implement this issue or feature?

Yes, used Claude Opus 5 on High reasoning to generate the patch. Audited myself (since it's a small change)
