### PR TITLE
Refactor RideModes into FlagHolder

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3107,14 +3107,14 @@ namespace OpenRCT2::Ui::Windows
             if (ride == nullptr)
                 return;
 
-            auto availableModes = ride->getAvailableModes();
+            RideModes availableModes = ride->getAvailableModes();
 
             // Create dropdown list
             auto numAvailableModes = 0;
             auto checkedIndex = -1;
             for (auto i = 0; i < static_cast<uint8_t>(RideMode::count); i++)
             {
-                if (availableModes & (1uLL << i))
+                if (availableModes.has(static_cast<RideMode>(i)))
                 {
                     gDropdown.items[numAvailableModes] = Dropdown::MenuLabel(kRideModeNames[i]);
 
@@ -3376,11 +3376,11 @@ namespace OpenRCT2::Ui::Windows
                 case WIDX_MODE_DROPDOWN:
                 {
                     RideMode rideMode = RideMode::nullMode;
-                    auto availableModes = ride->getAvailableModes();
+                    RideModes availableModes = ride->getAvailableModes();
                     auto modeInDropdownIndex = -1;
                     for (RideMode rideModeIndex = RideMode::normal; rideModeIndex < RideMode::count; rideModeIndex++)
                     {
-                        if (availableModes & EnumToFlag(rideModeIndex))
+                        if (availableModes.has(rideModeIndex))
                         {
                             modeInDropdownIndex++;
                             if (modeInDropdownIndex == dropdownIndex)

--- a/src/openrct2/actions/ride/RideSetSettingAction.cpp
+++ b/src/openrct2/actions/ride/RideSetSettingAction.cpp
@@ -254,7 +254,7 @@ namespace OpenRCT2::GameActions
 
     bool RideSetSettingAction::RideIsModeValid(const Ride& ride) const
     {
-        return ride.getRideTypeDescriptor().RideModes & (1uLL << _value);
+        return ride.getRideTypeDescriptor().rideModes.has(static_cast<RideMode>(_value));
     }
 
     bool RideSetSettingAction::RideIsValidLiftHillSpeed(GameState_t& gameState, const Ride& ride) const

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5507,12 +5507,12 @@ namespace OpenRCT2
         }
     }
 
-    uint64_t Ride::getAvailableModes() const
+    RideModes Ride::getAvailableModes() const
     {
         if (getGameState().cheats.showAllOperatingModes)
             return kAllRideModesAvailable;
 
-        return getRideTypeDescriptor().RideModes;
+        return getRideTypeDescriptor().rideModes;
     }
 
     const RideTypeDescriptor& Ride::getRideTypeDescriptor() const

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -48,7 +48,6 @@ namespace OpenRCT2
     struct TrackElement;
 
     enum class EntranceType : uint8_t;
-    enum class RideMode : uint8_t;
     enum class RideStatus : uint8_t;
 
     constexpr uint8_t kRideAdjacencyCheckDistance = 5;
@@ -163,6 +162,52 @@ namespace OpenRCT2
             Breakdown::controlFailure,
         });
     constexpr auto kBreakdownCount = kAllBreakdownTypes.size();
+
+    enum class RideMode : uint8_t
+    {
+        normal,
+        continuousCircuit,
+        reverseInclineLaunchedShuttle,
+        poweredLaunchPassthrough, // RCT2 style, pass through station
+        shuttle,
+        boatHire,
+        upwardLaunch,
+        rotatingLift,
+        stationToStation,
+        singleRidePerAdmission,
+        unlimitedRidesPerAdmission = 10,
+        maze,
+        race,
+        dodgems,
+        swing,
+        shopStall,
+        rotation,
+        forwardRotation,
+        backwardRotation,
+        filmAvengingAviators,
+        mouseTails3DFilm = 20,
+        spaceRings,
+        beginners,
+        limPoweredLaunch,
+        filmThrillRiders,
+        stormChasers3DFilm,
+        spaceRaiders3DFilm,
+        intense,
+        berserk,
+        hauntedHouse,
+        circus = 30,
+        downwardLaunch,
+        crookedHouse,
+        freefallDrop,
+        continuousCircuitBlockSectioned,
+        poweredLaunch, // RCT1 style, don't pass through station
+        poweredLaunchBlockSectioned,
+
+        count,
+        nullMode = 255,
+    };
+    RideMode& operator++(RideMode& d, int);
+    using RideModes = FlagHolder<uint8_t, RideMode>;
 
     struct RideStation
     {
@@ -495,7 +540,7 @@ namespace OpenRCT2
 
         [[nodiscard]] std::unique_ptr<TrackDesign> saveToTrackDesign(TrackDesignState& tds) const;
 
-        uint64_t getAvailableModes() const;
+        RideModes getAvailableModes() const;
         const RideTypeDescriptor& getRideTypeDescriptor() const;
         RideNaming getTypeNaming() const;
         TrackElement* getOriginElement(StationIndex stationIndex) const;
@@ -649,52 +694,6 @@ namespace OpenRCT2
         simulating,
         count,
     };
-
-    enum class RideMode : uint8_t
-    {
-        normal,
-        continuousCircuit,
-        reverseInclineLaunchedShuttle,
-        poweredLaunchPassthrough, // RCT2 style, pass through station
-        shuttle,
-        boatHire,
-        upwardLaunch,
-        rotatingLift,
-        stationToStation,
-        singleRidePerAdmission,
-        unlimitedRidesPerAdmission = 10,
-        maze,
-        race,
-        dodgems,
-        swing,
-        shopStall,
-        rotation,
-        forwardRotation,
-        backwardRotation,
-        filmAvengingAviators,
-        mouseTails3DFilm = 20,
-        spaceRings,
-        beginners,
-        limPoweredLaunch,
-        filmThrillRiders,
-        stormChasers3DFilm,
-        spaceRaiders3DFilm,
-        intense,
-        berserk,
-        hauntedHouse,
-        circus = 30,
-        downwardLaunch,
-        crookedHouse,
-        freefallDrop,
-        continuousCircuitBlockSectioned,
-        poweredLaunch, // RCT1 style, don't pass through station
-        poweredLaunchBlockSectioned,
-
-        count,
-        nullMode = 255,
-    };
-
-    RideMode& operator++(RideMode& d, int);
 
     enum class RideCategory : uint8_t
     {

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -207,7 +207,7 @@ namespace OpenRCT2
         nullMode = 255,
     };
     RideMode& operator++(RideMode& d, int);
-    using RideModes = FlagHolder<uint8_t, RideMode>;
+    using RideModes = FlagHolder<uint64_t, RideMode>;
 
     struct RideStation
     {

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -389,7 +389,7 @@ namespace OpenRCT2
 
     bool RideTypeDescriptor::SupportsRideMode(RideMode rideMode) const
     {
-        return RideModes & EnumToFlag(rideMode);
+        return rideModes.has(rideMode);
     }
 
     static RideTrackGroups _enabledRideGroups = {};

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -616,43 +616,18 @@ namespace OpenRCT2
         return kRideComponentNames[EnumValue(type)];
     }
 
-    constexpr RideModes kAllRideModesAvailable = { RideMode::continuousCircuit,
-                                                   RideMode::continuousCircuitBlockSectioned,
-                                                   RideMode::reverseInclineLaunchedShuttle,
-                                                   RideMode::poweredLaunchPassthrough,
-                                                   RideMode::shuttle,
-                                                   RideMode::normal,
-                                                   RideMode::boatHire,
-                                                   RideMode::upwardLaunch,
-                                                   RideMode::rotatingLift,
-                                                   RideMode::stationToStation,
-                                                   RideMode::singleRidePerAdmission,
-                                                   RideMode::unlimitedRidesPerAdmission,
-                                                   RideMode::maze,
-                                                   RideMode::race,
-                                                   RideMode::dodgems,
-                                                   RideMode::swing,
-                                                   RideMode::shopStall,
-                                                   RideMode::rotation,
-                                                   RideMode::forwardRotation,
-                                                   RideMode::backwardRotation,
-                                                   RideMode::filmAvengingAviators,
-                                                   RideMode::mouseTails3DFilm,
-                                                   RideMode::spaceRings,
-                                                   RideMode::beginners,
-                                                   RideMode::limPoweredLaunch,
-                                                   RideMode::filmThrillRiders,
-                                                   RideMode::stormChasers3DFilm,
-                                                   RideMode::spaceRaiders3DFilm,
-                                                   RideMode::intense,
-                                                   RideMode::berserk,
-                                                   RideMode::hauntedHouse,
-                                                   RideMode::circus,
-                                                   RideMode::downwardLaunch,
-                                                   RideMode::crookedHouse,
-                                                   RideMode::freefallDrop,
-                                                   RideMode::poweredLaunch,
-                                                   RideMode::poweredLaunchBlockSectioned };
+    // clang-format off
+    constexpr RideModes kAllRideModesAvailable = {
+            RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle,
+            RideMode::poweredLaunchPassthrough, RideMode::shuttle, RideMode::normal, RideMode::boatHire, RideMode::upwardLaunch,
+            RideMode::rotatingLift, RideMode::stationToStation, RideMode::singleRidePerAdmission,
+            RideMode::unlimitedRidesPerAdmission, RideMode::maze, RideMode::race, RideMode::dodgems, RideMode::swing,
+            RideMode::shopStall, RideMode::rotation, RideMode::forwardRotation, RideMode::backwardRotation,
+            RideMode::filmAvengingAviators, RideMode::mouseTails3DFilm, RideMode::spaceRings, RideMode::beginners,
+            RideMode::limPoweredLaunch, RideMode::filmThrillRiders, RideMode::stormChasers3DFilm, RideMode::spaceRaiders3DFilm,
+            RideMode::intense, RideMode::berserk, RideMode::hauntedHouse, RideMode::circus, RideMode::downwardLaunch,
+            RideMode::crookedHouse, RideMode::freefallDrop, RideMode::poweredLaunch, RideMode::poweredLaunchBlockSectioned };
+    // clang-format on
 
     extern const CarEntry kCableLiftVehicle;
 

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -501,7 +501,7 @@ namespace OpenRCT2
         TrackDrawerDescriptor InvertedTrackPaintFunctions{};
         RtdFlags flags{};
         /** rct2: 0x0097C8AC */
-        uint64_t RideModes{};
+        RideModes rideModes{};
         RideMode DefaultMode{};
         /** rct2: 0x0097CF40 */
         RideOperatingSettings OperatingSettings{};
@@ -616,16 +616,43 @@ namespace OpenRCT2
         return kRideComponentNames[EnumValue(type)];
     }
 
