### PR TITLE
Fixes #11659: Speed of right-click camera drag depends on window scaling

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Fix: [#11659] Right-click dragging the viewport does not keep the cursor locked to the same world position when UI scale is not 1.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -595,12 +595,16 @@ namespace OpenRCT2
                 // As the user moved the mouse, don't interpret it as right click in any case.
                 _ticksSinceDragStart = std::nullopt;
 
-                // applying the zoom only with negative values avoids a "deadzone" effect where small positive value round to
-                // zero.
+                // Cursor position is in window pixels; savedViewPos is in viewport space. Apply zoom the same way
+                // Viewport::ScreenToViewportCoord does (only to negative values, to avoid a deadzone when zoomed in),
+                // then convert to UI pixels so panning stays 1:1 with the cursor at any window scale.
+                const auto windowScale = Config::Get().general.windowScale;
                 const bool posX = differentialCoords.x > 0;
                 const bool posY = differentialCoords.y > 0;
-                differentialCoords.x = (viewport->zoom + 1).ApplyTo(-std::abs(differentialCoords.x));
-                differentialCoords.y = (viewport->zoom + 1).ApplyTo(-std::abs(differentialCoords.y));
+                differentialCoords.x = viewport->zoom.ApplyTo(-std::abs(differentialCoords.x));
+                differentialCoords.y = viewport->zoom.ApplyTo(-std::abs(differentialCoords.y));
+                differentialCoords.x = static_cast<int32_t>(std::round(differentialCoords.x / windowScale));
+                differentialCoords.y = static_cast<int32_t>(std::round(differentialCoords.y / windowScale));
                 differentialCoords.x = posX ? -differentialCoords.x : differentialCoords.x;
                 differentialCoords.y = posY ? -differentialCoords.y : differentialCoords.y;
 
@@ -1741,8 +1745,8 @@ namespace OpenRCT2
         // Apply zoom scaling (same logic as mouse drag)
         const bool posX = differentialCoords.x > 0;
         const bool posY = differentialCoords.y > 0;
-        differentialCoords.x = (viewport->zoom + 1).ApplyTo(-std::abs(differentialCoords.x));
-        differentialCoords.y = (viewport->zoom + 1).ApplyTo(-std::abs(differentialCoords.y));
+        differentialCoords.x = viewport->zoom.ApplyTo(-std::abs(differentialCoords.x));
+        differentialCoords.y = viewport->zoom.ApplyTo(-std::abs(differentialCoords.y));
         differentialCoords.x = posX ? -differentialCoords.x : differentialCoords.x;
         differentialCoords.y = posY ? -differentialCoords.y : differentialCoords.y;
 


### PR DESCRIPTION
Fixes a bug where right-click dragging the viewport with UI scale not being 1 would make the world move faster / slower than it should.

### Description of changes

Right-click viewport panning now converts the mouse delta from window pixels into UI/viewport space, and applies the current zoom the same way `Viewport::ScreenToViewportCoord` does (zoom, not zoom + 1). Gamepad/smooth viewport scrolling uses that same zoom mapping so it stays consistent with mouse drag.

### Rationale behind changes

`InputViewportDragContinue` reads the cursor via `ContextGetCursorPosition()`, which is in window pixels, and applied that delta straight to `savedViewPos`. `savedViewPos` is in viewport space, so any UI scale other than 1 made the world slide faster (scale > 1) or slower (scale < 1) than the cursor.

It also used (`viewport->zoom + 1`), which doubled movement at the default zoom. That kept the grabbed world point from staying under the cursor even at UI scale 1. Using `viewport->zoom` matches how screen coordinates are converted to world/viewport coordinates.

Fixes #11659.

### Suggested testing steps

* Set UI scale to 1. Right-click drag the main viewport: the world point under the cursor should stay under the cursor (or match mouse travel 1:1 if invert drag is off and the cursor is hidden).
* Repeat at UI scale 1.5 and 2, and at 0.75 if available. Panning speed should still match the cursor, not the scale factor.
* Repeat at several zoom levels (zoomed in and zoomed out), including invert right-mouse dragging on and off.
* Check an extra viewport window as well as the main view.
* Optionally check gamepad/smooth viewport scrolling still feels right after zoom changes.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. Cursor (Grok) located the drag path in `MouseInput.cpp`, identified that the delta was in window pixels and that `zoom + 1` did not match `ScreenToViewportCoord`, and implemented the fix. Testing was done manually in-game afterwards.
