### PR TITLE
Refactor ViewportInteractionItems into FlagHolder

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -87,8 +87,7 @@ namespace OpenRCT2::Ui
 
         info = GetMapCoordinatesFromPos(
             screenCoords,
-            EnumsToFlags(
-                ViewportInteractionItem::entity, ViewportInteractionItem::ride, ViewportInteractionItem::parkEntrance));
+            { ViewportInteractionItem::entity, ViewportInteractionItem::ride, ViewportInteractionItem::parkEntrance });
         auto tileElement = info.interactionType != ViewportInteractionItem::entity ? info.Element : nullptr;
         // Only valid when info.interactionType == ViewportInteractionItem::entity, but can't assign nullptr without compiler
         // complaining
@@ -272,9 +271,12 @@ namespace OpenRCT2::Ui
         if (gLegacyScene == LegacyScene::trackDesigner && getGameState().editorStep != Editor::Step::rollerCoasterDesigner)
             return info;
 
-        constexpr auto flags = static_cast<int32_t>(
-            ~EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::water));
-        info = GetMapCoordinatesFromPos(screenCoords, flags);
+        constexpr ViewportInteractionItems kFlags{ ViewportInteractionItem::entity,       ViewportInteractionItem::ride,
+                                                   ViewportInteractionItem::scenery,      ViewportInteractionItem::footpath,
+                                                   ViewportInteractionItem::pathAddition, ViewportInteractionItem::parkEntrance,
+                                                   ViewportInteractionItem::wall,         ViewportInteractionItem::largeScenery,
+                                                   ViewportInteractionItem::label,        ViewportInteractionItem::banner };
+        info = GetMapCoordinatesFromPos(screenCoords, kFlags);
         auto tileElement = info.Element;
 
         switch (info.interactionType)
@@ -798,7 +800,7 @@ namespace OpenRCT2::Ui
         }
         auto viewport = window->viewport;
         auto info = GetMapCoordinatesFromPosWindow(
-            window, screenCoords, EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::water));
+            window, screenCoords, { ViewportInteractionItem::terrain, ViewportInteractionItem::water });
         auto initialPos = info.Loc;
 
         if (info.interactionType == ViewportInteractionItem::none)

--- a/src/openrct2-ui/interface/ViewportQuery.cpp
+++ b/src/openrct2-ui/interface/ViewportQuery.cpp
@@ -45,12 +45,12 @@ namespace OpenRCT2::Ui
             return position;
         }
         auto viewport = window->viewport;
-        auto info = GetMapCoordinatesFromPosWindow(window, screenCoords, EnumsToFlags(ViewportInteractionItem::footpath));
+        auto info = GetMapCoordinatesFromPosWindow(window, screenCoords, { ViewportInteractionItem::footpath });
         if (info.interactionType != ViewportInteractionItem::footpath
             || !(viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)))
         {
             info = GetMapCoordinatesFromPosWindow(
-                window, screenCoords, EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::footpath));
+                window, screenCoords, { ViewportInteractionItem::terrain, ViewportInteractionItem::footpath });
             if (info.interactionType == ViewportInteractionItem::none)
             {
                 auto position = info.Loc;
@@ -144,7 +144,7 @@ namespace OpenRCT2::Ui
             return ret;
         }
         auto viewport = window->viewport;
