### PR TITLE
Fix #16807: Log and skip invalid object JSON files

### DIFF
--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -538,6 +538,13 @@ namespace OpenRCT2::ObjectFactory
 
         std::unique_ptr<Object> result;
 
+        if (!jRoot["objectType"].is_string())
+        {
+            LOG_VERBOSE("Ignoring JSON file (%.*s): objectType is not a string",
+                static_cast<int>(path.length()), path.data());
+            return nullptr;
+        }
+
         auto lookup = kObjectTypeMap.find(Json::GetString(jRoot["objectType"]));
         if (lookup != kObjectTypeMap.end())
         {


### PR DESCRIPTION
### Description of changes

Added validation to ensure that the objectType field in JSON object files is a string before attempting to read it.

JSON files without a string objectType are now rejected explicitly and logged with LOG_VERBOSE level before the object type lookup.

### Rationale behind changes

Previously, if a JSON file in the object directory had a missing or non-string objectType field, the file would be silently skipped with no indication in the logs as to why. This made it hard to diagnose why a particular object wasn't loading. This change adds a LOG_VERBOSE message explaining the rejection.

Note: this PR addresses the objectType validation potential fix in the original issue specifically. The other suggested fix (verifying the JSON root is a dictionary, not an array) is already partially handled by an existing is_object() check earlier in the same function, but that path currently throws a std::runtime_error rather than logging via LOG_VERBOSE in the same style. Happy to make that consistent too in this PR or a follow-up, whichever you'd prefer.

### Suggested testing steps

1) Run OpenRCT2 with verbose logging enabled.
2) Add a JSON file to object directory without an objectType field 
3) verify that it is rejected and logged at LOG_VERBOSE level, e.g. {"foo": "bar"}
4) Confirm existing valid objects still load normally.

### Did you use AI to help find, test, or implement this issue or feature?

No this issue was worked on by myself