### PR TITLE
Automatically close shops before beginning construction

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -2681,7 +2681,7 @@ STR_5582    :Trap mouse cursor in window
 STR_5583    :{COMMA1DP16} m/s
 STR_5584    :SI
 STR_5585    :Unlocks ride operation limits, allowing for things like {VELOCITY} lift hills
-STR_5586    :Automatically open shops and stalls
+STR_5586    :Automatically open and close shops and stalls
 STR_5587    :Shops and stalls will be automatically opened after building them
 STR_5588    :Play with other players
 STR_5589    :Notification Settings

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Improved: [#21400] The selector for setting staff patrol areas is now drawn on the water as well as on the surface under water.
 - Improved: [#26947] Rain is now drawn next to the bottom info panels (in RCT2 style).
+- Improved: [#27110] The option to automatically open shops after construction now also closes them before construction.
 - Change: [#27100] Negative G-forces no longer turn red in the stats window and graph when below -2.50.
 - Fix: [#1514] Wrong capitalisation for strings in the Guest List window.
 - Fix: [#21320] RCT1 allows more cars per train on some rides than OpenRCT2.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1668,12 +1668,31 @@ namespace OpenRCT2::Ui::Windows
                     auto ride = GetRide(rideId);
                     if (ride != nullptr)
                     {
-                        RideConstructionStart(*ride);
-                        auto* windowMgr = GetWindowManager();
-                        if (windowMgr->FindByNumber(WindowClass::rideConstruction, ride->id.ToUnderlying()) != nullptr)
+                        // Auto close shops if required
+                        if (ride->mode == RideMode::shopStall && ride->status == RideStatus::open
+                            && Config::Get().general.autoOpenShops)
                         {
-                            close();
-                            return;
+                            auto gameAction = GameActions::RideSetStatusAction(ride->id, RideStatus::closed);
+                            gameAction.SetCallback(
+                                [ride](const GameActions::GameAction* ga, const GameActions::Result* result) {
+                                    if (result->error != GameActions::Status::ok)
+                                        return;
+                                    RideConstructionStart(*ride);
+                                    // Close ride window if construction window opened
+                                    auto* windowMgr = GetWindowManager();
+                                    const auto id = ride->id.ToUnderlying();
+                                    if (windowMgr->FindByNumber(WindowClass::rideConstruction, id) != nullptr)
+                                        windowMgr->CloseByNumber(WindowClass::ride, id);
+                                });
+                            GameActions::Execute(&gameAction, getGameState());
+                        }
+                        else
+                        {
+                            RideConstructionStart(*ride);
+                            // Close ride window if construction window opened
+                            auto* windowMgr = GetWindowManager();
+                            if (windowMgr->FindByNumber(WindowClass::rideConstruction, ride->id.ToUnderlying()) != nullptr)
+                                close();
                         }
                     }
                     break;


### PR DESCRIPTION
### Description of changes

This improves the "Automatically open shops and stalls" option to also automatically close shops before beginning construction.

<img width="714" height="417" alt="animation" src="https://github.com/user-attachments/assets/8e424f85-46b0-4571-907f-e0f4a75cd0c9" />

### Rationale behind changes

I often want to move shops around, but for this, I need to manually close them before clicking the construction button. Since there is already an option to automatically open shops after construction, it seemed natural to extend this into the other direction of automatically closing them before construction.

### Suggested testing steps

- Place a shop in any park and open it.
- Make sure the "Automatically open and close shops and stalls" option is checked.
- Click the construction button without closing the shop first.
- Check the shop is properly closed (in the rides list) and that the construction window opened.

### Did you use AI to help find, test, or implement this issue or feature?

No.

### Implementation questions

The following questions arised while implementing this:

- Should this be a separate option from "Automatically open shops and stalls", or is my implementation of extending this related option preferred? Is it okay to rename `Config::General::autoOpenShops` to `autoOpenCloseShops` in this case or is that ugly since the stored setting is still named `auto_open_shops`?
- ~~Closing the shop before construction requires a GameAction callback that knows the ride ID. I added the ride ID as `RideSetStatusAction` data for this, though I could've also captured it in the callback lambda or even take it from the window itself that is already captured. I am not sure what is preferred here.~~ answered, capturing the ride is okay
