### PR TITLE
Fix #21320: RCT1 allows more cars per train on some rides than OpenRCT2

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.5.6 (in development)
 ------------------------------------------------------------------------
+- Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4842,7 +4842,13 @@ namespace OpenRCT2
             if (!stationNumTiles.has_value())
                 return;
 
-            auto stationLength = (stationNumTiles.value() * 0x44180) - 0x16B2A;
+            // Change: RCT2 builds in a safety margin, presumably to ensure a block brake just before the station
+            // is never blocked by a tiny overhang from a train in the station. However, this also means
+            // it allows fewer trains or fewer cars per train even for non-block sectioned rides.
+            // For this reason, limit this margin to just block sectioned rides. This also improves
+            // compatibility with RCT1 parks and track designs.
+            const auto safetyMargin = isBlockSectioned() ? 0x16B2A : 0;
+            auto stationLength = (stationNumTiles.value() * 0x44180) - safetyMargin;
             int32_t maxMass = rtd.MaxMass << 8;
             int32_t newMaxCarsPerTrain = 1;
             for (int32_t numCars = rideEntry->max_cars_in_train; numCars > 0; numCars--)


### PR DESCRIPTION
Fixes https://github.com/openRCT2/openRCT2/issues/21320.

Extensive research and testing by Maji showed that this safety margin avoids locking up Mango Muncher, as having the train in the station at the maximum length without the margin _just_ about fouls the block brake just before it. More information can be found in the Discord discussion.

As such, limit this margin to just block sectioned rides, allowing longer trains to fit on non-block sectioned rides and improving compatibility with RCT1.