-    constexpr uint64_t kAllRideModesAvailable = EnumsToFlags(
-        RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle,
-        RideMode::poweredLaunchPassthrough, RideMode::shuttle, RideMode::normal, RideMode::boatHire, RideMode::upwardLaunch,
-        RideMode::rotatingLift, RideMode::stationToStation, RideMode::singleRidePerAdmission,
-        RideMode::unlimitedRidesPerAdmission, RideMode::maze, RideMode::race, RideMode::dodgems, RideMode::swing,
-        RideMode::shopStall, RideMode::rotation, RideMode::forwardRotation, RideMode::backwardRotation,
-        RideMode::filmAvengingAviators, RideMode::mouseTails3DFilm, RideMode::spaceRings, RideMode::beginners,
-        RideMode::limPoweredLaunch, RideMode::filmThrillRiders, RideMode::stormChasers3DFilm, RideMode::spaceRaiders3DFilm,
-        RideMode::intense, RideMode::berserk, RideMode::hauntedHouse, RideMode::circus, RideMode::downwardLaunch,
-        RideMode::crookedHouse, RideMode::freefallDrop, RideMode::poweredLaunch, RideMode::poweredLaunchBlockSectioned);
+    constexpr RideModes kAllRideModesAvailable = { RideMode::continuousCircuit,
+                                                   RideMode::continuousCircuitBlockSectioned,
+                                                   RideMode::reverseInclineLaunchedShuttle,
+                                                   RideMode::poweredLaunchPassthrough,
+                                                   RideMode::shuttle,
+                                                   RideMode::normal,
+                                                   RideMode::boatHire,
+                                                   RideMode::upwardLaunch,
+                                                   RideMode::rotatingLift,
+                                                   RideMode::stationToStation,
+                                                   RideMode::singleRidePerAdmission,
+                                                   RideMode::unlimitedRidesPerAdmission,
+                                                   RideMode::maze,
+                                                   RideMode::race,
+                                                   RideMode::dodgems,
+                                                   RideMode::swing,
+                                                   RideMode::shopStall,
+                                                   RideMode::rotation,
+                                                   RideMode::forwardRotation,
+                                                   RideMode::backwardRotation,
+                                                   RideMode::filmAvengingAviators,
+                                                   RideMode::mouseTails3DFilm,
+                                                   RideMode::spaceRings,
+                                                   RideMode::beginners,
+                                                   RideMode::limPoweredLaunch,
+                                                   RideMode::filmThrillRiders,
+                                                   RideMode::stormChasers3DFilm,
+                                                   RideMode::spaceRaiders3DFilm,
+                                                   RideMode::intense,
+                                                   RideMode::berserk,
+                                                   RideMode::hauntedHouse,
+                                                   RideMode::circus,
+                                                   RideMode::downwardLaunch,
+                                                   RideMode::crookedHouse,
+                                                   RideMode::freefallDrop,
+                                                   RideMode::poweredLaunch,
+                                                   RideMode::poweredLaunchBlockSectioned };
 
     extern const CarEntry kCableLiftVehicle;
 
@@ -641,7 +668,7 @@ namespace OpenRCT2
         .TrackPaintFunctions = {},
         .InvertedTrackPaintFunctions = {},
         .flags = { RtdFlag::isDummyType },
-        .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+        .rideModes = { RideMode::continuousCircuit },
         .DefaultMode = RideMode::continuousCircuit,
         .OperatingSettings = {},
         .TrackSpeedSettings = {},

--- a/src/openrct2/ride/rtd/coaster/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/AirPoweredVerticalCoaster.h
@@ -29,7 +29,7 @@ constexpr RideTypeDescriptor kAirPoweredVerticalCoasterRTD =
     }),
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt | RtdFlags(RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch),
+    .rideModes = { RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch },
     .DefaultMode = RideMode::poweredLaunchPassthrough,
     .OperatingSettings = { 30, 50 },
     .TrackSpeedSettings = { 60, 60 },

--- a/src/openrct2/ride/rtd/coaster/AlpineCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/AlpineCoaster.h
@@ -33,7 +33,7 @@ constexpr RideTypeDescriptor kAlpineCoasterRTD =
                           RtdFlag::allowMusic, RtdFlag::interestingToLookAt, RtdFlag::supportsMultipleColourSchemes,
                           RtdFlag::canSynchroniseWithAdjacentStations, RtdFlag::hasEntranceAndExit,
                           RtdFlag::noTestMode, RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::upInclineRequiresLift),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .TrackSpeedSettings = { 10, 10 },

--- a/src/openrct2/ride/rtd/coaster/BobsleighCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/BobsleighCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kBobsleighCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .Naming = { STR_RIDE_NAME_BOBSLEIGH_COASTER, STR_RIDE_DESCRIPTION_BOBSLEIGH_COASTER },