-        auto info = GetMapCoordinatesFromPosWindow(window, screenCoords, EnumsToFlags(ViewportInteractionItem::ride));
+        auto info = GetMapCoordinatesFromPosWindow(window, screenCoords, ViewportInteractionItem::ride);
         *tileElement = info.Element;
         if (info.interactionType == ViewportInteractionItem::ride
             && viewport->flags & (VIEWPORT_FLAG_UNDERGROUND_INSIDE | VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_VERTICAL)
@@ -164,7 +164,7 @@ namespace OpenRCT2::Ui
 
         info = GetMapCoordinatesFromPosWindow(
             window, screenCoords,
-            EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::footpath, ViewportInteractionItem::ride));
+            { ViewportInteractionItem::terrain, ViewportInteractionItem::footpath, ViewportInteractionItem::ride });
         if (info.interactionType == ViewportInteractionItem::ride && (*tileElement)->getType() == TileElementType::entrance)
         {
             uint32_t directions = (*tileElement)->asEntrance()->getDirections();

--- a/src/openrct2-ui/ride/Construction.cpp
+++ b/src/openrct2-ui/ride/Construction.cpp
@@ -374,7 +374,7 @@ namespace OpenRCT2
         CoordsXYZD entranceExitCoords{};
         gRideEntranceExitPlaceDirection = kInvalidDirection;
         // determine if the mouse is hovering over a station - that's the station to add the entrance to
-        auto info = GetMapCoordinatesFromPos(screenCoords, EnumsToFlags(ViewportInteractionItem::ride));
+        auto info = GetMapCoordinatesFromPos(screenCoords, ViewportInteractionItem::ride);
         if (info.interactionType != ViewportInteractionItem::none)
         {
             if (info.Element->getType() == TileElementType::track)

--- a/src/openrct2-ui/scripting/CustomMenu.cpp
+++ b/src/openrct2-ui/scripting/CustomMenu.cpp
@@ -263,14 +263,14 @@ namespace OpenRCT2::Scripting
             JSValue filter = JS_GetPropertyStr(ctx, value, "filter");
             if (JS_IsArray(filter))
             {
-                customTool.Filter = 0;
+                customTool.Filter.clearAll();
                 int64_t len = -1;
                 JS_GetLength(ctx, filter, &len);
                 for (int64_t i = 0; i < len; i++)
                 {
                     JSValue curFilter = JS_GetPropertyInt64(ctx, filter, i);
                     auto elem = FilterJSValToEnum(ctx, curFilter);
-                    customTool.Filter |= static_cast<uint32_t>(EnumToFlag(elem));
+                    customTool.Filter.set(elem);
                     JS_FreeValue(ctx, curFilter);
                 }
             }

--- a/src/openrct2-ui/scripting/CustomMenu.h
+++ b/src/openrct2-ui/scripting/CustomMenu.h
@@ -14,6 +14,7 @@
     #include <memory>
     #include <openrct2/Context.h>
     #include <openrct2/interface/Cursors.h>
+    #include <openrct2/interface/Viewport.h>
     #include <openrct2/scripting/ScriptEngine.h>
     #include <string>
     #include <vector>
@@ -77,7 +78,7 @@ namespace OpenRCT2::Scripting
         std::shared_ptr<Plugin> Owner;
         std::string Id;
         CursorID Cursor = CursorID::undefined;
-        uint32_t Filter{};
+        ViewportInteractionItems Filter{};
         bool MouseDown{};
 
         // Event handlers

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -907,11 +907,12 @@ namespace OpenRCT2::Ui::Windows
             // First, store the initial copy/ctrl state
             if (!_footpathPlaceCtrlState && im.isModifierKeyPressed(ModifierKey::ctrl))
             {
-                constexpr auto interactionFlags = EnumsToFlags(
-                    ViewportInteractionItem::terrain, ViewportInteractionItem::ride, ViewportInteractionItem::scenery,
-                    ViewportInteractionItem::footpath, ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery);
+                constexpr ViewportInteractionItems kInteractionFlags = {
+                    ViewportInteractionItem::terrain,  ViewportInteractionItem::ride, ViewportInteractionItem::scenery,
+                    ViewportInteractionItem::footpath, ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery
+                };
 
-                auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
+                auto info = GetMapCoordinatesFromPos(screenCoords, kInteractionFlags);
                 if (info.interactionType != ViewportInteractionItem::none)
                 {
                     const bool allowInvalidHeights = getGameState().cheats.allowTrackPlaceInvalidHeights;
@@ -972,7 +973,7 @@ namespace OpenRCT2::Ui::Windows
             if (!_footpathPlaceCtrlState)
             {
                 auto info = GetMapCoordinatesFromPos(
-                    screenCoords, EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::footpath));
+                    screenCoords, { ViewportInteractionItem::terrain, ViewportInteractionItem::footpath });
 
                 if (info.interactionType == ViewportInteractionItem::none)
                     return std::nullopt;
@@ -1256,7 +1257,7 @@ namespace OpenRCT2::Ui::Windows
                 return { _footpathPlaceZ, { FootpathSlopeType::flat } };
 
             const auto info = GetMapCoordinatesFromPos(
-                screenCoords, EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::footpath));
+                screenCoords, { ViewportInteractionItem::terrain, ViewportInteractionItem::footpath });
             return FootpathGetPlacementFromInfo(info);
         }
 

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -463,7 +463,8 @@ namespace OpenRCT2::Ui::Windows
             gMapSelectFlags.unset(MapSelectFlag::enable);
 
             auto info = GetMapCoordinatesFromPos(
-                screenCoords, EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::water));
+                screenCoords, { ViewportInteractionItem::terrain, ViewportInteractionItem::water });
+
             if (info.interactionType == ViewportInteractionItem::none)
             {
                 if (_landRightsCost != kMoney64Undefined)

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -278,9 +278,7 @@ namespace OpenRCT2::Ui::Windows
         std::optional<CoordsXY> GetBestCoordsFromPos(const ScreenCoordsXY& pos)
         {
             auto info = GetMapCoordinatesFromPos(
-                pos,
-                EnumsToFlags(
-                    ViewportInteractionItem::terrain, ViewportInteractionItem::water, ViewportInteractionItem::footpath));
+                pos, { ViewportInteractionItem::terrain, ViewportInteractionItem::water, ViewportInteractionItem::footpath });
             if (info.interactionType == ViewportInteractionItem::none)
                 return std::nullopt;
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4284,7 +4284,7 @@ namespace OpenRCT2::Ui::Windows
         void SetTrackColourScheme(const ScreenCoordsXY& screenPos)
         {
             auto newColourScheme = static_cast<uint8_t>(_rideColour);
-            auto info = GetMapCoordinatesFromPos(screenPos, EnumsToFlags(ViewportInteractionItem::ride));
+            auto info = GetMapCoordinatesFromPos(screenPos, ViewportInteractionItem::ride);
 
             if (info.interactionType != ViewportInteractionItem::ride)
                 return;
@@ -5843,10 +5843,11 @@ namespace OpenRCT2::Ui::Windows
             _lastSceneryY = screenCoords.y;
             _collectTrackDesignScenery = true; // Default to true in case user does not select anything valid
 
-            constexpr auto interactionFlags = EnumsToFlags(
-                ViewportInteractionItem::scenery, ViewportInteractionItem::footpath, ViewportInteractionItem::wall,
-                ViewportInteractionItem::largeScenery);
-            auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
+            constexpr ViewportInteractionItems kInteractionFlags = { ViewportInteractionItem::scenery,
+                                                                     ViewportInteractionItem::footpath,
+                                                                     ViewportInteractionItem::wall,
+                                                                     ViewportInteractionItem::largeScenery };
+            auto info = GetMapCoordinatesFromPos(screenCoords, kInteractionFlags);
             switch (info.interactionType)
             {
                 case ViewportInteractionItem::scenery:
@@ -5868,10 +5869,11 @@ namespace OpenRCT2::Ui::Windows
             _lastSceneryX = screenCoords.x;
             _lastSceneryY = screenCoords.y;
 
-            constexpr auto interactionFlags = EnumsToFlags(
-                ViewportInteractionItem::scenery, ViewportInteractionItem::footpath, ViewportInteractionItem::wall,
-                ViewportInteractionItem::largeScenery);
-            auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
+            constexpr ViewportInteractionItems kInteractionFlags = { ViewportInteractionItem::scenery,
+                                                                     ViewportInteractionItem::footpath,
+                                                                     ViewportInteractionItem::wall,
+                                                                     ViewportInteractionItem::largeScenery };
+            auto info = GetMapCoordinatesFromPos(screenCoords, kInteractionFlags);
             switch (info.interactionType)
             {
                 case ViewportInteractionItem::scenery:

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3003,12 +3003,14 @@ namespace OpenRCT2::Ui::Windows
         {
             if (im.isModifierKeyPressed(ModifierKey::ctrl))
             {
-                constexpr auto interactionFlags = EnumsToFlags(
-                    ViewportInteractionItem::terrain, ViewportInteractionItem::ride, ViewportInteractionItem::footpath,
-                    ViewportInteractionItem::pathAddition, ViewportInteractionItem::largeScenery,
-                    ViewportInteractionItem::label, ViewportInteractionItem::banner);
+                constexpr ViewportInteractionItems kInteractionFlags = {
+                    ViewportInteractionItem::terrain,      ViewportInteractionItem::ride,
+                    ViewportInteractionItem::footpath,     ViewportInteractionItem::pathAddition,
+                    ViewportInteractionItem::largeScenery, ViewportInteractionItem::label,
+                    ViewportInteractionItem::banner
+                };
 
-                auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
+                auto info = GetMapCoordinatesFromPos(screenCoords, kInteractionFlags);
                 if (info.interactionType != ViewportInteractionItem::none)
                 {
                     _trackPlaceCtrlZ = info.Element->getBaseZ();

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -2234,10 +2234,10 @@ namespace OpenRCT2::Ui::Windows
          */
         void RepaintSceneryToolDown(const ScreenCoordsXY& screenCoords, WidgetIndex widgetIndex)
         {
-            constexpr auto flag = EnumsToFlags(
-                ViewportInteractionItem::scenery, ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery,
-                ViewportInteractionItem::banner);
-            auto info = GetMapCoordinatesFromPos(screenCoords, flag);
+            constexpr ViewportInteractionItems kFlags = { ViewportInteractionItem::scenery, ViewportInteractionItem::wall,
+                                                          ViewportInteractionItem::largeScenery,
+                                                          ViewportInteractionItem::banner };
+            auto info = GetMapCoordinatesFromPos(screenCoords, kFlags);
             auto& gameState = getGameState();
             switch (info.interactionType)
             {
@@ -2312,10 +2312,11 @@ namespace OpenRCT2::Ui::Windows
 
         void SceneryEyedropperToolDown(const ScreenCoordsXY& screenCoords, WidgetIndex widgetIndex)
         {
-            constexpr auto flag = EnumsToFlags(
-                ViewportInteractionItem::scenery, ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery,
-                ViewportInteractionItem::banner, ViewportInteractionItem::pathAddition);
-            auto info = GetMapCoordinatesFromPos(screenCoords, flag);
+            constexpr ViewportInteractionItems kFlags = { ViewportInteractionItem::scenery, ViewportInteractionItem::wall,
+                                                          ViewportInteractionItem::largeScenery,
+                                                          ViewportInteractionItem::banner,
+                                                          ViewportInteractionItem::pathAddition };
+            auto info = GetMapCoordinatesFromPos(screenCoords, kFlags);
             switch (info.interactionType)
             {
                 case ViewportInteractionItem::scenery:
@@ -2404,11 +2405,12 @@ namespace OpenRCT2::Ui::Windows
                     if (im.isModifierKeyPressed(ModifierKey::ctrl))
                     {
                         // CTRL pressed
-                        constexpr auto flag = EnumsToFlags(
-                            ViewportInteractionItem::terrain, ViewportInteractionItem::ride, ViewportInteractionItem::scenery,
-                            ViewportInteractionItem::footpath, ViewportInteractionItem::wall,
-                            ViewportInteractionItem::largeScenery);
-                        auto info = GetMapCoordinatesFromPos(screenPos, flag);
+                        constexpr ViewportInteractionItems kFlags = {
+                            ViewportInteractionItem::terrain, ViewportInteractionItem::ride,
+                            ViewportInteractionItem::scenery, ViewportInteractionItem::footpath,
+                            ViewportInteractionItem::wall,    ViewportInteractionItem::largeScenery
+                        };
+                        auto info = GetMapCoordinatesFromPos(screenPos, kFlags);
 
                         if (info.interactionType != ViewportInteractionItem::none)
                         {
@@ -2574,9 +2576,10 @@ namespace OpenRCT2::Ui::Windows
             // If CTRL not pressed
             if (!gSceneryCtrlPressed)
             {
-                constexpr auto flag = EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::water);
+                constexpr ViewportInteractionItems kFlags = { ViewportInteractionItem::terrain,
+                                                              ViewportInteractionItem::water };
 
-                auto info = GetMapCoordinatesFromPos(screenPos, flag);
+                auto info = GetMapCoordinatesFromPos(screenPos, kFlags);
                 gridPos = info.Loc;
 
                 if (info.interactionType == ViewportInteractionItem::none)
@@ -2660,8 +2663,9 @@ namespace OpenRCT2::Ui::Windows
             updatePlacementUpdateScreenCoordsAndButtonsPressed(false, screenPos);
 
             // Path additions
-            constexpr auto flag = EnumsToFlags(ViewportInteractionItem::footpath, ViewportInteractionItem::pathAddition);
-            auto info = GetMapCoordinatesFromPos(screenPos, flag);
+            constexpr ViewportInteractionItems kFlags = { ViewportInteractionItem::footpath,
+                                                          ViewportInteractionItem::pathAddition };
+            auto info = GetMapCoordinatesFromPos(screenPos, kFlags);
             gridPos = info.Loc;
 
             if (info.interactionType == ViewportInteractionItem::none)
@@ -2862,8 +2866,9 @@ namespace OpenRCT2::Ui::Windows
             updatePlacementUpdateScreenCoordsAndButtonsPressed(false, screenPos);
 
             // Banner
-            constexpr auto flag = EnumsToFlags(ViewportInteractionItem::footpath, ViewportInteractionItem::pathAddition);
-            auto info = GetMapCoordinatesFromPos(screenPos, flag);
+            constexpr ViewportInteractionItems kFlags = { ViewportInteractionItem::footpath,
+                                                          ViewportInteractionItem::pathAddition };
+            auto info = GetMapCoordinatesFromPos(screenPos, kFlags);
             gridPos = info.Loc;
 
             if (info.interactionType == ViewportInteractionItem::none)
@@ -3059,7 +3064,7 @@ namespace OpenRCT2::Ui::Windows
             }
             else
             {
-                auto info = GetMapCoordinatesFromPos(screenCoords, EnumsToFlags(ViewportInteractionItem::terrain));
+                auto info = GetMapCoordinatesFromPos(screenCoords, ViewportInteractionItem::terrain);
 
                 if (info.interactionType == ViewportInteractionItem::none)
                     return std::nullopt;

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -463,10 +463,11 @@ namespace OpenRCT2::Ui::Windows
         MakeGroupboxSettings(kBannerDetailsHeight, kBannerPropertiesHeight, STR_TILE_INSPECTOR_GROUPBOX_BANNER_INFO),
     };
 
-    static constexpr int32_t ViewportInteractionFlags = EnumsToFlags(
-        ViewportInteractionItem::terrain, ViewportInteractionItem::ride, ViewportInteractionItem::scenery,
+    static constexpr ViewportInteractionItems kViewportInteractionFlags{
+        ViewportInteractionItem::terrain,  ViewportInteractionItem::ride,         ViewportInteractionItem::scenery,
         ViewportInteractionItem::footpath, ViewportInteractionItem::pathAddition, ViewportInteractionItem::parkEntrance,
-        ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery, ViewportInteractionItem::banner);
+        ViewportInteractionItem::wall,     ViewportInteractionItem::largeScenery, ViewportInteractionItem::banner
+    };
 
     static constexpr WidgetIndex kDisabledWidgetsDefault[] = {
         WIDX_BUTTON_MOVE_UP, WIDX_BUTTON_MOVE_DOWN, WIDX_BUTTON_REMOVE, WIDX_BUTTON_ROTATE, WIDX_BUTTON_COPY,
@@ -964,7 +965,7 @@ namespace OpenRCT2::Ui::Windows
             bool mouseOnViewport = false;
             if (GetInputManager().isModifierKeyPressed(ModifierKey::ctrl))
             {
-                auto info = GetMapCoordinatesFromPos(screenCoords, ViewportInteractionFlags);
+                auto info = GetMapCoordinatesFromPos(screenCoords, kViewportInteractionFlags);
                 clickedElement = info.Element;
                 mapCoords = info.Loc;
             }
@@ -1801,7 +1802,7 @@ namespace OpenRCT2::Ui::Windows
             TileElement* clickedElement = nullptr;
             if (ctrlIsHeldDown)
             {
-                auto info = GetMapCoordinatesFromPos(screenCoords, ViewportInteractionFlags);
+                auto info = GetMapCoordinatesFromPos(screenCoords, kViewportInteractionFlags);
                 clickedElement = info.Element;
                 mapCoords = info.Loc;
             }

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -490,11 +490,12 @@ namespace OpenRCT2::Ui::Windows
 
             if (!_trackPlaceCtrlState && im.isModifierKeyPressed(ModifierKey::ctrl))
             {
-                constexpr auto interactionFlags = EnumsToFlags(
-                    ViewportInteractionItem::terrain, ViewportInteractionItem::ride, ViewportInteractionItem::scenery,
-                    ViewportInteractionItem::footpath, ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery);
+                constexpr ViewportInteractionItems kInteractionFlags = {
+                    ViewportInteractionItem::terrain,  ViewportInteractionItem::ride, ViewportInteractionItem::scenery,
+                    ViewportInteractionItem::footpath, ViewportInteractionItem::wall, ViewportInteractionItem::largeScenery
+                };
 
-                auto info = GetMapCoordinatesFromPos(screenCoords, interactionFlags);
+                auto info = GetMapCoordinatesFromPos(screenCoords, kInteractionFlags);
                 if (info.interactionType == ViewportInteractionItem::terrain)
                 {
                     _trackPlaceCtrlZ = floor2(surfaceElement->getBaseZ(), kCoordsZStep);

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -327,7 +327,7 @@ namespace OpenRCT2::Ui::Windows
             gMapSelectFlags.unset(MapSelectFlag::enable);
 
             auto info = GetMapCoordinatesFromPos(
-                screenPos, EnumsToFlags(ViewportInteractionItem::terrain, ViewportInteractionItem::water));
+                screenPos, { ViewportInteractionItem::terrain, ViewportInteractionItem::water });
 
             if (info.interactionType == ViewportInteractionItem::none)
             {

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -670,7 +670,7 @@ static void ConsoleCommandGet(InteractiveConsole& console, const arguments_t& ar
             {
                 Viewport* viewport = WindowGetViewport(w);
                 auto info = GetMapCoordinatesFromPosWindow(
-                    w, { viewport->width / 2, viewport->height / 2 }, EnumsToFlags(ViewportInteractionItem::terrain));
+                    w, { viewport->width / 2, viewport->height / 2 }, ViewportInteractionItem::terrain);
 
                 auto tileMapCoord = TileCoordsXY(info.Loc);
                 console.WriteFormatLine("location %d %d", tileMapCoord.x, tileMapCoord.y);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1474,18 +1474,11 @@ namespace OpenRCT2
     /**
      * Checks if a PaintStruct sprite type is in the filter mask.
      */
-    static bool PSInteractionTypeIsInFilter(PaintStruct* ps, uint16_t filter)
+    static bool PSInteractionTypeIsInFilter(PaintStruct* ps, ViewportInteractionItems filter)
     {
-        if (ps->InteractionItem != ViewportInteractionItem::none && ps->InteractionItem != ViewportInteractionItem::label
-            && ps->InteractionItem <= ViewportInteractionItem::banner)
-        {
-            auto mask = EnumToFlag(ps->InteractionItem);
-            if (filter & mask)
-            {
-                return true;
-            }
-        }
-        return false;
+        return (ps->InteractionItem != ViewportInteractionItem::none && ps->InteractionItem != ViewportInteractionItem::label
+                && ps->InteractionItem <= ViewportInteractionItem::banner)
+            && filter.has(ps->InteractionItem);
     }
 
     /**
@@ -1648,7 +1641,8 @@ namespace OpenRCT2
      *
      *  rct2: 0x0068862C
      */
-    InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32_t viewFlags, uint16_t filter)
+    InteractionInfo SetInteractionInfoFromPaintSession(
+        PaintSession* session, uint32_t viewFlags, ViewportInteractionItems filter)
     {
         PROFILED_FUNCTION();
 
@@ -1705,14 +1699,15 @@ namespace OpenRCT2
      * tileElement: edx
      * viewport: edi
      */
-    InteractionInfo GetMapCoordinatesFromPos(const ScreenCoordsXY& screenCoords, int32_t flags)
+    InteractionInfo GetMapCoordinatesFromPos(const ScreenCoordsXY& screenCoords, ViewportInteractionItems flags)
     {
         auto* windowMgr = Ui::GetWindowManager();
         WindowBase* window = windowMgr->FindFromPoint(screenCoords);
         return GetMapCoordinatesFromPosWindow(window, screenCoords, flags);
     }
 
-    InteractionInfo GetMapCoordinatesFromPosWindow(WindowBase* window, const ScreenCoordsXY& screenCoords, int32_t flags)
+    InteractionInfo GetMapCoordinatesFromPosWindow(
+        WindowBase* window, const ScreenCoordsXY& screenCoords, ViewportInteractionItems flags)
     {
         InteractionInfo info{};
         if (window == nullptr || window->viewport == nullptr)
@@ -1748,7 +1743,7 @@ namespace OpenRCT2
             PaintSession* session = PaintSessionAlloc(rt, viewport->flags, viewport->rotation);
             PaintSessionGenerate(*session);
             PaintSessionArrange(*session);
-            info = SetInteractionInfoFromPaintSession(session, viewport->flags, flags & 0xFFFF);
+            info = SetInteractionInfoFromPaintSession(session, viewport->flags, flags);
             PaintSessionFree(session);
         }
         return info;
@@ -1820,7 +1815,7 @@ namespace OpenRCT2
             return std::nullopt;
         }
         auto myViewport = window->viewport;
-        auto info = GetMapCoordinatesFromPosWindow(window, screenCoords, EnumsToFlags(ViewportInteractionItem::terrain));
+        auto info = GetMapCoordinatesFromPosWindow(window, screenCoords, ViewportInteractionItem::terrain);
         if (info.interactionType == ViewportInteractionItem::none)
         {
             return std::nullopt;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
+#include "../core/FlagHolder.hpp"
 #include "../interface/ScreenCoords.hpp"
 #include "../interface/ZoomLevel.h"
 #include "../world/Location.hpp"
 #include "Window.h"
 
-#include <limits>
 #include <list>
 #include <optional>
 #include <sfl/static_vector.hpp>
@@ -149,6 +149,7 @@ enum class ViewportInteractionItem : uint8_t
     label,
     banner
 };
+using ViewportInteractionItems = FlagHolder<uint16_t, ViewportInteractionItem>;
 
 enum class ViewportVisibility : uint8_t
 {
@@ -162,7 +163,12 @@ enum class ViewportVisibility : uint8_t
 
 namespace OpenRCT2
 {
-    constexpr uint16_t kViewportInteractionItemAll = std::numeric_limits<uint16_t>::max();
+    constexpr ViewportInteractionItems kViewportInteractionItemAll{
+        ViewportInteractionItem::terrain,      ViewportInteractionItem::entity,       ViewportInteractionItem::ride,
+        ViewportInteractionItem::water,        ViewportInteractionItem::scenery,      ViewportInteractionItem::footpath,
+        ViewportInteractionItem::pathAddition, ViewportInteractionItem::parkEntrance, ViewportInteractionItem::wall,
+        ViewportInteractionItem::largeScenery, ViewportInteractionItem::label,        ViewportInteractionItem::banner
+    };
 
     struct InteractionInfo
     {
@@ -215,10 +221,12 @@ namespace OpenRCT2
     void HideConstructionRights();
     void ViewportSetVisibility(ViewportVisibility mode);
 
-    InteractionInfo GetMapCoordinatesFromPos(const ScreenCoordsXY& screenCoords, int32_t flags);
-    InteractionInfo GetMapCoordinatesFromPosWindow(WindowBase* window, const ScreenCoordsXY& screenCoords, int32_t flags);
+    InteractionInfo GetMapCoordinatesFromPos(const ScreenCoordsXY& screenCoords, ViewportInteractionItems flags);
+    InteractionInfo GetMapCoordinatesFromPosWindow(
+        WindowBase* window, const ScreenCoordsXY& screenCoords, ViewportInteractionItems flags);
 
-    InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32_t viewFlags, uint16_t filter);
+    InteractionInfo SetInteractionInfoFromPaintSession(
+        PaintSession* session, uint32_t viewFlags, ViewportInteractionItems filter);
 
     std::optional<CoordsXY> ScreenGetMapXY(const ScreenCoordsXY& screenCoords, Viewport** viewport);
     std::optional<CoordsXY> ScreenGetMapXYWithZ(const ScreenCoordsXY& screenCoords, int32_t z);


### PR DESCRIPTION
### Description of changes

For https://github.com/OpenRCT2/OpenRCT2/issues/27089: Refactor `ViewportInteractionItems` to use a `FlagHolder` so it replaces the need for `EnumsToFlags`.

### Rationale behind changes

Replace the need for lots of EnumsToFlags calls.

### Suggested testing steps

N/A

### Did you use AI to help find, test, or implement this issue or feature?

No AI was used.
