### PR TITLE
Remove red for when negative g's go below -2.5

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#21400] The selector for setting staff patrol areas is now drawn on the water as well as on the surface under water.
 - Improved: [#26947] Rain is now drawn next to the bottom info panels (in RCT2 style).
+- Change: [#27100] Negative G-forces no longer turn red in the stats window and graph when below -2.50.
 - Fix: [#1514] Wrong capitalisation for strings in the Guest List window.
 - Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -625,7 +625,6 @@ namespace OpenRCT2::Ui::Windows
     };
     static_assert(std::size(GraphsYAxisDetails) == 4);
 
-    static constexpr auto kRideGForcesRedNegVertical = -MakeFixed16_2dp(2, 50);
     static constexpr auto kRideGForcesRedLateral = MakeFixed16_2dp(2, 80);
 
     // Used for sorting the ride type cheat dropdown.
@@ -6094,16 +6093,13 @@ namespace OpenRCT2::Ui::Windows
                         {
                             // Max. positive vertical G's
                             stringId = STR_MAX_POSITIVE_VERTICAL_G;
-
                             ft = Formatter();
                             ft.Add<fixed16_2dp>(ride->maxPositiveVerticalG);
                             drawText(rt, screenCoords, stringId, ft);
                             screenCoords.y += kListRowHeight;
 
                             // Max. negative vertical G's
-                            stringId = ride->maxNegativeVerticalG <= kRideGForcesRedNegVertical
-                                ? STR_MAX_NEGATIVE_VERTICAL_G_RED
-                                : STR_MAX_NEGATIVE_VERTICAL_G;
+                            stringId = STR_MAX_NEGATIVE_VERTICAL_G;
                             ft = Formatter();
                             ft.Add<int32_t>(ride->maxNegativeVerticalG);
                             drawText(rt, screenCoords, stringId, ft);
@@ -6464,7 +6460,6 @@ namespace OpenRCT2::Ui::Windows
                     case GRAPH_VERTICAL:
                         firstPoint = measurement->vertical[x] + VerticalGraphHeightOffset;
                         secondPoint = measurement->vertical[x + 1] + VerticalGraphHeightOffset;
-                        intensityThresholdNegative = (kRideGForcesRedNegVertical / 8) + VerticalGraphHeightOffset;
                         break;
                     case GRAPH_LATERAL:
                         firstPoint = measurement->lateral[x] + LateralGraphHeightOffset;
@@ -6501,7 +6496,7 @@ namespace OpenRCT2::Ui::Windows
                     previousMeasurement ? PaletteIndex::pi17 : PaletteIndex::pi21);
 
                 // Draw red over extreme values (if supported by graph type).
-                if (listType == GRAPH_VERTICAL || listType == GRAPH_LATERAL)
+                if (listType == GRAPH_LATERAL)
                 {
                     const auto redLineColour = previousMeasurement ? PaletteIndex::pi171 : PaletteIndex::pi173;
 


### PR DESCRIPTION
The vanilla game marks the positive and negative vertical g's in the stats screen red when they are at least 5.00 or -2.00 respectively, and the lateral g's will be red when it's at least 2.80 or -2.80. This does make sense for the lateral g's as above 2.8 you get a penalty, but no such penalty exists for the vertical g's so it's a bit confusing.

In 2018 the graphs were changed so that the line now shows up red whenever the g's are above those thresholds that make them red in the stats screen: #7730. Then, in 2022, the thresholds for red vertical g's got changed. The one for the positive vertical g's got removed entirely as at no point does it give a penalty or does it even stop giving extra excitement. The negative vertical g's also don't give a penalty, but they do stop giving excitement after -2.50, so that threshold was changed to -2.50: #16915.

And now I'm here arguing that we should remove the red for negative g's entirely. My reasoning for this is that red is otherwise only used for actual penalties. You get it when the intensity goes above 10 and penalizes the excitement rating, and when the lateral g's are above 2.80 and give you a sudden intensity boost. The negative g's don't do that, all they do after -2.50 is stop giving extra excitement, but with that logic the drop count should turn red when it's above 9, the inversion count when it's above 6, and so on. And to make it even more confusing, the lateral g's already stop giving extra excitement above 1.50 yet they don't turn red until 2.81 when they start giving a penalty. If 15 inversions and 39 drops don't show up as red, then why would -4.23 negative g's be red?