--- a/src/openrct2/ride/rtd/coaster/ClassicMiniRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ClassicMiniRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kClassicMiniRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::allowDoorsOnTrack,
                      RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle },
     .DefaultMode = RideMode::continuousCircuit,
    .OperatingSettings = { 5, 27 },
     .BoosterSettings = { 17, 16 },

--- a/src/openrct2/ride/rtd/coaster/ClassicStandUpRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ClassicStandUpRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kClassicStandUpRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .Naming = { STR_RIDE_NAME_CLASSIC_STAND_UP_ROLLER_COASTER, STR_RIDE_DESCRIPTION_CLASSIC_STAND_UP_ROLLER_COASTER },

--- a/src/openrct2/ride/rtd/coaster/ClassicWoodenRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ClassicWoodenRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kClassicWoodenRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                         RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .BoosterSettings = { 0, 68 },

--- a/src/openrct2/ride/rtd/coaster/ClassicWoodenTwisterRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ClassicWoodenTwisterRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kClassicWoodenTwisterRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                         RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .BoosterSettings = { 0, 68 },

--- a/src/openrct2/ride/rtd/coaster/CompactInvertedCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/CompactInvertedCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kCompactInvertedCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::isSuspended, RtdFlag::reverseInclineLaunchAffectsReliability),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .Naming = { STR_RIDE_NAME_COMPACT_INVERTED_COASTER, STR_RIDE_DESCRIPTION_COMPACT_INVERTED_COASTER },

--- a/src/openrct2/ride/rtd/coaster/CorkscrewRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/CorkscrewRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kCorkscrewRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch, RideMode::reverseInclineLaunchedShuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch, RideMode::reverseInclineLaunchedShuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },

--- a/src/openrct2/ride/rtd/coaster/FlyingRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/FlyingRollerCoaster.h
@@ -37,7 +37,7 @@ constexpr RideTypeDescriptor kFlyingRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::hasInvertedVariant,
                      RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits, RtdFlag::startConstructionInverted),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },
@@ -112,7 +112,7 @@ constexpr RideTypeDescriptor kFlyingRollerCoasterAltRTD =
     }),
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::startConstructionInverted, RtdFlag::isDummyType),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },

--- a/src/openrct2/ride/rtd/coaster/GigaCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/GigaCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kGigaCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                  RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                               RtdFlag::allowMultipleCircuits, RtdFlag::allowCableLiftHill, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .TrackSpeedSettings = { 60, 60 },

--- a/src/openrct2/ride/rtd/coaster/HeartlineTwisterCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/HeartlineTwisterCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kHeartlineTwisterCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                  RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                               RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },

--- a/src/openrct2/ride/rtd/coaster/HybridCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/HybridCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kHybridCoasterRTD =
         RtdFlags(RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourSupports,
                      RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 15, 52 },

--- a/src/openrct2/ride/rtd/coaster/HyperTwister.h
+++ b/src/openrct2/ride/rtd/coaster/HyperTwister.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kHyperTwisterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .TrackSpeedSettings = { 60, 60 },

--- a/src/openrct2/ride/rtd/coaster/Hypercoaster.h
+++ b/src/openrct2/ride/rtd/coaster/Hypercoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kHypercoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation,
                      RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch, RideMode::reverseInclineLaunchedShuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch, RideMode::reverseInclineLaunchedShuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .TrackSpeedSettings = { 60, 60 },

--- a/src/openrct2/ride/rtd/coaster/InvertedHairpinCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/InvertedHairpinCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kInvertedHairpinCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::isSuspended),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_INVERTED_HAIRPIN_COASTER, STR_RIDE_DESCRIPTION_INVERTED_HAIRPIN_COASTER },

--- a/src/openrct2/ride/rtd/coaster/InvertedImpulseCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/InvertedImpulseCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kInvertedImpulseCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                  RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                               RtdFlag::allowMultipleCircuits, RtdFlag::isSuspended, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch),
+    .rideModes = { RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch },
     .DefaultMode = RideMode::poweredLaunchPassthrough,
     .OperatingSettings = { 10, 33 },
     .BoosterSettings = { 25, 25 },

--- a/src/openrct2/ride/rtd/coaster/InvertedRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/InvertedRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kInvertedRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::isSuspended, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .BoosterSettings = { 0, 38 },

--- a/src/openrct2/ride/rtd/coaster/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/JuniorRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kJuniorRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::allowDoorsOnTrack,
                      RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .TrackSpeedSettings = { 30, 15 },

--- a/src/openrct2/ride/rtd/coaster/LIMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/LIMLaunchedRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kLIMLaunchedRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch, RideMode::poweredLaunchBlockSectioned),
+    .rideModes = { RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch, RideMode::poweredLaunchBlockSectioned },
     .DefaultMode = RideMode::poweredLaunch,
     .OperatingSettings = { 10, 31 },
     .BoosterSettings = { 18, 52 },

--- a/src/openrct2/ride/rtd/coaster/LSMLaunchedRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/LSMLaunchedRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kLSMLaunchedRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                  RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                               RtdFlag::allowMultipleCircuits, RtdFlag::allowCableLiftHill, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunch, RideMode::poweredLaunchBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::poweredLaunch, RideMode::poweredLaunchBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 2, 10 },
     .TrackSpeedSettings = { 60, 60 },

--- a/src/openrct2/ride/rtd/coaster/LayDownRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/LayDownRollerCoaster.h
@@ -40,7 +40,7 @@ constexpr RideTypeDescriptor kLayDownRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::hasInvertedVariant,
                      RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },
@@ -111,7 +111,7 @@ constexpr RideTypeDescriptor kLayDownRollerCoasterAltRTD =
     }),
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::isDummyType),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },

--- a/src/openrct2/ride/rtd/coaster/LoopingRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/LoopingRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kLoopingRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains, RtdFlag::poweredLaunchAffectsReliability),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle, RideMode::poweredLaunchPassthrough, RideMode::poweredLaunch },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 18, 18 },

--- a/src/openrct2/ride/rtd/coaster/MineRide.h
+++ b/src/openrct2/ride/rtd/coaster/MineRide.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kMineRideRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .Naming = { STR_RIDE_NAME_MINE_RIDE, STR_RIDE_DESCRIPTION_MINE_RIDE },

--- a/src/openrct2/ride/rtd/coaster/MineTrainCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/MineTrainCoaster.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kMineTrainCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .Naming = { STR_RIDE_NAME_MINE_TRAIN_COASTER, STR_RIDE_DESCRIPTION_MINE_TRAIN_COASTER },

--- a/src/openrct2/ride/rtd/coaster/MiniRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/MiniRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kMiniRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .BoosterSettings = { 0, 68 },

--- a/src/openrct2/ride/rtd/coaster/MiniSuspendedCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/MiniSuspendedCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kMiniSuspendedCoasterRTD =
     .flags = kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourSupports,
                      RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces, RtdFlag::isSuspended),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_MINI_SUSPENDED_COASTER, STR_RIDE_DESCRIPTION_MINI_SUSPENDED_COASTER },

--- a/src/openrct2/ride/rtd/coaster/MultiDimensionRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/MultiDimensionRollerCoaster.h
@@ -37,7 +37,7 @@ constexpr RideTypeDescriptor kMultiDimensionRollerCoasterRTD =
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::hasInvertedVariant,
                      RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits, RtdFlag::hasSeatRotation,
                      RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },
@@ -111,7 +111,7 @@ constexpr RideTypeDescriptor kMultiDimensionRollerCoasterAltRTD =
     }),
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::hasSeatRotation, RtdFlag::isDummyType),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 25, 25 },

--- a/src/openrct2/ride/rtd/coaster/ReverseFreefallCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ReverseFreefallCoaster.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kReverseFreefallCoasterRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt
         | RtdFlags(RtdFlag::allowReversedTrains, RtdFlag::hasLsmBehaviourOnFlat),
