### PR TITLE
Fix: Some rides in RCT1 saves have a wrong number of cars per train

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Change: [#27100] Negative G-forces no longer turn red in the stats window and graph when below -2.50.
 - Fix: [#1514] Wrong capitalisation for strings in the Guest List window.
 - Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.
+- Fix: [#21576] RCT1 Wooden wild mouse track designs with 2-car trains are not imported correctly.
 - Fix: [#24457] Yellow is always rendered as third remap in Ride window.
 - Fix: [#26754] Switching window tabs by touch could crash the game on some Linux builds.
 - Fix: [#27052] Unnamed rides in RCT2 base and Wacky Worlds scenarios have hardcoded English names.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,6 +12,7 @@
 - Fix: [#27084] [Plugin] `PermissionType` for `drag_path_area` is missing.
 - Fix: [#27087] The ‘Update available’ widget is offset incorrectly.
 - Fix: [#27093] Pause and fast forward buttons are shown in multiplayer.
+- Fix: [#27109] Some rides in RCT1 saves have a wrong number of cars per train. 
 
 0.5.5 (2026-09-06)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -935,10 +935,11 @@ namespace OpenRCT2::RCT1
             }
 
             dst->numTrains = src->numTrains;
-            dst->numCarsPerTrain = src->numCarsPerTrain + rideEntry->zero_cars;
+            const auto additionalZeroCars = getAdditionalZeroCars(src->vehicleType);
+            dst->numCarsPerTrain = src->numCarsPerTrain + additionalZeroCars;
             dst->proposedNumTrains = src->numTrains;
             dst->maxTrains = src->maxTrains;
-            dst->proposedNumCarsPerTrain = src->numCarsPerTrain + rideEntry->zero_cars;
+            dst->proposedNumCarsPerTrain = src->numCarsPerTrain + additionalZeroCars;
             auto split = splitCombinedHelicesAndSpecialElements(src->specialTrackElements);
             dst->numHelices = split.first;
             dst->specialTrackElements = split.second;

--- a/src/openrct2/rct1/T4Importer.cpp
+++ b/src/openrct2/rct1/T4Importer.cpp
@@ -245,7 +245,8 @@ namespace OpenRCT2::RCT1
             td->appearance.stationObjectIdentifier = GetStationIdentifierFromStyle(RCT12_STATION_STYLE_PLAIN);
             td->operation.departFlags = td4Base.DepartFlags;
             td->trackAndVehicle.numberOfTrains = td4Base.NumberOfTrains;
-            td->trackAndVehicle.numberOfCarsPerTrain = td4Base.NumberOfCarsPerTrain;
+            td->trackAndVehicle.numberOfCarsPerTrain = td4Base.NumberOfCarsPerTrain
+                + getAdditionalZeroCars(td4Base.VehicleType);
             td->operation.minWaitingTime = td4Base.MinWaitingTime;
             td->operation.maxWaitingTime = td4Base.MaxWaitingTime;
             td->operation.operationSetting = std::min(

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -1514,4 +1514,23 @@ namespace OpenRCT2::RCT1
                 return false;
         }
     }
+
+    uint8_t getAdditionalZeroCars(const VehicleType vehicleType)
+    {
+        switch (vehicleType)
+        {
+            case VehicleType::woodenMineCars:
+            case VehicleType::woodenMouseCars:
+            case VehicleType::steelMouseCars:
+            case VehicleType::sportscars:
+            case VehicleType::racingCars:
+            case VehicleType::trucks:
+            case VehicleType::vintageCars:
+            case VehicleType::catCars:
+            case VehicleType::helicopterCars:
+                return 2;
+            default:
+                return 0;
+        }
+    }
 } // namespace OpenRCT2::RCT1

--- a/src/openrct2/rct1/Tables.h
+++ b/src/openrct2/rct1/Tables.h
@@ -57,4 +57,9 @@ namespace OpenRCT2::RCT1
     const std::vector<const char*> GetSceneryObjects(uint8_t sceneryType);
 
     bool VehicleTypeIsReversed(VehicleType vehicleType);
+    /**
+     * For some vehicles, OpenRCT2 has added zero cars in order to make them work with scenery doors.
+     * When setting the number of cars per train, this has to be taken into account.
+     */
+    uint8_t getAdditionalZeroCars(VehicleType vehicleType);
 } // namespace OpenRCT2::RCT1


### PR DESCRIPTION
This code was added by me 10 years ago, but I’ll be damned if I know why. My best guess is that RCT1 does not subtract the number of zero cars from the count in the Ride window, which means a Steam Train with 4 usable cars will appear as having 6 cars, and that I was confused by that.

Before:
<img width="478" height="474" alt="Schermafdruk van 2026-09-12 10-38-00" src="https://github.com/user-attachments/assets/dfc1129e-3b77-4967-9f37-0905d17feaae" />
<img width="322" height="237" alt="Schermafdruk van 2026-09-12 11-10-10" src="https://github.com/user-attachments/assets/01a714d9-5e88-41b6-9f11-75bfcb69553f" />

After:
<img width="368" height="449" alt="Schermafdruk van 2026-09-12 11-25-38" src="https://github.com/user-attachments/assets/2d01e12e-2711-43f5-9305-781305318b00" />
<img width="322" height="237" alt="Schermafdruk van 2026-09-12 11-23-29" src="https://github.com/user-attachments/assets/d415d30d-84ba-4a64-bbb8-0420a96c15a8" />