-    .RideModes = EnumsToFlags(RideMode::limPoweredLaunch),
+    .rideModes = { RideMode::limPoweredLaunch },
     .DefaultMode = RideMode::limPoweredLaunch,
     .OperatingSettings = { 7, 30 },
     .TrackSpeedSettings = { 60, 60 },

--- a/src/openrct2/ride/rtd/coaster/ReverserRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/ReverserRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kReverserRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                  RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation,
                               RtdFlag::checkGForces, RtdFlag::layeredVehiclePreview),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_REVERSER_ROLLER_COASTER, STR_RIDE_DESCRIPTION_REVERSER_ROLLER_COASTER },

--- a/src/openrct2/ride/rtd/coaster/SideFrictionRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/SideFrictionRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kSideFrictionRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .Naming = { STR_RIDE_NAME_SIDE_FRICTION_ROLLER_COASTER, STR_RIDE_DESCRIPTION_SIDE_FRICTION_ROLLER_COASTER },
     .NameConvention = { RideComponentType::train, RideComponentType::track, RideComponentType::station },

--- a/src/openrct2/ride/rtd/coaster/SingleRailRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/SingleRailRollerCoaster.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kSingleRailRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt|
                  RtdFlags(RtdFlag::hasTrackColourSupports, RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation,
                               RtdFlag::checkGForces, RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .BoosterSettings = { 15, 52 },

--- a/src/openrct2/ride/rtd/coaster/SpinningWildMouse.h
+++ b/src/openrct2/ride/rtd/coaster/SpinningWildMouse.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kSpinningWildMouseRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                  RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_SPINNING_WILD_MOUSE, STR_RIDE_DESCRIPTION_SPINNING_WILD_MOUSE },

--- a/src/openrct2/ride/rtd/coaster/SpiralRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/SpiralRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kSpiralRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 17, 17 },

--- a/src/openrct2/ride/rtd/coaster/StandUpRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/StandUpRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kStandUpRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .Naming = { STR_RIDE_NAME_STAND_UP_ROLLER_COASTER, STR_RIDE_DESCRIPTION_STAND_UP_ROLLER_COASTER },

--- a/src/openrct2/ride/rtd/coaster/SteelWildMouse.h
+++ b/src/openrct2/ride/rtd/coaster/SteelWildMouse.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kSteelWildMouseRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
                 RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::allowDoorsOnTrack,
                              RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_WILD_MOUSE, STR_RIDE_DESCRIPTION_WILD_MOUSE },

--- a/src/openrct2/ride/rtd/coaster/Steeplechase.h
+++ b/src/openrct2/ride/rtd/coaster/Steeplechase.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kSteeplechaseRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_STEEPLECHASE, STR_RIDE_DESCRIPTION_STEEPLECHASE },

--- a/src/openrct2/ride/rtd/coaster/SuspendedSwingingCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/SuspendedSwingingCoaster.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kSuspendedSwingingCoasterRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces, RtdFlag::isSuspended),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .Naming = { STR_RIDE_NAME_SUSPENDED_SWINGING_COASTER, STR_RIDE_DESCRIPTION_SUSPENDED_SWINGING_COASTER },

--- a/src/openrct2/ride/rtd/coaster/TwisterRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/TwisterRollerCoaster.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kTwisterRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 17, 68 },

--- a/src/openrct2/ride/rtd/coaster/VerticalDropCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/VerticalDropCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kVerticalDropCoasterRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 10, 27 },
     .BoosterSettings = { 17, 68 },

--- a/src/openrct2/ride/rtd/coaster/VirginiaReel.h
+++ b/src/openrct2/ride/rtd/coaster/VirginiaReel.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kVirginiaReelRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
          RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_VIRGINIA_REEL, STR_RIDE_DESCRIPTION_VIRGINIA_REEL },

--- a/src/openrct2/ride/rtd/coaster/WaterCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/WaterCoaster.h
@@ -43,7 +43,7 @@ constexpr RideTypeDescriptor kWaterCoasterRTD =
     .InvertedTrackPaintFunctions = {},
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::hasCoveredPieces, RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .TrackSpeedSettings = { 30, 15 },

--- a/src/openrct2/ride/rtd/coaster/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/rtd/coaster/WoodenRollerCoaster.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kWoodenRollerCoasterRTD =
     .flags = kRtdFlagsHasThreeColours | kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::checkGForces,
                      RtdFlag::allowMultipleCircuits, RtdFlag::allowReversedTrains),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::continuousCircuitBlockSectioned, RideMode::reverseInclineLaunchedShuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 7, 27 },
     .BoosterSettings = { 0, 68 },

--- a/src/openrct2/ride/rtd/coaster/WoodenWildMouse.h
+++ b/src/openrct2/ride/rtd/coaster/WoodenWildMouse.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kWoodenWildMouseRTD =
     .flags = kRtdFlagsCommonCoaster | kRtdFlagsCommonCoasterNonAlt |
         RtdFlags(RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourSupports,
                      RtdFlag::hasLeaveWhenAnotherVehicleArrivesAtStation, RtdFlag::allowDoorsOnTrack, RtdFlag::checkGForces),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_WOODEN_WILD_MOUSE, STR_RIDE_DESCRIPTION_WOODEN_WILD_MOUSE },

--- a/src/openrct2/ride/rtd/gentle/CarRide.h
+++ b/src/openrct2/ride/rtd/gentle/CarRide.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kCarRideRTD =
                      RtdFlag::allowDoorsOnTrack, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::showInTrackDesigner,
                      RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_CAR_RIDE, STR_RIDE_DESCRIPTION_CAR_RIDE },

--- a/src/openrct2/ride/rtd/gentle/Circus.h
+++ b/src/openrct2/ride/rtd/gentle/Circus.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kCircusRTD =
                      RtdFlag::isFlatRide, RtdFlag::describeAsInside, RtdFlag::hasVehicleColours,
                      RtdFlag::hasMusicByDefault, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::circus),
+    .rideModes = { RideMode::circus },
     .DefaultMode = RideMode::circus,
     .Naming = { STR_RIDE_NAME_CIRCUS, STR_RIDE_DESCRIPTION_CIRCUS },
     .NameConvention = { RideComponentType::building, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/gentle/CrookedHouse.h
+++ b/src/openrct2/ride/rtd/gentle/CrookedHouse.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kCrookedHouseRTD =
                      RtdFlag::isFlatRide, RtdFlag::describeAsInside, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::crookedHouse),
+    .rideModes = { RideMode::crookedHouse },
     .DefaultMode = RideMode::crookedHouse,
     .Naming = { STR_RIDE_NAME_CROOKED_HOUSE, STR_RIDE_DESCRIPTION_CROOKED_HOUSE },
     .NameConvention = { RideComponentType::building, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/gentle/Dodgems.h
+++ b/src/openrct2/ride/rtd/gentle/Dodgems.h
@@ -33,7 +33,7 @@ constexpr RideTypeDescriptor kDodgemsRTD =
                      RtdFlag::isFlatRide, RtdFlag::hasVehicleColours, RtdFlag::hasMusicByDefault,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::slightlyInterestingToLookAt, RtdFlag::hasRoofOverWholeRide),
-    .RideModes = EnumsToFlags(RideMode::dodgems),
+    .rideModes = { RideMode::dodgems },
     .DefaultMode = RideMode::dodgems,
     .OperatingSettings = { 20, 180 },
     .Naming = { STR_RIDE_NAME_DODGEMS, STR_RIDE_DESCRIPTION_DODGEMS },
@@ -68,7 +68,7 @@ constexpr RideTypeDescriptor kDodgemsRTD =
         false,
         {
             // Special case, passing -2 to represent division by 2
-            { RatingsModifierType::bonusOperationOption, 0, 1, -2, 0 }, 
+            { RatingsModifierType::bonusOperationOption, 0, 1, -2, 0 },
             { RatingsModifierType::bonusNumTrains,       4, RideRating::make(0, 80), 0, 0 },
             { RatingsModifierType::bonusScenery,         0, 5577, 0, 0 },
         },

--- a/src/openrct2/ride/rtd/gentle/FerrisWheel.h
+++ b/src/openrct2/ride/rtd/gentle/FerrisWheel.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kFerrisWheelRTD =
                      RtdFlag::isFlatRide, RtdFlag::hasVehicleColours, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::slightlyInterestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::forwardRotation, RideMode::backwardRotation),
+    .rideModes = { RideMode::forwardRotation, RideMode::backwardRotation },
     .DefaultMode = RideMode::forwardRotation,
     .OperatingSettings = { 1, 3 },
     .Naming = { STR_RIDE_NAME_FERRIS_WHEEL, STR_RIDE_DESCRIPTION_FERRIS_WHEEL },

--- a/src/openrct2/ride/rtd/gentle/FlyingSaucers.h
+++ b/src/openrct2/ride/rtd/gentle/FlyingSaucers.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kFlyingSaucersRTD =
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::hasVehicleColours,
                      RtdFlag::hasMusicByDefault, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::singleSession, RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::dodgems),
+    .rideModes = { RideMode::dodgems },
     .DefaultMode = RideMode::dodgems,
     .OperatingSettings = { 20, 180 },
     .Naming = { STR_RIDE_NAME_FLYING_SAUCERS, STR_RIDE_DESCRIPTION_FLYING_SAUCERS },
@@ -66,7 +66,7 @@ constexpr RideTypeDescriptor kFlyingSaucersRTD =
         false,
         {
             // Special case, passing -2 to represent division by 2
-            { RatingsModifierType::bonusOperationOption, 0, 1, -2, 0 }, 
+            { RatingsModifierType::bonusOperationOption, 0, 1, -2, 0 },
             { RatingsModifierType::bonusNumTrains,       4, RideRating::make(0, 80), 0, 0 },
             { RatingsModifierType::bonusScenery,         0, 5577, 0, 0 },
         },

--- a/src/openrct2/ride/rtd/gentle/GhostTrain.h
+++ b/src/openrct2/ride/rtd/gentle/GhostTrain.h
@@ -36,7 +36,7 @@ constexpr RideTypeDescriptor kGhostTrainRTD =
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits,
                      RtdFlag::hasAirTime, RtdFlag::showInTrackDesigner, RtdFlag::interestingToLookAt,
                      RtdFlag::hasLandscapeDoors),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_GHOST_TRAIN, STR_RIDE_DESCRIPTION_GHOST_TRAIN },

--- a/src/openrct2/ride/rtd/gentle/HauntedHouse.h
+++ b/src/openrct2/ride/rtd/gentle/HauntedHouse.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kHauntedHouseRTD =
                      RtdFlag::isFlatRide, RtdFlag::describeAsInside, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::hauntedHouse),
+    .rideModes = { RideMode::hauntedHouse },
     .DefaultMode = RideMode::hauntedHouse,
     .Naming = { STR_RIDE_NAME_HAUNTED_HOUSE, STR_RIDE_DESCRIPTION_HAUNTED_HOUSE },
     .NameConvention = { RideComponentType::building, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/gentle/Maze.h
+++ b/src/openrct2/ride/rtd/gentle/Maze.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kMazeRTD =
     .flags = RtdFlags(RtdFlag::hasTrackColourSupports, RtdFlag::hasSinglePieceStation, RtdFlag::noTestMode, RtdFlag::noVehicles,
                      RtdFlag::noWallsAroundTrack, RtdFlag::describeAsInside, RtdFlag::hasTrack, RtdFlag::hasEntranceAndExit,
                      RtdFlag::guestsCanUseUmbrella),
-    .RideModes = EnumsToFlags(RideMode::maze),
+    .rideModes = { RideMode::maze },
     .DefaultMode = RideMode::maze,
     .OperatingSettings = { 1, 64 },
     .Naming = { STR_RIDE_NAME_MAZE, STR_RIDE_DESCRIPTION_MAZE },

--- a/src/openrct2/ride/rtd/gentle/MerryGoRound.h
+++ b/src/openrct2/ride/rtd/gentle/MerryGoRound.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kMerryGoRoundRTD =
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::interestingToLookAt, RtdFlag::listVehiclesSeparately,
                      RtdFlag::requireExplicitListingInMusicObjects),
-    .RideModes = EnumsToFlags(RideMode::rotation),
+    .rideModes = { RideMode::rotation },
     .DefaultMode = RideMode::rotation,
     .OperatingSettings = { 4, 25 },
     .Naming = { STR_RIDE_NAME_MERRY_GO_ROUND, STR_RIDE_DESCRIPTION_MERRY_GO_ROUND },

--- a/src/openrct2/ride/rtd/gentle/MiniGolf.h
+++ b/src/openrct2/ride/rtd/gentle/MiniGolf.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kMiniGolfRTD =
     .flags = kRtdFlagsHasThreeColours | RtdFlags(RtdFlag::noTestMode, RtdFlag::hasTrack, RtdFlag::hasOneStation,
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .Naming = { STR_RIDE_NAME_MINI_GOLF, STR_RIDE_DESCRIPTION_MINI_GOLF },
     .NameConvention = { RideComponentType::player, RideComponentType::course, RideComponentType::station },

--- a/src/openrct2/ride/rtd/gentle/MiniHelicopters.h
+++ b/src/openrct2/ride/rtd/gentle/MiniHelicopters.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kMiniHelicoptersRTD =
                      RtdFlag::allowDoorsOnTrack, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::showInTrackDesigner,
                      RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_MINI_HELICOPTERS, STR_RIDE_DESCRIPTION_MINI_HELICOPTERS },

--- a/src/openrct2/ride/rtd/gentle/MonorailCycles.h
+++ b/src/openrct2/ride/rtd/gentle/MonorailCycles.h
@@ -34,7 +34,7 @@ constexpr RideTypeDescriptor kMonorailCyclesRTD =
                      RtdFlag::guestsWillRideAgain, RtdFlag::hasVehicleColours, RtdFlag::hasTrack,
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_MONORAIL_CYCLES, STR_RIDE_DESCRIPTION_MONORAIL_CYCLES },

--- a/src/openrct2/ride/rtd/gentle/MonsterTrucks.h
+++ b/src/openrct2/ride/rtd/gentle/MonsterTrucks.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kMonsterTrucksRTD =
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::showInTrackDesigner,
                      RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = (1uLL << static_cast<uint8_t>(RideMode::continuousCircuit)),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_MONSTER_TRUCKS, STR_RIDE_DESCRIPTION_MONSTER_TRUCKS },

--- a/src/openrct2/ride/rtd/gentle/ObservationTower.h
+++ b/src/openrct2/ride/rtd/gentle/ObservationTower.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kObservationTowerRTD =
                      RtdFlag::hasLoadOptions, RtdFlag::noWallsAroundTrack, RtdFlag::hasVehicleColours, RtdFlag::hasTrack,
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::showInTrackDesigner, RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::rotatingLift),
+    .rideModes = { RideMode::rotatingLift },
     .DefaultMode = RideMode::rotatingLift,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_OBSERVATION_TOWER, STR_RIDE_DESCRIPTION_OBSERVATION_TOWER },

--- a/src/openrct2/ride/rtd/gentle/SpaceRings.h
+++ b/src/openrct2/ride/rtd/gentle/SpaceRings.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kSpaceRingsRTD =
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::hasVehicleColours,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::slightlyInterestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::spaceRings),
+    .rideModes = { RideMode::spaceRings },
     .DefaultMode = RideMode::spaceRings,
     .Naming = { STR_RIDE_NAME_SPACE_RINGS, STR_RIDE_DESCRIPTION_SPACE_RINGS },
     .NameConvention = { RideComponentType::ring, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/gentle/SpiralSlide.h
+++ b/src/openrct2/ride/rtd/gentle/SpiralSlide.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kSpiralSlideRTD =
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::interestingToLookAt,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::singleRidePerAdmission, RideMode::unlimitedRidesPerAdmission),
+    .rideModes = { RideMode::singleRidePerAdmission, RideMode::unlimitedRidesPerAdmission },
     .DefaultMode = RideMode::singleRidePerAdmission,
     .OperatingSettings = { 1, 5 },
     .Naming = { STR_RIDE_NAME_SPIRAL_SLIDE, STR_RIDE_DESCRIPTION_SPIRAL_SLIDE },

--- a/src/openrct2/ride/rtd/shops/CashMachine.h
+++ b/src/openrct2/ride/rtd/shops/CashMachine.h
@@ -29,7 +29,7 @@ constexpr RideTypeDescriptor kCashMachineRTD =
     .flags = RtdFlags(RtdFlag::hasSinglePieceStation, RtdFlag::cannotHaveGaps, RtdFlag::noTestMode,
                      RtdFlag::noVehicles, RtdFlag::isShopOrFacility,
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .Naming = { STR_RIDE_NAME_CASH_MACHINE, STR_RIDE_DESCRIPTION_CASH_MACHINE },
     .NameConvention = { RideComponentType::car, RideComponentType::building, RideComponentType::station },

--- a/src/openrct2/ride/rtd/shops/DrinkStall.h
+++ b/src/openrct2/ride/rtd/shops/DrinkStall.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kDrinkStallRTD =
                      RtdFlag::noVehicles, RtdFlag::isShopOrFacility, RtdFlag::noWallsAroundTrack,
                      RtdFlag::isFlatRide, RtdFlag::sellsDrinks, RtdFlag::listVehiclesSeparately,
                      RtdFlag::hasTrackColourMain),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .Naming = { STR_RIDE_NAME_DRINK_STALL, STR_RIDE_DESCRIPTION_DRINK_STALL },
     .NameConvention = { RideComponentType::car, RideComponentType::building, RideComponentType::station },

--- a/src/openrct2/ride/rtd/shops/FirstAid.h
+++ b/src/openrct2/ride/rtd/shops/FirstAid.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kFirstAidRTD =
                      RtdFlag::noVehicles, RtdFlag::isShopOrFacility, RtdFlag::noWallsAroundTrack,
                      RtdFlag::isFlatRide, RtdFlag::guestsShouldGoInsideFacility,
                      RtdFlag::describeAsInside, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .OperatingSettings = { 8, 8 },
     .Naming = { STR_RIDE_NAME_FIRST_AID, STR_RIDE_DESCRIPTION_FIRST_AID },

--- a/src/openrct2/ride/rtd/shops/FoodStall.h
+++ b/src/openrct2/ride/rtd/shops/FoodStall.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kFoodStallRTD =
                      RtdFlag::noVehicles, RtdFlag::isShopOrFacility, RtdFlag::noWallsAroundTrack,
                      RtdFlag::isFlatRide, RtdFlag::sellsFood, RtdFlag::listVehiclesSeparately,
                      RtdFlag::hasTrackColourMain),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .Naming = { STR_RIDE_NAME_FOOD_STALL, STR_RIDE_DESCRIPTION_FOOD_STALL },
     .NameConvention = { RideComponentType::car, RideComponentType::building, RideComponentType::station },

--- a/src/openrct2/ride/rtd/shops/InformationKiosk.h
+++ b/src/openrct2/ride/rtd/shops/InformationKiosk.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kInformationKioskRTD =
                      RtdFlag::cannotHaveGaps, RtdFlag::noTestMode, RtdFlag::noVehicles,
                      RtdFlag::isShopOrFacility, RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .Naming = { STR_RIDE_NAME_INFORMATION_KIOSK, STR_RIDE_DESCRIPTION_INFORMATION_KIOSK },
     .NameConvention = { RideComponentType::car, RideComponentType::building, RideComponentType::station },

--- a/src/openrct2/ride/rtd/shops/Shop.h
+++ b/src/openrct2/ride/rtd/shops/Shop.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kShopRTD =
                      RtdFlag::cannotHaveGaps, RtdFlag::noTestMode, RtdFlag::noVehicles,
                      RtdFlag::isShopOrFacility, RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .Naming = { STR_RIDE_NAME_SHOP, STR_RIDE_DESCRIPTION_SHOP },
     .NameConvention = { RideComponentType::car, RideComponentType::building, RideComponentType::station },

--- a/src/openrct2/ride/rtd/shops/Toilets.h
+++ b/src/openrct2/ride/rtd/shops/Toilets.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kToiletsRTD =
                      RtdFlag::noVehicles, RtdFlag::isShopOrFacility, RtdFlag::noWallsAroundTrack,
                      RtdFlag::isFlatRide, RtdFlag::guestsShouldGoInsideFacility, RtdFlag::describeAsInside,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::shopStall),
+    .rideModes = { RideMode::shopStall },
     .DefaultMode = RideMode::shopStall,
     .OperatingSettings = { 4, 4 },
     .Naming = { STR_RIDE_NAME_TOILETS, STR_RIDE_DESCRIPTION_TOILETS },

--- a/src/openrct2/ride/rtd/thrill/3DCinema.h
+++ b/src/openrct2/ride/rtd/thrill/3DCinema.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kCinemaRTD =
                      RtdFlag::isFlatRide, RtdFlag::describeAsInside, RtdFlag::hasVehicleColours,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::mouseTails3DFilm, RideMode::stormChasers3DFilm, RideMode::spaceRaiders3DFilm),
+    .rideModes = { RideMode::mouseTails3DFilm, RideMode::stormChasers3DFilm, RideMode::spaceRaiders3DFilm },
     .DefaultMode = RideMode::mouseTails3DFilm,
     .Naming = { STR_RIDE_NAME_3D_CINEMA, STR_RIDE_DESCRIPTION_3D_CINEMA },
     .NameConvention = { RideComponentType::building, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/thrill/Enterprise.h
+++ b/src/openrct2/ride/rtd/thrill/Enterprise.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kEnterpriseRTD =
                      RtdFlag::isFlatRide, RtdFlag::guestsWillRideAgain, RtdFlag::hasVehicleColours,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::interestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::rotation),
+    .rideModes = { RideMode::rotation },
     .DefaultMode = RideMode::rotation,
     .OperatingSettings = { 10, 20 },
     .Naming = { STR_RIDE_NAME_ENTERPRISE, STR_RIDE_DESCRIPTION_ENTERPRISE },
@@ -59,7 +59,7 @@ constexpr RideTypeDescriptor kEnterpriseRTD =
         3,
         false,
         {
-            { RatingsModifierType::bonusOperationOption, 0, 1, 16, 16 }, 
+            { RatingsModifierType::bonusOperationOption, 0, 1, 16, 16 },
             { RatingsModifierType::bonusScenery,         0, 19521, 0, 0 },
         },
     },

--- a/src/openrct2/ride/rtd/thrill/GoKarts.h
+++ b/src/openrct2/ride/rtd/thrill/GoKarts.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kGoKartsRTD =
     .flags = RtdFlags(RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourSupports, RtdFlag::noTestMode, RtdFlag::hasOneStation,
                      RtdFlag::noWallsAroundTrack, RtdFlag::guestsWillRideAgain, RtdFlag::hasVehicleColours, RtdFlag::hasTrack,
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::race, RideMode::continuousCircuit),
+    .rideModes = { RideMode::race, RideMode::continuousCircuit },
     .DefaultMode = RideMode::race,
     .OperatingSettings = { 1, 10 },
     .Naming = { STR_RIDE_NAME_GO_KARTS, STR_RIDE_DESCRIPTION_GO_KARTS },

--- a/src/openrct2/ride/rtd/thrill/LaunchedFreefall.h
+++ b/src/openrct2/ride/rtd/thrill/LaunchedFreefall.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kLaunchedFreefallRTD =
                      RtdFlag::hasDataLogging, RtdFlag::hasLoadOptions, RtdFlag::noWallsAroundTrack, RtdFlag::guestsWillRideAgain,
                      RtdFlag::hasVehicleColours, RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::showInTrackDesigner, RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::upwardLaunch, RideMode::downwardLaunch),
+    .rideModes = { RideMode::upwardLaunch, RideMode::downwardLaunch },
     .DefaultMode = RideMode::upwardLaunch,
     .OperatingSettings = { 10, 40 },
     .Naming = { STR_RIDE_NAME_LAUNCHED_FREEFALL, STR_RIDE_DESCRIPTION_LAUNCHED_FREEFALL },

--- a/src/openrct2/ride/rtd/thrill/MagicCarpet.h
+++ b/src/openrct2/ride/rtd/thrill/MagicCarpet.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kMagicCarpetRTD =
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::hasVehicleColours,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::interestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::swing),
+    .rideModes = { RideMode::swing },
     .DefaultMode = RideMode::swing,
     .OperatingSettings = { 7, 15 },
     .Naming = { STR_RIDE_NAME_MAGIC_CARPET, STR_RIDE_DESCRIPTION_MAGIC_CARPET },
@@ -64,7 +64,7 @@ constexpr RideTypeDescriptor kMagicCarpetRTD =
         0,
         false,
         {
-            { RatingsModifierType::bonusOperationOption, 0, 10, 20, 20 }, 
+            { RatingsModifierType::bonusOperationOption, 0, 10, 20, 20 },
             { RatingsModifierType::bonusScenery,         0, 11155, 0, 0 },
         },
     },

--- a/src/openrct2/ride/rtd/thrill/MotionSimulator.h
+++ b/src/openrct2/ride/rtd/thrill/MotionSimulator.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kMotionSimulatorRTD =
                      RtdFlag::isFlatRide, RtdFlag::hasVehicleColours, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::slightlyInterestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::filmAvengingAviators, RideMode::filmThrillRiders),
+    .rideModes = { RideMode::filmAvengingAviators, RideMode::filmThrillRiders },
     .DefaultMode = RideMode::filmAvengingAviators,
     .Naming = { STR_RIDE_NAME_MOTION_SIMULATOR, STR_RIDE_DESCRIPTION_MOTION_SIMULATOR },
     .NameConvention = { RideComponentType::car, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/thrill/RotoDrop.h
+++ b/src/openrct2/ride/rtd/thrill/RotoDrop.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kRotoDropRTD =
                      RtdFlag::guestsWillRideAgain, RtdFlag::hasVehicleColours, RtdFlag::hasTrack,
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::singleSession, RtdFlag::showInTrackDesigner, RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::freefallDrop),
+    .rideModes = { RideMode::freefallDrop },
     .DefaultMode = RideMode::freefallDrop,
     .Naming = { STR_RIDE_NAME_ROTO_DROP, STR_RIDE_DESCRIPTION_ROTO_DROP },
     .NameConvention = { RideComponentType::car, RideComponentType::track, RideComponentType::station },

--- a/src/openrct2/ride/rtd/thrill/SwingingInverterShip.h
+++ b/src/openrct2/ride/rtd/thrill/SwingingInverterShip.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kSwingingInverterShipRTD =
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::hasVehicleColours,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::interestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::swing),
+    .rideModes = { RideMode::swing },
     .DefaultMode = RideMode::swing,
     .OperatingSettings = { 7, 15 },
     .Naming = { STR_RIDE_NAME_SWINGING_INVERTER_SHIP, STR_RIDE_DESCRIPTION_SWINGING_INVERTER_SHIP },
@@ -63,7 +63,7 @@ constexpr RideTypeDescriptor kSwingingInverterShipRTD =
         0,
         false,
         {
-            { RatingsModifierType::bonusOperationOption, 0, 11, 22, 22 }, 
+            { RatingsModifierType::bonusOperationOption, 0, 11, 22, 22 },
             { RatingsModifierType::bonusScenery,         0, 11155, 0, 0 },
         },
     },

--- a/src/openrct2/ride/rtd/thrill/SwingingShip.h
+++ b/src/openrct2/ride/rtd/thrill/SwingingShip.h
@@ -33,7 +33,7 @@ constexpr RideTypeDescriptor kSwingingShipRTD =
                      RtdFlag::isFlatRide, RtdFlag::hasVehicleColours, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::singleSession, RtdFlag::interestingToLookAt,
                      RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::swing),
+    .rideModes = { RideMode::swing },
     .DefaultMode = RideMode::swing,
     .OperatingSettings = { 7, 25 },
     .Naming = { STR_RIDE_NAME_SWINGING_SHIP, STR_RIDE_DESCRIPTION_SWINGING_SHIP },
@@ -63,7 +63,7 @@ constexpr RideTypeDescriptor kSwingingShipRTD =
         0,
         false,
         {
-            { RatingsModifierType::bonusOperationOption, 0, 5, 5, 10 }, 
+            { RatingsModifierType::bonusOperationOption, 0, 5, 5, 10 },
             { RatingsModifierType::bonusScenery,         0, 16732, 0, 0 },
         },
     },

--- a/src/openrct2/ride/rtd/thrill/TopSpin.h
+++ b/src/openrct2/ride/rtd/thrill/TopSpin.h
@@ -32,7 +32,7 @@ constexpr RideTypeDescriptor kTopSpinRTD =
                      RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide, RtdFlag::hasVehicleColours,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::singleSession,
                      RtdFlag::interestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::beginners, RideMode::intense, RideMode::berserk),
+    .rideModes = { RideMode::beginners, RideMode::intense, RideMode::berserk },
     .DefaultMode = RideMode::beginners,
     .Naming = { STR_RIDE_NAME_TOP_SPIN, STR_RIDE_DESCRIPTION_TOP_SPIN },
     .NameConvention = { RideComponentType::car, RideComponentType::structure, RideComponentType::station },

--- a/src/openrct2/ride/rtd/thrill/Twist.h
+++ b/src/openrct2/ride/rtd/thrill/Twist.h
@@ -30,7 +30,7 @@ constexpr RideTypeDescriptor kTwistRTD =
                      RtdFlag::vehicleIsIntegral, RtdFlag::noWallsAroundTrack, RtdFlag::isFlatRide,
                      RtdFlag::hasVehicleColours, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::singleSession, RtdFlag::interestingToLookAt, RtdFlag::listVehiclesSeparately),
-    .RideModes = EnumsToFlags(RideMode::rotation),
+    .rideModes = { RideMode::rotation },
     .DefaultMode = RideMode::rotation,
     .OperatingSettings = { 3, 6, 3 },
     .Naming = { STR_RIDE_NAME_TWIST, STR_RIDE_DESCRIPTION_TWIST },

--- a/src/openrct2/ride/rtd/transport/Chairlift.h
+++ b/src/openrct2/ride/rtd/transport/Chairlift.h
@@ -34,7 +34,7 @@ constexpr RideTypeDescriptor kChairliftRTD =
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::isTransportRide, RtdFlag::showInTrackDesigner,
                      RtdFlag::slightlyInterestingToLookAt, RtdFlag::isSuspended, RtdFlag::runningSpeedAffectsReliability),
-    .RideModes = EnumsToFlags(RideMode::stationToStation),
+    .rideModes = { RideMode::stationToStation },
     .DefaultMode = RideMode::stationToStation,
     .OperatingSettings = { 1, 4 },
     .Naming = { STR_RIDE_NAME_CHAIRLIFT, STR_RIDE_DESCRIPTION_CHAIRLIFT },

--- a/src/openrct2/ride/rtd/transport/Lift.h
+++ b/src/openrct2/ride/rtd/transport/Lift.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kLiftRTD =
                      RtdFlag::cannotHaveGaps, RtdFlag::hasLoadOptions, RtdFlag::noWallsAroundTrack, RtdFlag::hasVehicleColours,
                      RtdFlag::hasTrack, RtdFlag::allowExtraTowerBases, RtdFlag::supportsMultipleColourSchemes,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::isTransportRide, RtdFlag::showInTrackDesigner),
-    .RideModes = EnumsToFlags(RideMode::shuttle),
+    .rideModes = { RideMode::shuttle },
     .DefaultMode = RideMode::shuttle,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_LIFT, STR_RIDE_DESCRIPTION_LIFT },

--- a/src/openrct2/ride/rtd/transport/MiniatureRailway.h
+++ b/src/openrct2/ride/rtd/transport/MiniatureRailway.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kMiniatureRailwayRTD =
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits,
                      RtdFlag::allowMultipleCircuits, RtdFlag::isTransportRide, RtdFlag::showInTrackDesigner,
                      RtdFlag::supportsLevelCrossings),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::shuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::shuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_MINIATURE_RAILWAY, STR_RIDE_DESCRIPTION_MINIATURE_RAILWAY },

--- a/src/openrct2/ride/rtd/transport/Monorail.h
+++ b/src/openrct2/ride/rtd/transport/Monorail.h
@@ -34,7 +34,7 @@ constexpr RideTypeDescriptor kMonorailRTD =
                      RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits,
                      RtdFlag::allowMultipleCircuits, RtdFlag::isTransportRide, RtdFlag::showInTrackDesigner),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::shuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::shuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_MONORAIL, STR_RIDE_DESCRIPTION_MONORAIL },

--- a/src/openrct2/ride/rtd/transport/SuspendedMonorail.h
+++ b/src/openrct2/ride/rtd/transport/SuspendedMonorail.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kSuspendedMonorailRTD =
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits,
                      RtdFlag::allowMultipleCircuits, RtdFlag::isTransportRide, RtdFlag::showInTrackDesigner,
                      RtdFlag::isSuspended),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit, RideMode::shuttle),
+    .rideModes = { RideMode::continuousCircuit, RideMode::shuttle },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_SUSPENDED_MONORAIL, STR_RIDE_DESCRIPTION_SUSPENDED_MONORAIL },

--- a/src/openrct2/ride/rtd/water/BoatHire.h
+++ b/src/openrct2/ride/rtd/water/BoatHire.h
@@ -31,7 +31,7 @@ constexpr RideTypeDescriptor kBoatHireRTD =
     .flags = RtdFlags(RtdFlag::hasTrackColourMain, RtdFlag::hasTrackColourSupports, RtdFlag::trackMustBeOnWater,
                      RtdFlag::noTestMode, RtdFlag::hasLoadOptions, RtdFlag::hasVehicleColours, RtdFlag::checkForStalling,
                      RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit),
-    .RideModes = EnumsToFlags(RideMode::boatHire),
+    .rideModes = { RideMode::boatHire },
     .DefaultMode = RideMode::boatHire,
     .OperatingSettings = { 5, 18 },
     .Naming = { STR_RIDE_NAME_BOAT_HIRE, STR_RIDE_DESCRIPTION_BOAT_HIRE },

--- a/src/openrct2/ride/rtd/water/DinghySlide.h
+++ b/src/openrct2/ride/rtd/water/DinghySlide.h
@@ -47,7 +47,7 @@ constexpr RideTypeDescriptor kDinghySlideRTD =
                      RtdFlag::checkForStalling, RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::hasAirTime,
                      RtdFlag::showInTrackDesigner, RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_DINGHY_SLIDE, STR_RIDE_DESCRIPTION_DINGHY_SLIDE },

--- a/src/openrct2/ride/rtd/water/LogFlume.h
+++ b/src/openrct2/ride/rtd/water/LogFlume.h
@@ -34,7 +34,7 @@ constexpr RideTypeDescriptor kLogFlumeRTD =
                      RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit,
                      RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::hasAirTime, RtdFlag::showInTrackDesigner,
                      RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_LOG_FLUME, STR_RIDE_DESCRIPTION_LOG_FLUME },

--- a/src/openrct2/ride/rtd/water/RiverRafts.h
+++ b/src/openrct2/ride/rtd/water/RiverRafts.h
@@ -34,7 +34,7 @@ constexpr RideTypeDescriptor kRiverRaftsRTD =
                      RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits,
                      RtdFlag::showInTrackDesigner, RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_RIVER_RAFTS, STR_RIDE_DESCRIPTION_RIVER_RAFTS },

--- a/src/openrct2/ride/rtd/water/RiverRapids.h
+++ b/src/openrct2/ride/rtd/water/RiverRapids.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kRiverRapidsRTD =
                      RtdFlag::hasVehicleColours, RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes,
                      RtdFlag::allowMusic, RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits,
                      RtdFlag::hasAirTime, RtdFlag::showInTrackDesigner, RtdFlag::interestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_RIVER_RAPIDS, STR_RIDE_DESCRIPTION_RIVER_RAPIDS },

--- a/src/openrct2/ride/rtd/water/SplashBoats.h
+++ b/src/openrct2/ride/rtd/water/SplashBoats.h
@@ -35,7 +35,7 @@ constexpr RideTypeDescriptor kSplashBoatsRTD =
                      RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes, RtdFlag::allowMusic,
                      RtdFlag::hasEntranceAndExit, RtdFlag::allowMoreVehiclesThanStationFits, RtdFlag::hasAirTime,
                      RtdFlag::showInTrackDesigner, RtdFlag::slightlyInterestingToLookAt),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .OperatingSettings = { 5, 27 },
     .Naming = { STR_RIDE_NAME_SPLASH_BOATS, STR_RIDE_DESCRIPTION_SPLASH_BOATS },

--- a/src/openrct2/ride/rtd/water/SubmarineRide.h
+++ b/src/openrct2/ride/rtd/water/SubmarineRide.h
@@ -34,7 +34,7 @@ constexpr RideTypeDescriptor kSubmarineRideRTD =
                      RtdFlag::hasVehicleColours, RtdFlag::hasTrack, RtdFlag::supportsMultipleColourSchemes,
                      RtdFlag::allowMusic, RtdFlag::checkGForces, RtdFlag::hasEntranceAndExit,
                      RtdFlag::allowMoreVehiclesThanStationFits),
-    .RideModes = EnumsToFlags(RideMode::continuousCircuit),
+    .rideModes = { RideMode::continuousCircuit },
     .DefaultMode = RideMode::continuousCircuit,
     .Naming = { STR_RIDE_NAME_SUBMARINE_RIDE, STR_RIDE_DESCRIPTION_SUBMARINE_RIDE },
     .NameConvention = { RideComponentType::boat, RideComponentType::track, RideComponentType::dockingPlatform },


### PR DESCRIPTION
### Description of changes

For https://github.com/OpenRCT2/OpenRCT2/issues/27088: Create a `FlagHolder for RideModes` to replace `EnumsToFlags`.

### Rationale behind changes

Replace multiple `EnumsToFlags` calls.

### Suggested testing steps

N/A

### Did you use AI to help find, test, or implement this issue or feature?

No AI was used.
